### PR TITLE
Add patching for to and empty with layout

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -132,6 +132,29 @@ class TestSpyreTensorLayout(TestCase):
         y_4 = SpyreTensorLayout([7, 3, 64, 256], torch.float16, x_4.host_dim_order())
         self.assertEqual(x_4, y_4)
 
+    def test_to_layout_patched(self):
+        x = torch.rand([512, 256], dtype=torch.float16)
+        x = torch.rand([512, 256], dtype=torch.float16)
+        x_stl = SpyreTensorLayout([512, 256], torch.float16)
+        x_dev = x.to("spyre", device_layout=x_stl)
+        stl = x_dev.device_tensor_layout()
+        self.assertEqual(x_dev, x_dev.cpu())
+        self.assertEqual(stl.device_size, [4, 512, 64])
+        self.assertEqual(stl.device_strides(), [32768, 64, 1])
+        self.assertEqual(stl.dim_map, [1, 0, 1])
+        self.assertEqual(stl.format, StickFormat.Dense)
+        self.assertEqual(stl.num_stick_dims, 1)
+
+    def test_empty_layout_patched(self):
+        x_stl = SpyreTensorLayout([512, 8, 256], torch.float16, [2, 1, 0])
+        x = torch.empty((512, 8, 256), device_layout=x_stl, dtype=torch.float16)
+        stl = x.device_tensor_layout()
+        self.assertEqual(stl.device_size, [8, 8, 256, 64])
+        self.assertEqual(stl.device_strides(), [131072, 16384, 64, 1])
+        self.assertEqual(stl.dim_map, [1, 0, 2, 0])
+        self.assertEqual(stl.format, StickFormat.Dense)
+        self.assertEqual(stl.num_stick_dims, 1)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -255,6 +255,7 @@ PYBIND11_MODULE(_C, m) {
   m.def("convert_artifacts", &spyre::convertArtifacts);
   m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);
   m.def("to_with_layout", &spyre::to_with_layout);
+  m.def("empty_with_layout", &spyre::empty_with_layout);
 
   py::enum_<DataFormats>(m, "DataFormats")
       .value("SEN169_FP16", DataFormats::SEN169_FP16)

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -38,4 +38,11 @@ at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
 
 at::Tensor to_with_layout(const at::Tensor& self,
                           SpyreTensorLayout device_layout);
+
+at::Tensor empty_with_layout(
+    c10::IntArrayRef size, SpyreTensorLayout device_layout,
+    std::optional<c10::ScalarType> dtype_opt,
+    std::optional<c10::Layout> layout_opt,
+    std::optional<c10::Device> device_opt, std::optional<bool> pin_memory_opt,
+    std::optional<c10::MemoryFormat> memory_format_opt);
 }  // namespace spyre


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds monkey patching to allow users to specify the device layout of a tensor (`SpyeTensorLayout`) when using the `torch.empty` and `torch.Tensor.to` functions. The original functions are used when no device layout is specified. 

#### Which issue(s) this PR is related to:
Related to #242 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
```
=============================================================================================================== test session starts ================================================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/senuser/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 239 items                                                                                                                                                                                                                                

torch-spyre/tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                                                   [  2%]
torch-spyre/tests/_inductor/test_inductor_ops.py ..s.......................................................................................................................................                                                  [ 60%]
torch-spyre/tests/tensor/test_tensor_layout.py ............                                                                                                                                                                                  [ 65%]
torch-spyre/tests/test_fallbacks.py ........                                                                                                                                                                                                 [ 68%]
torch-spyre/tests/test_modules.py ssssss.                                                                                                                                                                                                    [ 71%]
torch-spyre/tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                                                                                                                                             [ 92%]
torch-spyre/tests/test_spyre.py .s...s...........                                                                                                                                                                                            [ 99%]
torch-spyre/tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                [100%]

==================================================================================================== 210 passed, 29 skipped in 65.78s (0:01:05) ====================================================================================================
```