### PR TITLE
[REFACTOR] Quiet the backend logging by default

### DIFF
--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -133,3 +133,9 @@ def _autoload():
     # Set all the appropriate state on PyTorch
     torch.utils.rename_privateuse1_backend(DEVICE_NAME)
     torch._register_device_module(DEVICE_NAME, make_spyre_module())
+
+    # set the default backend debugging to quiet
+    # enable these if you would like to see runtime/compiler logging
+    os.environ.setdefault("TORCH_SENDNN_LOG", "CRITICAL")
+    os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")
+    os.environ.setdefault("DTLOG_LEVEL", "error")


### PR DESCRIPTION
This PR will set the default logging to quiet to reduce the amount of logs for the user