### PR TITLE
Enable torch.le in inductor

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -256,13 +256,18 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     cached_randn((256,)),
                     cached_randn((256,)),
                 ),
+                "ne": (
+                    lambda x, y: x != y,
+                    cached_randn((256,)),
+                    cached_randn((256,)),
+                ),
                 "ge": (
                     lambda x, y: x >= y,
                     cached_randn((256,)),
                     cached_randn((256,)),
                 ),
-                "ne": (
-                    lambda x, y: x != y,
+                "le": (
+                    lambda x, y: x <= y,
                     cached_randn((256,)),
                     cached_randn((256,)),
                 ),

--- a/torch_spyre/_inductor/opfuncs.py
+++ b/torch_spyre/_inductor/opfuncs.py
@@ -71,6 +71,7 @@ def _initialize_opfunc_mapping():
     pointwise_ops["eq"] = "equal"
     pointwise_ops["ne"] = "notequal"
     pointwise_ops["ge"] = "greaterequal"
+    pointwise_ops["le"] = "lesserequal"
     pointwise_ops["where"] = "where3"
     pointwise_ops["clamp"] = "clip"
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR enables torch.le in inductor.

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/106

#### Special notes for your reviewer:

NA

#### Does this PR introduce a user-facing change?

NA

#### Additional note:

To run this op on spyre, the backend needs to support the le opfunc.