### PR TITLE
Fix build for new runtime headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,9 @@ if "RUNTIME_INSTALL_DIR" in os.environ:
         RUNTIME_DIR / "include",
     ]
     INCLUDE_DIRS += [
+        RUNTIME_DIR / "include" / "common",
+    ]
+    INCLUDE_DIRS += [
         RUNTIME_DIR / "include" / "concurrentqueue" / "moodycamel",
     ]
     INCLUDE_DIRS += [


### PR DESCRIPTION
With the latest runtime binary, we need this change to ensure all the c++ are found.