### PR TITLE
Make SpyreTensorLayouts read-only from Python

### DIFF
--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -253,11 +253,10 @@ PYBIND11_MODULE(_C, m) {
       .value("Sparse", spyre::SpyreTensorLayout::StickFormat::Sparse)
       .value("SparseMulti", spyre::SpyreTensorLayout::StickFormat::SparseMulti);
 
-  dci_cls.def_readwrite("device_size", &spyre::SpyreTensorLayout::device_size)
-      .def_readwrite("dim_map", &spyre::SpyreTensorLayout::dim_map)
-      .def_readwrite("num_stick_dims",
-                     &spyre::SpyreTensorLayout::num_stick_dims)
-      .def_readwrite("format", &spyre::SpyreTensorLayout::format)
+  dci_cls.def_readonly("device_size", &spyre::SpyreTensorLayout::device_size)
+      .def_readonly("dim_map", &spyre::SpyreTensorLayout::dim_map)
+      .def_readonly("num_stick_dims", &spyre::SpyreTensorLayout::num_stick_dims)
+      .def_readonly("format", &spyre::SpyreTensorLayout::format)
       .def("__str__",
            [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
       .def("__repr__",


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Exports the fields of SpyreTensorLayout as readonly.  This makes it marginally harder to
break the relationships between its fields established by the C++ constructor.

Fixed code in stickily.py that was improperly modifying SpyreTensorLayouts after construction.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
======================================================================== test session starts ========================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 165 items                                                                                                                                                 

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                [  3%]
tests/_inductor/test_inductor_ops.py ..s.....................................................ss...........                                                    [ 45%]
tests/tensor/test_tensor_layout.py ........                                                                                                                   [ 50%]
tests/test_fallbacks.py ........                                                                                                                              [ 55%]
tests/test_modules.py ssssss.                                                                                                                                 [ 59%]
tests/test_ops.py ..sssss...................sss..ssss.s........s.ss                                                                                           [ 89%]
tests/test_spyre.py .s...s...........                                                                                                                         [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                             [100%]

========================================================================= warnings summary ==========================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 136 passed, 29 skipped, 2 warnings in 85.16s (0:01:25) =======================================================

```

#### Does this PR introduce a user-facing change?

#### Additional note:
