### PR TITLE
Fixes #280 Removes temporary deeptools ipPatch.txt file after run

### DIFF
--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "module.h"
+#include <filesystem>
+#include <iostream>
 
 #include <c10/core/ScalarType.h>
 #include <pybind11/native_enum.h>
@@ -151,6 +153,17 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
   status = gl.ParseGraph();
   if (!status.IsOk()) throw std::runtime_error(status.Message());
 
+  // Remove deeptools ipPatch.txt temporary file
+  try {
+        if (std::filesystem::remove("ipPatch.txt")) {
+            std::cout << "File deleted successfully\n";
+        } else {
+            std::cout << "File does not exist\n";
+        }
+    } catch (const std::filesystem::filesystem_error& e) {
+        std::cerr << "Error: " << e.what() << '\n';
+    }
+  
   // Create sendnn tensors
   std::vector<sendnn::ConstTensor> sen_inputs;
   std::vector<sendnn::Tensor> sen_outputs;

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -39,6 +39,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <filesystem>
+#include <iostream>
 
 #include "logging.h"
 #include "module.h"
@@ -375,6 +377,16 @@ auto create_dma_graph(const at::Tensor& self, const at::Tensor& dst,
     SEN_THROW_NOK(gl->CompileGraph());
     SEN_THROW_NOK(gl->ParseGraph());
   }
+  // Remove deeptools ipPatch.txt temporary file
+  try {
+        if (std::filesystem::remove("ipPatch.txt")) {
+            std::cout << "File deleted successfully\n";
+        } else {
+            std::cout << "File does not exist\n";
+        }
+    } catch (const std::filesystem::filesystem_error& e) {
+        std::cerr << "Error: " << e.what() << '\n';
+    }
   return gl;
 }
 auto copy_host_to_device(const at::Tensor& self, const at::Tensor& dst) {


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Removes the ipPatch.txt file after the deeptools method `CompileGraph` completed running. 

#### Which issue(s) this PR is related to:

Fixes #280 

#### Special notes for your reviewer:

This file is created at the deeptools code - the ipPatch.txt file path is hardcoded and saved at current work dir. To my mind, it would be best if we could have an environment variable that could be set to pass a custom path if we want to change this and keep the file somewhere else. In case, this is not a temporary file that can be removed after it was used.

Let me know!!

#### Does this PR introduce a user-facing change?

Yes, the user currently can see the file created at the current work dir.

#### Additional note:

If this solution is acceptable, we can have a reusable method to remove the temporary files (?)
