### PR TITLE
[WIP] Implement torch.nn.functional.batch_norm

### DIFF
--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -194,3 +194,21 @@ def _(
     dtype: Optional[torch.dtype] = None,
 ):
     return torch.empty(size, dtype=dtype, device="spyre")
+
+
+@torch.library.custom_op("spyre::batchnormfwd", mutates_args=(), device_types="spyre")
+def batchnormfwd(
+    input: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> torch.Tensor:
+    pass
+
+
+@batchnormfwd.register_fake
+def _(
+    input: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+):
+    return input.new_empty(input.size())

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -153,3 +153,54 @@ def lt_decomp(
     out_le = torch.le(input, other).to(dtype=torch.float16)
     out_ne = torch.ne(input, other).to(dtype=torch.float16)
     return torch.mul(out_le, out_ne, out=out).to(dtype=torch.bool)
+
+
+@register_decomposition([torch.ops.aten._native_batch_norm_legit_no_training.default])
+def _native_batch_norm_legit_no_training(
+    input: torch.Tensor,
+    weight: Optional[torch.Tensor],
+    bias: Optional[torch.Tensor],
+    running_mean: torch.Tensor,
+    running_var: torch.Tensor,
+    momentum: float,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    scale = weight
+    offset = bias
+    mean = running_mean
+    var = running_var
+    epsilon = eps
+
+    e = torch.full(
+        var.size(),
+        epsilon,
+        dtype=var.dtype,
+        device=var.device,
+    )
+    v = torch.add(var, e)
+    s = torch.sqrt(v)
+    factor = torch.reciprocal(s)
+    a = torch.mul(scale, factor)
+    x = torch.mul(scale, mean)
+    y = torch.mul(x, factor)
+    b = torch.sub(offset, y)
+
+    # Example inputs here
+    #   input: size: (1, 2048, 844)
+    #   a: size: (2048)
+    #   b: size: (2048)
+    #
+    # Shapes of a and b should be update as follows.
+    #
+    # a = a.unsqueeze(-1)
+    # b = b.unsqueeze(-1)
+    #
+    #   a: size: (2048, 1), strides: (1, 1)
+    #   b: size (2048, 1), strides: (1, 1)
+    #
+    # Can we achieve this via custom lowering and/or superDSC?
+
+    # a and b need to be broadcasted to the shape of input
+    output = torch.ops.spyre.batchnormfwd(input, a, b)
+
+    return (output, mean, factor)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -287,3 +287,34 @@ def lower_clamp(x, min=None, max=None):
     )
     pw.realize()
     return pw
+
+
+lowering.register_op_dtype_propagation_rules(
+    "batchnormfwd", lowering.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT, None
+)
+
+
+@lowering.register_lowering(torch.ops.spyre.batchnormfwd)
+def lower_batchnormfwd(input, a, b):
+    fn = lowering.ops_wrapper(torch.ops.spyre.batchnormfwd.__name__)
+
+    size = a.get_size()
+    assert b.get_size() == size
+
+    def inner_fn(index):
+        return fn(
+            input.make_loader()(index),
+            a.make_loader()(index[1 : 1 + len(size)]),
+            b.make_loader()(index[1 : 1 + len(size)]),
+        )
+
+    pw = Pointwise.create(
+        device=input.get_device(),
+        dtype=input.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=input.get_size(),
+        origin_node=input.get_origin_node(),
+        traceback=input.get_traceback(),
+    )
+    pw.realize()
+    return pw

--- a/torch_spyre/_inductor/preload.py
+++ b/torch_spyre/_inductor/preload.py
@@ -39,6 +39,9 @@ decomps_to_exclude = [
     # The default decomposition for torch.full (defined in pytorch/torch/refs/__init__.py)
     # is duplicated with the decomposition in torch_spyre/_inductor/decompositions.py.
     torch.ops.aten.full,
+    # We use a custom decomposition that relies on a Spyre-specific custom op for
+    # batch_norm, instead of the default decomposition.
+    torch.ops.aten._native_batch_norm_legit_no_training.default,
 ]
 
 # Remove the selected decompositions from Inductor's registry for Spyre.

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -102,6 +102,10 @@ class SpyreOpFuncs:
         return PointwiseOp("add", [a, b])
 
     @staticmethod
+    def batchnormfwd(input, a, b):
+        return PointwiseOp("batchnormfwd", [input, a, b])
+
+    @staticmethod
     def clamp(x, min, max):
         op_info = {
             "constants": {


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR implements [torch.nn.functional.batch_norm](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.batch_norm.html) on Spyre.

Fixes #149  

#### Which issue(s) this PR is related to:

- https://github.com/torch-spyre/torch-spyre/issues/149

#### Special notes for your reviewer:

PyTorch’s default decomposition for batch_norm is defined here.

https://github.com/pytorch/pytorch/blob/v2.9.1/torch/_decomp/decompositions.py#L1863-L1889

When compiled, it translates into the following FX graph:

```
    def forward(self, arg0_1: "f16[1, 2048, 896]", arg1_1: "f16[2048]", arg2_1: "f16[2048]", arg3_1: "f16[2048]", arg4_1: "f16[2048]"):
         # File: /home/yohei/test/batch_norm/inductor/batch_norm.py:7 in test, code: return torch.nn.functional.batch_norm(
        add: "f16[2048]" = torch.ops.aten.add.Tensor(arg2_1, 1e-05);  arg2_1 = None
        sqrt: "f16[2048]" = torch.ops.aten.sqrt.default(add);  add = None
        reciprocal: "f16[2048]" = torch.ops.aten.reciprocal.default(sqrt);  sqrt = None
        mul: "f16[2048]" = torch.ops.aten.mul.Tensor(reciprocal, 1);  reciprocal = None
        unsqueeze: "f16[2048, 1]" = torch.ops.aten.unsqueeze.default(arg1_1, -1);  arg1_1 = None
        unsqueeze_1: "f16[2048, 1]" = torch.ops.aten.unsqueeze.default(mul, -1);  mul = None
        sub: "f16[1, 2048, 896]" = torch.ops.aten.sub.Tensor(arg0_1, unsqueeze);  arg0_1 = unsqueeze = None
        mul_1: "f16[1, 2048, 896]" = torch.ops.aten.mul.Tensor(sub, unsqueeze_1);  sub = unsqueeze_1 = None
        unsqueeze_2: "f16[2048, 1]" = torch.ops.aten.unsqueeze.default(arg3_1, -1);  arg3_1 = None
        mul_2: "f16[1, 2048, 896]" = torch.ops.aten.mul.Tensor(mul_1, unsqueeze_2);  mul_1 = unsqueeze_2 = None
        unsqueeze_3: "f16[2048, 1]" = torch.ops.aten.unsqueeze.default(arg4_1, -1);  arg4_1 = None
        add_1: "f16[1, 2048, 896]" = torch.ops.aten.add.Tensor(mul_2, unsqueeze_3);  mul_2 = unsqueeze_3 = None
        return (add_1,)
```

Notice that unsqueeze produces tensors with shape [2048, 1]. Supporting these tensors is non-trivial because the stick dimension contains only a single element.


#### Does this PR introduce a user-facing change?

#### Additional note:
