### PR TITLE
Eliminate StickFormat.SparseMulti

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -219,7 +219,7 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
             output.size,
             output.dtype,
             x_stl.host_dim_order(),
-            StickFormat.SparseMulti,
+            StickFormat.Sparse,
         )
         return FixedTiledLayout(
             output.device, output.dtype, output.size, output.stride, stl

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -284,8 +284,7 @@ PYBIND11_MODULE(_C, m) {
 
   py::enum_<spyre::SpyreTensorLayout::StickFormat>(m, "StickFormat")
       .value("Dense", spyre::SpyreTensorLayout::StickFormat::Dense)
-      .value("Sparse", spyre::SpyreTensorLayout::StickFormat::Sparse)
-      .value("SparseMulti", spyre::SpyreTensorLayout::StickFormat::SparseMulti);
+      .value("Sparse", spyre::SpyreTensorLayout::StickFormat::Sparse);
 
   dci_cls.def_readonly("device_size", &spyre::SpyreTensorLayout::device_size)
       .def_readonly("dim_map", &spyre::SpyreTensorLayout::dim_map)

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -218,10 +218,8 @@ std::string SpyreTensorLayout::toString() const {
   ss << this->num_stick_dims;
   if (this->format == StickFormat::Dense) {
     ss << ", format=StickFormat.Dense, ";
-  } else if (this->format == StickFormat::Sparse) {
-    ss << ", format=StickFormat.Sparse, ";
   } else {
-    ss << ", format=StickFormat.SparseMulti, ";
+    ss << ", format=StickFormat.Sparse, ";
   }
   ss << "device_dtype=DataFormats."
      << EnumsConversion::dataFormatsToString(this->device_dtype);

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -34,7 +34,6 @@ class SpyreTensorLayout {
   enum StickFormat {
     Dense = 0,
     Sparse,
-    SparseMulti,
   };
 
   /**


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ x ] cleanup

#### What this PR does:

This was originally introduced to capture the unusual layout of the result of the exx2 custom operation with the idea of enabling it to be DMAed back to the host for inspection.  This is not needed, since this operation is an implementation detail that can be kept internal.  Therefore we do not need a special StickFormat for just this use case.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
============================================================= test session starts =============================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 253 items                                                                                                                           

tests/_inductor/test_building_blocks.py .s.s..                                                                                          [  2%]
tests/_inductor/test_inductor_ops.py ...s.............................................................................................. [ 41%]
.................................................                                                                                       [ 60%]
tests/tensor/test_tensor_layout.py ............                                                                                         [ 65%]
tests/test_fallbacks.py ........                                                                                                        [ 68%]
tests/test_modules.py ssssss.                                                                                                           [ 71%]
tests/test_ops.py ..ssssss.......................sss..ssss.s.......ss.ss                                                                [ 92%]
tests/test_spyre.py .s...s............                                                                                                  [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                       [100%]

================================================= 224 passed, 29 skipped in 105.77s (0:01:45) =================================================
```

#### Does this PR introduce a user-facing change?

#### Additional note:
