### PR TITLE
[INFRA][FORMAT] Remove --check flag to ruff format in precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: ruff-check
         args: [--output-format, github, --fix]
       - id: ruff-format
-        args: [--check]
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: v0.9.31
     hooks:


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR makes it possible to run `pre-commit run --all-files` to format python files in addition to applying linter fixes.