### PR TITLE
Add NopKernelSchedulerNode

### DIFF
--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -27,6 +27,7 @@ from torch._inductor.scheduler import (
     BaseSchedulerNode,
     ExternKernelSchedulerNode,
     SchedulerNode,
+    NopKernelSchedulerNode,
 )
 
 from . import Unsupported
@@ -135,6 +136,8 @@ def core_division_planning(
                 pass
             else:
                 print(f"Warning: unhandled node type {type(n.node)}")
+        elif isinstance(n, NopKernelSchedulerNode):
+            pass
         else:
             print(f"Warning: unhandled scheduler node type {type(n)}")
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds support for NopKernelSchedulerNode in handling spyre tensor layout.

In the decomposition of torch.cat, the output buffer is allocated first and the concatenation comes next. In LoopLevel IR, the buffer is represented using NopKernelSchedulerNode such as:

```
op0: NopKernelSchedulerNode(ComputedBuffer)
op0.writes = [MemoryDep('buf0', 128*d0 + d1, {d0: 0, d1: 0})]
op0.unmet_dependencies = []
op0.met_dependencies = []
op0.outputs = [
    buf0: ComputedBuffer
    buf0.layout = FixedLayout('spyre:0', torch.float16, size=[96, 128], stride=[128, 1])
    buf0.users = [NodeUser(node=SchedulerNode(name='op1'), can_inplace=False, is_weak=False)]
]

op1: SchedulerNode(ComputedBuffer)
op1.writes = [MemoryDep('buf1', 128*c0 + c1, {c0: 32, c1: 128})]
op1.unmet_dependencies = 
    [   MemoryDep('buf0', 128*c0 + c1, {c0: 32, c1: 128}),
        StarDep(name='buf0', mode=None)]
op1.met_dependencies = [MemoryDep('arg0_1', 128*c0 + c1, {c0: 32, c1: 128})]
op1.outputs = [
    buf1: ComputedBuffer
    buf1.layout = MutationLayoutSHOULDREMOVE('spyre:0', torch.float16, size=[96, 128], stride=[128, 1])
    buf1.mutations = ['buf0']
    buf1.users = [NodeUser(node=SchedulerNode(name='op2'), can_inplace=False, is_weak=False)]
]
op1.group.device = spyre:0
op1.group.iteration = (4096, 1)
op1.sizes = ([32, 128], [])
arg0_1_layout = FixedLayout('spyre:0', torch.float16, size=[32, 128], stride=[128, 1])
buf0_layout = FixedLayout('spyre:0', torch.float16, size=[96, 128], stride=[128, 1])
buf0_layout = FixedLayout('spyre:0', torch.float16, size=[96, 128], stride=[128, 1])
buf1_layout = MutationLayoutSHOULDREMOVE('spyre:0', torch.float16, size=[96, 128], stride=[128, 1])
class op1_loop_body:
    var_ranges = {p0: 32, p1: 128}
    index0 = 128*p0 + p1
    def body(self, ops):
        get_index = self.get_index('index0')
        load = ops.load('arg0_1', get_index)
        get_index_1 = self.get_index('index0')
        load_1 = ops.load('buf0', get_index_1)
        overwrite = ops.overwrite(load, load_1, 0, 0)
        get_index_2 = self.get_index('index0')
        store = ops.store('buf1', get_index_2, overwrite, None)
        return store
    :
```

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
