### PR TITLE
[INFRA][DEPENDENCY] Add uv.lock to the commit

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -42,6 +42,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add requirements/*.txt
+          git add requirements/*.txt uv.lock
           git commit -m "[dependabot skip] chore: recompile requirements after dependency update"
           git push


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The dependabot workflow creates a commit that should include both requirements/* files as well as changes to uv.lock.
The latter was missing.

#### Which issue(s) this PR is related to:

Fixes: #135

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
