### PR TITLE
Fix launch for kernels with 6 arguments

### DIFF
--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -182,7 +182,14 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
   sen_outputs.push_back(tensor);
 
   // Execute device init
-  if (args.size() >= 3) {
+  if (args.size() == 6) {
+    // Filling in segment 5 adds another input to the device init supernode
+    status =
+        gl.Predict(sendnn::Outputs(), {sen_inputs[1], sen_outputs.front()}, 1);
+    if (!status.IsOk()) throw std::runtime_error(status.Message());
+    status = gl.Compute(sen_outputs, sen_inputs, 2);
+    if (!status.IsOk()) throw std::runtime_error(status.Message());
+  } else if (args.size() >= 3) {
     status = gl.Predict(sendnn::Outputs(), {sen_inputs[1]}, 1);
     if (!status.IsOk()) throw std::runtime_error(status.Message());
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Fixes kernel launch error when kernels have 6 arguments. 

#### Which issue(s) this PR is related to:

Fixes #54

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
```
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux -- Python 3.12.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/senuser/dt-inductor/torch-spyre
configfile: pyproject.toml
collected 198 items                                                                                                                                                                                                                                                                                                                                                      

torch-spyre/tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                                                                                                                                                                         [  3%]
torch-spyre/tests/_inductor/test_inductor_ops.py ..s...................................................................................................                                                                                                                                                                                                            [ 54%]
torch-spyre/tests/tensor/test_tensor_layout.py ........                                                                                                                                                                                                                                                                                                            [ 58%]
torch-spyre/tests/test_fallbacks.py ........                                                                                                                                                                                                                                                                                                                       [ 62%]
torch-spyre/tests/test_modules.py ssssss.                                                                                                                                                                                                                                                                                                                          [ 66%]
torch-spyre/tests/test_ops.py ..sssss...................sss..ssss.s.......ss.ss                                                                                                                                                                                                                                                                                    [ 90%]
torch-spyre/tests/test_spyre.py .s...s...........                                                                                                                                                                                                                                                                                                                  [ 99%]
torch-spyre/tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                                                                                                                      [100%]

============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/senuser/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/senuser/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================================================================== 170 passed, 28 skipped, 2 warnings in 59.68s ==============================================================================================================================================================
```