### PR TITLE
Complete code division logic transfer to inductor

### DIFF
--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -82,8 +82,11 @@ def divide_reduction_op(n: SchedulerNode, args: list[SchedNodeArg], max_cores):
         return
 
     if red.reduction_type == MATMUL_REDUCTION_OP:
-        pass
-        # TODO: Here is where we look for matmul cases we support and update divsion
+        device_size = output.device_layout.device_size
+        num_cores = core_split(device_size[-3], max_cores)
+        if num_cores > 1:
+            for cd in n.spyre_core_division:
+                cd[-3] = num_cores
 
 
 def core_division_planning(


### PR DESCRIPTION
This PR eliminates the now redundant core division logic from superdsc generation that was ported to inductor in #308. It also adds the missing logic for matmul in inductor.

<img width="1011" height="529" alt="Screenshot 2025-12-19 at 11 38 53 AM" src="https://github.com/user-attachments/assets/2e05b2b4-77e8-4704-bc69-e9901cc09b62" />
