### PR TITLE
remove hardwired scales array from matmul KernelSpec

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -521,7 +521,11 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
                 create_tensor_arg(True, actuals.index(y.name), y.layout),
                 create_tensor_arg(False, actuals.index(dst.name), dst.layout),
             ]
-            scales = [[1, 1, -1], [-1, 1, 1], [1, -1, 1]]
+            scales = [
+                self.analyze_tensor_access(di, x),
+                self.analyze_tensor_access(di, y),
+                self.analyze_tensor_access(di, dst),
+            ]
             self.kernel_specs.append(
                 create_kernel_spec(value.op, True, di, args, scales, op_info)
             )


### PR DESCRIPTION

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

#559 missed a case in matmul.  This PR fixes that oversight.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 268 items                                                                                                                                                                                            

tests/_inductor/test_building_blocks.py .s..                                                                                                                                                             [  1%]
tests/_inductor/test_inductor_ops.py ...s............................................................................................................................................................... [ 62%]
.                                                                                                                                                                                                        [ 62%]
tests/tensor/test_tensor_layout.py ............                                                                                                                                                          [ 67%]
tests/test_fallbacks.py ........                                                                                                                                                                         [ 70%]
tests/test_modules.py ssssss.                                                                                                                                                                            [ 72%]
tests/test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                                                                                                 [ 92%]
tests/test_spyre.py .s..ss............                                                                                                                                                                   [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                        [100%]

============================================================================ 243 passed, 24 skipped, 1 xfailed in 177.96s (0:02:57) ============================================================================
```

#### Does this PR introduce a user-facing change?

#### Additional note:
