### PR TITLE
Change dimension ordering for 4D tensors

### DIFF
--- a/torch_spyre/_inductor/codegen/data_ops.py
+++ b/torch_spyre/_inductor/codegen/data_ops.py
@@ -656,35 +656,35 @@ def generate_transpose_4d_stick(
                                 "pdsName_": "pds0",
                                 "wordLength": 2,
                                 "dataformat": "SEN169_FP16",
-                                "layoutDimOrder_": ["mb", "x", "out", "y"],
+                                "layoutDimOrder_": ["mb", "out", "x", "y"],
                                 "stickDimOrder_": ["out"],
                                 "dimToLayoutSize_": {
-                                    "mb": dimensions[2],
+                                    "mb": dimensions[0],
                                     "out": dimensions[-1],
                                     "x": dimensions[1],
-                                    "y": dimensions[0],
+                                    "y": dimensions[2],
                                 },
                                 "dimToStickSize_": {"out": 64},
                                 "validGap_": {
-                                    "mb": [[dimensions[2], 0]],
+                                    "mb": [[dimensions[0], 0]],
                                     "out": [[dimensions[-1], 0]],
                                     "x": [[dimensions[1], 0]],
-                                    "y": [[dimensions[0], 0]],
+                                    "y": [[dimensions[2], 0]],
                                 },
                                 "PieceInfo": [
                                     {
                                         "key_": "p0",
                                         "dimToSize_": {
-                                            "mb": 64 if transpose_2_3 else 1,
+                                            "mb": 64 if transpose_0_3 else 1,
                                             "out": 64,
                                             "x": 64 if transpose_1_3 else 1,
-                                            "y": 64 if transpose_0_3 else 1,
+                                            "y": 64 if transpose_2_3 else 1,
                                         },
                                         "validGap_": {
                                             "out": [[64, 0]],
-                                            "mb": [[64 if transpose_2_3 else 1, 0]],
+                                            "mb": [[64 if transpose_0_3 else 1, 0]],
                                             "x": [[64 if transpose_1_3 else 1, 0]],
-                                            "y": [[64 if transpose_0_3 else 1, 0]],
+                                            "y": [[64 if transpose_2_3 else 1, 0]],
                                         },
                                         "PlacementInfo": [
                                             {
@@ -704,16 +704,16 @@ def generate_transpose_4d_stick(
                                     {
                                         "key_": "p1",
                                         "dimToSize_": {
-                                            "mb": 64 if transpose_2_3 else 1,
+                                            "mb": 64 if transpose_0_3 else 1,
                                             "out": 64,
                                             "x": 64 if transpose_1_3 else 1,
-                                            "y": 64 if transpose_0_3 else 1,
+                                            "y": 64 if transpose_2_3 else 1,
                                         },
                                         "validGap_": {
                                             "out": [[64, 0]],
-                                            "mb": [[64 if transpose_2_3 else 1, 0]],
+                                            "mb": [[64 if transpose_0_3 else 1, 0]],
                                             "x": [[64 if transpose_1_3 else 1, 0]],
-                                            "y": [[64 if transpose_0_3 else 1, 0]],
+                                            "y": [[64 if transpose_2_3 else 1, 0]],
                                         },
                                         "PlacementInfo": [
                                             {
@@ -735,35 +735,35 @@ def generate_transpose_4d_stick(
                                 "pdsName_": "pds0",
                                 "wordLength": 2,
                                 "dataformat": "SEN169_FP16",
-                                "layoutDimOrder_": ["mb", "x", "y", "out"],
-                                "stickDimOrder_": ["y"],
+                                "layoutDimOrder_": ["out", "mb", "x", "y"],
+                                "stickDimOrder_": ["mb"],
                                 "dimToLayoutSize_": {
-                                    "mb": dimensions[2],
+                                    "mb": dimensions[0],
                                     "out": dimensions[-1],
                                     "x": dimensions[1],
-                                    "y": dimensions[0],
+                                    "y": dimensions[2],
                                 },
-                                "dimToStickSize_": {"y": 64},
+                                "dimToStickSize_": {"mb": 64},
                                 "validGap_": {
-                                    "mb": [[dimensions[2], 0]],
+                                    "mb": [[dimensions[0], 0]],
                                     "out": [[dimensions[-1], 0]],
                                     "x": [[dimensions[1], 0]],
-                                    "y": [[dimensions[0], 0]],
+                                    "y": [[dimensions[2], 0]],
                                 },
                                 "PieceInfo": [
                                     {
                                         "key_": "p0",
                                         "dimToSize_": {
-                                            "mb": 64 if transpose_2_3 else 1,
+                                            "mb": 64 if transpose_0_3 else 1,
                                             "out": 64,
                                             "x": 64 if transpose_1_3 else 1,
-                                            "y": 64 if transpose_0_3 else 1,
+                                            "y": 64 if transpose_2_3 else 1,
                                         },
                                         "validGap_": {
                                             "out": [[64, 0]],
-                                            "mb": [[64 if transpose_2_3 else 1, 0]],
+                                            "mb": [[64 if transpose_0_3 else 1, 0]],
                                             "x": [[64 if transpose_1_3 else 1, 0]],
-                                            "y": [[64 if transpose_0_3 else 1, 0]],
+                                            "y": [[64 if transpose_2_3 else 1, 0]],
                                         },
                                         "PlacementInfo": [
                                             {
@@ -783,16 +783,16 @@ def generate_transpose_4d_stick(
                                     {
                                         "key_": "p1",
                                         "dimToSize_": {
-                                            "mb": 64 if transpose_2_3 else 1,
+                                            "mb": 64 if transpose_0_3 else 1,
                                             "out": 64,
                                             "x": 64 if transpose_1_3 else 1,
-                                            "y": 64 if transpose_0_3 else 1,
+                                            "y": 64 if transpose_2_3 else 1,
                                         },
                                         "validGap_": {
                                             "out": [[64, 0]],
-                                            "mb": [[64 if transpose_2_3 else 1, 0]],
+                                            "mb": [[64 if transpose_0_3 else 1, 0]],
                                             "x": [[64 if transpose_1_3 else 1, 0]],
-                                            "y": [[64 if transpose_0_3 else 1, 0]],
+                                            "y": [[64 if transpose_2_3 else 1, 0]],
                                         },
                                         "PlacementInfo": [
                                             {
@@ -816,42 +816,44 @@ def generate_transpose_4d_stick(
                             "coreIDtoANInfo": {
                                 "0": {
                                     "loopCount": {
-                                        "out": dimensions[-1] // 64,
-                                        "mb": dimensions[2],
+                                        "out": dimensions[0] // 64,
+                                        "mb": dimensions[-1] // 64,
                                         "x": dimensions[1],
-                                        "y": dimensions[0] // 64
-                                        if transpose_0_3
-                                        else dimensions[0],
+                                        "y": dimensions[2],
                                     },
                                     "loopCountL3SU": {
-                                        "out": dimensions[-1] // 64,
-                                        "mb": dimensions[2],
+                                        "out": dimensions[0] // 64,
+                                        "mb": dimensions[-1] // 64,
                                         "x": dimensions[1],
-                                        "y": dimensions[0] // 64
-                                        if transpose_0_3
-                                        else dimensions[0],
+                                        "y": dimensions[2],
                                     },
                                     "addr_info_": {
                                         "l3lu": {
                                             "type_": "stride",
                                             "offset_": {
-                                                "mb": 1,
-                                                "out": dimensions[2] * dimensions[1],
-                                                "y": dimensions[2]
+                                                "mb": dimensions[0],
+                                                "out": 64,
+                                                "y": dimensions[0]
                                                 * dimensions[1]
-                                                * dimensions[-1],
-                                                "x": dimensions[2],
+                                                * dimensions[-1]
+                                                // 64,
+                                                "x": dimensions[-1]
+                                                * dimensions[0]
+                                                // 64,
                                             },
                                         },
                                         "l3su": {
                                             "type_": "stride",
                                             "offset_": {
-                                                "mb": 1,
-                                                "out": dimensions[0]
+                                                "mb": 64,
+                                                "out": dimensions[-1],
+                                                "y": dimensions[0]
                                                 * dimensions[1]
-                                                * dimensions[2],
-                                                "y": dimensions[2] * dimensions[1],
-                                                "x": dimensions[2],
+                                                * dimensions[-1]
+                                                // 64,
+                                                "x": dimensions[-1]
+                                                * dimensions[0]
+                                                // 64,
                                             },
                                         },
                                     },

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -58,8 +58,8 @@ auto get_generic_stick_layout(int rank, std::vector<int32_t> host_dim_order)
                  host_dim_order[2]};
       break;
     case 4:
-      dim_map = {host_dim_order[0], host_dim_order[3], host_dim_order[1],
-                 host_dim_order[2], host_dim_order[3]};
+      dim_map = {host_dim_order[1], host_dim_order[2], host_dim_order[3],
+                 host_dim_order[0], host_dim_order[3]};
       break;
     default:
       std::stringstream ss;
@@ -85,7 +85,7 @@ std::vector<int32_t> SpyreTensorLayout::host_dim_order() {
       host_dim_order = {this->dim_map[2], this->dim_map[0], this->dim_map[3]};
       break;
     case 4:
-      host_dim_order = {this->dim_map[0], this->dim_map[2], this->dim_map[3],
+      host_dim_order = {this->dim_map[3], this->dim_map[0], this->dim_map[1],
                         this->dim_map[4]};
       break;
     default:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
This PR changes the generic stick ordering for 4D tensors to match the same pattern as 3D. The sdsc generation for 4d transpose is updated to reflect this. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
```
==================================================================================================================================================== test session starts ====================================================================================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/senuser/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 248 items                                                                                                                                                                                                                                                                                                         

torch-spyre/tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                                                                                                                                            [  2%]
torch-spyre/tests/_inductor/test_inductor_ops.py ..s...............................................................................................................................................                                                                                                                   [ 61%]
torch-spyre/tests/tensor/test_tensor_layout.py ............                                                                                                                                                                                                                                                           [ 66%]
torch-spyre/tests/test_fallbacks.py ........                                                                                                                                                                                                                                                                          [ 69%]
torch-spyre/tests/test_modules.py ssssss.                                                                                                                                                                                                                                                                             [ 72%]
torch-spyre/tests/test_ops.py ..ssssss...................sss..ssss.s.......ss.ss                                                                                                                                                                                                                                      [ 92%]
torch-spyre/tests/test_spyre.py .s...s............                                                                                                                                                                                                                                                                    [ 99%]
torch-spyre/tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                                                                         [100%]

======================================================================================================================================== 219 passed, 29 skipped in 72.77s (0:01:12) =========================================================================================================================================
```
