### PR TITLE
[CI] Use spyre-bot GitHub app token

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -13,9 +13,15 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94  # v2.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.SPYRE_BOT_APP_ID }}
+          private-key: ${{ secrets.SPYRE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
         with:
@@ -27,7 +33,9 @@ jobs:
       - name: Check for changes
         id: git-check
         run: |
-          git diff --exit-code requirements/ || echo "changed=true" >> "$GITHUB_OUTPUT"
+          if ! git diff --quiet uv.lock; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push if changed
         if: steps.git-check.outputs.changed == 'true'


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

In the dependabot workflow, that updates dependabot PRs with uv.lock and requirement updates, start using a token from the Spyre-bot GitHub app.

This is required because commits created with GITHUB_TOKEN do not trigger workflows (to avoid potential loops).

This PR also updates the check for changed files to verify `uv.lock`, since the lock file was introduced.

#### Which issue(s) this PR is related to:

Fixes: #135

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
