### PR TITLE
Move conversion of compile artifacts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ if "RUNTIME_INSTALL_DIR" in os.environ:
     # take lower precedence than CMAKE_LIBRARY_PATH and CMAKE_INCLUDE_PATH
     RUNTIME_DIR = Path(os.environ["RUNTIME_INSTALL_DIR"])
     SENLIB_DIR = Path(os.environ["SENLIB_INSTALL_DIR"])
+    DEEPTOOLS_DIR = Path(os.environ["DEEPTOOLS_INSTALL_DIR"])
     INCLUDE_DIRS += [
         RUNTIME_DIR / "include",
     ]
@@ -105,9 +106,12 @@ if "RUNTIME_INSTALL_DIR" in os.environ:
     INCLUDE_DIRS += [
         SENLIB_DIR / "include",
     ]
+    INCLUDE_DIRS += [
+        DEEPTOOLS_DIR / "include",
+    ]
     LIBRARY_DIRS += [RUNTIME_DIR / "lib"]
 
-LIBRARIES = ["sendnn", "flex"]
+LIBRARIES = ["sendnn", "flex", "dee_internal"]
 
 # FIXME: added no-deprecated as this fails in sentensor_shape.hpp
 # - we need to fix there

--- a/torch_spyre/_inductor/runtime/async_compile.py
+++ b/torch_spyre/_inductor/runtime/async_compile.py
@@ -19,7 +19,7 @@ import os
 import subprocess
 
 from torch._inductor.runtime.runtime_utils import cache_dir
-
+from torch_spyre._C import convert_artifacts
 from torch_spyre._inductor.codegen.superdsc import generate_sdsc
 from torch_spyre._inductor.constants import SEGMENT_OFFSETS
 from . import KernelSpec, ConstantArg, UnimplementedOp
@@ -90,6 +90,7 @@ class SpyreAsyncCompile:
             print(f"Generating {file.name}")
             json.dump(dt_sdsc, file, indent=2)
         subprocess.run(["dxp_standalone", "-d", kernel_output_dir], check=True)
+        convert_artifacts(kernel_output_dir)
         return SpyreSDSCKernelRunner(kernel_name, kernel_output_dir, arg_mapping)
 
     def wait(self, scope: dict[str, Any]) -> None:

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -22,6 +22,7 @@
 #include <util/sen_data_convert.h>
 #include <util/sendefs.h>
 
+#include <dee_internal/dee_graph_converter.hpp>
 #include <flex/flex_factory.hpp>
 #include <memory>
 #include <sendnn/graph.hpp>
@@ -191,6 +192,24 @@ uint32_t encodeConstant(float torch_const, const std::string &data_format) {
   }
   return sen_const;
 }
+void convertArtifacts(std::string artifacts_path) {
+  dee::PBD pbd;
+  sendnn::Graph g2;
+
+  setenv("DEEPRT_EXPORT_DIR", artifacts_path.c_str(), 1);
+  senbfcc::GlobalTracedSettings::Get().UpdateValue("DEEPRT_EXPORT_DIR",
+                                                   artifacts_path);
+
+  setenv("SENDNN_SERIALIZER_FORMAT", "CBOR", 1);
+
+  // Convert compiled artifacts to sendnn g2 graph
+  pbd.FromGraph(&g2);
+
+  // Serialize g2 graph
+  sendnn::Serialize(g2, artifacts_path + "/g2");
+
+  return;
+}
 }  // namespace spyre
 
 PYBIND11_MODULE(_C, m) {
@@ -200,7 +219,7 @@ PYBIND11_MODULE(_C, m) {
   m.def("launch_kernel", &spyre::launchKernel);
   m.def("encode_constant", &spyre::encodeConstant);
   m.def("get_sen_data_format", &spyre::getSenDataFormat);
-
+  m.def("convert_artifacts", &spyre::convertArtifacts);
   py::class_<spyre::SpyreTensorLayout> dci_cls(m, "SpyreTensorLayout");
 
   py::enum_<spyre::SpyreTensorLayout::StickFormat>(m, "StickFormat")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
To accommodate new build process, the conversion of the compilation artifacts -> sendnn G2 graph needs to be handled in the compiler frontend. This PR adds a function to generate a G2 graph from these artifacts after the compiler backend exits. 

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
<img width="3416" height="424" alt="image" src="https://github.com/user-attachments/assets/4a03b963-03c8-4dee-8671-c80ee36e2c18" />
