### PR TITLE
Fix errors related to constant arguments

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -230,7 +230,7 @@ class SpyreKernelOpsHandler(DefaultHandler):
         else:
             return UnimplementedOp(name)
 
-    def constant(value: Union[bool, float, int], dtype: torch.dtype) -> RValue:
+    def constant(self, value: Union[bool, float, int], dtype: torch.dtype) -> RValue:
         return Constant(value, dtype)
 
     def load(self, name: str, index: sympy.Expr) -> RValue:
@@ -379,8 +379,10 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
                     )
                     scales.append(scale)
                 elif isinstance(input, Constant):
-                    args.append(ConstantArg(input.value, input.dtype))
-                    scales.append([-1] * len(di))
+                    # TODO: Re-enable these lines once support for ConstantArg is implemented.
+                    # args.append(ConstantArg(input.value, input.dtype))
+                    # scales.append([-1] * len(di))
+                    pass
                 else:
                     raise Unsupported(f"unexpected argument {input} to {value.op}")
             scale = self.analyze_tensor_access(di, dst.index)


### PR DESCRIPTION
This patch resolves issues in constant argument handling and temporarily disables some lines for ongoing work to implement full ConstantArg support. These changes prevent errors in the current code until the feature is complete.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

While working on the batch_norm implementation, I encountered errors related to constant argument handling. It appears that some lines are part of ongoing work to support ConstantArg, but they are incompatible with the current temporary approach.

This PR disables those lines to avoid errors and also fixes a minor bug in a method argument.

#### Which issue(s) this PR is related to:

- #332 

#### Special notes for your reviewer:

I encountered the following error while working on #322.

```
Traceback (most recent call last):
  File "/home/yohei/test/batch_norm/batch_norm.py", line 29, in <module>
    output_spyre = compiled(
                   ^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_dynamo/eval_frame.py", line 845, in compile_wrapper
    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_dynamo/output_graph.py", line 2196, in _call_user_compiler
    raise BackendCompilerFailed(
  File "/home/yohei/dt-inductor/pytorch/torch/_dynamo/output_graph.py", line 2171, in _call_user_compiler
    compiled_fn = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_dynamo/repro/after_dynamo.py", line 156, in __call__
    compiled_gm = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/__init__.py", line 2392, in __call__
    return compile_fx(model_, inputs_, config_patches=self.config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/compile_fx.py", line 2681, in compile_fx
    return aot_autograd(
           ^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/patches.py", line 50, in __call__
    return super().__call__(gm, example_inputs, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_dynamo/backends/common.py", line 117, in __call__
    cg = aot_module_simplified(gm, example_inputs, **self.kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_functorch/aot_autograd.py", line 1106, in aot_module_simplified
    compiled_fn, _ = aot_stage2_compile(aot_state, aot_graph_capture)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_functorch/_aot_autograd/graph_compile.py", line 242, in aot_stage2_compile
    return aot_stage2_inference(aot_state, aot_graph_capture)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_functorch/_aot_autograd/graph_compile.py", line 315, in aot_stage2_inference
    compiled_fw = compiler(fw_module, updated_flat_args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_functorch/_aot_autograd/schemas.py", line 1251, in __call__
    return self.compiler_fn(gm, example_inputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/compile_fx.py", line 2558, in fw_compiler_base
    return compile_fx_forward(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/compile_fx.py", line 2275, in compile_fx_forward
    return inner_compile(
           ^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/compile_fx.py", line 782, in compile_fx_inner
    return wrap_compiler_debug(_compile_fx_inner, compiler_name="inductor")(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_dynamo/repro/after_aot.py", line 144, in debug_wrapper
    inner_compiled_fn = compiler_fn(gm, example_inputs)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/compile_fx.py", line 963, in _compile_fx_inner
    mb_compiled_graph = fx_codegen_and_compile(
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/compile_fx.py", line 1695, in fx_codegen_and_compile
    return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/compile_fx.py", line 1505, in codegen_and_compile
    compiled_module = graph.compile_to_module()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/__init__.py", line 64, in <lambda>
    lambda graph: spyre_compile_to_module(graph, orig_compile_to_module)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/patches.py", line 58, in spyre_compile_to_module
    return original_compile_to_module(graph)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/graph.py", line 2319, in compile_to_module
    return self._compile_to_module()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/graph.py", line 2329, in _compile_to_module
    mod = self._compile_to_module_lines(wrapper_code)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/graph.py", line 2397, in _compile_to_module_lines
    mod = PyCodeCache.load_by_key_path(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/codecache.py", line 3548, in load_by_key_path
    mod = _reload_python_module(key, path, set_sys_modules=in_toplevel)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/pytorch/torch/_inductor/runtime/compile_tasks.py", line 33, in _reload_python_module
    exec(code, mod.__dict__, mod.__dict__)
  File "/tmp/torchinductor_yohei/tmpcak621zc/yv/cyvgzktobnbacihm3kkg4xfbkwnwzebadzqd4qhjm7uhnuzvqq32.py", line 49, in <module>
    sdsc_fused__native_batch_norm_legit_no_training_0 = async_compile.sdsc('sdsc_fused__native_batch_norm_legit_no_training_0',
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/runtime/async_compile.py", line 55, in sdsc
    raise RuntimeError("TOOO: implement SDSC generation for constants")
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
RuntimeError: TOOO: implement SDSC generation for constants
```

#### Does this PR introduce a user-facing change?

#### Additional note:


```
$ pytest tests
====================================================================== test session starts ======================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 198 items

tests/_inductor/test_building_blocks.py .s.s..                                                                                                            [  3%]
tests/_inductor/test_inductor_ops.py ..s...................................................................................................               [ 54%]
tests/tensor/test_tensor_layout.py ........                                                                                                               [ 58%]
tests/test_fallbacks.py ........                                                                                                                          [ 62%]
tests/test_modules.py ssssss.                                                                                                                             [ 66%]
tests/test_ops.py ..sssss...................sss..ssss.s........s.ss                                                                                       [ 90%]
tests/test_spyre.py .s...s...........                                                                                                                     [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                         [100%]

======================================================================= warnings summary ========================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/yohei/dt-inductor/pytorch/torch/_inductor/ops_handler.py:746: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/yohei/dt-inductor/pytorch/torch/_inductor/ops_handler.py:746: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 171 passed, 27 skipped, 2 warnings in 72.52s (0:01:12) =====================================================
```
