### PR TITLE
Eliminate case statement on ndims in generate_spf_ops

### DIFF
--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -337,12 +337,9 @@ def generate_sfp_op(pointers, *, op, dimensions, inputs, outputs, reduction, **k
     if reduction and tensors[-1]["scale"][-1] == 1:
         op += "nonstick"
 
-    # Dimension layout for the operation is the generic device layout
-    # of an ndim-dimensional tensor
-    device_layout = tensors[0]["device_layout"].get_generic_stick_layout(
-        list(range(ndim))
-    )
-    dim_indices = device_layout[::-1][1:]  # reverse and remove stick tiling
+    # Get operation dim map from input or output tensor
+    tensor = inputs[0] if reduction else outputs[0]
+    dim_indices = tensor["device_layout"].dim_map[::-1][1:]
 
     dim_labels = INPUT_DIM_LABELS[: ndim - 1] + OUTPUT_DIM_LABELS[:1]
     dim_splits = [1] * (ndim - 1) + [cores]

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -50,6 +50,6 @@ SPYRE_FP32_OPS = [
 
 LAYOUT_LABELS = ["INPUT", "OUTPUT", "KERNEL", "KERNEL_IDX"]
 
-# TODO: Populate more valid labels here
+# Populate more valid labels from deeptools here if needed
 INPUT_DIM_LABELS = ["mb", "x", "y", "i", "j"]
 OUTPUT_DIM_LABELS = ["out"]

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -290,8 +290,6 @@ PYBIND11_MODULE(_C, m) {
       .def("__repr__",
            [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
       .def("elems_per_stick", &spyre::SpyreTensorLayout::elems_per_stick)
-      .def("get_generic_stick_layout",
-           &spyre::SpyreTensorLayout::get_generic_stick_layout)
       .def("host_stick_dim", &spyre::SpyreTensorLayout::host_stick_dim)
       .def(py::self == py::self)
       .def(py::init<std::vector<int64_t>, c10::ScalarType>(),

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -28,8 +28,6 @@
 namespace spyre {
 
 int64_t elems_per_stick(const DataFormats& df);
-std::vector<int32_t> get_generic_stick_layout(
-    std::vector<int32_t> host_dim_order);
 
 class SpyreTensorLayout {
  public:
@@ -100,11 +98,6 @@ class SpyreTensorLayout {
 
   int64_t elems_per_stick() {
     return spyre::elems_per_stick(this->device_dtype);
-  }
-
-  std::vector<int32_t> get_generic_stick_layout(
-      std::vector<int32_t> host_dim_order) {
-    return spyre::get_generic_stick_layout(host_dim_order);
   }
 
   bool operator==(const SpyreTensorLayout& other) const {


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

- Eliminates the case statement on ndim, getting info from SpyreTensorLayout
- Unifies all list reordering to be inside DimInfos class
- Moves the scale array into DimInfos so code that accesses it is simpler

#### Which issue(s) this PR is related to:

None

#### Special notes for your reviewer:

~~The dimension order of the operation is computed in a way that is fragile, but this can be fixed as soon as we push more information through the SpyreTensorLayout~~

Dimension order for the operation is now computed by propagating `get_generic_stick_layout` into SpyreTensorLayout so that compute_ops.py can get the default layout the operation.  Without this, it needed to be computed by iterating over all tensors and inferring it.  We should agree this is the best option.

#### Does this PR introduce a user-facing change?
No

#### Additional note:

=========================================================================== test session starts ============================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/marnold/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 268 items

tests/_inductor/test_building_blocks.py .s.s..                                                                                                                       [  2%]
tests/_inductor/test_inductor_ops.py ...s........................................................................................................................... [ 49%]
...................................                                                                                                                                  [ 62%]
tests/tensor/test_tensor_layout.py ............                                                                                                                      [ 67%]
tests/test_fallbacks.py ........                                                                                                                                     [ 70%]
tests/test_modules.py ssssss.                                                                                                                                        [ 72%]
tests/test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                                                             [ 92%]
tests/test_spyre.py .s..ss............                                                                                                                               [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                    [100%]

========================================================== 242 passed, 25 skipped, 1 xfailed in 91.49s (0:01:31) ===========================================================