### PR TITLE
[INFRA][DEPENDENCY] Only update python deps from pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: torch
+    exclude-paths:
+      - requirements/*

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ scripts/release_notes/*.json
 sccache-stats*.json
 lint.json
 merge_record.json
+.python-version
 
 # These files get copied over on invoking setup.py
 torchgen/packaged/*


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Instruct dependabot to ignore files under requirements/*. Those files are generated from pyproject.toml, which must be the single source of dependency updates.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### Which issue(s) this PR is related to:

The issue can be observed in https://github.com/torch-spyre/torch-spyre/pull/212

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
