### PR TITLE
Add tensor layout tests that cover H2D copy of sparse layout

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -128,5 +128,6 @@ class TestSpyreTensorLayout(TestCase):
         self.assertEqual(x_stl.device_size, [256, 512, 64])
         self.assertEqual(x_stl.dim_map, [1, 0, -1])
 
+
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The added tests should cover copying pytorch tensor to and from spyre device with "sparse" tensor layout. The unit tests in test_inductor_ops.py do not cover H2D
 
#### Which issue(s) this PR is related to:
NA

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

#### Additional note:
```
==================================================== test session starts ====================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0 -- /home/ccyang/dt-inductor/dti-venv/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/ccyang/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 11 items                                                                                                          

tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_device_alloc PASSED                                         [  9%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_dim_order PASSED                                            [ 18%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_empty_layout_patched PASSED                                 [ 27%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_equality PASSED                                             [ 36%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_explicit_stl_constructor PASSED                             [ 45%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_generic_stick PASSED                                        [ 54%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_initializes PASSED                                          [ 63%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_sparse_dim_order PASSED                                     [ 72%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_stl_str PASSED                                              [ 81%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_to_layout_patched PASSED                                    [ 90%]
tensor/test_tensor_layout.py::TestSpyreTensorLayout::test_to_spyre_layout PASSED                                      [100%]

==================================================== 11 passed in 10.36s ====================================================
```
