### PR TITLE
[FIX] Add check for SpyreTensorImpl

### DIFF
--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -263,7 +263,7 @@ int32_t get_device_size_in_bytes(SpyreTensorLayout stl) {
 SpyreTensorLayout get_spyre_tensor_layout(const at::Tensor& tensor) {
   TORCH_CHECK(tensor.is_privateuseone());
   SpyreTensorLayout stl;
-  SpyreTensorImpl *impl;
+  SpyreTensorImpl* impl;
   if (impl = dynamic_cast<SpyreTensorImpl*>(tensor.unsafeGetTensorImpl())) {
     stl = impl->spyre_layout;
   } else {


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR adds a check if tensors have `SpyreTensorImpl` in `get_spyre_tensor_layout`. In the future, I believe all device tensors should have a `SpyreTensorImpl`. This adds a check to avoid memory errors until this is the case. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
```
pytest torch-spyre/tests/
=============================================================================================================== test session starts ================================================================================================================
platform linux -- Python 3.12.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/senuser/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 204 items                                                                                                                                                                                                                                

torch-spyre/tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                                                   [  2%]
torch-spyre/tests/_inductor/test_inductor_ops.py ..s........................................................................................................                                                                                 [ 55%]
torch-spyre/tests/tensor/test_tensor_layout.py ........                                                                                                                                                                                      [ 59%]
torch-spyre/tests/test_fallbacks.py ........                                                                                                                                                                                                 [ 63%]
torch-spyre/tests/test_modules.py ssssss.                                                                                                                                                                                                    [ 66%]
torch-spyre/tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                                                                                                                                             [ 91%]
torch-spyre/tests/test_spyre.py .s...s...........                                                                                                                                                                                            [ 99%]
torch-spyre/tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                [100%]

================================================================================================================= warnings summary =================================================================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/senuser/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/senuser/dt-inductor/dti-venv/lib64/python3.12/site-packages/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================== 175 passed, 29 skipped, 2 warnings in 60.76s (0:01:00) ==============================================================================================
```