### PR TITLE
Fix 4D transpose kernel summary

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -396,6 +396,7 @@ class SpyreKernel(SIMDKernel[SpyreKernelCSEVariable]):
             scales.append(scale)
             ks = KernelSummary(in_di, scales, args, self.op_info)
             if in_di != out_di:
+                self.spyre_op = TRANSPOSE_OP
                 ks.op_info["transposed_dims"] = [
                     d for d in range(len(in_di)) if in_di[d].var != out_di[d].var
                 ]


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR sets the operation to transpose if the dimension ordering differs between the input and the output. The 4D transpose test case hit an error on some runs as the operation is set to `slice` due to the input/output strides. On these runs, the `["transposed_dims"]` in the operation info was still filled in to reflect the change in dimension ordering. 

#### Which issue(s) this PR is related to:

Fixes #287 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
<img width="1298" height="487" alt="image" src="https://github.com/user-attachments/assets/237463e7-9a82-4811-b25b-6e2fcabd1ed2" />

