### PR TITLE
[INFRA][TEST] port additional inductor tests to open source

### DIFF
--- a/tests/_inductor/test_building_blocks.py
+++ b/tests/_inductor/test_building_blocks.py
@@ -1,0 +1,116 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from utils_inductor import compare, compare_with_cpu, cached_randn
+
+
+class TestBuildingBlocks(unittest.TestCase):
+    torch.manual_seed(0xAFFE)
+
+    @unittest.skip("eager result is incorrect")
+    def test_softmax(self):
+        compare(lambda x: torch.softmax(x, dim=0), cached_randn((512, 1024)))
+        compare(lambda x: torch.softmax(x, dim=1), cached_randn((512, 1024)))
+        compare(lambda x: torch.softmax(x, dim=-1), cached_randn((512, 1024)))
+
+    # Temporary until eager mode implements softmax correctly.
+    def test_softmax_cpu(self):
+        compare_with_cpu(lambda x: torch.softmax(x, dim=0), cached_randn((512, 1024)))
+        compare_with_cpu(lambda x: torch.softmax(x, dim=1), cached_randn((512, 1024)))
+        compare_with_cpu(lambda x: torch.softmax(x, dim=-1), cached_randn((512, 1024)))
+
+    def test_softplus(self):
+        # beta * x >= threshold ? x : (log(1 + exp(-abs(beta * x)) + relu(beta * x)
+        # Reference: https://github.com/onnx/onnx-mlir/pull/2792
+        #
+        # TODO: "one" and "minus" should be created inside the function, not passed via parameter
+        def softplus(x, beta, threshold, one, minus):
+            bx = beta * x
+            return torch.where(
+                bx >= threshold,
+                x,
+                torch.log(one + torch.exp(minus * abs(bx))) + F.relu(bx),
+            )
+
+        T, D = 128, 64
+        beta = 1.0
+        threshold = 20.0
+        activation = torch.randn(D, T, dtype=torch.float16)
+
+        compare_with_cpu(
+            lambda x, beta, threshold, one, minus: softplus(
+                x, beta, threshold, one, minus
+            ),
+            activation,
+            torch.full([D, T], beta, dtype=torch.float16),
+            torch.full([D, T], threshold, dtype=torch.float16),
+            torch.full([D, T], 1.0, dtype=torch.float16),
+            torch.full([D, T], -1.0, dtype=torch.float16),
+        )
+
+    def test__simple_attn(self):
+        H = 4  # heads per group
+        Q = 64  # Q len
+        L = 256  # KV len
+        D = 128  # head dim
+        q = torch.randn(H * Q, D, dtype=torch.float16)
+        k = torch.randn(L, D, dtype=torch.float16)
+        v = torch.randn(L, D, dtype=torch.float16)
+        sm_scale = torch.tensor(1 / (D**0.5), dtype=torch.float16)
+
+        def attn(q, k, v, sm_scale):
+            qk = q @ k.transpose(-1, -2).contiguous()
+            qk = qk * sm_scale
+            p = qk.softmax(dim=-1)
+            return p @ v
+
+        compare_with_cpu(
+            lambda q, k, v, sm_scale: attn(q, k, v, sm_scale),
+            q,
+            k,
+            v,
+            sm_scale.repeat(k.shape[0]),
+        )
+
+    @unittest.skip("result divergent from CPU -- need to investigate")
+    def test_mlp(self):
+        seq_len = 256
+        emb_dim = 1024
+        x = torch.randn(seq_len, emb_dim)
+        gate_proj_weight = torch.empty(emb_dim, 4 * emb_dim)
+        up_proj_weight = torch.empty(emb_dim, 4 * emb_dim)
+        down_proj_weight = torch.empty(4 * emb_dim, emb_dim)
+        nn.init.kaiming_uniform_(gate_proj_weight)
+        nn.init.kaiming_uniform_(up_proj_weight)
+        nn.init.kaiming_uniform_(down_proj_weight)
+
+        def mlp(x, gate, up, down):
+            gate_out = x @ gate
+            up_out = x @ up
+            swiglu_out = up_out * F.silu(gate_out)
+            out = swiglu_out @ down
+            return out
+
+        compare_with_cpu(
+            lambda x, g, u, d: mlp(x, g, u, d),
+            x,
+            gate_proj_weight,
+            up_proj_weight,
+            down_proj_weight,
+        )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ x ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

port additional inductor tests to open source

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
```
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.1
collected 123 items                                                                                                                                                      

tests/_inductor/test_building_blocks.py .ss..                                                                                                                      [  4%]
tests/_inductor/test_inductor_ops.py s...................................ss.........                                                                               [ 42%]
tests/tensor/test_tensor_layout.py ......                                                                                                                          [ 47%]
tests/test_modules.py ssssss.                                                                                                                                      [ 52%]
tests/test_ops.py ..sssss...............sss.sssss.s........s.ss                                                                                                    [ 89%]
tests/test_spyre.py .s...s.......                                                                                                                                  [100%]

=============================================================== 93 passed, 30 skipped in 112.54s (0:01:52) ===============================================================
```
#### Does this PR introduce a user-facing change?

#### Additional note:
