### PR TITLE
Model-Centric Functional Verification for OpFunc Enablement

### DIFF
--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -126,7 +126,7 @@ We plan per-model YAML, with option for subclasses variants:
 Deduplication is based on normalized op signature and input shapes, not model name.
 - **Disable dedupe:** `--no-dedupe` (explicit).
 - **Selective model runs:** Choose one or many models at runtime (e.g., run only `granite3-speech`).
-- **Select cases**: integrate with pytest.ini design, register custom markers for cleanliness.
+- **Select cases**: integrate with pytest.ini design, register custom markers for cleanliness. **Can skip tests at each input set**.
 Marker usage and registration follow pytest documentation best practices, enabling selection and skip/xfail logic
 
 **CLI Examples**

--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -1,0 +1,408 @@
+
+# RFC-0186: YAML-driven Torch.ops Test Framework for Spyre/AIU-backed Models
+
+**Authors:**
+- Tuan M. Hoang Trong (YKT)
+- Kazuaki Ishizaki (TRL)
+- Umamaheswari Devi (IRL)
+
+**Tracking issue:** #241
+**Target repository:** `torch-spyre/torch-spyre`
+**Related issues/PRs:** #323
+
+---
+
+## Summary
+
+We propose a YAML-driven test framework (built on `pytest`) to validate functional correctness of `torch.ops` used by Spyre/AIU-supported models.
+Outside the scope of this RFC, there is an existing internal framework to extract per-model sets of `torch.ops` and their inputs via a scanning codegen pass. This internal framework is modified accordingly to emits compact YAML descriptors instead of per-op Python test files.
+This RFC does not propose changes to the scanning logic beyond YAML emission.
+
+The proposed framework:
+
+- Accept the generated YAML files
+- Generates and runs tests from YAML, with optional deduplication across models.
+- Pytest markers & selection: We use pytest.mark (registered in pytest.ini) for flexible selection, skipping, expected failures, etc.
+- Integrates with CI as nightly tests (not every PR), initially focusing on `*-spyre.yaml` variants, then converging to canonical `<model>.yaml` once torch-spyre stabilizes.
+
+This design reduces boilerplate, centralizes test intent, simplifies maintenance, and lets us scale coverage across models with consistent correctness checks.
+
+**Amenability to broader use-cases**:
+While this RFC focuses on validating `torch.ops` for Spyre/AIU-backed models, the proposed YAML-driven framework is generic by design. It can be applied to other scenarios where:
+
+- Hand-written YAML manifests are preferred for custom operator testing.
+- Backend-specific correctness checks are needed outside Spyre/AIU.
+- Debugging workflows require reproducible inputs from .pt files or controlled presets.
+
+This flexibility makes the framework suitable for future extensions beyond the scope of this RFC.
+
+---
+
+## Motivation
+
+### Problem
+Current test generation emits one Python file per op+input, leading to:
+- Significant code duplication.
+- Large and noisy commits that are hard to review and maintain.
+- Difficulty updating shapes/inputs as models evolve.
+
+### Goals
+- **Functional correctness:** Validate each `torch.op` against a CPU reference for corresponding shapes and data.
+- **Nightly monitoring:** Continuously track correctness of enabled `opFuncs`.
+- **Maintainability:** Make test intent readable and updatable (shapes, dtypes, tolerances) in YAML.
+- **Scalability:** Support multiple models (Granite-4h, GPT-oss, Granite-vision-3, Granite-speech) with cross-model deduplication.
+
+### Non-goals (for now)
+- **Performance tracking:** Only scoped as “N/A” initially (we list future scenarios and metrics below).
+- **Per-PR gating:** Runs in nightly CI/CD, not on every PR.
+
+---
+
+## Proposed Implementation
+
+### Overview
+We use two cooperating frameworks:
+
+1) **Model scan & codegen (existing, internal, modified):**  
+   - Scan target models and extract the set of `torch.ops` along with input shapes and/or sample inputs.  
+   - **Change:** Generate **YAML** instead of Python test files.
+
+2) **YAML test runner (the proposed one):**  
+   - Load YAML case definitions.  
+   - Codegen lightweight test functions dynamically (via `pytest`).  
+   - Execute ops, compare against CPU reference, and report results.
+   - Skip tests if needed.
+
+---
+### Execution strategy
+
+- Run all extracted ops for a model (subject to dedupe).
+- Avoid redundant runs (global cache keyed by <op, normalized_inputs>).
+- Make test parameters easy to understand for debugging (schema + description fields).
+
+---
+
+### Models & files
+We plan per-model YAML, with option for subclasses variants:
+
+- `tests/_inductor/models/template.yaml`
+- `tests/_inductor/models/gpt-oss.yaml`
+- `tests/_inductor/models/gpt-oss-spyre.yaml`  
+  *Temporary, backend-specific functional correctness checks. May relax original shapes and can be deleted once features are stable.*
+
+**Naming:** (notice to changes in internal scripts) Permanent test cases (e.g., no `_fp16`) reside in files **without** postfixes. Backend-temporary cases use the `-spyre` postfix file.
+
+---
+
+### Deduplication & selection
+- **Cross-model deduplication (default):** If `op-A(input-B)` was already tested for model-C, skip rerunning for model-D, if that test case is part of model-D.
+Deduplication is based on normalized op signature and input shapes, not model name.
+- **Disable dedupe:** `--no-dedupe` (explicit).
+- **Selective model runs:** Choose one or many models at runtime (e.g., run only `granite3-speech`).
+- **Select cases**: integrate with pytest.ini design, register custom markers for cleanliness.
+Marker usage and registration follow pytest documentation best practices, enabling selection and skip/xfail logic
+
+**CLI Examples**
+
+```bash
+# List available models/cases
+pytest --list-models 2>&1 | tee logs_test.txt
+pytest --list-cases  2>&1 | tee logs_test.txt
+
+# Run a single case by name
+pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "mul_ok"
+
+# Run all 'torch.add' ops for GPT-oss
+pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "torch.add"
+
+# Run for multiple models
+pytest --model gpt_oss tests/
+pytest --model gpt_oss --model granite4h tests/
+```
+
+**Full argument list**
+
+supported arguments: pytest
+
+```bash
+pytest \
+  [--model <model-name>]*
+  --dedupe / --no-dedupe
+  --list-models, --list-cases
+  --compile-backend "inductor"
+    TEST_COMPILE_BACKEND: env. variable to change the default backend “inductor”
+```
+
+---
+
+### Source Layout
+
+Below is the proposed directory structure for the YAML-driven test framework:
+
+```bash
+tests/
+├── conftest.py
+└── _inductor/
+    ├── init.py
+    ├── test_model_ops.py          # Entry point for pytest-based tests
+    ├── model_cases_loader.py      # Loads and parses YAML files
+    ├── op_registry.py             # Maintains mapping of ops to test logic
+    ├── runner.py                  # Executes tests dynamically from YAML
+    └── models/                    # YAML manifests per model
+        ├── gpt_oss.yaml
+        └── granite3_speech.yaml
+```
+
+## YAML Schema
+
+Top-level structure
+
+```yaml
+
+model: <model-name>
+default:
+  dtype: <DTYPE_MAP value>
+  seed: <int>
+  rtol: <float>
+  atol: <float>
+cases:
+  - name: <case-name>
+    op: <torch.op>            # as registered via OP_REGISTRY
+    inputs:                   # map of arguments for the op
+      tensor:                 # tensor description (see below)
+      value:                  # scalar input
+      py:                     # restricted Python literal (tuples, None, Ellipsis, slice, ints, floats, lists, inf, -inf, nan)
+      tensor_list:            # sequences (list/tuple) of tensors
+      file:                   # .pt file holding values for a tensor
+    description: <text>       # e.g., trace where the op was extracted
+    expects_error:            # expected error (optional) - expected error type and message substring
+      type: <ExceptionType>
+      match: <substring>
+
+    # Test control
+    mark: <pytest marker(s)>
+    skip_if:                  # Conditional skip logic for backend/device)
+      expr: <python boolean>  # if True -> skip
+      reason: <text>
+
+    # Per-case overrides of defaults
+    dtype: <DTYPE_MAP value>
+    seed: <int>
+    rtol: <float>
+    atol: <float>
+
+```
+
+---
+
+### Input to a test case
+
+A test case is generated based on the op to test, and the input sources which is a sequence of arguments, each can be one of the following
+
+- -tensor: randomly generated tensor(s) following shape, dtype, init, etc.
+- -value: scalars, lists, tuples.
+- -py: restricted Python literal expressions (tuples, None, Ellipsis, slices, ints, floats, lists, inf, -inf, nan).
+- -file: load from .pt files (torch.load("path/to/file.pt")).
+
+Rationale: Debugging error-sensitive bugs often requires specific tensor values, especially in the backward path, so YAML supports exact data (init: data) and file-based inputs (-file).
+
+### Input tensor description
+
+```yaml
+
+tensor:
+  shape: [dim0, dim1, ...]
+  init: rand | zeros | ones | arange | randint | uniform | data   # optional
+  dtype: <optional dtype>
+  preset: <optional preset for non-contiguous/layout-sensitive ops>
+  preset_args: <optional args for preset>
+
+  # init_args specify bounds for random generation
+  # If 'randint': allow 'low' (default 0), 'high'
+  # If 'uniform': allow 'low' (default 0), 'high' (default 1)
+  # If 'data': pass exact values as list(s)
+```
+
+---
+
+### Supporting Constants
+
+The framework uses predefined mappings for dtypes and error names to ensure consistency between YAML descriptors and Python runtime.
+
+#### DTYPE_MAP
+Maps string keys in YAML to actual `torch` dtypes:
+
+```python
+DTYPE_MAP = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+    "int64": torch.int64,
+    "bool": torch.bool,
+}
+```
+
+##### Error type
+
+The value in `expected_errors` is a string which is mapped to Python exception classes based on the following map:
+
+```python
+_ERR_NAME_TO_TYPE = {
+    "RuntimeError": RuntimeError,
+    "ValueError": ValueError,
+    "TypeError": TypeError,
+    "AssertionError": AssertionError,
+}
+```
+
+---
+
+### Example YAML File
+
+Below is a sample `template.yaml` illustrating the proposed schema and advanced features such as dtype overrides, skip conditions, error expectations, and presets for non-contiguous layouts.
+
+```yaml
+model: template
+default:
+  dtype: fp16        # Default dtype for all cases unless overridden
+  seed: 123          # Seed for reproducibility
+  rtol: 1.0e-3       # Default relative tolerance
+  atol: 1.0e-3       # Default absolute tolerance
+
+cases:
+  - name: add_basic
+    op: torch.add
+    inputs:
+      - tensor: {shape: [4, 128, 768], init: randn}
+      - tensor: {shape: [4, 128, 768], init: randn}
+    description: |
+      Example from GPT-oss forward path:
+      File: site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138
+      Code: next_states = next_states * routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
+
+  - name: op_bool_tensors
+    op: torch.logical_and
+    inputs:
+      - tensor: {shape: [11, 6], dtype: bool}
+      - tensor: {shape: [11, 6], dtype: bool}
+    description: |
+      Ops with randomly generated bool tensors (50% chance of True)
+
+  - name: op_different_dtypes
+    op: torch.add
+    inputs:
+      - tensor: {shape: [11, 6], dtype: fp32, init: randn}
+      - tensor: {shape: [11, 6], dtype: int64, init: randint, init_args: {high: 100}}
+    description: |
+      Ops with args of different dtypes
+
+  - name: mul_tensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: uniform, init_args: {low: -1.0, high: 1.0}}
+      - value: 3.0
+    description: |
+      Ops with tensor and scalar as args
+
+  - name: mul_inttensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: randint, init_args: {low: 1, high: 100}}
+      - value: 3
+    description: |
+      Ops with tensor and scalar as args
+
+  - name: aten_view
+    op: torch.ops.aten.view
+    inputs:
+      - tensor: {shape: [1, 64]}
+      - value: [2, 32]
+    description: |
+      Value can accept scalar, list or tuple
+
+  - name: softmax_lastdim
+    op: torch.nn.functional.softmax
+    attrs: {dim: -1}
+    inputs:
+      - tensor: {shape: [2, 4, 8], init: arange}
+
+  - name: cat_list
+    op: torch.cat
+    attrs: {dim: -1}
+    inputs:
+      - tensor_list:
+          - {shape: [2, 3, 4], init: randn}
+          - {shape: [2, 3, 5], init: randn}
+
+  - name: view_should_error_on_noncontig
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: [2, 24]
+
+  - name: view_should_error_on_noncontig_167
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: 32
+      - value: -1
+      - value: 2880
+
+  - name: contiguous_from_transpose_view
+    op: torch.contiguous
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: transpose_view
+          preset_args: {dim0: 1, dim1: 2}
+
+  - name: rsqrt_skip_example
+    op: torch.rsqrt
+    skip_if:
+      - expr: cfg.test_device.type == 'spyre' and dtype_str == 'fp16'
+        reason: Spyre fp16 rsqrt not supported yet
+    inputs:
+      - tensor: {shape: [64, 1024], init: rand}
+
+  - name: getitem_ellipsis_none_fullslice
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 5760]
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))
+```
+
+---
+## Metrics
+Initial (functional) metrics:
+
+- Pass rate per model and per-op.
+- Coverage (# distinct ops and input shapes per model; % of enabled opFuncs).
+- Deduplication efficiency (skipped duplicates vs unique executed cases).
+- Stability trend across nightly runs (failures/new regressions).
+- Runtime per case and total (optional for capacity planning).
+
+Future (performance) metrics if enabled:
+
+- Regression detection across releases (op latency deltas).
+- Impact of backend optimizations.
+- Comparison against baseline (CPU or another backend).
+
+---
+## Dependencies
+
+- Existing internal scripts for op & input extraction.
+- pytest runner (markers defined in pytest.ini). [docs.pytest.org]
+- torch for CPU reference and .pt loading (baseline correctness). [docs.pytorch.org]

--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -207,7 +207,7 @@ cases:
       match: <substring>
 
     # Test control
-    mark: <pytest marker(s)>
+    marks: <pytest marker(s)>
     skip_if:                  # Conditional skip logic for backend/device)
       expr: <python boolean>  # if True -> skip
       reason: <text>

--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -145,6 +145,14 @@ pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "torch.add"
 # Run for multiple models
 pytest --model gpt_oss tests/
 pytest --model gpt_oss --model granite4h tests/
+
+# Show selected tests based on marks 
+pytest --list-cases-by-mark 
+pytest --list-cases-by-mark --model gpt-oss
+# Show excluded tests based on marks 
+pytest --list-cases-by-mark --show-excluded 
+pytest --list-cases-by-mark --show-excluded --model gpt-oss
+
 ```
 
 **Full argument list**
@@ -158,6 +166,7 @@ pytest \
   --list-models, --list-cases
   --compile-backend "inductor"
     TEST_COMPILE_BACKEND: env. variable to change the default backend “inductor”
+  --list-cases-by-mark [marks] [--show-excluded]
 ```
 
 ---

--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -142,6 +142,9 @@ pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "mul_ok"
 # Run all 'torch.add' ops for GPT-oss
 pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "torch.add"
 
+# Run all tests ignoring default marker filters
+pytest tests/_inductor/test_model_ops.py --model gpt-oss-20b -m ""
+
 # Run for multiple models
 pytest --model gpt_oss tests/
 pytest --model gpt_oss --model granite4h tests/
@@ -228,6 +231,26 @@ cases:
     atol: <float>
 
 ```
+
+---
+
+### pytest.ini Configuration
+
+The `pytest.ini` file contains default marker expressions that filter tests:
+
+```ini
+[pytest]
+markers =
+    paddedtensor: tests for tensors requiring padding
+    largedimtensor: tests for 4D and 5D tensors
+    fp32operation: tests for fp32 operations
+    bf16operation: tests for bfloat16 operations
+    constant: tests for operations with constants
+
+addopts = -m "not largedimtensor and not fp32operation and not bf16operation and not constant"
+```
+
+By default, tests marked with largedimtensor, fp32operation, bf16operation, or constant are excluded. To run all tests regardless of markers, use `-m ""` option.
 
 ---
 

--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -40,6 +40,10 @@ This flexibility makes the framework suitable for future extensions beyond the s
 
 ## Motivation
 
+### Backgroud
+In past, we met problems that the inference results are almost functinally correct but some of torch operations return incorrect results. This behavior is fragile and became obstacles to adding new features such as fine-tuning.
+So, we believe that test cases per operation with actual parameters in models are crucial.
+
 ### Problem
 Current test generation emits one Python file per op+input, leading to:
 - Significant code duplication.

--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -146,11 +146,11 @@ pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "torch.add"
 pytest --model gpt_oss tests/
 pytest --model gpt_oss --model granite4h tests/
 
-# Show selected tests based on marks 
-pytest --list-cases-by-mark 
+# Show selected tests based on marks
+pytest --list-cases-by-mark
 pytest --list-cases-by-mark --model gpt-oss
-# Show excluded tests based on marks 
-pytest --list-cases-by-mark --show-excluded 
+# Show excluded tests based on marks
+pytest --list-cases-by-mark --show-excluded
 pytest --list-cases-by-mark --show-excluded --model gpt-oss
 
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@ markers =
     fpoperation: tests for fp32 and bfloat16 operations
     constant: tests for operations with constants
 
-addopts = -m "not paddedtensor and not largedimtensor and not fpoperation and not constant"
+addopts = -m "not largedimtensor and not fpoperation and not constant"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+markers =
+    paddedtensor: tests for tensors requiring padding
+    largedimtensor: tests for 4D and 5D tensors
+    fpoperation: tests for fp32 and bfloat16 operations
+    constant: tests for operations with constats
+
+addopts = -m "not paddedtensor and not largedimtensor and not fpoperation and not constant"

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,4 @@ markers =
     bf16operation: tests for bfloat16 operations
     constant: tests for operations with constants
 
-addopts = -m "not largedimtensor and not fp32operation and not bf16operation and not constant"
+addopts = -m "not fp32operation and not bf16operation and not constant"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,8 @@
 markers =
     paddedtensor: tests for tensors requiring padding
     largedimtensor: tests for 4D and 5D tensors
-    fpoperation: tests for fp32 and bfloat16 operations
+    fp32operation: tests for fp32 operations
+    bf16operation: tests for bfloat16 operations
     constant: tests for operations with constants
 
-addopts = -m "not largedimtensor and not fpoperation and not constant"
+addopts = -m "not largedimtensor and not fp32operation and not bf16operation and not constant"

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,6 @@ markers =
     paddedtensor: tests for tensors requiring padding
     largedimtensor: tests for 4D and 5D tensors
     fpoperation: tests for fp32 and bfloat16 operations
-    constant: tests for operations with constats
+    constant: tests for operations with constants
 
 addopts = -m "not paddedtensor and not largedimtensor and not fpoperation and not constant"

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -42,7 +42,7 @@ def freeze(x: Any) -> Any:
         return tuple(sorted((k, freeze(v)) for k, v in x.items()))
     if isinstance(x, (list, tuple)):
         return tuple(freeze(v) for v in x)
-    if isinstance(x,str):
+    if isinstance(x,str) and "torch." not in x:
         return eval(x)
     return x
 

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -40,8 +40,10 @@ def models_dir(pytest_root: Path) -> Path:
 def freeze(x: Any) -> Any:
     if isinstance(x, dict):
         return tuple(sorted((k, freeze(v)) for k, v in x.items()))
-    if isinstance(x, list):
+    if isinstance(x, (list, tuple)):
         return tuple(freeze(v) for v in x)
+    if isinstance(x,str):
+        return eval(x)
     return x
 
 

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ast
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
@@ -43,7 +44,10 @@ def freeze(x: Any) -> Any:
     if isinstance(x, (list, tuple)):
         return tuple(freeze(v) for v in x)
     if isinstance(x,str) and "torch." not in x:
-        return eval(x)
+        try:
+            return ast.literal_eval(x)
+        except (ValueError, SyntaxError):
+            return x
     return x
 
 

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -109,7 +109,7 @@ def load_all_cases(pytest_root: Path) -> List[LoadedCase]:
             continue
         spec = yaml.safe_load(p.read_text())
         model = spec.get("model", p.stem)
-        defaults = dict(spec.get("default", {}))
+        defaults = dict(spec.get("defaults", {}))
         for case in spec.get("cases", []):
             # allow "cases" to omit "op" if the YAML provides a top-level op (optional)
             if "op" not in case and "op" in spec:

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -1,0 +1,140 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import pytest
+import regex as re
+import yaml
+
+
+@dataclass(frozen=True)
+class LoadedCase:
+    model: str
+    defaults: Dict[str, Any]
+    case: Dict[str, Any]
+    source_path: Path
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^0-9a-zA-Z_]+", "_", s)
+
+
+def models_dir(pytest_root: Path) -> Path:
+    # adjust if needed; this is robust regardless of current working directory
+    return pytest_root / "tests" / "_inductor" / "models"
+
+
+def freeze(x: Any) -> Any:
+    if isinstance(x, dict):
+        return tuple(sorted((k, freeze(v)) for k, v in x.items()))
+    if isinstance(x, list):
+        return tuple(freeze(v) for v in x)
+    return x
+
+
+def case_key(case: Dict[str, Any], defaults: Dict[str, Any]) -> tuple:
+    # Used for dedupe; intentionally does NOT include model name.
+    op = case["op"]
+    dtype = case.get("dtype", defaults.get("dtype", "float32"))
+    seed = case.get("seed", defaults.get("seed", None))
+    attrs = freeze(case.get("attrs", {}))
+
+    inputs_sig = []
+    for inp in case.get("inputs", []):
+        if "tensor" in inp:
+            t = inp["tensor"]
+            inputs_sig.append(
+                (
+                    "tensor",
+                    tuple(t["shape"]),
+                    t.get("init", "rand"),
+                    freeze(t.get("init_args", {})),
+                    freeze(t.get("data", None)),
+                    bool(t.get("contiguous", True)),
+                    t.get("preset", None),
+                    freeze(t.get("preset_args", {})),
+                    freeze(t.get("base_shape", None)),
+                )
+            )
+        elif "tensor_list" in inp:
+            lst = []
+            for t in inp["tensor_list"]:
+                lst.append(
+                    (
+                        tuple(t["shape"]),
+                        t.get("init", "rand"),
+                        freeze(t.get("init_args", {})),
+                        freeze(t.get("data", None)),
+                        bool(t.get("contiguous", True)),
+                        t.get("preset", None),
+                        freeze(t.get("preset_args", {})),
+                        freeze(t.get("base_shape", None)),
+                    )
+                )
+            inputs_sig.append(("tensor_list", tuple(lst)))
+        elif "value" in inp:
+            inputs_sig.append(("value", freeze(inp["value"])))
+        else:
+            raise ValueError(f"Unknown input entry: {inp}")
+
+    return (op, dtype, seed, attrs, tuple(inputs_sig))
+
+
+def load_all_cases(pytest_root: Path) -> List[LoadedCase]:
+    items: List[LoadedCase] = []
+    for p in sorted(models_dir(pytest_root).glob("*.yaml")):
+        if p.name.endswith("template.yaml"):  # skip template.yaml file
+            continue
+        spec = yaml.safe_load(p.read_text())
+        model = spec.get("model", p.stem)
+        defaults = dict(spec.get("default", {}))
+        for case in spec.get("cases", []):
+            # allow "cases" to omit "op" if the YAML provides a top-level op (optional)
+            if "op" not in case and "op" in spec:
+                case = dict(case)
+                case["op"] = spec["op"]
+            items.append(
+                LoadedCase(model=model, defaults=defaults, case=case, source_path=p)
+            )
+    return items
+
+
+def to_pytest_params(items: Iterable[LoadedCase]) -> List[Any]:
+    params = []
+    for it in items:
+        marks = []
+
+        # auto mark per-model: -m model_granite3_speech
+        marks.append(getattr(pytest.mark, f"model_{_slug(it.model)}"))
+
+        # case-level marks
+        m = it.case.get("mark", None)
+        ms = it.case.get("marks", None)
+        if m:
+            marks.append(getattr(pytest.mark, m))
+        if isinstance(ms, list):
+            for mm in ms:
+                marks.append(getattr(pytest.mark, mm))
+
+        case_name = it.case.get("name", it.case["op"])
+        test_id = f"{it.model}::{case_name}::{it.case['op']}"
+
+        params.append(
+            pytest.param(
+                it.model, it.case, it.defaults, it.source_path, marks=marks, id=test_id
+            )
+        )
+    return params

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import ast
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
@@ -121,6 +122,7 @@ def load_all_cases(pytest_root: Path) -> List[LoadedCase]:
 
 
 def to_pytest_params(items: Iterable[LoadedCase]) -> List[Any]:
+    seen_test_ids = set()
     params = []
     for it in items:
         marks = []
@@ -137,7 +139,11 @@ def to_pytest_params(items: Iterable[LoadedCase]) -> List[Any]:
                 marks.append(getattr(pytest.mark, mm))
 
         case_name = it.case.get("name", it.case["op"])
-        test_id = f"{it.model}::{case_name}::{it.case['op']}"
+        test_id = f"{it.model}::{case_name}"
+        if test_id in seen_test_ids:
+            basename = os.path.basename(it.source_path)
+            test_id = test_id + "::" + basename
+        seen_test_ids.add(test_id)
 
         params.append(
             pytest.param(

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -54,7 +54,7 @@ def freeze(x: Any) -> Any:
 def case_key(case: Dict[str, Any], defaults: Dict[str, Any]) -> tuple:
     # Used for dedupe; intentionally does NOT include model name.
     op = case["op"]
-    dtype = case.get("dtype", defaults.get("dtype", "float32"))
+    dtype = case.get("dtype", defaults.get("dtype", "float16"))
     seed = case.get("seed", defaults.get("seed", None))
     attrs = freeze(case.get("attrs", {}))
 

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -89,6 +89,8 @@ def case_key(case: Dict[str, Any], defaults: Dict[str, Any]) -> tuple:
             inputs_sig.append(("tensor_list", tuple(lst)))
         elif "value" in inp:
             inputs_sig.append(("value", freeze(inp["value"])))
+        elif "py" in inp:
+            inputs_sig.append(("py", freeze(inp["py"])))
         else:
             raise ValueError(f"Unknown input entry: {inp}")
 

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -43,7 +43,7 @@ def freeze(x: Any) -> Any:
         return tuple(sorted((k, freeze(v)) for k, v in x.items()))
     if isinstance(x, (list, tuple)):
         return tuple(freeze(v) for v in x)
-    if isinstance(x,str) and "torch." not in x:
+    if isinstance(x, str) and "torch." not in x:
         try:
             return ast.literal_eval(x)
         except (ValueError, SyntaxError):

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -121,10 +121,9 @@ def to_pytest_params(items: Iterable[LoadedCase]) -> List[Any]:
         marks.append(getattr(pytest.mark, f"model_{_slug(it.model)}"))
 
         # case-level marks
-        m = it.case.get("mark", None)
         ms = it.case.get("marks", None)
-        if m:
-            marks.append(getattr(pytest.mark, m))
+        if ms is not None and not isinstance(ms, list):
+            ms = [ms]
         if isinstance(ms, list):
             for mm in ms:
                 marks.append(getattr(pytest.mark, mm))

--- a/tests/_inductor/models/gpt_oss.yaml
+++ b/tests/_inductor/models/gpt_oss.yaml
@@ -10,12 +10,20 @@ cases:
   - name: mul_ok
     op: torch.mul
     inputs:
-      - tensor: {shape: [1, 64]}
-      - tensor: {shape: [1, 64]}
+    - tensor:
+        shape: [1, 64]
+    - tensor:
+        shape: [1, 64]
 
-  - name: mul_ng_broadcast
+  - name: mul_ng_fp32
     op: torch.mul
-    mark: paddedtensor
+    marks:
+    - paddedtensor
+    - fpoperation
     inputs:
-      - tensor: {shape: [1, 64]}
-      - tensor: {shape: [1, 1]}
+    - tensor:
+        shape: [1, 64]
+    - tensor:
+        shape: [1, 1]
+        dtype: torch.float32
+        init: rand

--- a/tests/_inductor/models/gpt_oss.yaml
+++ b/tests/_inductor/models/gpt_oss.yaml
@@ -1,5 +1,4 @@
 model: gpt-oss
-op: torch.mul
 
 defaults:
   dtype: fp16

--- a/tests/_inductor/models/gpt_oss.yaml
+++ b/tests/_inductor/models/gpt_oss.yaml
@@ -1,0 +1,22 @@
+model: gpt-oss
+op: torch.mul
+
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 1.0e-2
+  rtol: 1.0e-2
+
+cases:
+  - name: mul_ok
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64]}
+      - tensor: {shape: [1, 64]}
+
+  - name: mul_ng_broadcast
+    op: torch.mul
+    mark: paddedtensor
+    inputs:
+      - tensor: {shape: [1, 64]}
+      - tensor: {shape: [1, 1]}

--- a/tests/_inductor/models/template.yaml
+++ b/tests/_inductor/models/template.yaml
@@ -12,6 +12,8 @@ cases:
     inputs:
       - tensor: {shape: [4, 128, 768], init: randn}
       - tensor: {shape: [4, 128, 768], init: randn}
+    description: |
+      This is some of the text File: site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
 
   - name: mul_tensor_scalar
     op: torch.mul
@@ -43,6 +45,18 @@ cases:
           preset_args: {dim: 1, step: 2}
       - value: [2, 24]
 
+  - name: view_should_error_on_noncontig_167
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: 32
+      - value: -1
+      - value: 2880
+
   - name: contiguous_from_transpose_view
     op: torch.contiguous
     inputs:
@@ -58,3 +72,10 @@ cases:
         reason: Spyre fp16 rsqrt not supported yet
     inputs:
       - tensor: {shape: [64, 1024], init: rand}
+  - name: getitem_ellipsis_none_fullslice
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 5760]
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))

--- a/tests/_inductor/models/template.yaml
+++ b/tests/_inductor/models/template.yaml
@@ -1,0 +1,60 @@
+model: template
+
+default:
+  dtype: fp16
+  seed: 123
+  rtol: 1.0e-3
+  atol: 1.0e-3
+
+cases:
+  - name: add_basic
+    op: torch.add
+    inputs:
+      - tensor: {shape: [4, 128, 768], init: randn}
+      - tensor: {shape: [4, 128, 768], init: randn}
+
+  - name: mul_tensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: uniform, init_args: {low: -1.0, high: 1.0}}
+      - value: 3.0
+
+  - name: softmax_lastdim
+    op: torch.nn.functional.softmax
+    attrs: {dim: -1}
+    inputs:
+      - tensor: {shape: [2, 4, 8], init: arange}
+
+  - name: cat_list
+    op: torch.cat
+    attrs: {dim: -1}
+    inputs:
+      - tensor_list:
+          - {shape: [2, 3, 4], init: randn}
+          - {shape: [2, 3, 5], init: randn}
+
+  - name: view_should_error_on_noncontig
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: [2, 24]
+
+  - name: contiguous_from_transpose_view
+    op: torch.contiguous
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: transpose_view
+          preset_args: {dim0: 1, dim1: 2}
+
+  - name: rsqrt_skip_example
+    op: torch.rsqrt
+    skip_if:
+      - expr: cfg.test_device.type == 'spyre' and dtype_str == 'fp16'
+        reason: Spyre fp16 rsqrt not supported yet
+    inputs:
+      - tensor: {shape: [64, 1024], init: rand}

--- a/tests/_inductor/models/template.yaml
+++ b/tests/_inductor/models/template.yaml
@@ -3,8 +3,8 @@ model: template
 default:
   dtype: fp16
   seed: 123
-  rtol: 1.0e-3
-  atol: 1.0e-3
+  rtol: 5.0e-3
+  atol: 5.0e-3
 
 cases:
   - name: add_basic

--- a/tests/_inductor/models/template.yaml
+++ b/tests/_inductor/models/template.yaml
@@ -15,11 +15,45 @@ cases:
     description: |
       This is some of the text File: site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
 
+  - name: op_bool_tensors
+    op: torch.logical_and
+    inputs:
+      - tensor: {shape: [11, 6], dtype: bool}
+      - tensor: {shape: [11, 6], dtype: bool}
+    description: |
+      ops with args of randomly generated bool tensors (50% chance of True)
+
+  - name: op_different_dtypes
+    op: torch.add
+    inputs:
+      - tensor: {shape: [11, 6], dtype: fp32, init: randn}
+      - tensor: {shape: [11, 6], dtype: int64, init: randint, init_args: {high: 100}}
+    description: |
+      ops with args of different dtypes
+
   - name: mul_tensor_scalar
     op: torch.mul
     inputs:
       - tensor: {shape: [1, 64], init: uniform, init_args: {low: -1.0, high: 1.0}}
       - value: 3.0
+    description: |
+      ops with tensor and scalar as args 
+
+  - name: mul_inttensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: randint, init_args: {low: 1, high: 100}}
+      - value: 3
+    description: |
+      ops with tensor and scalar as args 
+
+  - name: aten_view
+    op: torch.ops.aten.view
+    inputs:
+      - tensor: {shape: [1, 64]}
+      - value: [2, 32]
+    description: |
+      value can accept scalar, list or tuple
 
   - name: softmax_lastdim
     op: torch.nn.functional.softmax

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -1,0 +1,408 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import torch
+
+
+@dataclass(frozen=True)
+class OpAdapter:
+    name: str
+    fn: Callable[..., Any]
+    is_inplace: bool = False
+    # pre hook may normalize (args, attrs) (e.g., set dropout(training=False))
+    pre: Optional[Callable[[list, dict], Tuple[list, dict]]] = None
+
+
+# -----------------------------
+# Helpers: resolve paths lazily
+# -----------------------------
+def _resolve_attr_path(root: Any, path: str) -> Any:
+    cur = root
+    for part in path.split("."):
+        cur = getattr(cur, part)
+    return cur
+
+
+def lazy_torch(path: str) -> Callable[..., Any]:
+    """
+    Returns a callable that resolves torch.<path> at runtime and calls it.
+
+    Example: lazy_torch("amp.autocast_mode._enter_autocast")
+    """
+
+    def _fn(*args, **kwargs):
+        target = _resolve_attr_path(torch, path)
+        return target(*args, **kwargs)
+
+    _fn.__name__ = f"lazy_torch__{path.replace('.', '_')}"
+    return _fn
+
+
+def _dropout_pre(args: list, attrs: dict) -> tuple[list, dict]:
+    # default deterministic behavior unless case overrides
+    attrs = dict(attrs)
+    attrs.setdefault("training", False)
+    return args, attrs
+
+
+# -----------------------------
+# Wrappers for Tensor methods
+# -----------------------------
+def _tensor_contiguous(x: torch.Tensor) -> torch.Tensor:
+    return x.contiguous()
+
+
+def _tensor_expand(x: torch.Tensor, shape) -> torch.Tensor:
+    return x.expand(*shape) if isinstance(shape, (list, tuple)) else x.expand(shape)
+
+
+def _tensor_expand_as(x: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+    return x.expand_as(other)
+
+
+def _tensor_float(x: torch.Tensor) -> torch.Tensor:
+    return x.float()
+
+
+def _tensor_int(x: torch.Tensor) -> torch.Tensor:
+    return x.int()
+
+
+def _tensor_to(x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    # allow YAML to pass (dtype/device/etc.) via args/kwargs
+    return x.to(*args, **kwargs)
+
+
+def _tensor_repeat(x: torch.Tensor, reps) -> torch.Tensor:
+    return x.repeat(*reps) if isinstance(reps, (list, tuple)) else x.repeat(reps)
+
+
+def _tensor_view(x: torch.Tensor, shape) -> torch.Tensor:
+    return x.view(*shape) if isinstance(shape, (list, tuple)) else x.view(shape)
+
+
+def _tensor_permute(x: torch.Tensor, dims) -> torch.Tensor:
+    return x.permute(*dims) if isinstance(dims, (list, tuple)) else x.permute(dims)
+
+
+def _tensor_transpose(x: torch.Tensor, dim0: int, dim1: int) -> torch.Tensor:
+    return x.transpose(dim0, dim1)
+
+
+def _tensor_unsqueeze(x: torch.Tensor, dim: int) -> torch.Tensor:
+    return x.unsqueeze(dim)
+
+
+def _tensor_item(x: torch.Tensor):
+    return x.item()
+
+
+def _tensor_numel(x: torch.Tensor) -> int:
+    return x.numel()
+
+
+def _tensor_new_ones(x: torch.Tensor, size, *args, **kwargs) -> torch.Tensor:
+    # size can be list/tuple/int; forward to Tensor.new_ones
+    if isinstance(size, (list, tuple)):
+        return x.new_ones(tuple(size), *args, **kwargs)
+    return x.new_ones(size, *args, **kwargs)
+
+
+def _tensor_getitem(x: torch.Tensor, idx):
+    return x.__getitem__(idx)
+
+
+def _tensor_setitem_(x: torch.Tensor, idx, value):
+    x.__setitem__(idx, value)
+    return x  # treat as in-place op returning mutated tensor
+
+
+# -----------------------------
+# Wrappers for Python operator-like torch names
+# -----------------------------
+def _torch___and__(a, b):
+    return a.__and__(b)
+
+
+def _torch___eq__(a, b):
+    return a.__eq__(b)
+
+
+def _torch_le(a, b):
+    return a.__le__(b)
+
+
+def _torch_ne(a, b):
+    return a.__ne__(b)
+
+
+def _torch_gt(a, b):
+    return a.__gt__(b)
+
+
+def _torch_neg(a):
+    return -a
+
+
+def _torch_truediv(a, b):
+    return a.__truediv__(b)
+
+
+# -----------------------------
+# Special / internal wrappers
+# -----------------------------
+def _aten_index(x, indices):
+    """
+    torch.ops.aten.index has overloads; prefer .Tensor then .default if present.
+    Typical signature: aten::index(Tensor self, Tensor?[] indices) -> Tensor
+    """
+    pkt = torch.ops.aten.index
+    if hasattr(pkt, "Tensor"):
+        return pkt.Tensor(x, indices)
+    if hasattr(pkt, "default"):
+        return pkt.default(x, indices)
+    # last resort: try calling packet itself
+    return pkt(x, indices)
+
+
+def _scalar_tensor(val, *, dtype=None, device=None):
+    # torch.scalar_tensor exists in recent versions
+    return torch.scalar_tensor(val, dtype=dtype, device=device)
+
+
+def _sym_sum(x, dim=None):
+    # torch.sym_sum exists for SymInt/SymFloat paths; fall back to torch.sum if absent
+    if hasattr(torch, "sym_sum"):
+        return torch.sym_sum(x, dim=dim) if dim is not None else torch.sym_sum(x)
+    return torch.sum(x, dim=dim) if dim is not None else torch.sum(x)
+
+
+def _vmap_lazy_load_decompositions():
+    # torch._functorch.vmap.lazy_load_decompositions
+    return _resolve_attr_path(torch, "_functorch.vmap.lazy_load_decompositions")()
+
+
+# SDPA / attention internals (these often return context managers or control flags)
+def _attn_backend_from_string(s: str):
+    return _resolve_attr_path(torch, "nn.attention._backend_from_string")(s)
+
+
+def _attn_sdpa_kernel(*args, **kwargs):
+    return _resolve_attr_path(torch, "nn.attention._sdpa_kernel")(*args, **kwargs)
+
+
+# -----------------------------
+# In-place wrappers (Tensor methods)
+# -----------------------------
+def _tensor_add_(x: torch.Tensor, other, alpha=1):
+    return x.add_(other, alpha=alpha)
+
+
+def _tensor_scatter_(x: torch.Tensor, dim: int, index: torch.Tensor, src):
+    # src can be tensor or scalar
+    return x.scatter_(dim, index, src)
+
+
+def _tensor_masked_fill_(x: torch.Tensor, mask: torch.Tensor, value):
+    return x.masked_fill_(mask, value)
+
+
+def _tensor_index_copy_(
+    x: torch.Tensor, dim: int, index: torch.Tensor, source: torch.Tensor
+):
+    return x.index_copy_(dim, index, source)
+
+
+# -----------------------------
+# OP_REGISTRY: unique ops only
+# -----------------------------
+OP_REGISTRY: Dict[str, OpAdapter] = {
+    "torch.cat": OpAdapter("torch.cat", torch.cat),
+    "torch.chunk": OpAdapter("torch.chunk", torch.chunk),
+    # Basic math / reductions
+    "torch.add": OpAdapter("torch.add", torch.add),
+    "torch.sub": OpAdapter("torch.sub", torch.sub),
+    "torch.mul": OpAdapter("torch.mul", torch.mul),
+    "torch.pow": OpAdapter("torch.pow", torch.pow),
+    "torch.truediv": OpAdapter("torch.truediv", _torch_truediv),
+    "torch.neg": OpAdapter("torch.neg", _torch_neg),
+    "torch.sum": OpAdapter("torch.sum", torch.sum),
+    "torch.mean": OpAdapter("torch.mean", torch.mean),
+    "torch.max": OpAdapter("torch.max", torch.max),
+    "torch.all": OpAdapter("torch.all", torch.all),
+    "torch.numel": OpAdapter("torch.numel", _tensor_numel),
+    "torch.rsqrt": OpAdapter("torch.rsqrt", torch.rsqrt),
+    "torch.sigmoid": OpAdapter("torch.sigmoid", torch.sigmoid),
+    "torch.sin": OpAdapter("torch.sin", torch.sin),
+    "torch.cos": OpAdapter("torch.cos", torch.cos),
+    "torch.clamp": OpAdapter("torch.clamp", torch.clamp),
+    "torch.where": OpAdapter("torch.where", torch.where),
+    # Linear algebra
+    "torch.matmul": OpAdapter("torch.matmul", torch.matmul),
+    "torch.bmm": OpAdapter("torch.bmm", torch.bmm),
+    "torch.functional.einsum": OpAdapter(
+        "torch.functional.einsum", torch.functional.einsum
+    ),
+    # Shape / view / layout
+    # stride-sensitive ops
+    "torch.contiguous": OpAdapter("torch.contiguous", _tensor_contiguous),
+    "torch.reshape": OpAdapter("torch.reshape", torch.reshape),
+    "torch.view": OpAdapter("torch.view", _tensor_view),
+    "torch.transpose": OpAdapter("torch.transpose", _tensor_transpose),
+    "torch.permute": OpAdapter("torch.permute", _tensor_permute),
+    "torch.unsqueeze": OpAdapter("torch.unsqueeze", _tensor_unsqueeze),
+    "torch.flatten": OpAdapter("torch.flatten", torch.flatten),
+    "torch.expand": OpAdapter("torch.expand", _tensor_expand),
+    "torch.expand_as": OpAdapter("torch.expand_as", _tensor_expand_as),
+    "torch.repeat": OpAdapter("torch.repeat", _tensor_repeat),
+    "torch.clone": OpAdapter("torch.clone", torch.clone),
+    # Indexing / getitem / setitem
+    "torch.getitem": OpAdapter("torch.getitem", _tensor_getitem),
+    "_operator.setitem": OpAdapter(
+        "_operator.setitem", _tensor_setitem_, is_inplace=True
+    ),
+    "torch.ops.aten.index": OpAdapter("torch.ops.aten.index", _aten_index),
+    # Scatter / copy / masking
+    "torch.scatter_": OpAdapter("torch.scatter_", _tensor_scatter_, is_inplace=True),
+    # "torch.scatter_": OpAdapter("torch.scatter_", torch.Tensor.scatter_, is_inplace=True),
+    "torch.index_copy_": OpAdapter(
+        "torch.index_copy_", _tensor_index_copy_, is_inplace=True
+    ),
+    "torch.masked_fill_": OpAdapter(
+        "torch.masked_fill_", _tensor_masked_fill_, is_inplace=True
+    ),
+    "torch.masked_scatter": OpAdapter("torch.masked_scatter", torch.masked_scatter),
+    # Comparisons / bitwise
+    "torch.__and__": OpAdapter("torch.__and__", _torch___and__),
+    "torch.__eq__": OpAdapter("torch.__eq__", _torch___eq__),
+    "torch.le": OpAdapter("torch.le", _torch_le),
+    "torch.ne": OpAdapter("torch.ne", _torch_ne),
+    "torch.gt": OpAdapter("torch.gt", _torch_gt),
+    # Type/device conversions
+    "torch.float": OpAdapter("torch.float", _tensor_float),
+    "torch.int": OpAdapter("torch.int", _tensor_int),
+    "torch.to": OpAdapter("torch.to", _tensor_to),
+    # Creation
+    "torch.zeros": OpAdapter("torch.zeros", torch.zeros),
+    "torch.zeros_like": OpAdapter("torch.zeros_like", torch.zeros_like),
+    "torch.ones": OpAdapter("torch.ones", torch.ones),
+    "torch.arange": OpAdapter("torch.arange", torch.arange),
+    "torch.tensor": OpAdapter("torch.tensor", torch.tensor),
+    "torch.scalar_tensor": OpAdapter("torch.scalar_tensor", _scalar_tensor),
+    "torch.new_ones": OpAdapter("torch.new_ones", _tensor_new_ones),
+    # Topk
+    "torch.topk": OpAdapter("torch.topk", torch.topk),
+    # NNs / functionals (use F.* where appropriate)
+    "torch.nn.functional.dropout": OpAdapter(
+        "torch.nn.functional.dropout", torch.nn.functional.dropout, pre=_dropout_pre
+    ),
+    "torch.nn.functional.embedding": OpAdapter(
+        "torch.nn.functional.embedding", torch.nn.functional.embedding
+    ),
+    "torch.nn.functional.softmax": OpAdapter(
+        "torch.nn.functional.softmax", torch.nn.functional.softmax
+    ),
+    "torch.nn.functional.layer_norm": OpAdapter(
+        "torch.nn.functional.layer_norm", torch.nn.functional.layer_norm
+    ),
+    "torch.nn.functional.batch_norm": OpAdapter(
+        "torch.nn.functional.batch_norm", torch.nn.functional.batch_norm
+    ),
+    "torch.nn.functional.glu": OpAdapter(
+        "torch.nn.functional.glu", torch.nn.functional.glu
+    ),
+    "torch.nn.functional.silu": OpAdapter(
+        "torch.nn.functional.silu", torch.nn.functional.silu
+    ),
+    # gelu has both torch.nn.functional.gelu and torch.nn.gelu depending on version
+    "torch.nn.gelu": OpAdapter(
+        "torch.nn.gelu",
+        getattr(torch.nn, "gelu", torch.nn.functional.gelu),
+    ),
+    # linear: prefer torch.nn.functional.linear; torch.nn.linear may exist in some builds
+    "torch.nn.linear": OpAdapter(
+        "torch.nn.linear",
+        getattr(torch.nn, "linear", torch.nn.functional.linear),
+    ),
+    "torch.nn.pad": OpAdapter(
+        "torch.nn.pad",
+        getattr(torch.nn, "pad", torch.nn.functional.pad),
+    ),
+    # Attention / SDPA
+    "torch.nn.scaled_dot_product_attention": OpAdapter(
+        "torch.nn.scaled_dot_product_attention",
+        getattr(
+            torch.nn,
+            "scaled_dot_product_attention",
+            torch.nn.functional.scaled_dot_product_attention,
+        ),
+    ),
+    "torch.nn.functional.multi_head_attention_forward": OpAdapter(
+        "torch.nn.functional.multi_head_attention_forward",
+        torch.nn.functional.multi_head_attention_forward,
+    ),
+    "torch.nn.attention._backend_from_string": OpAdapter(
+        "torch.nn.attention._backend_from_string",
+        _attn_backend_from_string,
+    ),
+    "torch.nn.attention._sdpa_kernel": OpAdapter(
+        "torch.nn.attention._sdpa_kernel",
+        _attn_sdpa_kernel,
+    ),
+    # Conv
+    "torch.conv1d": OpAdapter("torch.conv1d", torch.conv1d),
+    "torch.conv2d": OpAdapter("torch.conv2d", torch.conv2d),
+    # Autocast internal enter/exit (kept for completeness; not usually unit-tested directly)
+    "torch.amp.autocast_mode._enter_autocast": OpAdapter(
+        "torch.amp.autocast_mode._enter_autocast",
+        lazy_torch("amp.autocast_mode._enter_autocast"),
+    ),
+    "torch.amp.autocast_mode._exit_autocast": OpAdapter(
+        "torch.amp.autocast_mode._exit_autocast",
+        lazy_torch("amp.autocast_mode._exit_autocast"),
+    ),
+    # Functorch internal vmap plumbing (kept for completeness)
+    "torch._functorch.vmap.lazy_load_decompositions": OpAdapter(
+        "torch._functorch.vmap.lazy_load_decompositions",
+        _vmap_lazy_load_decompositions,
+    ),
+    "torch._C._functorch._add_batch_dim": OpAdapter(
+        "torch._C._functorch._add_batch_dim",
+        lazy_torch("_C._functorch._add_batch_dim"),
+    ),
+    "torch._C._functorch._remove_batch_dim": OpAdapter(
+        "torch._C._functorch._remove_batch_dim",
+        lazy_torch("_C._functorch._remove_batch_dim"),
+    ),
+    "torch._C._functorch._vmap_increment_nesting": OpAdapter(
+        "torch._C._functorch._vmap_increment_nesting",
+        lazy_torch("_C._functorch._vmap_increment_nesting"),
+    ),
+    "torch._C._functorch._vmap_decrement_nesting": OpAdapter(
+        "torch._C._functorch._vmap_decrement_nesting",
+        lazy_torch("_C._functorch._vmap_decrement_nesting"),
+    ),
+    # Symbolic sum (present in some builds; fallback provided)
+    "torch.sym_sum": OpAdapter("torch.sym_sum", _sym_sum),
+    # Misc
+    "torch.item": OpAdapter("torch.item", _tensor_item),
+    # In-place add_ listed separately
+    "torch.add_": OpAdapter("torch.add_", _tensor_add_, is_inplace=True),
+    # "torch.add_": OpAdapter("torch.add_", torch.Tensor.add_, is_inplace=True),
+}
+
+# Handy set if you want it:
+INPLACE_OPS = {name for (name, a) in OP_REGISTRY.items() if a.is_inplace}

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -302,6 +302,7 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.clone": OpAdapter("torch.clone", torch.clone),
     # Indexing / getitem / setitem
     "torch.getitem": OpAdapter("torch.getitem", _tensor_getitem),
+    "operator.__getitem__": OpAdapter("torch.getitem", _tensor_getitem),
     "_operator.setitem": OpAdapter(
         "_operator.setitem", _tensor_setitem_, is_inplace=True
     ),

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -92,8 +92,14 @@ def _tensor_to(x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
     return x.to(*args, **kwargs)
 
 
-def _tensor_repeat(x: torch.Tensor, reps) -> torch.Tensor:
-    return x.repeat(*reps) if isinstance(reps, (list, tuple)) else x.repeat(reps)
+def _tensor_repeat(x: torch.Tensor, rep, *args) -> torch.Tensor:
+    if isinstance(rep, (list, tuple)):
+        final_reps = list(rep)
+    elif args:
+        final_reps = [rep] + list(args)
+    else:
+        final_reps = [rep]
+    return x.repeat(final_reps)
 
 
 def _tensor_view(x: torch.Tensor, shape, *args) -> torch.Tensor:
@@ -318,6 +324,7 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.gt": OpAdapter("torch.gt", _torch_gt),
     # Type/device conversions
     "torch.float": OpAdapter("torch.float", _tensor_float),
+    "float": OpAdapter("torch.float", _tensor_float),
     "torch.int": OpAdapter("torch.int", _tensor_int),
     "torch.to": OpAdapter("torch.to", _tensor_to),
     # Creation

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -317,6 +317,9 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.repeat": OpAdapter("torch.repeat", _tensor_repeat),
     "torch.clone": OpAdapter("torch.clone", torch.clone),
     "torch.split": OpAdapter("torch.split", torch.split),
+    "torch.functional.split": OpAdapter(
+        "torch.functional.split", torch.functional.split
+    ),
     "torch.Tensor.copy_": OpAdapter("torch.copy_", _tensor_copy_, is_inplace=True),
     # Indexing / getitem / setitem
     "torch.getitem": OpAdapter("torch.getitem", _tensor_getitem),

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -87,6 +87,10 @@ def _tensor_int(x: torch.Tensor) -> torch.Tensor:
     return x.int()
 
 
+def _tensor_long(x: torch.Tensor) -> torch.Tensor:
+    return x.long()
+
+
 def _tensor_to(x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
     # allow YAML to pass (dtype/device/etc.) via args/kwargs
     return x.to(*args, **kwargs)
@@ -235,6 +239,10 @@ def _tensor_add_(x: torch.Tensor, other, alpha=1):
     return x.add_(other, alpha=alpha)
 
 
+def _tensor_copy_(x: torch.Tensor, source: torch.Tensor):
+    return x.copy_(source)
+
+
 def _tensor_scatter_(x: torch.Tensor, dim: int, index: torch.Tensor, src):
     # src can be tensor or scalar
     return x.scatter_(dim, index, src)
@@ -258,25 +266,33 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.chunk": OpAdapter("torch.chunk", torch.chunk),
     # Basic math / reductions
     "torch.add": OpAdapter("torch.add", torch.add),
+    "torch.Tensor.add": OpAdapter("torch.add", torch.add),
     "operator.__add__": OpAdapter("torch.add", torch.add),
     "torch.sub": OpAdapter("torch.sub", torch.sub),
     "operator.__sub__": OpAdapter("torch.sub", torch.sub),
     "torch.mul": OpAdapter("torch.mul", torch.mul),
+    "torch.Tensor.mul": OpAdapter("torch.mul", torch.mul),
     "operator.__mul__": OpAdapter("torch.mul", torch.mul),
+    "torch.invert": OpAdapter("torch.bitwise_not", torch.bitwise_not),
     "torch.pow": OpAdapter("torch.pow", torch.pow),
     "torch.truediv": OpAdapter("torch.truediv", _torch_truediv),
     "torch.neg": OpAdapter("torch.neg", _torch_neg),
     "torch.sum": OpAdapter("torch.sum", torch.sum),
     "torch.mean": OpAdapter("torch.mean", torch.mean),
     "torch.max": OpAdapter("torch.max", torch.max),
+    "torch.softmax": OpAdapter("torch.softmax", torch.max),
+    "torch.cumsum": OpAdapter("torch.cumsum", torch.cumsum),
     "torch.all": OpAdapter("torch.all", torch.all),
     "torch.numel": OpAdapter("torch.numel", _tensor_numel),
+    "torch.exp": OpAdapter("torch.exp", torch.exp),
     "torch.rsqrt": OpAdapter("torch.rsqrt", torch.rsqrt),
     "torch.sigmoid": OpAdapter("torch.sigmoid", torch.sigmoid),
     "torch.sin": OpAdapter("torch.sin", torch.sin),
     "torch.cos": OpAdapter("torch.cos", torch.cos),
     "torch.clamp": OpAdapter("torch.clamp", torch.clamp),
     "torch.where": OpAdapter("torch.where", torch.where),
+    "torch.tril": OpAdapter("torch.tril", torch.tril),
+    "torch.triu": OpAdapter("torch.triu", torch.triu),
     # Linear algebra
     "torch.matmul": OpAdapter("torch.matmul", torch.matmul),
     "operator.__matmul__": OpAdapter("torch.matmul", torch.matmul),
@@ -300,6 +316,8 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.expand_as": OpAdapter("torch.expand_as", _tensor_expand_as),
     "torch.repeat": OpAdapter("torch.repeat", _tensor_repeat),
     "torch.clone": OpAdapter("torch.clone", torch.clone),
+    "torch.split": OpAdapter("torch.split", torch.split),
+    "torch.Tensor.copy_": OpAdapter("torch.copy_", _tensor_copy_, is_inplace=True),
     # Indexing / getitem / setitem
     "torch.getitem": OpAdapter("torch.getitem", _tensor_getitem),
     "operator.__getitem__": OpAdapter("torch.getitem", _tensor_getitem),
@@ -327,7 +345,9 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.float": OpAdapter("torch.float", _tensor_float),
     "float": OpAdapter("torch.float", _tensor_float),
     "torch.int": OpAdapter("torch.int", _tensor_int),
+    "torch.long": OpAdapter("torch.long", _tensor_long),
     "torch.to": OpAdapter("torch.to", _tensor_to),
+    "torch.type_as": OpAdapter("torch.Tensor.type_as", torch.Tensor.type_as),
     # Creation
     "torch.zeros": OpAdapter("torch.zeros", torch.zeros),
     "torch.zeros_like": OpAdapter("torch.zeros_like", torch.zeros_like),
@@ -354,11 +374,17 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.nn.functional.batch_norm": OpAdapter(
         "torch.nn.functional.batch_norm", torch.nn.functional.batch_norm
     ),
+    "torch.nn.functional.gelu": OpAdapter(
+        "torch.nn.functional.gelu", torch.nn.functional.gelu
+    ),
     "torch.nn.functional.glu": OpAdapter(
         "torch.nn.functional.glu", torch.nn.functional.glu
     ),
     "torch.nn.functional.silu": OpAdapter(
         "torch.nn.functional.silu", torch.nn.functional.silu
+    ),
+    "torch.nn.functional.softplus": OpAdapter(
+        "torch.nn.functional.softplus", torch.nn.functional.softplus
     ),
     # gelu has both torch.nn.functional.gelu and torch.nn.gelu depending on version
     "torch.nn.gelu": OpAdapter(
@@ -385,6 +411,10 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
             "scaled_dot_product_attention",
             torch.nn.functional.scaled_dot_product_attention,
         ),
+    ),
+    "torch.nn.functional.scaled_dot_product_attention": OpAdapter(
+        "torch.nn.functional.scaled_dot_product_attention",
+        torch.nn.functional.scaled_dot_product_attention,
     ),
     "torch.nn.functional.multi_head_attention_forward": OpAdapter(
         "torch.nn.functional.multi_head_attention_forward",

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -234,8 +234,11 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
     "torch.chunk": OpAdapter("torch.chunk", torch.chunk),
     # Basic math / reductions
     "torch.add": OpAdapter("torch.add", torch.add),
+    "operator.__add__": OpAdapter("torch.add", torch.add),
     "torch.sub": OpAdapter("torch.sub", torch.sub),
+    "operator.__sub__": OpAdapter("torch.sub", torch.sub),
     "torch.mul": OpAdapter("torch.mul", torch.mul),
+    "operator.__mul__": OpAdapter("torch.mul", torch.mul),
     "torch.pow": OpAdapter("torch.pow", torch.pow),
     "torch.truediv": OpAdapter("torch.truediv", _torch_truediv),
     "torch.neg": OpAdapter("torch.neg", _torch_neg),

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -371,8 +371,7 @@ OP_REGISTRY: Dict[str, OpAdapter] = {
         getattr(torch.nn, "linear", torch.nn.functional.linear),
     ),
     "torch.nn.functional.linear": OpAdapter(
-        "torch.nn.functional.linear",
-        torch.nn.functional.linear
+        "torch.nn.functional.linear", torch.nn.functional.linear
     ),
     "torch.nn.pad": OpAdapter(
         "torch.nn.pad",

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -410,14 +410,16 @@ def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> 
         inp_seed = None if seed is None else int(seed) + i * 1000
 
         if "tensor" in inp:
+            tensor_conf = inp["tensor"]
+            tensor_dtype = parse_dtype(tensor_conf.get("dtype", dtype_str))
             cpu_args.append(
-                make_tensor_from_conf(inp["tensor"], dtype=dtype, seed=inp_seed)
+                make_tensor_from_conf(tensor_conf, dtype=tensor_dtype, seed=inp_seed)
             )
         elif "tensor_list" in inp:
             lst = [
                 make_tensor_from_conf(
                     t,
-                    dtype=dtype,
+                    dtype=parse_dtype(t.get("dtype", dtype_str)),
                     seed=(None if seed is None else int(seed) + i * 1000 + j),
                 )
                 for j, t in enumerate(inp["tensor_list"])

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -1,0 +1,390 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ast
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import pytest
+import regex as re
+import torch
+import torch.nn as nn
+
+from op_registry import OP_REGISTRY
+
+DTYPE_MAP = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+    "int64": torch.int64,
+    "bool": torch.bool,
+}
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    test_device: torch.device
+    ref_device: torch.device = torch.device("cpu")
+    compile_backend: Optional[str] = None  # if set, run Spyre through torch.compile
+
+
+# ---------- safe skip/xfail condition evaluation ----------
+_ALLOWED_AST = (
+    ast.Expression,
+    ast.BoolOp,
+    ast.UnaryOp,
+    ast.Compare,
+    ast.Name,
+    ast.Load,
+    ast.Attribute,
+    ast.Constant,
+    ast.And,
+    ast.Or,
+    ast.Not,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+)
+
+
+def _safe_eval_bool(expr: str, ctx: dict) -> bool:
+    tree = ast.parse(expr, mode="eval")
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_AST):
+            raise ValueError(
+                f"Disallowed syntax in expr: {expr} (node={type(node).__name__})"
+            )
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            raise ValueError("Dunder attribute access is not allowed")
+    return bool(eval(compile(tree, "<expr>", "eval"), {"__builtins__": {}}, ctx))
+
+
+def _maybe_skip_or_xfail(
+    case: Dict[str, Any], defaults: Dict[str, Any], ctx: dict
+) -> None:
+    skip_if = case.get("skip_if", defaults.get("skip_if", None))
+    if skip_if:
+        if isinstance(skip_if, str):
+            if _safe_eval_bool(skip_if, ctx):
+                pytest.skip("skip_if matched")
+        elif isinstance(skip_if, list):
+            for item in skip_if:
+                expr = item["expr"]
+                reason = item.get("reason", "skip_if matched")
+                if _safe_eval_bool(expr, ctx):
+                    pytest.skip(reason)
+
+    xfail_reason = case.get("xfail_reason", defaults.get("xfail_reason", None))
+    if xfail_reason:
+        xfail_if = case.get("xfail_if", defaults.get("xfail_if", None))
+        if xfail_if is None or _safe_eval_bool(str(xfail_if), ctx):
+            pytest.xfail(str(xfail_reason))
+
+
+# ---------- tensor construction (deterministic) ----------
+def _fork_seed(seed: Optional[int]):
+    if seed is None:
+        return torch.random.fork_rng(devices=[])
+    # fork_rng keeps global RNG clean
+    ctx = torch.random.fork_rng(devices=[])
+    ctx.__enter__()
+    torch.manual_seed(int(seed))
+    return ctx
+
+
+def _numel(shape) -> int:
+    if len(shape) == 0:
+        return 1
+    n = 1
+    for d in shape:
+        n *= int(d)
+    return n
+
+
+def _make_base(shape, dtype, seed):
+    with torch.random.fork_rng(devices=[]):
+        if seed is not None:
+            torch.manual_seed(int(seed))
+        return torch.randn(tuple(shape), device="cpu", dtype=dtype)
+
+
+def make_tensor_from_conf(
+    tconf: Dict[str, Any], *, dtype: torch.dtype, seed: Optional[int]
+) -> torch.Tensor:
+    shape = list(tconf["shape"])
+    init = tconf.get("init", "rand")
+    init_args = dict(tconf.get("init_args", {}))
+    preset = tconf.get("preset", None)
+    preset_args = dict(tconf.get("preset_args", {}))
+    base_shape = tconf.get("base_shape", None)
+
+    # presets create noncontig/aliasing views
+    if preset is None:
+        with torch.random.fork_rng(devices=[]):
+            if seed is not None:
+                torch.manual_seed(int(seed))
+            if init == "rand":
+                t = torch.rand(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "randn":
+                t = torch.randn(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "zeros":
+                t = torch.zeros(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "ones":
+                t = torch.ones(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "arange":
+                t = torch.arange(_numel(shape), dtype=dtype, device="cpu").reshape(
+                    shape
+                )
+            elif init == "uniform":
+                low = float(init_args.get("low", 0.0))
+                high = float(init_args.get("high", 1.0))
+                t = torch.empty(tuple(shape), dtype=dtype, device="cpu").uniform_(
+                    low, high
+                )
+            elif init == "data":
+                data = tconf["data"]
+                t = torch.tensor(data, dtype=dtype, device="cpu").reshape(shape)
+            else:
+                raise ValueError(f"Unknown init: {init}")
+    else:
+        # build a base then view it
+        if preset == "noncontig_slice":
+            dim = int(preset_args.get("dim", 1 if len(shape) > 1 else 0))
+            step = int(preset_args.get("step", 2))
+            if base_shape is None:
+                base_shape = shape[:]
+                base_shape[dim] = shape[dim] * step
+            base = _make_base(base_shape, dtype, seed)
+            slc = [slice(None)] * base.ndim
+            slc[dim] = slice(0, base.shape[dim], step)
+            t = base[tuple(slc)]
+        elif preset == "transpose_view":
+            dim0 = int(preset_args.get("dim0", 0))
+            dim1 = int(preset_args.get("dim1", 1))
+            if base_shape is None:
+                base_shape = shape[:]
+                base_shape[dim0], base_shape[dim1] = shape[dim1], shape[dim0]
+            base = _make_base(base_shape, dtype, seed)
+            t = base.transpose(dim0, dim1)
+        elif preset == "expand_view0":
+            if base_shape is None:
+                raise ValueError("expand_view0 requires base_shape")
+            base = _make_base(base_shape, dtype, seed)
+            t = base.expand(*shape)
+        else:
+            raise ValueError(f"Unknown preset: {preset}")
+
+        if list(t.shape) != shape:
+            raise ValueError(
+                f"Preset {preset} produced shape {list(t.shape)} != expected {shape}"
+            )
+
+    if tconf.get("contiguous", True):
+        t = t.contiguous()
+    return t
+
+
+def to_device(x: Any, device: torch.device) -> Any:
+    if torch.is_tensor(x):
+        return x.to(device)
+    if isinstance(x, (tuple, list)):
+        return type(x)(to_device(y, device) for y in x)
+    return x
+
+
+def _normalize_out(out: Any) -> Any:
+    if torch.is_tensor(out):
+        return out
+    if isinstance(out, (tuple, list)):
+        return tuple(_normalize_out(x) for x in out)
+    return out
+
+
+def _assert_same(
+    ref_out: Any, test_out: Any, *, rtol: float, atol: float, case_name: str
+) -> None:
+    ref_out = _normalize_out(ref_out)
+    test_out = _normalize_out(test_out)
+
+    if torch.is_tensor(ref_out):
+        try:
+            torch.testing.assert_close(test_out, ref_out, rtol=rtol, atol=atol)
+        except AssertionError as e:
+            diff = (ref_out - test_out).abs()
+            raise AssertionError(
+                f"{case_name} FAILED\n"
+                f"shape={tuple(ref_out.shape)} dtype={ref_out.dtype}\n"
+                f"atol={atol} rtol={rtol}\n"
+                f"max_abs_diff={diff.max().item()}\n"
+            ) from e
+        return
+
+    if isinstance(ref_out, tuple):
+        assert isinstance(test_out, tuple) and len(test_out) == len(ref_out)
+        for r, d in zip(ref_out, test_out):
+            _assert_same(r, d, rtol=rtol, atol=atol, case_name=case_name)
+        return
+
+    assert test_out == ref_out
+
+
+# ---------- expects_error ----------
+_ERR_NAME_TO_TYPE = {
+    "RuntimeError": RuntimeError,
+    "ValueError": ValueError,
+    "TypeError": TypeError,
+    "AssertionError": AssertionError,
+}
+
+
+def _exc_type(name: Optional[str]):
+    if not name:
+        return Exception
+    return _ERR_NAME_TO_TYPE.get(str(name), Exception)
+
+
+def _run_and_capture(fn, args, attrs):
+    try:
+        out = fn(*args, **attrs)
+        return False, None, out
+    except BaseException as e:
+        return True, e, None
+
+
+def _assert_raised(label: str, raised: bool, exc: BaseException, spec: dict):
+    assert raised, f"{label} expected to raise but did not"
+    want_t = _exc_type(spec.get("type", "RuntimeError"))
+    assert isinstance(exc, want_t), f"{label} raised {type(exc)} expected {want_t}"
+    m = spec.get("match", None)
+    if m:
+        assert re.search(m, str(exc)), f"{label} message did not match /{m}/. msg={exc}"
+
+
+# ---------- optional torch.compile path ----------
+class _OpModule(nn.Module):
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+
+def _maybe_compile_call(
+    fn, args, attrs, device: torch.device, compile_backend: Optional[str]
+):
+    if compile_backend is None or device.type == "cpu":
+        return fn(*args, **attrs)
+    mod = _OpModule(fn).to(device)
+    compiled = torch.compile(mod, backend=compile_backend)
+    return compiled(*args, **attrs)
+
+
+# ---------- main entry ----------
+def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> None:
+    op_name = case["op"]
+    adapter = OP_REGISTRY[op_name]
+
+    case_name = case.get("name", op_name)
+
+    dtype_str = case.get("dtype", defaults.get("dtype", "fp32"))
+    dtype = DTYPE_MAP[dtype_str]
+    seed = case.get("seed", defaults.get("seed", None))
+
+    rtol = float(case.get("rtol", defaults.get("rtol", 1e-3)))
+    atol = float(case.get("atol", defaults.get("atol", 1e-3)))
+    attrs = dict(case.get("attrs", {}))
+
+    ctx = {
+        "cfg": cfg,
+        "op_name": op_name,
+        "dtype_str": dtype_str,
+        "env": dict(os.environ),
+        "torch": torch,
+    }
+    _maybe_skip_or_xfail(case, defaults, ctx)
+
+    # Build CPU args ONCE, then copy to Spyre (identical values)
+    cpu_args = []
+    for i, inp in enumerate(case.get("inputs", [])):
+        # derive per-input seed so tensors differ deterministically
+        inp_seed = None if seed is None else int(seed) + i * 1000
+
+        if "tensor" in inp:
+            cpu_args.append(
+                make_tensor_from_conf(inp["tensor"], dtype=dtype, seed=inp_seed)
+            )
+        elif "tensor_list" in inp:
+            lst = [
+                make_tensor_from_conf(
+                    t,
+                    dtype=dtype,
+                    seed=(None if seed is None else int(seed) + i * 1000 + j),
+                )
+                for j, t in enumerate(inp["tensor_list"])
+            ]
+            cpu_args.append(lst)
+        elif "value" in inp:
+            cpu_args.append(inp["value"])  # python scalar or list, etc.
+        else:
+            raise ValueError(f"Unknown input entry: {inp}")
+
+    test_args = []
+    for a in cpu_args:
+        # also move tensors inside lists (cat)
+        if isinstance(a, list):
+            test_args.append([to_device(x, cfg.test_device) for x in a])
+        else:
+            test_args.append(to_device(a, cfg.test_device))
+
+    if adapter.pre:
+        cpu_args, attrs = adapter.pre(cpu_args, attrs)
+        test_args, _ = adapter.pre(test_args, attrs)
+
+    # expects_error: both must raise
+    expects_error = case.get("expects_error", None)
+    if expects_error:
+        if "ref" in expects_error or "spyre" in expects_error:
+            ref_spec = expects_error.get("ref", {})
+            test_spec = expects_error.get("spyre", {})
+        else:
+            ref_spec = test_spec = expects_error
+
+        ref_raised, ref_exc, _ = _run_and_capture(adapter.fn, cpu_args, attrs)
+        test_raised, test_exc, _ = _run_and_capture(adapter.fn, test_args, attrs)
+        _assert_raised("CPU", ref_raised, ref_exc, ref_spec)
+        _assert_raised("Spyre", test_raised, test_exc, test_spec)
+        return
+
+    # Run
+    with torch.no_grad():
+        ref_out = adapter.fn(*cpu_args, **attrs)
+        test_out = _maybe_compile_call(
+            adapter.fn, test_args, attrs, cfg.test_device, cfg.compile_backend
+        )
+
+        if adapter.is_inplace:
+            # compare mutated arg0
+            ref_out = cpu_args[0]
+            test_out = test_args[0]
+
+    ref_out_cpu = to_device(ref_out, torch.device("cpu"))
+    test_out_cpu = to_device(test_out, torch.device("cpu"))
+    _assert_same(ref_out_cpu, test_out_cpu, rtol=rtol, atol=atol, case_name=case_name)

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -272,7 +272,6 @@ def _assert_same(
                 f"{case_name} FAILED since output is not close to an expected result\n"
                 f"{e}\n"
                 f"shape={tuple(ref_out.shape)} dtype={ref_out.dtype}\n"
-                f"max_abs_diff={diff.max().item()}\n"
             ) from e
         return
 
@@ -379,7 +378,7 @@ def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> 
 
     case_name = case.get("name", op_name)
 
-    dtype_str = case.get("dtype", defaults.get("dtype", "fp32"))
+    dtype_str = case.get("dtype", defaults.get("dtype", "fp16"))
     dtype = parse_dtype(dtype_str)
     dtype_str = str(dtype)
     seed = case.get("seed", defaults.get("seed", None))

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -489,7 +489,6 @@ def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> 
             test_out = test_args[0]
 
     ref_out_cpu = to_device(ref_out, torch.device("cpu"))
-    print(test_out)
     assert confirm_device(test_out, "spyre"), "this result must be on spyre"
     test_out_cpu = to_device(test_out, torch.device("cpu"))
     _assert_same(ref_out_cpu, test_out_cpu, rtol=rtol, atol=atol, case_name=case_name)

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -390,8 +390,8 @@ def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> 
     dtype_str = str(dtype)
     seed = case.get("seed", defaults.get("seed", None))
 
-    rtol = float(case.get("rtol", defaults.get("rtol", 1e-3)))
-    atol = float(case.get("atol", defaults.get("atol", 1e-3)))
+    rtol = float(case.get("rtol", defaults.get("rtol", 5e-3)))
+    atol = float(case.get("atol", defaults.get("atol", 5e-3)))
     attrs = dict(case.get("attrs", {}))
 
     ctx = {

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -437,11 +437,14 @@ def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> 
             raise ValueError(f"Unknown input entry: {inp}")
 
     for key, value in case.get("kwmap", {}).items():
-        if isinstance(value, str):
-            try:
-                value = ast.literal_eval(value)
-            except (ValueError, SyntaxError):
-                pass
+        if key == "dtype":
+            value = parse_dtype(value)
+        else:
+            if isinstance(value, str):
+                try:
+                    value = ast.literal_eval(value)
+                except (ValueError, SyntaxError):
+                    pass
         attrs[key] = value
 
     test_args = []

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -185,8 +185,8 @@ def make_tensor_from_conf(
                     shape
                 )
             elif init == "randint":
-                low = float(init_args.get("low", 0))
-                high = float(init_args.get("high", -1))
+                low = int(init_args.get("low", 0))
+                high = int(init_args.get("high", -1))
                 if high < 0:
                     raise ValueError(
                         "Invalid value (high for randint): must be provided (via init_args) and must be positive"
@@ -382,7 +382,10 @@ def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> 
             ]
             cpu_args.append(lst)
         elif "value" in inp:
-            cpu_args.append(inp["value"])  # python scalar or list, etc.
+            val = inp["value"]
+            if isinstance(val, str):
+                val = eval(val)
+            cpu_args.append(val)  # python scalar or list, etc.
         elif "py" in inp:
             cpu_args.append(parse_py_value(inp["py"]))
         else:

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -391,6 +391,14 @@ def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> 
         else:
             raise ValueError(f"Unknown input entry: {inp}")
 
+    for key, value in case.get("kwmap", {}).items():
+        if isinstance(value, str):
+            try:
+                value = ast.literal_eval(value)
+            except (ValueError, SyntaxError):
+                pass
+        attrs[key] = value
+
     test_args = []
     for a in cpu_args:
         # also move tensors inside lists (cat)

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -333,7 +333,7 @@ def _maybe_compile_call(
     if compile_backend is None or device.type == "cpu":
         return fn(*args, **attrs)
     mod = _OpModule(fn).to(device)
-    torch._dynamo.reset_code_caches() # kernel caching workaround
+    torch._dynamo.reset_code_caches()  # kernel caching workaround
     compiled = torch.compile(mod, backend=compile_backend)
     return compiled(*args, **attrs)
 

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -269,9 +269,9 @@ def _assert_same(
         except AssertionError as e:
             diff = (ref_out - test_out).abs()
             raise AssertionError(
-                f"{case_name} FAILED\n"
+                f"{case_name} FAILED since output is not close to an expected result\n"
+                f"{e}\n"
                 f"shape={tuple(ref_out.shape)} dtype={ref_out.dtype}\n"
-                f"atol={atol} rtol={rtol}\n"
                 f"max_abs_diff={diff.max().item()}\n"
             ) from e
         return

--- a/tests/_inductor/test_model_ops.py
+++ b/tests/_inductor/test_model_ops.py
@@ -1,0 +1,64 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+import pytest
+import torch
+
+from model_cases_loader import case_key, load_all_cases, to_pytest_params
+from runner import RunConfig, run_case
+
+
+def _collect_params(pytest_root: Path):
+    items = load_all_cases(pytest_root)
+    return to_pytest_params(items)
+
+
+# NOTE: this runs at collection time; use pytestconfig.rootpath so paths are stable
+def pytest_generate_tests(metafunc):
+    if "model" in metafunc.fixturenames and "case" in metafunc.fixturenames:
+        root = metafunc.config.rootpath
+        params = _collect_params(root)
+        metafunc.parametrize("model,case,defaults,source_path", params)
+
+
+def test_model_ops(
+    model,
+    case,
+    defaults,
+    source_path,
+    selected_models,
+    dedupe_enabled,
+    seen_case_keys,
+    test_device_str,
+    compile_backend,
+):
+    # 1) Model filtering (keeps your “only ops from granite3-speech” capability)
+    if selected_models and model not in selected_models:
+        pytest.skip(f"Filtered out by --model (selected={sorted(selected_models)})")
+
+    # 2) Optional cross-model dedupe (do NOT dedupe at collection time!)
+    if dedupe_enabled:
+        k = case_key(case, defaults)
+        if k in seen_case_keys:
+            pytest.skip(
+                "duplicate signature already tested (enable/disable via --no-dedupe)"
+            )
+        seen_case_keys.add(k)
+
+    cfg = RunConfig(
+        test_device=torch.device(test_device_str),
+        compile_backend=compile_backend,
+    )
+    run_case(case, defaults, cfg)

--- a/tests/_inductor/test_model_ops.py
+++ b/tests/_inductor/test_model_ops.py
@@ -27,11 +27,9 @@ from torch.testing._internal.opinfo.core import (
     OpInfo,
 )
 from torch.testing._internal.common_device_type import (
+    PrivateUse1TestBase,
     ops,
     instantiate_device_type_tests,
-)
-from torch.testing._internal.common_utils import (
-    TestCase,
 )
 from op_registry import OP_REGISTRY, OpAdapter
 
@@ -107,7 +105,7 @@ def _init_model_ops_db():
 _init_model_ops_db()
 
 
-class TestCommon(TestCase):
+class TestSpyre(PrivateUse1TestBase):
     @ops(model_ops_db)
     def test_model_ops_db(
         self,
@@ -173,6 +171,6 @@ class TestCommon(TestCase):
             torch._dynamo.reset()
 
 
-# Instantiate device type tests for the TestCommon class
+# Instantiate device type tests for the TestSpyre class
 # This is required for @ops decorator to work properly
-instantiate_device_type_tests(TestCommon, globals())
+instantiate_device_type_tests(TestSpyre, globals())

--- a/tests/_inductor/test_model_ops.py
+++ b/tests/_inductor/test_model_ops.py
@@ -61,4 +61,7 @@ def test_model_ops(
         test_device=torch.device(test_device_str),
         compile_backend=compile_backend,
     )
-    run_case(case, defaults, cfg)
+    try:
+        run_case(case, defaults, cfg)
+    finally:
+        torch._dynamo.reset()

--- a/tests/_inductor/test_model_ops.py
+++ b/tests/_inductor/test_model_ops.py
@@ -11,57 +11,168 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pathlib import Path
+import os
+import sys
 
 import pytest
 import torch
 
-from model_cases_loader import case_key, load_all_cases, to_pytest_params
+from model_cases_loader import LoadedCase, case_key, load_all_cases
 from runner import RunConfig, run_case
+import shared_config
+
+from typing import Any, Dict, List
+
+from torch.testing._internal.opinfo.core import (
+    OpInfo,
+)
+from torch.testing._internal.common_device_type import (
+    ops,
+    instantiate_device_type_tests,
+)
+from torch.testing._internal.common_utils import (
+    TestCase,
+)
+from op_registry import OP_REGISTRY, OpAdapter
 
 
-def _collect_params(pytest_root: Path):
-    items = load_all_cases(pytest_root)
-    return to_pytest_params(items)
+class ModelOpInfo(OpInfo):
+    """operator information for model-centric verification."""
+
+    def __init__(
+        self,
+        name,
+        *,
+        dtypes,
+        sample_inputs_func=None,
+        reference_inputs_func=None,
+        model="",
+        defaults: Dict[str, Any] = {},
+        loadedCase: LoadedCase,
+        adapter: OpAdapter,
+        description: str = "",
+        # Options from the OpInfo base class
+        **kwargs,
+    ):
+        super().__init__(
+            name,
+            dtypes=dtypes,
+            sample_inputs_func=sample_inputs_func,
+            reference_inputs_func=reference_inputs_func,
+            op=adapter.fn,
+            **kwargs,
+        )
+        self.loadedCase = loadedCase
+        self.adapter = adapter
+        self.defaults = defaults
+        self.description = description
 
 
-# NOTE: this runs at collection time; use pytestconfig.rootpath so paths are stable
-def pytest_generate_tests(metafunc):
-    if "model" in metafunc.fixturenames and "case" in metafunc.fixturenames:
-        root = metafunc.config.rootpath
-        params = _collect_params(root)
-        metafunc.parametrize("model,case,defaults,source_path", params)
+model_ops_db: list[ModelOpInfo] = []
 
 
-def test_model_ops(
-    model,
-    case,
-    defaults,
-    source_path,
-    selected_models,
-    dedupe_enabled,
-    seen_case_keys,
-    test_device_str,
-    compile_backend,
-):
-    # 1) Model filtering (keeps your “only ops from granite3-speech” capability)
-    if selected_models and model not in selected_models:
-        pytest.skip(f"Filtered out by --model (selected={sorted(selected_models)})")
-
-    # 2) Optional cross-model dedupe (do NOT dedupe at collection time!)
-    if dedupe_enabled:
-        k = case_key(case, defaults)
-        if k in seen_case_keys:
-            pytest.skip(
-                "duplicate signature already tested (enable/disable via --no-dedupe)"
+def add_model_ops_db(loadedCases: List[LoadedCase]):
+    seen_test_names = set()
+    for loadedCase in loadedCases:
+        test_name = loadedCase.case["name"]
+        op_name = loadedCase.case["op"]
+        adapter = OP_REGISTRY[op_name]
+        basename = os.path.basename(loadedCase.source_path)
+        test_name = f"{test_name}__{basename}_"
+        assert test_name not in seen_test_names
+        seen_test_names.add(test_name)
+        model_ops_db.append(
+            ModelOpInfo(
+                test_name,
+                # variant_test_name="",
+                dtypes=(torch.float16,),
+                loadedCase=loadedCase,
+                adapter=adapter,
             )
-        seen_case_keys.add(k)
+        )
 
-    cfg = RunConfig(
-        test_device=torch.device(test_device_str),
-        compile_backend=compile_backend,
-    )
-    try:
-        run_case(case, defaults, cfg)
-    finally:
-        torch._dynamo.reset()
+
+def _init_model_ops_db():
+    """Initialize model_ops_db at module import time."""
+    global model_ops_db
+    if len(model_ops_db) > 0:
+        return
+
+    if "pytest" in sys.modules:
+        root = shared_config._PYTEST_CONFIG.rootpath
+        loadedCases = load_all_cases(root)
+        add_model_ops_db(loadedCases)
+
+
+_init_model_ops_db()
+
+
+class TestCommon(TestCase):
+    @ops(model_ops_db)
+    def test_model_ops_db(
+        self,
+        device,
+        dtype,
+        op,
+    ):
+        pytestconfig = shared_config._PYTEST_CONFIG
+        selected_models = set(pytestconfig.getoption("--model") or [])
+        dedupe_enabled = bool(pytestconfig.getoption("dedupe", True))
+        compile_backend = str(
+            pytestconfig.getoption("--compile-backend") or "inductor"
+        ).strip()
+        test_device_str = "spyre"
+        seen_case_keys = set()
+
+        loadedCase: LoadedCase = op.loadedCase
+        model = loadedCase.model
+        case: Any = loadedCase.case
+        defaults = loadedCase.defaults
+
+        # 1) Model filtering (keeps your "only ops from granite3-speech" capability)
+        if selected_models and model not in selected_models:
+            pytest.skip(f"Filtered out by --model (selected={sorted(selected_models)})")
+
+        # 2) Check pytest -m marker expression
+        mark_expr = pytestconfig.option.markexpr
+        if mark_expr:
+            from _pytest.mark.expression import Expression
+
+            compiled_expr = Expression.compile(mark_expr)
+
+            # Get marks from YAML case
+            case_marks = set()
+            marks = case.get("marks")
+            if isinstance(marks, str) and marks.strip():
+                case_marks.add(marks.strip())
+            elif isinstance(marks, (list, tuple)):
+                for m in marks:
+                    if isinstance(m, str) and m.strip():
+                        case_marks.add(m.strip())
+
+            # Evaluate if this test should run based on marks
+            if not compiled_expr.evaluate(lambda m: m in case_marks):
+                pytest.skip(f"Skipped by marker expression: {mark_expr}")
+
+        # 3) Optional cross-model dedupe (do NOT dedupe at collection time!)
+        if dedupe_enabled:
+            k = case_key(case, defaults)
+            if k in seen_case_keys:
+                pytest.skip(
+                    "duplicate signature already tested (enable/disable via --no-dedupe)"
+                )
+            seen_case_keys.add(k)
+
+        cfg = RunConfig(
+            test_device=torch.device(test_device_str),
+            compile_backend=compile_backend,
+        )
+        try:
+            run_case(case, defaults, cfg)
+        finally:
+            torch._dynamo.reset()
+
+
+# Instantiate device type tests for the TestCommon class
+# This is required for @ops decorator to work properly
+instantiate_device_type_tests(TestCommon, globals(), only_for="privateuse1")

--- a/tests/_inductor/test_model_ops.py
+++ b/tests/_inductor/test_model_ops.py
@@ -175,4 +175,4 @@ class TestCommon(TestCase):
 
 # Instantiate device type tests for the TestCommon class
 # This is required for @ops decorator to work properly
-instantiate_device_type_tests(TestCommon, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestCommon, globals())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ import yaml
 import pytest
 
 
+import shared_config
+
+
 def _get_case_marks(case: dict) -> set[str]:
     """
     Support either:
@@ -265,6 +268,7 @@ def compile_backend(pytestconfig):
 
 
 def pytest_configure(config):
+    shared_config._PYTEST_CONFIG = config
     # auto-register model_<name> markers based on YAML files
     mdir = config.rootpath / "tests" / "_inductor" / "models"
     for p in mdir.glob("*.yaml"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,12 @@ def pytest_addoption(parser):
         default=False,
         help="With --list-cases-by-mark, list cases excluded by the mark expression (i.e., NOT matching).",
     )
+    group.addoption(
+        "--show-skipped",
+        action="store_true",
+        default=False,
+        help="List cases skipped by model filtering or duplications",
+    )
 
 
 def _models_dir(rootpath: Path) -> Path:
@@ -287,3 +293,15 @@ def pytest_collection_modifyitems(config, items):
     if deselect:
         config.hook.pytest_deselected(items=deselect)
         items[:] = keep
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if not config.getoption("--show-skipped"):
+        return
+    skipped = terminalreporter.stats.get("skipped", [])
+    if not skipped:
+        return
+
+    terminalreporter.section("Skipped tests (full list)")
+    for rep in skipped:
+        #terminalreporter.write_line(rep)
+        terminalreporter.write_line(rep.nodeid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,6 +298,7 @@ def pytest_collection_modifyitems(config, items):
         config.hook.pytest_deselected(items=deselect)
         items[:] = keep
 
+
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if not config.getoption("--show-skipped"):
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import yaml
 import pytest
 
+
 def _get_case_marks(case: dict) -> set[str]:
     """
     Support either:
@@ -65,45 +66,44 @@ def pytest_sessionstart(session):
 
     opt = cfg.getoption("--list-cases-by-mark")
     if opt is not None:
-       if opt == "__USE_PYTEST_M__":
-           # This is the *effective* -m expression after addopts + CLI parsing.
-           expr = (cfg.option.markexpr or "").strip()
-           # If no -m anywhere, treat as "select all"
-           if not expr:
-               expr = "True"
-       else:
-           expr = opt.strip()
-       from _pytest.mark.expression import Expression
-       compiled = Expression.compile(expr)
+        if opt == "__USE_PYTEST_M__":
+            # This is the *effective* -m expression after addopts + CLI parsing.
+            expr = (cfg.option.markexpr or "").strip()
+            # If no -m anywhere, treat as "select all"
+            if not expr:
+                expr = "True"
+        else:
+            expr = opt.strip()
+        from _pytest.mark.expression import Expression
 
-       show_excluded = cfg.getoption("--show-excluded")
-       chosen = []
-       excluded = []
+        compiled = Expression.compile(expr)
 
-       def case_selected(case: dict) -> bool:
-           marks = _get_case_marks(case)  # set[str]
-           return compiled.evaluate(lambda m: m in marks)
-       for model, name, op, p, case in _iter_yaml_cases(root):
-           if selected and model not in selected:
-               continue
+        show_excluded = cfg.getoption("--show-excluded")
+        chosen = []
+        excluded = []
 
-           marks = _get_case_marks(case)
+        def case_selected(case: dict) -> bool:
+            marks = _get_case_marks(case)  # set[str]
+            return compiled.evaluate(lambda m: m in marks)
 
-           rec = f"{model}::{name}::{op}  ({p})"
-           if case_selected(case):
-               chosen.append(rec)
-           else:
-               excluded.append(rec)
+        for model, name, op, p, case in _iter_yaml_cases(root):
+            if selected and model not in selected:
+                continue
 
-       if show_excluded:
-           for r in excluded:
+            rec = f"{model}::{name}::{op}  ({p})"
+            if case_selected(case):
+                chosen.append(rec)
+            else:
+                excluded.append(rec)
+
+        if show_excluded:
+            for r in excluded:
                 print(r)
-           pytest.exit(f"listed excluded cases by mark (NOT {expr})", returncode=0)
-       else:
-           for r in chosen:
+            pytest.exit(f"listed excluded cases by mark (NOT {expr})", returncode=0)
+        else:
+            for r in chosen:
                 print(r)
-           pytest.exit(f"listed selected cases by mark ({expr})", returncode=0)
-
+            pytest.exit(f"listed selected cases by mark ({expr})", returncode=0)
 
 
 def pytest_addoption(parser):
@@ -171,6 +171,7 @@ def pytest_addoption(parser):
 def _models_dir(rootpath: Path) -> Path:
     return rootpath / "tests" / "_inductor" / "models"
 
+
 def load_yaml_or_fail(path: Path) -> dict:
     text = path.read_text()
     try:
@@ -196,9 +197,9 @@ def load_yaml_or_fail(path: Path) -> dict:
             msg.append("Context:")
             for i in range(start, end):
                 prefix = ">>" if i == mark.line else "  "
-                msg.append(f"{prefix} {i+1:4d}: {lines[i]}")
+                msg.append(f"{prefix} {i + 1:4d}: {lines[i]}")
                 if i == mark.line:
-                    msg.append(f"     {' ' * (col-1)}^")
+                    msg.append(f"     {' ' * (col - 1)}^")
 
         # Include the underlying YAML error message too
         msg.append(f"YAML error: {e}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,10 @@ def pytest_sessionstart(session):
     Called after the Session object has been created and
     before performing collection and entering the run test loop.
     """
+
+    # avoid circular imports when using xdist
+    import torch  # noqa: F401
+
     os.environ.setdefault("DTLOG_LEVEL", "error")
     os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,5 +307,5 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
     terminalreporter.section("Skipped tests (full list)")
     for rep in skipped:
-        #terminalreporter.write_line(rep)
+        # terminalreporter.write_line(rep)
         terminalreporter.write_line(rep.nodeid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,12 @@ def pytest_addoption(parser):
         default=False,
         help="List cases skipped by model filtering or duplications",
     )
+    parser.addoption(
+        "--test-names",
+        action="append",
+        default=[],
+        help="Run only tests matching these test names",
+    )
 
 
 def _models_dir(rootpath: Path) -> Path:

--- a/tests/shared_config.py
+++ b/tests/shared_config.py
@@ -1,0 +1,1 @@
+_PYTEST_CONFIG = None


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

This PR introduces a model-centric functional verification framework, built on pytest, to validate the correctness of individual Torch operators exercised by target models. The goal is to provide a more meaningful readiness signal for Spyre card support than existing PyTorch operator tests.

The operators under test, along with input arguments info (e.g. tensor shapes, and types), possibly with actual input values are extracted during model execution using an internal operator-extraction framework (out of scope for this PR). Additional design details and motivation are described in the [RFC document](https://github.com/torch-spyre/torch-spyre/blob/9631b9d130f5d1895f04d858db8eb5fc8cdb6ddf/RFCs/0186-TestFrameworks/0186-TestFrameworks.md)

* supported arguments: pass to pytest
```
--model <model-name>
--dedupe
--no-dedupe
--list-models
--list-cases
--compile-backend “inductor”
```

* structure of YAML file: to be added correspondingly

The test cases will be defined as part of YAML files under `tests/_inductor/models`. Currently, we have two files:
* `gpt_oss.yaml` _ which holds two test cases extracted from the GPT-oss model.
* `template.yaml` _ which holds examples that can be used in a YAML file. This file is not part of the test cases.

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

This work builds on discussions with @kiszk and @umacdevi to analyze the core requirements for addressing the issue raised in #186.  This PR introduces a YAML-based test framework that will serve as the foundation for a series of PRs adding extracted operations later. The new approach replaces PR #241, which is based on running hundreds of generated Python files. The existing method resulted in significant code duplication and an unmanageable volume of added code, making review impractical. 


<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

Using this framework, we have been able to quickly identify bugs that have not been detected by existing tests. 
https://github.com/torch-spyre/torch-spyre/issues?q=state%3Aopen%20label%3A%22op%20coverage%20(models)%22

#### Does this PR introduce a user-facing change?

Yes, for running certain tests related to ops from models, we can make use of the new arguments to pytest shared above.

#### Additional note:


