### PR TITLE
Pass host_size to SDSC gen to support op with different input/output shapes

### DIFF
--- a/torch_spyre/_inductor/runtime/async_compile.py
+++ b/torch_spyre/_inductor/runtime/async_compile.py
@@ -59,6 +59,7 @@ class SpyreAsyncCompile:
                         "name": _argument_names[index],
                         "scale": ks.scales[index],
                         "device_layout": ts.device_layout,
+                        "host_size": ts.host_size,
                     }
                 )
                 arg_mapping.append(ts.arg_index)
@@ -68,6 +69,7 @@ class SpyreAsyncCompile:
                         "name": _argument_names[index],
                         "scale": ks.scales[index],
                         "device_layout": ts.device_layout,
+                        "host_size": ts.host_size,
                     }
                 )
                 arg_mapping.append(ts.arg_index)


### PR DESCRIPTION
shapes

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds host_size of input/output to kernel_descriptor so that they could be used in SDSC gen.

Ops like torch.cat, torch.slice, and torch.repeat have different input and output tensor sizes.
* torch.cat: multiple inputs with different sizes to single output
* torch.repeat: single input to larger output with repeated elements
* tensor slicing: single input to smaller output

The dimensions field is not sufficient to support SDSC gen for such ops.

#### Which issue(s) this PR is related to:

Related to #122 #268 #342 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
