### PR TITLE
Replace KernelSummary with KernelSpec

### DIFF
--- a/torch_spyre/_inductor/runtime/__init__.py
+++ b/torch_spyre/_inductor/runtime/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import dataclasses
-from typing import Union
+from typing import Any, Sequence, Union
 import torch
 from torch_spyre._C import SpyreTensorLayout
 
@@ -38,9 +38,9 @@ class KernelSpec:
     op: str
     is_reduction: bool
     dimensions: list[int]
-    args: list[TensorArg | ConstantArg]
+    args: Sequence[TensorArg | ConstantArg]
     scales: list[list[int]]
-    op_info: dict[list, str]
+    op_info: dict[str, Any]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ x ] cleanup

#### What this PR does:

Cleanup suggested in review of https://github.com/torch-spyre/torch-spyre/pull/321 -- use KernelSpec directly instead of introducing the virtually identical KernelSummary class in the compiler.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
============================================================ test session starts ============================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 196 items                                                                                                                         

tests/_inductor/test_building_blocks.py .s.s..                                                                                        [  3%]
tests/_inductor/test_inductor_ops.py ..s............................................................................................. [ 52%]
....                                                                                                                                  [ 54%]
tests/tensor/test_tensor_layout.py ........                                                                                           [ 58%]
tests/test_fallbacks.py ........                                                                                                      [ 62%]
tests/test_modules.py ssssss.                                                                                                         [ 65%]
tests/test_ops.py ..sssss...................sss..ssss.s........s.ss                                                                   [ 90%]
tests/test_spyre.py .s...s...........                                                                                                 [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                     [100%]

============================================================= warnings summary ==============================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== 169 passed, 27 skipped, 2 warnings in 81.26s (0:01:21) ===========================================
```
#### Does this PR introduce a user-facing change?
No.
#### Additional note:
