### PR TITLE
[Refactoring] Automatically remove default decompositions and lowerings for fallback ops

### DIFF
--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -20,6 +20,7 @@ import torch._inductor.lowering as lowering
 
 from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 from torch_spyre._C import get_elem_in_stick
+from torch_spyre.fallbacks import fallback_ops
 from .ir import SpyreReduction
 
 
@@ -54,17 +55,17 @@ def register_spyre_lowering(
 # Implicit fallback to an eager op does not become effective when lowering of
 # the op is registered by default. Here, we unregister ops that are falling back
 # to eager ops
-lowerings_to_exclude = [torch.ops.aten.cos.default, torch.ops.aten.sin.default]
+# Note: If an op has a decomposition defined, a lowering is not registered
+def unregister_lowering(op, lowering_dict=lowering.lowerings, allow_missing=False):
+    for overload in lowering.get_overloads(op):
+        if overload in lowering_dict:
+            del lowering_dict[overload]
+        elif not allow_missing:
+            raise RuntimeError(f"lowering of {overload} is not registered")
 
 
-def unregister_lowering(op, lowering_dict=lowering.lowerings):
-    if op not in lowering_dict:
-        raise RuntimeError(f"lowering of {op} is not registered")
-    del lowering_dict[op]
-
-
-for op in lowerings_to_exclude:
-    unregister_lowering(op)
+for op in fallback_ops:
+    unregister_lowering(op, allow_missing=True)
 
 
 def ensure_default_handler(op_name):

--- a/torch_spyre/_inductor/preload.py
+++ b/torch_spyre/_inductor/preload.py
@@ -17,6 +17,7 @@
 
 import torch
 from torch._inductor.decomposition import decompositions
+from torch_spyre.fallbacks import fallback_ops
 
 # Exclude specific Inductor default decompositions on Spyre.
 #
@@ -24,14 +25,6 @@ from torch._inductor.decomposition import decompositions
 # We disable them here and rely on implicit fallbacks to eager ops instead. Once
 # the blocking issues are resolved, these exclusions can be removed.
 decomps_to_exclude = [
-    # The default decomposition for torch.arange (defined in pytorch/torch/refs/__init__.py)
-    # uses prims.iota, which is non-trivial to implement on Spyre at the moment.
-    # See: https://github.com/torch-spyre/torch-spyre/pull/178#issuecomment-3610709413
-    torch.ops.aten.arange.default,
-    torch.ops.aten.arange.out,
-    torch.ops.aten.arange.start,
-    torch.ops.aten.arange.start_step,
-    torch.ops.aten.arange.start_out,
     # The default decomposition for torch.new_ones (defined in pytorch/torch/refs/__init__.py)
     # uses torch.full, which is not yet supported in Spyre eager mode.
     # See: https://github.com/torch-spyre/torch-spyre/issues/128#issuecomment-3576168221
@@ -43,3 +36,6 @@ decomps_to_exclude = [
 
 # Remove the selected decompositions from Inductor's registry for Spyre.
 torch._decomp.remove_decompositions(decompositions, decomps_to_exclude)
+
+# Remove decompositions for fallback ops defined in fallbacks.py
+torch._decomp.remove_decompositions(decompositions, fallback_ops)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

We need to ensure that any default decompositions or lowerings associated with an operator are removed when that operator is registered for fallback. Currently, these removals are tracked in separate lists, which is error‑prone and can easily become inconsistent.

This PR refactors the fallback‑op registration mechanism so that decompositions and lowerings are automatically removed at registration time. As a result, separate removal lists are no longer needed.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional note:


```
$ pytest tests
================================================ test session starts =================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 248 items

tests/_inductor/test_building_blocks.py .s.s..                                                                 [  2%]
tests/_inductor/test_inductor_ops.py ..s...................................................................... [ 31%]
.........................................................................                                      [ 61%]
tests/tensor/test_tensor_layout.py ............                                                                [ 66%]
tests/test_fallbacks.py ........                                                                               [ 69%]
tests/test_modules.py ssssss.                                                                                  [ 72%]
tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                           [ 92%]
tests/test_spyre.py .s...s............                                                                         [ 99%]
tests/test_spyre_lazy_silent.py .                                                                              [100%]

===================================== 219 passed, 29 skipped in 81.99s (0:01:21) =====================================
```
