### PR TITLE
[REFACTOR] Switch to StickFormat in bmm function

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -119,10 +119,7 @@ def spyre_bmm_result_shape(
 ) -> Tuple[Sequence[int], SpyreTensorLayout]:
     x_layout: SpyreTensorLayout = x.get_spyre_layout()
     y_layout: SpyreTensorLayout = y.get_spyre_layout()
-    if (
-        x_layout.format != SpyreTensorLayout.StickFormat.Dense
-        or y_layout.format != SpyreTensorLayout.StickFormat.Dense
-    ):
+    if x_layout.format != StickFormat.Dense or y_layout.format != StickFormat.Dense:
         raise Unsupported(f"bmm on non-dense tensors {x_layout} {y_layout}")
     if x_layout.host_dim_order() != y_layout.host_dim_order():
         raise Unsupported(f"bmm stick dimensions mismatch {x_layout} {y_layout}")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR fixes an error caused by the switch from `SpyreTensorLayout.StickFormat.Dense` -> `StickFormat.Dense` in the handling for the result shape of the bmm operation. 

cc: @cyang49 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
