### PR TITLE
Compiler support for passing SpyreTensorLayout to new_empty

### DIFF
--- a/torch_spyre/_inductor/wrapper.py
+++ b/torch_spyre/_inductor/wrapper.py
@@ -54,7 +54,7 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
             """
                 from torch_spyre._inductor.runtime import ConstantArg, TensorArg, KernelSpec, UnimplementedOp
                 from torch_spyre._inductor.runtime.async_compile import SpyreAsyncCompile
-                from torch_spyre._C import SpyreTensorLayout, StickFormat, spyre_empty
+                from torch_spyre._C import SpyreTensorLayout, StickFormat, spyre_empty_with_layout
                 import subprocess
             """,
             strip=True,
@@ -75,15 +75,11 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
         codegen_stride_tuple = self.codegen_python_shape_tuple(tuple(layout.stride))
 
         out = (
-            f"{name} = spyre_empty("
+            f"{name} = spyre_empty_with_layout("
             f"{codegen_allocation_shape_tuple}, "
             f"{codegen_stride_tuple}, "
             f"{layout.dtype}, "
-            f"SpyreTensorLayout({layout.device_layout.device_size}, "
-            f"{layout.device_layout.device_strides}, "
-            f"{layout.device_layout.dim_map}, "
-            f"{layout.device_layout.num_stick_dims}, "
-            f"{layout.device_layout.format}))"
+            f"{layout.device_layout!r})"
         )
         if codegen_shape_tuple != codegen_allocation_shape_tuple:
             out = out + f".as_strided({codegen_shape_tuple}, {codegen_stride_tuple})"

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -221,7 +221,7 @@ PYBIND11_MODULE(_C, m) {
   m.def("encode_constant", &spyre::encodeConstant);
   m.def("get_sen_data_format", &spyre::getSenDataFormat);
   m.def("convert_artifacts", &spyre::convertArtifacts);
-  m.def("spyre_empty", &spyre::spyre_empty_strided_layout);
+  m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);
 
   py::class_<spyre::SpyreTensorLayout> dci_cls(m, "SpyreTensorLayout");
 

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -713,10 +713,10 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
   return tensor;
 }
 
-at::Tensor spyre_empty_strided_layout(c10::IntArrayRef size,
-                                      c10::IntArrayRef stride,
-                                      c10::ScalarType dtype,
-                                      SpyreTensorLayout device_layout) {
+at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
+                                   c10::IntArrayRef stride,
+                                   c10::ScalarType dtype,
+                                   SpyreTensorLayout device_layout) {
   // TEMP: forward to empty_strided for now.
   return spyre_empty_strided(size, stride, dtype, std::nullopt, std::nullopt,
                              std::nullopt);

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -31,8 +31,8 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
                            bool non_blocking);
 
 class SpyreTensorLayout;
-at::Tensor spyre_empty_strided_layout(c10::IntArrayRef size,
-                                      c10::IntArrayRef stride,
-                                      c10::ScalarType dtype,
-                                      SpyreTensorLayout device_layout);
+at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
+                                   c10::IntArrayRef stride,
+                                   c10::ScalarType dtype,
+                                   SpyreTensorLayout device_layout);
 }  // namespace spyre


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ x ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Stubs out native API that compiled-code can use to allocate buffers passing the SpyreTensorLayout as an argument.

A typical snippet of generated host code is:
```
def call(args):
    arg0_1, = args
    args.clear()
    assert_size_stride(arg0_1, (512, 1024), (1024, 1))
    buf0 = spyre_empty((512, 1), (1, 512), torch.float16, SpyreTensorLayout([1, 512, 64], [32768, 64, 1], [1, 0, 1], 1, StickFormat.Sparse))
    sdsc_fused__softmax_0.run(arg0_1, buf0)
    buf1 = spyre_empty((512, 1024), (1024, 1), torch.float16, SpyreTensorLayout([16, 512, 64], [32768, 64, 1], [1, 0, 1], 1, StickFormat.Dense))
    sdsc_fused__softmax_1.run(arg0_1, buf0, buf1)
    del arg0_1
    buf2 = spyre_empty((512, 1024), (1024, 1), torch.float16, SpyreTensorLayout([16, 512, 64], [32768, 64, 1], [1, 0, 1], 1, StickFormat.Dense))
    sdsc_fused__softmax_2.run(buf1, buf2)
    buf3 = buf0; del buf0  # reuse
    sdsc_fused__softmax_3.run(buf2, buf3)
    buf4 = buf1; del buf1  # reuse
    sdsc_fused__softmax_4.run(buf2, buf3, buf4)
    return (buf4, )
```

#### Which issue(s) this PR is related to:

This is the inductor-side piece of #210. 

#### Special notes for your reviewer:
```
================================================= test session starts =================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 135 items                                                                                                   

tests/_inductor/test_building_blocks.py .ss..                                                                   [  3%]
tests/_inductor/test_inductor_ops.py s........................................ss..........                      [ 42%]
tests/tensor/test_tensor_layout.py ........                                                                     [ 48%]
tests/test_modules.py ssssss.                                                                                   [ 54%]
tests/test_ops.py ..sssss...................sss..ssss.s........s.ss                                             [ 90%]
tests/test_spyre.py .s...s.......                                                                               [100%]

===================================== 106 passed, 29 skipped in 60.63s (0:01:00) ======================================

```
#### Does this PR introduce a user-facing change?

#### Additional note:
