### PR TITLE
Fix inconsistency in dim order handling

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -234,9 +234,11 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
         sparse_tensor = is_stick_reduction and not keep_dim
         # add extra dim of size 1 if sparse tensor
         fixed_size = output.size + ([1] if sparse_tensor else [])
-        stl = SpyreTensorLayout(
-            fixed_size, output.dtype, list(range(len(fixed_size))), format
-        )
+        # filter dim_order to remove all non-stick dimensions of size 1's
+        dim_order = [i for i, size in enumerate(fixed_size[:-1]) if size != 1]
+        dim_order += [len(fixed_size) - 1]
+
+        stl = SpyreTensorLayout(fixed_size, output.dtype, dim_order, format)
         return FixedTiledLayout(
             output.device, output.dtype, output.size, output.stride, stl
         )

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -117,10 +117,19 @@ std::vector<int32_t> SpyreTensorLayout::host_dim_order() {
 void SpyreTensorLayout::init(std::vector<int64_t> host_size,
                              c10::ScalarType dtype) {
   int host_dims = static_cast<int32_t>(host_size.size());
+
+  // PyTorch expects to be able to freely add/remove size 1 dimensions
+  // without changing the memory layout of a tensor.  We enable this by
+  // filtering dim_order to remove all non-stick dimensions of size 1's
+  // before we compute the device_size (ie, on-device tiled memory layout).
   std::vector<int32_t> dim_order;
-  for (int32_t i = 0; i < host_dims; i++) {
-    dim_order.push_back(i);
+  for (int32_t i = 0; i < host_dims - 1; i++) {
+    if (host_size[i] != 1) {
+      dim_order.push_back(i);
+    }
   }
+  dim_order.push_back(host_dims - 1);
+
   init(host_size, dtype, dim_order, Dense);
 }
 
@@ -128,8 +137,8 @@ void SpyreTensorLayout::init(std::vector<int64_t> host_size,
                              c10::ScalarType dtype,
                              std::vector<int32_t> dim_order,
                              StickFormat format) {
-  TORCH_CHECK(host_size.size() == dim_order.size(),
-              "Invalid arguments: host_size.size() != dim_order.size()");
+  TORCH_CHECK(host_size.size() >= dim_order.size(),
+              "Invalid arguments: host_size.size() < dim_order.size()");
 
   auto str_type = torchScalarToString[dtype];
   const auto [sen_dtype_cpu, sen_dtype_dev] =
@@ -147,23 +156,11 @@ void SpyreTensorLayout::init(std::vector<int64_t> host_size,
     return;
   }
 
-  // PyTorch expects to be able to freely add/remove size 1 dimensions
-  // without changing the memory layout of a tensor.  We enable this by
-  // filtering dim_order to remove all non-stick dimensions of size 1's
-  // before we compute the device_size (ie, on-device tiled memory layout).
-  std::vector<int32_t> filtered_dim_order;
-  for (auto i = 0; i < (dim_order.size() - 1); i++) {
-    if (host_size[dim_order[i]] != 1) {
-      filtered_dim_order.push_back(dim_order[i]);
-    }
-  }
-  filtered_dim_order.push_back(dim_order[dim_order.size() - 1]);
-
-  int device_dims = static_cast<int>(filtered_dim_order.size()) + 1;
+  int device_dims = static_cast<int>(dim_order.size()) + 1;
   auto elems_in_stick = format == Dense ? this->elems_per_stick() : 1;
 
   this->device_size.resize(device_dims);
-  this->dim_map = spyre::get_generic_stick_layout(filtered_dim_order);
+  this->dim_map = spyre::get_generic_stick_layout(dim_order);
   this->format = format;
 
   // Stick dim


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

device_layout.host_dim_order() returns a filtered dim order, but SpyreTensorLayout::init() expected an unfiltered one. This patch removes the mismatch by making all call sites use the filtered dim order consistently.

#### Which issue(s) this PR is related to:

Fixes:
- #510 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

```
(dti-venv) [yohei@yohei-spyre-dev torch-spyre]$ pytest ./tests
=================================================================== test session starts ===================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 266 items

tests/_inductor/test_building_blocks.py .s.s..                                                                                                      [  2%]
tests/_inductor/test_inductor_ops.py ...s.......................................................................................................... [ 43%]
..................................................                                                                                                  [ 62%]
tests/tensor/test_tensor_layout.py ............                                                                                                     [ 66%]
tests/test_fallbacks.py ........                                                                                                                    [ 69%]
tests/test_modules.py ssssss.                                                                                                                       [ 72%]
tests/test_ops.py .x.ssss.s......................sss..s.s..s..xs..sss.ss                                                                            [ 92%]
tests/test_spyre.py .s..ss............                                                                                                              [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                   [100%]

================================================== 235 passed, 29 skipped, 2 xfailed in 95.34s (0:01:35) ==================================================
```
