### PR TITLE
feat: add inductor test

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -176,6 +176,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "dim_1": (1, cached_randn((128, 256))),
             },
         },
+        ("test_max_unsqueeze_cpu", "test_max_unsqueeze_cpu"): {
+            "param_sets": {
+                "dim_0": (0, cached_randn((128, 256))),
+                "dim_1": (1, cached_randn((128, 256))),
+            },
+        },
         (
             "test_alias_operands",
             "test_unary_op",
@@ -313,6 +319,15 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return z
 
         compare_with_cpu(fn, x)  # eager mode crashes
+
+    def test_max_unsqueeze_cpu(self, dim: int, x):
+        def fn(x):
+            x_max = torch.max(x, dim=dim, keepdim=False)[0]
+            x_compact = torch.ops.spyre.compact(x_max)
+            z = torch.unsqueeze(x_compact, dim=dim)
+            return z
+        #eager mode crashes, test with compare_with_cpu  
+        compare_with_cpu(fn, x) 
 
     def test_transpose_2d_cpu(self, x):
         compare_with_cpu(lambda x: x.t().contiguous(), x)


### PR DESCRIPTION
#### What type of PR is this?

- [ x] bug
- [x ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This test checks tensor values after performing `max` followed by `compact` and `unsqueezed`. It currently fails.

#### Which issue(s) this PR is related to:

This test is potentially related to behavior in #141 

#### Special notes for your reviewer:
When run with pytest, this results in the error message:
```
E       AssertionError: cpu mismatch
E       
E       Tensor-likes are not close!
E       
E       Mismatched elements: 76 / 128 (59.4%)
E       Greatest absolute difference: 3.876953125 at index (125, 0) (up to 0.1 allowed)
E       Greatest relative difference: 1.0 at index (1, 0) (up to 0.1 allowed)
```
#### Does this PR introduce a user-facing change?

#### Additional note:
