### PR TITLE
[FEAT] allow a tensor on device to be printed out to console

### DIFF
--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -1,0 +1,48 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def _patch_tensor_for_spyre():
+    import torch
+
+    if getattr(torch.Tensor, "_spyre_repr_patched", False):
+        return
+
+    orig_repr = torch.Tensor.__repr__
+
+    def spyre_aware_repr(self):
+        dev = getattr(self, "device", None)
+        if dev is not None and dev.type == "spyre":
+            try:
+                s = orig_repr(self.to("cpu"))
+            except Exception:
+                # Fallback if .to("cpu") fails for some weird reason
+                return (
+                    f"SpyreTensor(shape={tuple(self.shape)}, "
+                    f"dtype={self.dtype}, device={self.device})"
+                )
+            if "device=" in s:
+                return s.replace("device='cpu'", f"device='{self.device}'")
+            if s.endswith(")"):
+                s = s[:-1] + f", device='{self.device}')"
+            else:
+                # Odd case: just append device info
+                s = s + f" (device='{self.device}')"
+            return s
+
+        # Non-spyre tensors use normal behavior
+        return orig_repr(self)
+
+    torch.Tensor.__repr__ = spyre_aware_repr
+    torch.Tensor._spyre_repr_patched = True


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
This allows us to print a tensor directly without explicitly copying it back to CPU.
```
print(tensor)
```

* One skipped test is enabled (repr)
* Two new tests added (str, print)

Current code:
<img width="1252" height="157" alt="image" src="https://github.com/user-attachments/assets/051872c6-a3f0-4cc9-b0e8-8e525ae69912" />

PR code:
<img width="1250" height="143" alt="image" src="https://github.com/user-attachments/assets/14b5e482-de72-4c20-a492-3b34b0cffd6f" />


#### Which issue(s) this PR is related to:

This PR is to address the issue #92. 

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

#### Additional note:
