### PR TITLE
[INFRA] add missing commit-hook related files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+BasedOnStyle: Google  # or LLVM, Chromium, Mozilla, etc.
+ColumnLimit: 80
+AllowShortFunctionsOnASingleLine: Empty
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false 
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: true
+  BeforeElse: false

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,1 @@
+codegen/inputs/RegistrationDeclarations.h

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+line-length = 88


### PR DESCRIPTION
Add missing clang-format files - this brings first-commit to no issue with pre-commit hooks. 