### PR TITLE
Enable and test torch.clone with int64, fp32, and bool

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -468,9 +468,40 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             "test_clone",
         ): {
             "param_sets": {
-                "1d": (cached_randn((128,), dtype=torch.float16),),
-                "2d": (cached_randn((256, 128), dtype=torch.float16),),
-                "3d": (cached_randn((8, 16, 256), dtype=torch.float16),),
+                "fp16_1d": (cached_randn((128,), dtype=torch.float16),),
+                "fp16_2d": (cached_randn((256, 128), dtype=torch.float16),),
+                "fp16_3d": (cached_randn((8, 16, 256), dtype=torch.float16),),
+                "int64_1d": (torch.randint(1000, (128,)),),
+                "int64_2d": (torch.randint(1000, (256, 128)),),
+                "int_3d": (torch.randint(1000, (8, 16, 256)),),
+                "fp32_1d": (cached_randn((128,), dtype=torch.float32),),
+                "fp32_2d": (cached_randn((256, 128), dtype=torch.float32),),
+                "fp32_3d": (cached_randn((8, 16, 256), dtype=torch.float32),),
+                "bool_1d": (
+                    torch.rand(
+                        (128,),
+                    )
+                    > 0.5,
+                ),
+                "bool_2d": (
+                    torch.rand(
+                        (
+                            256,
+                            128,
+                        ),
+                    )
+                    > 0.5,
+                ),
+                "bool_3d": (
+                    torch.rand(
+                        (
+                            8,
+                            16,
+                            256,
+                        ),
+                    )
+                    > 0.5,
+                ),
             },
         },
         (
@@ -675,6 +706,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     def test_activation_fn(self, op, input, err):
         compare_with_cpu(lambda x: op(x), input, atol=err, rtol=err)
 
+    @pytest.mark.filterwarnings(
+        "ignore:Backend Spyre does not support int64:UserWarning"
+    )
     def test_clone(self, x):
         compare_with_cpu(lambda a: torch.clone(a).contiguous(), x)
 

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -45,4 +45,5 @@ SPYRE_FP32_OPS = [
     "sigmoid",
     "exx2",
     "layernormnorm",
+    "clone",
 ]

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -315,6 +315,7 @@ def create_kernel_spec(
             torch.bool,
             torch.float16,
             torch.float32,
+            torch.int64,
         ]:
             raise Unsupported(f"operations on {arg.dtype} dtype")
     return KernelSpec(op, is_reduction, [d.numel for d in dims], args, scales, op_info)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Enables and tests [torch.clone](https://docs.pytorch.org/docs/stable/generated/torch.clone.html) on Spyre.

#### Which issue(s) this PR is related to:

Fixes #391.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

No.

#### Test results

```
(dti-venv) [inagaki@inagaki-pod torch-spyre]$ python3 -m pytest -k test_clone tests/_inductor/test_inductor_ops.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/inagaki/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 147 items / 135 deselected / 12 selected

tests/_inductor/test_inductor_ops.py ............                                                                                                                                                           [100%]

======================================================================================= 12 passed, 135 deselected in 12.96s =======================================================================================
(dti-venv) [inagaki@inagaki-pod torch-spyre]$
```

#### Messages from Bob

Successfully fixed the `generate_clone` function to support torch.int64, torch.float32, and other data types, and added proper warning suppression for int64 downcasting in tests.

## Changes Made:

### 1. Fixed `torch_spyre/_inductor/codegen/data_ops.py`:

**Added import:**
```python
from torch_spyre._inductor.codegen.compute_ops import num_bytes
```

**Modified `generate_clone` function to dynamically handle data types:**
- Extract data type info: `input_dtype = inputs[0]["ddtype"]`
- Calculate word length: `word_length = num_bytes(input_dtype)`
- Get data format name: `data_format = input_dtype.name`
- Get elements per stick: `elems_per_stick = input_dtype.elems_per_stick()`

**Replaced all hardcoded values:**
- Changed `wordLength: 2` → `wordLength: word_length`
- Changed `dataformat: "SEN169_FP16"` → `dataformat: data_format`
- Changed `dimToStickSize: {"out": 64}` → `dimToStickSize: {"out": elems_per_stick}`
- Updated all loop counts, piece sizes, offsets, and piece counts to use `elems_per_stick` instead of hardcoded 64

This ensures correct behavior for:
- **FP16**: 64 elements per stick, 2 bytes per element
- **FP32**: 32 elements per stick, 4 bytes per element
- **INT64**: 16 elements per stick, 8 bytes per element (downcasted to INT32)

### 2. Added warning suppression in `tests/_inductor/test_inductor_ops.py`:

```python
@pytest.mark.filterwarnings("ignore:Backend Spyre does not support int64:UserWarning")
def test_clone(self, x):
    compare_with_cpu(lambda a: torch.clone(a).contiguous(), x)
```

This suppresses the expected UserWarning about int64 downcasting to int32, which is the intended behavior since Spyre doesn't natively support int64.

The clone operator now works correctly for all supported data types on the Spyre device.

