### PR TITLE
Implement torch.Tensor.copy_ (inplace tensor copy)

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -50,7 +50,8 @@ def is_sparse(stl: SpyreTensorLayout) -> bool:
 def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLayout:
     pw: Pointwise = n.node.data
     output: FixedLayout = n.node.get_layout()
-    op = pw.get_origin_node().target
+    origin_node = next(iter(pw.origins))
+    op = origin_node.target
     if len(args) == 1:
         x = args[0]
         x_stl = x.layout.device_layout


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds the minimum changes required to support [torch.Tensor.copy_](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.copy_.html). 

Broadcasting semantics are left out for now and will be added in a follow-up PR.

Test cases are also added for torch.add_ and torch.mul_, both of which decompose through torch.copy_.

#### Which issue(s) this PR is related to:

Implement the prerequisites of:
- #465 

Fixes:
- #445 
- #443 

One test case is disabled due to this issue:
- #488 

#### Special notes for your reviewer:

To skip the allocation of an output buffer, its name is registered in V.graph.removed_buffers.

https://github.com/pytorch/pytorch/blob/v2.9.1/torch/_inductor/codegen/wrapper.py#L2994-L3002
```
    def codegen_allocation(self, buffer: ir.Buffer):
        name = buffer.get_name()


        if (
            name in V.graph.removed_buffers
            or name in self.allocated
            or isinstance(buffer, (ir.DonatedBuffer, ir.SubgraphBuffer))
        ):
            return
```

#### Does this PR introduce a user-facing change?

New ops are supported on Spyre.

#### Additional note:

```
(dti-venv) [yohei@yohei-spyre-dev torch-spyre]$ pytest ./tests
============================================ test session starts =============================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 264 items

tests/_inductor/test_building_blocks.py .s.s..                                                         [  2%]
tests/_inductor/test_inductor_ops.py ...s............................................................. [ 26%]
.............................................................................................          [ 62%]
tests/tensor/test_tensor_layout.py ............                                                        [ 66%]
tests/test_fallbacks.py ........                                                                       [ 69%]
tests/test_modules.py ssssss.                                                                          [ 72%]
tests/test_ops.py ..ssssss.......................sss..ssss.s.......ss.ss                               [ 92%]
tests/test_spyre.py .s...s............                                                                 [ 99%]
tests/test_spyre_lazy_silent.py .                                                                      [100%]

================================= 235 passed, 29 skipped in 99.09s (0:01:39) =================================
```
