### PR TITLE
Add reinterpret_tensor for Spyre

### DIFF
--- a/torch_spyre/_inductor/wrapper.py
+++ b/torch_spyre/_inductor/wrapper.py
@@ -59,6 +59,9 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
             """,
             strip=True,
         )
+        self.header.writeline(
+            "from torch_spyre._C import spyre_reinterpret_tensor as reinterpret_tensor"
+        )
         self.header.writeline("del async_compile")
         self.header.writeline("async_compile = SpyreAsyncCompile()")
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -245,6 +245,7 @@ PYBIND11_MODULE(_C, m) {
   m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);
   m.def("to_with_layout", &spyre::to_with_layout);
   m.def("empty_with_layout", &spyre::empty_with_layout);
+  m.def("spyre_reinterpret_tensor", &spyre::spyre_reinterpret_tensor);
 
   py::enum_<DataFormats>(m, "DataFormats")
       .value("SEN169_FP16", DataFormats::SEN169_FP16)

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -729,8 +729,11 @@ at::Tensor spyre_reinterpret_tensor(const at::Tensor& self,
                                     c10::IntArrayRef size,
                                     c10::IntArrayRef stride,
                                     int64_t offset_increment) {
-  DEBUGINFO("Size:", size, ", Stride: ", stride, " on device ", self.device()); 
-  auto device_layout = static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl())->spyre_layout;
+  DEBUGINFO("Size:", size, ", Stride: ", stride, " on device ", self.device());
+  auto orig_layout = get_spyre_tensor_layout(self);
+  auto dim_order = orig_layout.similar_dim_order(size.size());
+  auto device_layout = SpyreTensorLayout(
+      size.vec(), c10::typeMetaToScalarType(self.dtype()), dim_order);
   auto self_ = at::detail::make_tensor_base<SpyreTensorImpl>(
       self.storage(), self.key_set(), self.dtype(), device_layout);
   auto* self_tmp_ = self_.unsafeGetTensorImpl();

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -748,7 +748,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("as_strided", TORCH_FN(spyre_as_strided));
   m.impl("set_.source_Storage_storage_offset", TORCH_FN(spyre_set_storage));
   m.impl("_copy_from", TORCH_FN(spyre_copy_from));
-  m.impl("reinterpret_tensor", TORCH_FN(spyre_reinterpret_tensor));
+  m.impl("_reinterpret_tensor", TORCH_FN(spyre_reinterpret_tensor));
 }
 
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -45,4 +45,8 @@ at::Tensor empty_with_layout(
     std::optional<c10::Layout> layout_opt,
     std::optional<c10::Device> device_opt, std::optional<bool> pin_memory_opt,
     std::optional<c10::MemoryFormat> memory_format_opt);
+at::Tensor spyre_reinterpret_tensor(const at::Tensor& self,
+                                    c10::IntArrayRef size,
+                                    c10::IntArrayRef stride,
+                                    int64_t offset_increment);
 }  // namespace spyre


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR adds a spyre-specific implementation of `reinterpret_tensor` to ensure resulting tensors have `SpyreTensorImpls`. 
For now, we import `spyre_reinterpret_tensor` as `reinterpret_tensor` in the python host code as overriding the default operation does not work. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
```
=============================================================================================================== test session starts ================================================================================================================
platform linux -- Python 3.12.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/senuser/dt-inductor/torch-spyre
configfile: pyproject.toml
collected 198 items                                                                                                                                                                                                                                

torch-spyre/tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                                                   [  3%]
torch-spyre/tests/_inductor/test_inductor_ops.py ..s...................................................................................................                                                                                      [ 54%]
torch-spyre/tests/tensor/test_tensor_layout.py ........                                                                                                                                                                                      [ 58%]
torch-spyre/tests/test_fallbacks.py ........                                                                                                                                                                                                 [ 62%]
torch-spyre/tests/test_modules.py ssssss.                                                                                                                                                                                                    [ 66%]
torch-spyre/tests/test_ops.py ..sssss...................sss..ssss.s.......ss.ss                                                                                                                                                              [ 90%]
torch-spyre/tests/test_spyre.py .s...s...........                                                                                                                                                                                            [ 99%]
torch-spyre/tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                [100%]

================================================================================================================= warnings summary =================================================================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/senuser/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/senuser/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================== 170 passed, 28 skipped, 2 warnings in 60.64s (0:01:00) ==============================================================================================
```