### PR TITLE
[FIX] matmul stickification to elide trivial dimensions

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -225,8 +225,6 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
     elif red.reduction_type == BATCH_MATMUL_OP:
         x_stl = args[0].layout.device_layout
         y_stl = args[1].layout.device_layout
-        print(f"x: {args[0].layout}")
-        print(f"y: {args[1].layout}")
         if x_stl.format != StickFormat.Dense or y_stl.format != StickFormat.Dense:
             raise Unsupported(
                 f"{red.reduction_type} on non-dense tensors {x_stl} {y_stl}"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Enhance calculation of stick dimension for matmul to support the ellison of trivial (size 1) dimensions per torch semantics.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
========================================================================================== test session starts ==========================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 198 items                                                                                                                                                                                     

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                    [  3%]
tests/_inductor/test_inductor_ops.py ..s...................................................................................................                                                       [ 54%]
tests/tensor/test_tensor_layout.py ........                                                                                                                                                       [ 58%]
tests/test_fallbacks.py ........                                                                                                                                                                  [ 62%]
tests/test_modules.py ssssss.                                                                                                                                                                     [ 66%]
tests/test_ops.py ..sssss...................sss..ssss.s.......ss.ss                                                                                                                               [ 90%]
tests/test_spyre.py .s...s...........                                                                                                                                                             [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                 [100%]

=========================================================================================== warnings summary ============================================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 170 passed, 28 skipped, 2 warnings in 90.78s (0:01:30) =========================================================================
```

#### Does this PR introduce a user-facing change?

#### Additional note:
