### PR TITLE
fix monkey patching of aot_autograd

### DIFF
--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -58,7 +58,7 @@ def _autoload():
     import torch_spyre._inductor.lowering  # noqa: F401  # usort: skip
     from .patches import SpyreAotAutograd, spyre_compile_to_module
 
-    # Monkey patching these two methods let us install Spyre-specific overrides
+    # Monkey patching these methods let us install Spyre-specific overrides
     # and contexts that are not supported by existing extension points.
     # We need to hook both, because a user may directly compile a module for spyre without going through AotAutograd.
     torch._dynamo.backends.common.aot_autograd = lambda **kwargs: SpyreAotAutograd(
@@ -68,6 +68,10 @@ def _autoload():
     torch._inductor.graph.GraphLowering.compile_to_module = (
         lambda graph: spyre_compile_to_module(graph, orig_compile_to_module)
     )
+    import torch._inductor.compile_fx  # noqa: F401  # usort: skip
+
+    # This overwrites the copy of `aot_autograd` imported by compile_fx.py to use our monkey patch.
+    torch._inductor.compile_fx.aot_autograd = torch._dynamo.backends.common.aot_autograd
 
     # Customize inductor heuristics
     from .choices import SpyreHeuristics


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

We also need to monkey patch the copy of `aot_autograd` created by the import statement in compile_fx.py.

#### Which issue(s) this PR is related to:

Fixes #326

<!--
Please link relevant issues to help with tracking.
Examples:

<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 237 items                                                                                                                                                                                        

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                       [  2%]
tests/_inductor/test_inductor_ops.py ..s.......................................................................................................................................                      [ 60%]
tests/tensor/test_tensor_layout.py ..........                                                                                                                                                        [ 64%]
tests/test_fallbacks.py ........                                                                                                                                                                     [ 68%]
tests/test_modules.py ssssss.                                                                                                                                                                        [ 71%]
tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                                                                                                                 [ 92%]
tests/test_spyre.py .s...s...........                                                                                                                                                                [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                    [100%]

================================================================================ 208 passed, 29 skipped in 88.87s (0:01:28) ================================================================================
```

#### Does this PR introduce a user-facing change?

#### Additional note:
