### PR TITLE
[INFRA] Enable dependabot for actions and python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  # Update action versions in workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: '[INFRA][CI] '
+
+  # Update dependencies (except torch) in pyproject.toml
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+    ignore:
+      - dependency-name: torch

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,39 @@
+name: Recompile requirements for Dependabot
+
+on:
+  pull_request:
+    paths:
+      - pyproject.toml
+
+jobs:
+  recompile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@30ce38e20653a26dd16caa082b010cec334ccf56  # v7.1.3
+      - name: Recompile requirements
+        run: ./tools/update-requirements.sh
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code requirements/ || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push if changed
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add requirements/*.txt
+          git commit -m "[dependabot skip] chore: recompile requirements after dependency update"
+          git push


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup
- [x] ci/infra

#### What this PR does:

Enable dependabot for the GHA and Python ecosystem. The GHA one lets us keep actions in workflows up to date. The Python one updates all dependencies (including extras) defined in pyproject.toml.

A new workflow is used to add a commit on top of dependabot's Python updates. The new commit includes the requirements updates generated by recompiling pyproject.toml. This is required so that CI may pass.

Dependanbot Pytorch ecosystem is configured to bundle updates as much as possible so to avoid too many patches and merge conflicts. That can be switched back to individual PRs at any time if we prefer to update packages individually.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

This may need to be tweaked a bit once the PR is merged and dependabot starts running.
It won't have any impact on normal CI and other PRs

#### Does this PR introduce a user-facing change?

No

#### Additional note:
