### PR TITLE
Suppress undefined OpHandler warning

### DIFF
--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from contextlib import contextmanager
+import warnings
 
 import torch
 from torch._dynamo.backends.common import AotAutograd
@@ -39,17 +40,28 @@ class SpyreAotAutograd(AotAutograd):
         super().__init__(**kwargs)
 
     def __call__(self, gm: torch.fx.GraphModule, example_inputs, **kwargs):
-        if any(
-            isinstance(t, torch.Tensor) and t.device.type == "spyre"
-            for t in example_inputs
-        ):
-            with (
-                spyre_data_types(),
-                V.set_real_inputs(example_inputs),
+        # TODO: Remove this warning suppression once the issue causing the following
+        # warning is fixed:
+        #   UserWarning: undefined OpHandler.<op name>, please add missing op schema
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                action="ignore",
+                category=UserWarning,
+                module="torch._inductor.ops_handler",
+                message="^undefined OpHandler",
+            )
+
+            if any(
+                isinstance(t, torch.Tensor) and t.device.type == "spyre"
+                for t in example_inputs
             ):
+                with (
+                    spyre_data_types(),
+                    V.set_real_inputs(example_inputs),
+                ):
+                    return super().__call__(gm, example_inputs, **kwargs)
+            else:
                 return super().__call__(gm, example_inputs, **kwargs)
-        else:
-            return super().__call__(gm, example_inputs, **kwargs)
 
 
 def spyre_compile_to_module(graph: GraphLowering, original_compile_to_module):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR temporarily suppress the following noisy warnings until the issue is understood and resolved.

```
  UserWarning: undefined OpHandler.<op name>, please add missing op schema
```

This suppression is narrowly scoped to this specific message to avoid polluting log output without hiding unrelated warnings.

#### Which issue(s) this PR is related to:

- #301 

#### Special notes for your reviewer:

The warning originates from the `__getattr__` method of the `DefaultHandler` class in Inductor:
https://github.com/pytorch/pytorch/blob/v2.9.1/torch/_inductor/ops_handler.py#L740-L746
```
    def __getattr__(self, name: str) -> Any:
        def fallback(*args: Any, **kwargs: Any) -> Any:
            return self._default(name, args, kwargs)


        # would like to remove this function entirely, but it's used in MTIA backend
        warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")
        return fallback
```
The warning could be eliminated by overriding `__getattr__` in each subclass of `DefaultHandler`. In practice, this is not feasible: PyTorch defines many subclasses of it, and modifying them would require monkey‑patching.

For example, one subclass is instantiated here:
https://github.com/pytorch/pytorch/blob/v2.9.1/torch/_inductor/virtualized.py#L337
```
ops: OpsHandler[Any] = OpsWrapper()
```

Since we cannot safely override these handlers upstream, this PR adds a minimal, targeted suppression for this specific warning until the underlying issue is resolved.

#### Does this PR introduce a user-facing change?

Undefined OpHandler warnings will not appear.

#### Additional note:

```
(dti-venv) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
================================================ test session starts ================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 206 items

tests/_inductor/test_building_blocks.py .s.s..                                                                [  2%]
tests/_inductor/test_inductor_ops.py ..s..................................................................... [ 37%]
.....................................                                                                         [ 55%]
tests/tensor/test_tensor_layout.py ........                                                                   [ 59%]
tests/test_fallbacks.py ........                                                                              [ 63%]
tests/test_modules.py ssssss.                                                                                 [ 66%]
tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                          [ 91%]
tests/test_spyre.py .s...s...........                                                                         [ 99%]
tests/test_spyre_lazy_silent.py .                                                                             [100%]

==================================== 177 passed, 29 skipped in 73.11s (0:01:13) =====================================

```
