### PR TITLE
[FIX] Set default float16 min and max for clamp

### DIFF
--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -299,6 +299,10 @@ def lower_softplus(x, beta=1.0, threshold=20.0):
 
 @register_spyre_lowering(torch.ops.spyre.clamp)
 def lower_clamp(x, min=None, max=None):
+    if min is None:
+        min = torch.finfo(torch.float16).min
+    if max is None:
+        max = torch.finfo(torch.float16).max
     pw = Pointwise.create(
         device=x.get_device(),
         dtype=x.get_dtype(),


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Sets the default float16 min and max values of torch.clamp when the values are omitted or `None`.

#### Which issue(s) this PR is related to:

Fixes #397.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
