### PR TITLE
[FEAT] Add alternative to function including device layout

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -16,7 +16,7 @@
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch_spyre._C import SpyreTensorLayout, StickFormat, DataFormats, to_spyre_layout
+from torch_spyre._C import SpyreTensorLayout, StickFormat, DataFormats, to_with_layout
 
 
 class TestSpyreTensorLayout(TestCase):
@@ -105,19 +105,19 @@ class TestSpyreTensorLayout(TestCase):
         x = torch.rand([512, 256], dtype=torch.float16)
         x = torch.rand([512, 256], dtype=torch.float16)
         x_stl = SpyreTensorLayout([512, 256], torch.float16)
-        x_dev = to_spyre_layout(x, x_stl)
+        x_dev = to_with_layout(x, x_stl)
         self.assertEqual(x_dev, x_dev.cpu())
 
         y = torch.rand([512, 512], dtype=torch.float16)
         y_stl = SpyreTensorLayout(
             [8, 512, 64], [0, 1, 0], 1, StickFormat.Dense, DataFormats.SEN169_FP16
         )
-        y_dev = to_spyre_layout(y, y_stl)
+        y_dev = to_with_layout(y, y_stl)
         self.assertEqual(y_dev, y_dev.cpu())
 
         z = torch.rand([512, 8, 256], dtype=torch.float16)
         z_stl = SpyreTensorLayout([512, 8, 256], torch.float16, [2, 1, 0])
-        z_dev = to_spyre_layout(z, z_stl)
+        z_dev = to_with_layout(z, z_stl)
         self.assertEqual(z_dev, z_dev.cpu())
 
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -254,7 +254,7 @@ PYBIND11_MODULE(_C, m) {
   m.def("encode_constant", &spyre::encodeConstant);
   m.def("convert_artifacts", &spyre::convertArtifacts);
   m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);
-  m.def("to_spyre_layout", &spyre::to_spyre_layout);
+  m.def("to_with_layout", &spyre::to_with_layout);
 
   py::enum_<DataFormats>(m, "DataFormats")
       .value("SEN169_FP16", DataFormats::SEN169_FP16)

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -660,8 +660,14 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
     return at::_copy_from(self, dst, non_blocking);
   }
 }
-at::Tensor to_spyre_layout(const at::Tensor& self,
-                           SpyreTensorLayout device_layout) {
+at::Tensor to_with_layout(const at::Tensor& self,
+                          SpyreTensorLayout device_layout) {
+  DEBUGINFO(
+      "Tensor info on CPU (Size:", self.sizes(), ", Stride: ", self.strides(),
+      ", dtype: ", c10::typeMetaToScalarType(self.dtype()),
+      ") and to be mapped onto device ",
+      c10::impl::VirtualGuardImpl{c10::DeviceType::PrivateUse1}.getDevice(),
+      " with layout ", device_layout.toString());
   auto dst = spyre_empty_with_layout(self.sizes(), self.strides(),
                                      c10::typeMetaToScalarType(self.dtype()),
                                      device_layout);

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -36,6 +36,6 @@ at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
                                    c10::ScalarType dtype,
                                    SpyreTensorLayout device_layout);
 
-at::Tensor to_spyre_layout(const at::Tensor& self,
-                           SpyreTensorLayout device_layout);
+at::Tensor to_with_layout(const at::Tensor& self,
+                          SpyreTensorLayout device_layout);
 }  // namespace spyre


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR adds an alternative function for `to` that enables the user to control the on-device layout of the tensor using `SpyreTensorLayout`. This function, `to_with_layout`, creates a device tensor and transfers it to the device using the specified layout. If this tensor is copied back to the host, the DCI generated uses the `SpyreTensorLayout` specified by the user when the device tensor was created. 

#### Which issue(s) this PR is related to:

#242 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
