### PR TITLE
Handle degnerate matmul cases in KernelSpec construction

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -503,8 +503,14 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
                 di = [di_x[0], di_x[1], di_y[1]]
             elif len(di_x) == 1 and len(di_y) == 2:
                 di = [di_x[0], DimensionInfo(self.wildcard, 1), di_y[1]]
+                # TODO:  The KernelSpec we generate is correct, but the SDSC we generate
+                # will not compute the correct result.  Raise Unsupported to make this explicit.
+                raise Unsupported(f"matmul requires padding support: {value.arguments}")
             elif len(di_x) == 2 and len(di_y) == 1:
                 di = [di_x[0], di_x[1], DimensionInfo(self.wildcard, 1)]
+                # TODO:  The KernelSpec we generate is correct, but the SDSC we generate
+                # will not compute the correct result.  Raise Unsupported to make this explicit.
+                raise Unsupported(f"matmul requires padding support: {value.arguments}")
             else:
                 raise Unsupported(f"degenerate matmul: {value.arguments}")
             args = [


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes code generation of KernelSpec from LoopLevelIR to handle some
degenerate matmul cases (dim of size 1). 

#### Which issue(s) this PR is related to:

This is progress on #197, but is not a complete solution.

After this change, we do manage to generate SDSCs and a program,
but the result is not correct because we need to pad the non-stick dimensions
of the tensors to match the expectations of the DDL

We'll need similar changes to bmm, but I'd like to see the simpler mm case compute
the right answer before working on bmm.

#### Special notes for your reviewer:
```
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 252 items                                                                                                                                                                                

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                                               [  2%]
tests/_inductor/test_inductor_ops.py ..s...............................................................................................................................................      [ 60%]
tests/tensor/test_tensor_layout.py ............                                                                                                                                              [ 65%]
tests/test_fallbacks.py ........                                                                                                                                                             [ 68%]
tests/test_modules.py ssssss.                                                                                                                                                                [ 71%]
tests/test_ops.py ..ssssss.......................sss..ssss.s.......ss.ss                                                                                                                     [ 92%]
tests/test_spyre.py .s...s............                                                                                                                                                       [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                            [100%]

=========================================================================== 223 passed, 29 skipped in 101.54s (0:01:41) ============================================================================

```

#### Does this PR introduce a user-facing change?

#### Additional note:
