### PR TITLE
[FIX] bug that prevents work division for pointwise 2d

### DIFF
--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -56,10 +56,11 @@ def generate_sfp_op(pointers, *, op, dimensions, inputs, outputs, reduction, **k
 
     # implement core division on stick dimension
     cores = 1
+
     if "op_info" in kwargs and "core_division" in kwargs["op_info"]:
         # enable work division for non-reduction only for now
         if not reduction:
-            split_idx = -2 if not d3 else -3
+            split_idx = -3 if d3 else 0  # split along stick dim
             cores = kwargs["op_info"]["core_division"][-1][split_idx]
 
     # TODO: fix constant generation with multiple cores

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -72,7 +72,7 @@ def divide_pointwise_op(n: SchedulerNode, args: list[SchedNodeArg], max_cores):
             return
 
     device_size = output.device_layout.device_size
-    split_idx = -2 if len(device_size) == 2 else -3  # split along stick dim
+    split_idx = -3 if len(device_size) == 4 else 0  # split along stick dim
     num_cores = core_split(device_size[split_idx], max_cores)
     if num_cores > 1:
         for cd in n.spyre_core_division:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fix a index calculation bug that prevents work division when using 2d input for pointwise op.

#### Which issue(s) this PR is related to:

#353
#354 

#### Special notes for your reviewer:

Quick fix and make the index calculation more consistent in 2 different places.

#### Does this PR introduce a user-facing change?

#### Additional note:
cc @dgrove-oss 