### PR TITLE
Test torch.sigmoid

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -451,6 +451,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         ): {
             "ops_dict": {
                 "silu": torch.nn.functional.silu,
+                "sigmoid": torch.sigmoid,
             },
             "param_sets": {
                 "fp16": (


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Tests [`torch.sigmoid`](https://docs.pytorch.org/docs/stable/generated/torch.sigmoid.html) compiled by the inductor.

#### Which issue(s) this PR is related to:

Fixes #451.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
**Test results**
```
(dti-venv) [inagaki@inagaki-pod torch-spyre]$ python3 -m pytest -k test_activation_fn_sigmoid tests/_inductor/test_inductor_ops.py
======================================================== test session starts =========================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/inagaki/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 147 items / 146 deselected / 1 selected

tests/_inductor/test_inductor_ops.py .                                                                                         [100%]

================================================= 1 passed, 146 deselected in 11.81s =================================================
(dti-venv) [inagaki@inagaki-pod torch-spyre]$
```
**Output code**
```python
sdsc_fused_sigmoid_0 = async_compile.sdsc('sdsc_fused_sigmoid_0',
    KernelSpec(
        op='sigmoid',
        is_reduction=False,
        dimensions=[128, 128],
        scales=[[1, 1], [1, 1]],
        op_info={'core_division': [[1, 1, 1], [1, 1, 1]]},
        args=[
            TensorArg(is_input=True, arg_index=0, dtype=torch.float16, host_size=[128, 128], allocation={}, device_layout=SpyreTensorLayout(device_size=[2, 128, 64], dim_map =[1, 0, 1], num_stick_dims=1, format=StickFormat.Dense, device_dtype=DataFormats.SEN169_FP16)),
            TensorArg(is_input=False, arg_index=1, dtype=torch.float16, host_size=[128, 128], allocation={'lx': 0}, device_layout=SpyreTensorLayout(device_size=[2, 128, 64], dim_map =[1, 0, 1], num_stick_dims=1, format=StickFormat.Dense, device_dtype=DataFormats.SEN169_FP16)),
        ]
    )
)
```