### PR TITLE
SpyreTensorLayout adjustments

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -27,21 +27,21 @@ class TestSpyreTensorLayout(TestCase):
     def test_generic_stick(self):
         stl = SpyreTensorLayout([128], torch.float16)
         self.assertEqual(stl.device_size, [2, 64])
-        self.assertEqual(stl.device_strides, [64, 1])
+        self.assertEqual(stl.device_strides(torch.float16), [64, 1])
         self.assertEqual(stl.dim_map, [0, 0])
         self.assertEqual(stl.format, StickFormat.Dense)
         self.assertEqual(stl.num_stick_dims, 1)
 
         stl = SpyreTensorLayout([512, 256], torch.float16)
         self.assertEqual(stl.device_size, [4, 512, 64])
-        self.assertEqual(stl.device_strides, [32768, 64, 1])
+        self.assertEqual(stl.device_strides(torch.float16), [32768, 64, 1])
         self.assertEqual(stl.dim_map, [1, 0, 1])
         self.assertEqual(stl.format, StickFormat.Dense)
         self.assertEqual(stl.num_stick_dims, 1)
 
         stl = SpyreTensorLayout([512, 8, 256], torch.float16)
         self.assertEqual(stl.device_size, [4, 512, 8, 64])
-        self.assertEqual(stl.device_strides, [262144, 512, 64, 1])
+        self.assertEqual(stl.device_strides(torch.float16), [262144, 512, 64, 1])
         self.assertEqual(stl.dim_map, [2, 0, 1, 2])
         self.assertEqual(stl.format, StickFormat.Dense)
         self.assertEqual(stl.num_stick_dims, 1)
@@ -49,14 +49,14 @@ class TestSpyreTensorLayout(TestCase):
     def test_dim_order(self):
         stl = SpyreTensorLayout([512, 256], torch.float16, [1, 0])
         self.assertEqual(stl.device_size, [8, 256, 64])
-        self.assertEqual(stl.device_strides, [16384, 64, 1])
+        self.assertEqual(stl.device_strides(torch.float16), [16384, 64, 1])
         self.assertEqual(stl.dim_map, [0, 1, 0])
         self.assertEqual(stl.format, StickFormat.Dense)
         self.assertEqual(stl.num_stick_dims, 1)
 
         stl = SpyreTensorLayout([512, 8, 256], torch.float16, [2, 1, 0])
         self.assertEqual(stl.device_size, [8, 256, 8, 64])
-        self.assertEqual(stl.device_strides, [131072, 512, 64, 1])
+        self.assertEqual(stl.device_strides(torch.float16), [131072, 512, 64, 1])
         self.assertEqual(stl.dim_map, [0, 2, 1, 0])
         self.assertEqual(stl.format, StickFormat.Dense)
         self.assertEqual(stl.num_stick_dims, 1)
