### PR TITLE
Add get_device_dtype method to C APIs

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -16,7 +16,7 @@
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch_spyre._C import SpyreTensorLayout, DataFormats, to_with_layout
+from torch_spyre._C import SpyreTensorLayout, to_with_layout, get_device_dtype
 
 
 class TestSpyreTensorLayout(TestCase):
@@ -53,7 +53,9 @@ class TestSpyreTensorLayout(TestCase):
 
     def test_explicit_stl_constructor(self):
         stl_x = SpyreTensorLayout([512, 256], torch.float16)
-        stl_y = SpyreTensorLayout([4, 512, 64], [1, 0, 1], DataFormats.SEN169_FP16)
+        stl_y = SpyreTensorLayout(
+            [4, 512, 64], [1, 0, 1], get_device_dtype(torch.float16)
+        )
         self.assertEqual(stl_x.dim_map, stl_y.dim_map)
         self.assertEqual(stl_x.device_size, stl_y.device_size)
 
@@ -90,7 +92,9 @@ class TestSpyreTensorLayout(TestCase):
         self.assertEqual(x, x_dev.cpu())
 
         y = torch.rand([512, 512], dtype=torch.float16)
-        y_stl = SpyreTensorLayout([8, 512, 64], [1, 0, 1], DataFormats.SEN169_FP16)
+        y_stl = SpyreTensorLayout(
+            [8, 512, 64], [1, 0, 1], get_device_dtype(torch.float16)
+        )
         y_dev = to_with_layout(y, y_stl)
         self.assertEqual(y, y_dev.cpu())
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -244,6 +244,13 @@ int64_t get_elem_in_stick(c10::ScalarType torch_dtype) {
   return elems_per_stick(sen_dtype_dev);
 }
 
+DataFormats get_device_dtype(c10::ScalarType torch_dtype) {
+  auto str_type = torchScalarToString[torch_dtype];
+  const auto [sen_dtype_cpu, sen_dtype_dev] =
+      stringToDTDataFormatPair(str_type);
+  return sen_dtype_dev;
+}
+
 }  // namespace spyre
 
 PYBIND11_MODULE(_C, m) {
@@ -306,4 +313,5 @@ PYBIND11_MODULE(_C, m) {
   m.def("set_downcast_warning", &spyre::set_downcast_warn_enabled,
         "Enable/disable downcast warnings for this process.");
   m.def("get_elem_in_stick", &spyre::get_elem_in_stick);
+  m.def("get_device_dtype", &spyre::get_device_dtype);
 }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Adds a method `get_device_dtype` to the torch_spyre native APIs and exposes it to Python.

We need to be able to convert torch dtypes into device_dtypes to invoke the lowlevel SpyreTensorLayout
constructor from the compiler.  It's better to expose the native method to Python than to replicate it via
a switch statement mapping torch types to DataFormats in the compiler code.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
===================================================== test session starts =====================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 268 items                                                                                                           

tests/_inductor/test_building_blocks.py .s..                                                                            [  1%]
tests/_inductor/test_inductor_ops.py ...s.............................................................................. [ 32%]
..................................................................................                                      [ 62%]
tests/tensor/test_tensor_layout.py ............                                                                         [ 67%]
tests/test_fallbacks.py ........                                                                                        [ 70%]
tests/test_modules.py ssssss.                                                                                           [ 72%]
tests/test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                [ 92%]
tests/test_spyre.py .s..ss............                                                                                  [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                       [100%]

=================================== 243 passed, 24 skipped, 1 xfailed in 126.92s (0:02:06) ====================================
```

#### Does this PR introduce a user-facing change?

#### Additional note:
