### PR TITLE
[FIX] address issue #255

### DIFF
--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -133,6 +133,10 @@ def make_spyre_module() -> types.ModuleType:
 
     # Optional: forward unknown attrs to the impl or _C for convenience
     def __getattr__(name):
+        if name in ["__file__"]:
+            # Important: raising AttributeError ensures hasattr() returns False
+            # without triggering our lazy loader.
+            raise AttributeError(name)
         if hasattr(impl, name):
             return getattr(impl, name)
         if not hasattr(impl, "_C"):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

When bringing back the lazy loading mechanism (PR #249), there is an issue as detected in #255. 

After investigating, the root cause is that PyTorch’s torch.library.register_fake() tries to inspect the calling frame to record the source location of the registered fake op, which trigger the heavy loading of the torch-spyre. Somehow it is not an issue when I run all tests. It only shows when running a single test file. The solution is to avoid triggering the heavy loading when `__file__` attribute is queried. 


#### Which issue(s) this PR is related to:

Issue #255. 

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
<img width="1221" height="205" alt="image" src="https://github.com/user-attachments/assets/0d63241f-c995-406b-9d27-81d4e568f98a" />

<img width="1411" height="312" alt="image" src="https://github.com/user-attachments/assets/5ac3bdcf-eeae-4812-8d17-d7f28d91bf7b" />


#### Does this PR introduce a user-facing change?

None.

#### Additional note:

CC: @yoheiueda 