@@ -65,7 +65,6 @@ class TestSpyreTensorLayout(TestCase):
         stl_x = SpyreTensorLayout([512, 256], torch.float16)
         stl_y = SpyreTensorLayout(
             [4, 512, 64],
-            [32768, 64, 1],
             [1, 0, 1],
             1,
             StickFormat.Dense,
@@ -73,13 +72,14 @@ class TestSpyreTensorLayout(TestCase):
         self.assertEqual(stl_x.format, stl_y.format)
         self.assertEqual(stl_x.num_stick_dims, stl_y.num_stick_dims)
         self.assertEqual(stl_x.dim_map, stl_y.dim_map)
-        self.assertEqual(stl_x.device_strides, stl_y.device_strides)
+        self.assertEqual(
+            stl_x.device_strides(torch.float16), stl_y.device_strides(torch.float16)
+        )
         self.assertEqual(stl_x.device_size, stl_y.device_size)
 
     def test_sparse_stl_constructor(self):
         stl = SpyreTensorLayout(
-            [4, 512, 64],
-            [32768, 64, 1],
+            [256, 512, 1],
             [1, 0, 1],
             1,
             StickFormat.Sparse,
@@ -90,14 +90,14 @@ class TestSpyreTensorLayout(TestCase):
         stl = SpyreTensorLayout([512, 256], torch.float16)
         self.assertEqual(
             str(stl),
-            "SpyreTensorLayout(device_size=[4, 512, 64], device_strides=[32768, 64, 1], dim_map =[1, 0, 1], num_stick_dims=1, format=StickFormat.Dense)",
+            "SpyreTensorLayout(device_size=[4, 512, 64], dim_map =[1, 0, 1], num_stick_dims=1, format=StickFormat.Dense)",
         )
 
     def test_device_alloc(self):
         x = torch.rand([512, 256], dtype=torch.float16).to("spyre")
         stl = x.device_tensor_layout()
         self.assertEqual(stl.device_size, [4, 512, 64])
-        self.assertEqual(stl.device_strides, [32768, 64, 1])
+        self.assertEqual(stl.device_strides(torch.float16), [32768, 64, 1])
         self.assertEqual(stl.dim_map, [1, 0, 1])
         self.assertEqual(stl.format, StickFormat.Dense)
         self.assertEqual(stl.num_stick_dims, 1)

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -59,25 +59,9 @@ def stl_is_stick_reduction(self: SpyreTensorLayout, axis: list[int]) -> bool:
         return False
 
 
-def stl_spyre_fixed_layout(
-    self: SpyreTensorLayout, device: torch.device, size: torch.Size, dtype: torch.dtype
-):
-    cur_stride = (
-        1
-        if self.format == StickFormat.Dense
-        else 128 // dtype.itemsize  # TODO - get from self.device_strides?
-    )
-    stride: list[int | torch.SymInt] = [-1] * len(size)
-    for d in reversed(self.host_dim_order()):
-        stride[d] = cur_stride
-        cur_stride = cur_stride * size[d]
-    return FixedTiledLayout(device, dtype, list(size), stride, self)
-
-
 setattr(SpyreTensorLayout, "host_dim_order", stl_host_dim_order)
 setattr(SpyreTensorLayout, "stick_dim", stl_stick_dim)
 setattr(SpyreTensorLayout, "is_stick_reduction", stl_is_stick_reduction)
-setattr(SpyreTensorLayout, "spyre_fixed_layout", stl_spyre_fixed_layout)
 
 
 def stride_order_vars(index: sympy.Expr) -> Sequence[sympy.Symbol]:

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -229,8 +229,6 @@ PYBIND11_MODULE(_C, m) {
       .value("SparseMulti", spyre::SpyreTensorLayout::StickFormat::SparseMulti);
 
   dci_cls.def_readwrite("device_size", &spyre::SpyreTensorLayout::device_size)
-      .def_readwrite("device_strides",
-                     &spyre::SpyreTensorLayout::device_strides)
       .def_readwrite("dim_map", &spyre::SpyreTensorLayout::dim_map)
       .def_readwrite("num_stick_dims",
                      &spyre::SpyreTensorLayout::num_stick_dims)
@@ -239,6 +237,7 @@ PYBIND11_MODULE(_C, m) {
            [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
       .def("__repr__",
            [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
+      .def("device_strides", &spyre::SpyreTensorLayout::device_strides)
       .def(py::self == py::self)
       .def(py::init<std::vector<int64_t>, c10::ScalarType>(),
            py::arg("host_size"), py::arg("dtype"))
@@ -246,11 +245,10 @@ PYBIND11_MODULE(_C, m) {
                     spyre::SpyreTensorLayout::StickFormat>(),
            py::arg("host_size"), py::arg("dtype"), py::arg("dim_order"),
            py::arg("format") = spyre::SpyreTensorLayout::StickFormat::Dense)
-      .def(py::init<std::vector<int64_t>, std::vector<int64_t>,
-                    std::vector<int32_t>, int32_t,
+      .def(py::init<std::vector<int64_t>, std::vector<int32_t>, int32_t,
                     spyre::SpyreTensorLayout::StickFormat>(),
-           py::arg("device_size"), py::arg("device_strides"),
-           py::arg("dim_map"), py::arg("num_stick_dims"), py::arg("format"));
+           py::arg("device_size"), py::arg("dim_map"),
+           py::arg("num_stick_dims"), py::arg("format"));
 
   m.def("get_spyre_tensor_layout", &spyre::get_spyre_tensor_layout);
 }

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -43,12 +43,10 @@ void SpyreTensorLayout::init(std::vector<int64_t> host_size,
   if (host_size.size() == 0) {
     // Degenerate case of 0-dimension tensor (ie, a scalar)
     this->device_size.resize(1);
-    this->device_strides.resize(1);
     this->dim_map.resize(1);
     this->format = Sparse;
     this->num_stick_dims = 1;
     this->device_size[0] = 1;
-    this->device_strides[0] = 1;
     this->dim_map[0] = -1;  // host_size has no entries!
     return;
   }
@@ -56,13 +54,12 @@ void SpyreTensorLayout::init(std::vector<int64_t> host_size,
   int host_dims = static_cast<int>(host_size.size());
   int device_dims = host_dims + 1;
   auto elem_bytes = c10::elementSize(dtype);
-  auto elems_in_stick = BYTES_IN_STICK / elem_bytes;
+  auto elems_in_stick = format == Dense ? BYTES_IN_STICK / elem_bytes : 1;
 
   TORCH_CHECK(host_size.size() == dim_order.size(),
               "Invalid arguments: host_size.size() != dim_order.size()");
 
   this->device_size.resize(device_dims);
-  this->device_strides.resize(device_dims);
   this->dim_map.resize(device_dims);
   this->format = format;
   this->num_stick_dims = 1;
@@ -80,13 +77,22 @@ void SpyreTensorLayout::init(std::vector<int64_t> host_size,
     this->dim_map[i] = dim_order[i - 1];
     this->device_size[i] = host_size[dim_order[i - 1]];
   }
+}
 
-  int64_t cur_stride = elems_in_stick;
-  device_strides[device_dims - 1] = 1;
+std::vector<int64_t> SpyreTensorLayout::device_strides(c10::ScalarType dtype) {
+  int device_dims = static_cast<int>(this->device_size.size());
+  std::vector<int64_t> strides(device_dims);
+
+  // Stick dim
+  int64_t cur_stride = BYTES_IN_STICK / c10::elementSize(dtype);
+  strides[device_dims - 1] = 1;
+
+  // Non-stick dims
   for (int i = device_dims - 2; i >= 0; i--) {
-    this->device_strides[i] = cur_stride;
+    strides[i] = cur_stride;
     cur_stride = cur_stride * this->device_size[i];
   }
+  return strides;
 }
 
 std::string SpyreTensorLayout::toString() const {
@@ -96,13 +102,6 @@ std::string SpyreTensorLayout::toString() const {
   for (size_t i = 0; i < this->device_size.size(); i++) {
     ss << this->device_size[i];
     if (i < this->device_size.size() - 1) {
-      ss << ", ";
-    }
-  }
-  ss << "], device_strides=[";
-  for (size_t i = 0; i < this->device_strides.size(); i++) {
-    ss << this->device_strides[i];
-    if (i < this->device_strides.size() - 1) {
       ss << ", ";
     }
   }

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -34,8 +34,13 @@ class SpyreTensorLayout {
     SparseMulti,
   };
 
+  /**
+   * The on-device size array for the (Tiled) tensor.
+   * The dimensions are in decreasing stride order with the stick dimension(s)
+   * last.
+   */
   std::vector<int64_t> device_size;
-  std::vector<int64_t> device_strides;
+
   /**
    * Record the mapping from host size to device_size.
    * It has len(device_size) entires whose values are indices in the host size
@@ -69,11 +74,9 @@ class SpyreTensorLayout {
   }
 
   SpyreTensorLayout(std::vector<int64_t> device_size,
-                    std::vector<int64_t> device_strides,
                     std::vector<int32_t> dim_map, int32_t num_stick_dims,
                     StickFormat format)
       : device_size(device_size),
-        device_strides(device_strides),
         dim_map(dim_map),
         num_stick_dims(num_stick_dims),
         format(format) {}
@@ -94,9 +97,10 @@ class SpyreTensorLayout {
 
   std::string toString() const;
 
+  std::vector<int64_t> device_strides(c10::ScalarType dtype);
+
   bool operator==(const SpyreTensorLayout& other) const {
     return this->device_size == other.device_size &&
-           this->device_strides == other.device_strides &&
            this->dim_map == other.dim_map &&
            this->num_stick_dims == other.num_stick_dims &&
            this->format == other.format;


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
Tweak implementation of SpyreTensorLayout

1. compute device_strides on demand instead of storing.
2. device_size[-1] for non-dense sticks is 1

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
pytest tests 
==================================================== test session starts ====================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 135 items                                                                                                         

tests/_inductor/test_building_blocks.py .ss..                                                                         [  3%]
tests/_inductor/test_inductor_ops.py s........................................ss..........                            [ 42%]
tests/tensor/test_tensor_layout.py ........                                                                           [ 48%]
tests/test_modules.py ssssss.                                                                                         [ 54%]
tests/test_ops.py ..sssss...................sss..ssss.s........s.ss                                                   [ 90%]
tests/test_spyre.py .s...s.......                                                                                     [100%]

======================================== 106 passed, 29 skipped in 71.25s (0:01:11) =========================================
```
#### Does this PR introduce a user-facing change?

#### Additional note:
