### PR TITLE
[FIX] Fix BMM stickification for trivial dimension

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -49,6 +49,7 @@ spyreop = torch.ops.spyre
 
 def stl_host_dim_order(self: SpyreTensorLayout) -> list[int]:
     ndim = len(self.device_size)
+    assert ndim <= 5
     if ndim <= 3:
         order = self.dim_map[1:]
     elif ndim == 4:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR fixes the host dimension ordering for the BMM operation in the case of a trivial dimension. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
