### PR TITLE
Fix for degenerate var_ranges in KernelSpec codegen

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -322,6 +322,7 @@ def create_kernel_spec(
 
 class SpyreKernel(SIMDKernel[CSEVariable]):
     overrides = SpyreOpFuncs  # type: ignore[assignment]
+    wildcard = sympy.Symbol("*")
 
     def __init__(
         self,
@@ -573,7 +574,10 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
         """
         Return the scale implied by the given iteration space and indexing expression
         """
-        return [1 if di.var in index.free_symbols else -1 for di in op_dimensions]
+        return [
+            1 if (di.var == self.wildcard) or (di.var in index.free_symbols) else -1
+            for di in op_dimensions
+        ]
 
     def analyze_index_expr(self, index: sympy.Expr) -> list[DimensionInfo]:
         """
@@ -583,11 +587,14 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
         ordered_strides: Sequence[tuple[sympy.Symbol, sympy.Expr]] = sorted(
             strides.items(), key=lambda item: item[1], reverse=True
         )
-        result = []
         var_ranges = self.var_ranges()
-        for v, _ in ordered_strides:
-            result.append(DimensionInfo(v, int(var_ranges[v])))
-        return result
+        if var_ranges:
+            result = []
+            for v, _ in ordered_strides:
+                result.append(DimensionInfo(v, int(var_ranges[v])))
+            return result
+        else:
+            return [DimensionInfo(self.wildcard, 1)]
 
     def codegen_kernel(self):
         """Codegen the body of this kernel by pretty printing its KernelSpec"""


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes the analysis for LoopLevelIR var_ranges in KernelSpec creation to handle the
degenerate case of an empty var_ranges.  In LoopLevelIR, this represents a loop body
whose iteration space has 1 element (not zero).

#### Which issue(s) this PR is related to:

#455 

#### Special notes for your reviewer:

```
pytest tests 
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 252 items                                                                                                                                                                                

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                               [  2%]
tests/_inductor/test_inductor_ops.py ..s...............................................................................................................................................      [ 60%]
tests/tensor/test_tensor_layout.py ............                                                                                                                                              [ 65%]
tests/test_fallbacks.py ........                                                                                                                                                             [ 68%]
tests/test_modules.py ssssss.                                                                                                                                                                [ 71%]
tests/test_ops.py ..ssssss.......................sss..ssss.s.......ss.ss                                                                                                                     [ 92%]
tests/test_spyre.py .s...s............                                                                                                                                                       [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                            [100%]

=========================================================================== 223 passed, 29 skipped in 104.39s (0:01:44) ============================================================================

```

#### Does this PR introduce a user-facing change?

#### Additional note:
