### PR TITLE
Revert PR #297 to fix the pytest failure in test_cross_device_copy_dtypes

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -17,8 +17,6 @@
 import os
 import unittest
 import psutil
-import warnings
-from contextlib import contextmanager
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -121,21 +119,6 @@ class TestSpyre(TestCase):
         self.assertEqual(b, a + 2)
 
     def test_cross_device_copy_dtypes(self):
-        @contextmanager
-        def check_downcast_warning(expect_warning=False):
-            with warnings.catch_warnings(record=True) as rec:
-                warnings.simplefilter("always")
-                yield
-
-            msg = "does not support int64"
-            recorded = [str(w.message) for w in rec]
-            if expect_warning:
-                assert len(rec) == 1 and msg in str(rec[0].message), (
-                    f"Expected one warning containing '{msg}', got: {recorded}"
-                )
-            else:
-                assert len(rec) == 0, f"Expected no warnings, got: {recorded}"
-
         dtypes = [
             torch.float8_e4m3fn,
             torch.int8,
@@ -146,14 +129,12 @@ class TestSpyre(TestCase):
         ]
         for dtype in dtypes:
             x = None
-            expect_warning = False
             if dtype in [torch.int8]:
                 x = torch.rand(64, 64) * 100
                 x = x.to(dtype=dtype)
             elif dtype in [torch.bool]:
                 x = torch.randint(0, 2, (64, 64), dtype=dtype)
             elif dtype in [torch.int64]:
-                expect_warning = True
                 x = torch.randint(-32768, 32767, (64, 64), dtype=dtype)
             elif dtype in [torch.float8_e4m3fn]:
                 x = torch.rand(64, 64)
@@ -161,10 +142,7 @@ class TestSpyre(TestCase):
             else:
                 x = torch.rand(64, 64, dtype=dtype)
             assert x.device.type == "cpu", "initial device is not cpu"
-
-            with check_downcast_warning(expect_warning):
-                x_spyre = x.to("spyre")
-
+            x_spyre = x.to("spyre")
             assert x_spyre.device.type == "spyre", "to device is not spyre"
             assert x_spyre.dtype == x.dtype
             x_cpu = x_spyre.to("cpu")
@@ -236,6 +214,7 @@ class TestSpyre(TestCase):
 
     def test_warning_emitted_when_enabled(self):
         import torch_spyre  # noqa: F401
+        import warnings
 
         torch.set_warn_always(True)
         t = torch.randint(-32768, 32767, (64, 64), dtype=torch.int64)
@@ -248,6 +227,7 @@ class TestSpyre(TestCase):
 
     def test_warning_suppressed_when_disabled(self):
         import torch_spyre  # noqa: F401
+        import warnings
 
         torch.set_warn_always(True)
         torch.spyre.set_downcast_warning(False)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR reverts PR #297 to fix #504. A proper fix will follow.

#### Which issue(s) this PR is related to:

Fixes:
- #504

Reverts:
- #297 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
