### PR TITLE
[FIX] Remove keep_output_strides workaround

### DIFF
--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -81,9 +81,6 @@ def _autoload():
     # found here: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/ir.py#L1580
     torch._inductor.config.unroll_reductions_threshold = 1
 
-    # Do not force output tensor strides to conform to eager strides -- hack for dealing with stickified tensors for now.
-    torch._inductor.config.keep_output_stride = False
-
     from torch._inductor.ir import Loops
 
     # Force all operations to be realized when LoopLevel IR is initially constructed


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ x ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

Before SpyreTensorLayout, we needed this workaround to handle sparse stick tensors. We don't need it now.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

```
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 237 items                                                                                                                                                                    

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                   [  2%]
tests/_inductor/test_inductor_ops.py ..s.......................................................................................................................................  [ 60%]
tests/tensor/test_tensor_layout.py ..........                                                                                                                                    [ 64%]
tests/test_fallbacks.py ........                                                                                                                                                 [ 68%]
tests/test_modules.py ssssss.                                                                                                                                                    [ 71%]
tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                                                                                             [ 92%]
tests/test_spyre.py .s...s...........                                                                                                                                            [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                [100%]

=================================================================================== warnings summary ===================================================================================
tests/_inductor/test_inductor_ops.py::TestOps::test_activation_cls_gelu_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.gelu, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

tests/_inductor/test_inductor_ops.py::TestOps::test_pointwise_range_op_clamp_fp16
  /home/dgrove/dt-inductor/pytorch/torch/_inductor/ops_handler.py:745: UserWarning: undefined OpHandler.clamp, please add missing op schema
    warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 208 passed, 29 skipped, 2 warnings in 94.36s (0:01:34) ================================================================

```

#### Does this PR introduce a user-facing change?

#### Additional note:
