### PR TITLE
Virtualize make_indexer for SpyreTensorLayout

### DIFF
--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -101,3 +101,18 @@ class FixedTiledLayout(FixedLayout):
         return self.size
 
     __repr__ = __str__
+
+    def make_indexer(self) -> Callable[[Sequence[Expr]], Expr]:
+        """
+        Ignore the host-view of strides when creating the indexer (ie force row-major).
+        This virtual indexing allows us to reliably match variables in index expressions
+        back to the operation dimension in spyre_kernel codegen.
+        TODO: Redesign to do this more directly from the IRNode.
+        """
+        strides: list[Expr] = []
+        cur_stride = 1
+        for v in reversed(self.size):
+            strides = [cur_stride] + strides
+            # Virtually pad trivial dimensions to ensure total ordering
+            cur_stride = cur_stride * (2 if v == 1 else v)
+        return torch._inductor.ir._fixed_indexer(self.size, strides, self.offset)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Ensure a predictable mapping from the symbols in indexing expressions to operation dimensions by ignoring the host strides and using strides that encode a padded row major format (any dimension of size 1 is padded to 2 to force strictly increasing strides).  This fixes a latent bug in `spyre_kernel.analyze_index_expr` which would incorrectly order the dimensions if the defining tensor of the operation was not row major.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 208 items                                                                                                                                                                                                  

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                                 [  2%]
tests/_inductor/test_inductor_ops.py ..s............................................................................................................                                                           [ 56%]
tests/tensor/test_tensor_layout.py ........                                                                                                                                                                    [ 60%]
tests/test_fallbacks.py ........                                                                                                                                                                               [ 63%]
tests/test_modules.py ssssss.                                                                                                                                                                                  [ 67%]
tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                                                                                                                           [ 91%]
tests/test_spyre.py .s...s...........                                                                                                                                                                          [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                              [100%]

================================================================================================== warnings summary ==================================================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 179 passed, 29 skipped, 2 warnings in 96.98s (0:01:36) ===============================================================================

```

#### Does this PR introduce a user-facing change?

No.

#### Additional note:

This is probably only a tactical fix, but it fixes a known gap.  We'll very likely have to revisit this again
when we enable fusion and have multiple loop nests in the same SpyreKernel. 
