### PR TITLE
[REFACTOR] Move SpyreTensorLayout.host_dim_order to runtime

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -120,6 +120,18 @@ class TestSpyreTensorLayout(TestCase):
         z_dev = to_with_layout(z, z_stl)
         self.assertEqual(z_dev, z_dev.cpu())
 
+    def test_dim_order_round_trip(self):
+        """Tests the pattern used by inductor to propagate dim order from inputs to outputs"""
+        x_2 = SpyreTensorLayout([3, 256], torch.float16)
+        y_2 = SpyreTensorLayout([3, 256], torch.float16, x_2.host_dim_order())
+        self.assertEqual(x_2, y_2)
+        x_3 = SpyreTensorLayout([3, 64, 256], torch.float16)
+        y_3 = SpyreTensorLayout([3, 64, 256], torch.float16, x_3.host_dim_order())
+        self.assertEqual(x_3, y_3)
+        x_4 = SpyreTensorLayout([7, 3, 64, 256], torch.float16)
+        y_4 = SpyreTensorLayout([7, 3, 64, 256], torch.float16, x_4.host_dim_order())
+        self.assertEqual(x_4, y_4)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -47,19 +47,6 @@ aten = torch.ops.aten
 spyreop = torch.ops.spyre
 
 
-def stl_host_dim_order(self: SpyreTensorLayout) -> list[int]:
-    ndim = len(self.device_size)
-    assert ndim <= 5
-    if ndim <= 3:
-        order = self.dim_map[1:]
-    elif ndim == 4:
-        order = [self.dim_map[-2], self.dim_map[0], self.dim_map[-1]]
-    else:  # 4d
-        order = [self.dim_map[0]] + self.dim_map[2:]
-    assert len(order) == len(set(order))
-    return order
-
-
 def stl_stick_dim(self: SpyreTensorLayout) -> int:
     return self.dim_map[-1]
 
@@ -74,7 +61,6 @@ def stl_is_stick_reduction(self: SpyreTensorLayout, axis: list[int]) -> bool:
         return False
 
 
-setattr(SpyreTensorLayout, "host_dim_order", stl_host_dim_order)
 setattr(SpyreTensorLayout, "stick_dim", stl_stick_dim)
 setattr(SpyreTensorLayout, "is_stick_reduction", stl_is_stick_reduction)
 
@@ -232,7 +218,7 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
                 f"{red.reduction_type} on non-dense tensors {x_stl} {y_stl}"
             )
         if len(x_stl.device_size) != len(output.size) + 1:
-            output_host_dim_order = stl_host_dim_order(x_stl)[:-1]
+            output_host_dim_order = x_stl.host_dim_order()[:-1]
         if x_stl.host_dim_order() != y_stl.host_dim_order():
             raise Unsupported(
                 f"{red.reduction_type} stick dimensions mismatch {x_stl} {y_stl}"

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -297,6 +297,7 @@ PYBIND11_MODULE(_C, m) {
            [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
       .def("device_strides", &spyre::SpyreTensorLayout::device_strides)
       .def("elems_per_stick", &spyre::SpyreTensorLayout::elems_per_stick)
+      .def("host_dim_order", &spyre::SpyreTensorLayout::host_dim_order)
       .def(py::self == py::self)
       .def(py::init<std::vector<int64_t>, c10::ScalarType>(),
            py::arg("host_size"), py::arg("dtype"))

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -104,6 +104,13 @@ class SpyreTensorLayout {
 
   std::vector<int64_t> device_strides();
 
+  /**
+   * Return the host_dim_order that can be used as an argument to
+   * SpyreTensorLayout::init to create a new SpyreTensorLayout that
+   * will have the same dim_map as this SpyreTensorLayout.
+   */
+  std::vector<int32_t> host_dim_order();
+
   int64_t elems_per_stick() {
     return spyre::elems_per_stick(this->device_dtype);
   }


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ x ] cleanup

#### What this PR does:

The forward and backward functions between dim_map and host_dim_order should be defined in the same place so they can be kept in synch. 

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
======================================================================== test session starts =========================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 236 items                                                                                                                                                  

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                 [  2%]
tests/_inductor/test_inductor_ops.py ..s...................................................................................................................... [ 53%]
.................                                                                                                                                              [ 61%]
tests/tensor/test_tensor_layout.py .........                                                                                                                   [ 64%]
tests/test_fallbacks.py ........                                                                                                                               [ 68%]
tests/test_modules.py ssssss.                                                                                                                                  [ 71%]
tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                                                                           [ 92%]
tests/test_spyre.py .s...s...........                                                                                                                          [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                              [100%]

========================================================================== warnings summary ==========================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 207 passed, 29 skipped, 2 warnings in 95.88s (0:01:35) =======================================================

```

#### Does this PR introduce a user-facing change?

#### Additional note:
