### PR TITLE
Test torch.pow

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -190,6 +190,20 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ]
             ),
         },
+        (
+            "test_alias_operands_cpu",
+            "test_unary_op_cpu",
+        ): {
+            "ops_dict": {
+                "pow": lambda x: torch.pow(x, 2),
+            },
+            "param_sets": make_param_dict(
+                [
+                    ((256,),),
+                    ((67, 256),),
+                ]
+            ),
+        },
         # Compare with cpu for now to avoid hitting eager mode coverage issue
         ("test_max_keepdim0", "test_reduce_keepdim0_cpu"): {
             "ops_dict": {
@@ -449,6 +463,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             compare_with_cpu(op, x)
         else:
             compare(op, x)
+
+    def test_unary_op_cpu(self, op, x):
+        compare_with_cpu(op, x)
 
     def test_binary_op(self, op, a, b):
         if op == torch.div:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Tests [`torch.pow`](https://docs.pytorch.org/docs/stable/generated/torch.pow.html).

#### Which issue(s) this PR is related to:

Fixes #145. 

#### Special notes for your reviewer:
The warning messages are under investigation as #301.
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/inagaki/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 198 items

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                              [  3%]
tests/_inductor/test_inductor_ops.py ..s...................................................................................................                                                                 [ 54%]
tests/tensor/test_tensor_layout.py ........                                                                                                                                                                 [ 58%]
tests/test_fallbacks.py ........                                                                                                                                                                            [ 62%]
tests/test_modules.py ssssss.                                                                                                                                                                               [ 66%]
tests/test_ops.py ..sssss...................sss..ssss.s........s.ss                                                                                                                                         [ 90%]
tests/test_spyre.py .s...s...........                                                                                                                                                                       [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                           [100%]

================================================================================================ warnings summary =================================================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/inagaki/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:746: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/inagaki/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:746: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 171 passed, 27 skipped, 2 warnings in 73.09s (0:01:13) ==============================================================================
```

#### Does this PR introduce a user-facing change?

No

#### Additional note:

None