### PR TITLE
Fix codegen of slice and swap

### DIFF
--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -181,10 +181,15 @@ def lower_bmm(x, y):
 
 @register_spyre_lowering(torch.ops.spyre.swap)
 def lower_swap(x):
+    fn = lowering.ops_wrapper(torch.ops.spyre.swap.__name__)
+
+    def inner_fn(index):
+        return fn(x.make_loader()(index))
+
     pw = Pointwise.create(
         device=x.get_device(),
         dtype=x.get_dtype(),
-        inner_fn=x.make_loader(),
+        inner_fn=inner_fn,
         ranges=x.get_size(),
         origin_node=x.get_origin_node(),
         traceback=x.get_traceback(),
@@ -195,10 +200,15 @@ def lower_swap(x):
 
 @register_spyre_lowering(torch.ops.spyre.slice)
 def lower_slice(x):
+    fn = lowering.ops_wrapper(torch.ops.spyre.slice.__name__)
+
+    def inner_fn(index):
+        return fn(x.make_loader()(index))
+
     pw = Pointwise.create(
         device=x.get_device(),
         dtype=x.get_dtype(),
-        inner_fn=x.make_loader(),
+        inner_fn=inner_fn,
         ranges=x.get_size(),
         origin_node=x.get_origin_node(),
         traceback=x.get_traceback(),

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -174,6 +174,14 @@ class SpyreOpFuncs:
         return PointwiseOp("rsqrt", [x])
 
     @staticmethod
+    def slice(x):
+        return PointwiseOp("slice", [x])
+
+    @staticmethod
+    def swap(x):
+        return PointwiseOp("swap", [x])
+
+    @staticmethod
     def sigmoid(x):
         return PointwiseOp("sigmoid", [x])
 
@@ -415,8 +423,6 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
             )
         elif isinstance(value, TensorAccess):
             # Reshapes, transposes, and other dataops
-            input_stride = list(self.get_strides(value.index).values())[0]
-            output_stride = list(self.get_strides(dst.index).values())[0]
             in_di = self.derive_dim_info(value)
             out_di = self.derive_dim_info(dst)
             args = [
@@ -439,10 +445,6 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
                 elif Counter(in_di) == Counter(out_di) and in_di != out_di:
                     # Transpose: check that the input / output DimensionInfo are the same, but in different order.
                     op = TRANSPOSE_OP
-                elif input_stride == 64 and output_stride == 64:
-                    op = "swap"
-                elif input_stride == 64 and output_stride == 1:
-                    op = "slice"
                 elif (
                     args[1].device_layout.device_size
                     == args[0].device_layout.device_size
@@ -567,15 +569,6 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
             self.kernel_specs.append(
                 create_kernel_spec(value.op, True, di, args, scales, op_info)
             )
-
-    def get_strides(self, index: sympy.Expr) -> dict[sympy.Symbol, sympy.Expr]:
-        """
-        Compute the strides of the free variables in an index expression.
-        """
-        return {
-            s: sympy_subs(index, {s: 1}) - sympy_subs(index, {s: 0})
-            for s in index.free_symbols
-        }
 
     def analyze_tensor_access(
         self,

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -44,7 +44,7 @@ spyreop = torch.ops.spyre
 
 
 def is_sparse(stl: SpyreTensorLayout) -> bool:
-    return stl.device_size[-1] == -1
+    return stl.dim_map[-1] == -1
 
 
 def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLayout:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Fixes a bug in the `is_sparse` helper method in stickify.py introduced in #559.

Improves the lowering of the splice and swap custom ops so that the op name is preserved.
This eliminates a special case in code generation, since these can now be handled as normal
pointwise operations. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 263 items                                                                                                                                                                                          

tests/_inductor/test_building_blocks.py .s..                                                                                                                                                           [  1%]
tests/_inductor/test_inductor_ops.py ...s...........................................................................................................................................................   [ 61%]
tests/tensor/test_tensor_layout.py ............                                                                                                                                                        [ 66%]
tests/test_fallbacks.py ........                                                                                                                                                                       [ 69%]
tests/test_modules.py ssssss.                                                                                                                                                                          [ 72%]
tests/test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                                                                                               [ 92%]
tests/test_spyre.py .s..ss............                                                                                                                                                                 [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                      [100%]

=========================================================================== 238 passed, 24 skipped, 1 xfailed in 186.49s (0:03:06) ===========================================================================

```
#### Does this PR introduce a user-facing change?

#### Additional note:
