### PR TITLE
[FEAT] add light-weight library for hooks

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -257,6 +257,12 @@ class TestSpyre(TestCase):
             t2 = t.to(device="spyre")  # noqa: F841
         assert len(rec) == 0
 
+    def test_hooks_on_import(self):
+        import torch
+
+        dev = torch._C._get_accelerator()
+        assert str(dev) == "spyre"
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -156,6 +156,7 @@ def _autoload():
     _autoload._ran = True
 
     import torch  # noqa: E402
+    from . import _hooks  # noqa: F401
 
     # Set all the appropriate state on PyTorch
     torch.utils.rename_privateuse1_backend(DEVICE_NAME)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).



#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Calling `torch._C._get_accelerator()` failed with:
```
RuntimeError: Please register PrivateUse1HooksInterface by `RegisterPrivateUse1HooksInterface` first.
```
because our Spyre backend registered no hooks until the heavy _C module was imported, and our autoload path didn’t import _C (by design, to keep startup fast). This particular line of code is used in torch.distributed internals. 

* Introduce torch_spyre._hooks — a tiny pybind module that only registers our PrivateUse1HooksInterface in its PYBIND11_MODULE init. No driver init, no big deps. 
* Update autoload path in torch_spyre/__init__.py to import _hooks (fast) during the torch.backends entry‑point call. Heavy _C remains lazy.
* Split build into two extensions: _hooks (bootstrap) and _C (runtime). _hooks compiles only spyre_hooks.cpp; _C compiles everything else (plus codegen).
* Add a new test case for this check.


<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

Issue #447 

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

CC: @jjhursey 