### PR TITLE
on spyre torch.bool corresponds to float16

### DIFF
--- a/torch_spyre/csrc/types_mapping.h
+++ b/torch_spyre/csrc/types_mapping.h
@@ -67,7 +67,7 @@ inline std::pair<DataFormats, DataFormats> stringToDTDataFormatPair(
           {"int16", {DataFormats::SENINT16, DataFormats::SENINT16}},
           {"int32", {DataFormats::IEEE_INT32, DataFormats::IEEE_INT32}},
           {"int64", {DataFormats::IEEE_INT64, DataFormats::IEEE_INT32}},
-          {"bool", {DataFormats::SENINT8, DataFormats::SENINT8}},
+          {"bool", {DataFormats::IEEE_FP16, DataFormats::IEEE_FP16}},
           {"bfloat16", {DataFormats::BFLOAT16, DataFormats::BFLOAT16}},
           {"quint8", {DataFormats::SENUINT32, DataFormats::SENUINT32}},
           {"qint8", {DataFormats::SENINT8, DataFormats::SENINT8}},
@@ -117,7 +117,7 @@ stringToSenDatatypePair(const std::string& type_name) {
           // Boolean and string
           {"bool",
            {sendnn::sen_datatype_enum::boolean,
-            sendnn::sen_datatype_enum::sen_int8}},
+            sendnn::sen_datatype_enum::sen_fp16}},
           {"string",
            {sendnn::sen_datatype_enum::string,
             sendnn::sen_datatype_enum::string}},


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Booleans are represented on Spyre as float16 values where true is 1.0 and false is 0.0.

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
