### PR TITLE
fixed bug where sparse tensors would break during assertion in indexer (pytorch 2.10.0)

### DIFF
--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -120,14 +120,15 @@ class FixedTiledLayout(FixedLayout):
         stl = self.device_layout
 
         def indexer(index: Sequence[Expr]) -> Expr:
-            for d in stl.dim_map:
-                assert d < len(index)
             result = offset
             stick_dim = stl.dim_map[-1]
             for hd, stride in zip(stl.dim_map, stl.device_strides()):
+                if hd >= len(index):
+                    continue  # Skip extra dims for sparse tensors
                 if hd != stick_dim:
                     result = result + (index[hd] * stride)
-            result = result + index[stick_dim]  # stride of 1!
+            if stick_dim < len(index):
+                result = result + index[stick_dim]  # stride of 1!
             return result
 
         return indexer


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

fixed bug where sparse tensors would break during assertion in indexer (pytorch 2.10.0). This issue was introduced because 2.10.0 fixed view output getting padded incorrectly causing make_indexer to be called on reductions it wasnt called on in prior path

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#509 

#### Special notes for your reviewer:

NA

#### Does this PR introduce a user-facing change?

No

#### Additional note:

I believe this was introduced from this: https://github.com/pytorch/pytorch/pull/163398

Working in 2.9.1 and 2.10.0:

```
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /tmp/devel/src/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 266 items                                                                                                                                                                    

torch-spyre/tests/_inductor/test_building_blocks.py .s.s..                                                                                                                       [  2%]
torch-spyre/tests/_inductor/test_inductor_ops.py ...s........................................................................................................................... [ 50%]
.................................                                                                                                                                                [ 62%]
torch-spyre/tests/tensor/test_tensor_layout.py ............                                                                                                                      [ 66%]
torch-spyre/tests/test_fallbacks.py ........                                                                                                                                     [ 69%]
torch-spyre/tests/test_modules.py ssssss.                                                                                                                                        [ 72%]
torch-spyre/tests/test_ops.py .x.ssss.s......................sss..s.s..s..xs..sss.ss                                                                                             [ 92%]
torch-spyre/tests/test_spyre.py .s..ss............                                                                                                                               [ 99%]
torch-spyre/tests/test_spyre_lazy_silent.py .                                                                                                                                    [100%]

================================================================ 235 passed, 29 skipped, 2 xfailed in 95.29s (0:01:35) =================================================================
```