### PR TITLE
Support tensors with size‑1 dimensions in SFP ops

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -664,6 +664,38 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             }
         },
+        (
+            "test_size_one",
+            "test_unary_op_cpu",
+        ): {
+            "ops_dict": {
+                "exp": torch.exp,
+            },
+            "param_sets": {
+                "2d0": {cached_randn((1, 3), dtype=torch.float16)},
+                "2d1": {cached_randn((2, 1), dtype=torch.float16)},
+                "3d0": {cached_randn((1, 3, 4), dtype=torch.float16)},
+                "3d1": {cached_randn((2, 1, 4), dtype=torch.float16)},
+                "3d2": {cached_randn((2, 3, 1), dtype=torch.float16)},
+                "3d01": {cached_randn((1, 1, 4), dtype=torch.float16)},
+                "3d02": {cached_randn((2, 3, 1), dtype=torch.float16)},
+                "3d12": {cached_randn((1, 1, 4), dtype=torch.float16)},
+                "4d0": {cached_randn((1, 3, 4, 5), dtype=torch.float16)},
+                "4d1": {cached_randn((2, 1, 4, 5), dtype=torch.float16)},
+                "4d2": {cached_randn((2, 3, 1, 5), dtype=torch.float16)},
+                "4d3": {cached_randn((2, 3, 4, 1), dtype=torch.float16)},
+                "4d01": {cached_randn((1, 1, 4, 5), dtype=torch.float16)},
+                "4d02": {cached_randn((1, 3, 1, 5), dtype=torch.float16)},
+                "4d03": {cached_randn((1, 3, 4, 1), dtype=torch.float16)},
+                "4d12": {cached_randn((2, 1, 1, 1), dtype=torch.float16)},
+                "4d13": {cached_randn((2, 1, 4, 1), dtype=torch.float16)},
+                "4d23": {cached_randn((2, 3, 1, 1), dtype=torch.float16)},
+                "4d012": {cached_randn((1, 1, 1, 5), dtype=torch.float16)},
+                "4d013": {cached_randn((1, 1, 4, 1), dtype=torch.float16)},
+                "4d023": {cached_randn((1, 3, 1, 1), dtype=torch.float16)},
+                "4d123": {cached_randn((2, 1, 1, 1), dtype=torch.float16)},
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds support for tensors that include dimensions of size 1 when running SFP operators.

Tensors with size‑1 dimensions produce dim_maps that omit those dimensions. As a result, generate_sfp_op previously failed to handle such dim_maps correctly. This patch fixes the issue by adding proper handling for missing dimensions in dim_map.

Fixes #585

#### Which issue(s) this PR is related to:

- #585

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional note:

```
========================================================= test session starts ==========================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 296 items

tests/_inductor/test_building_blocks.py .s..                                                                                     [  1%]
tests/_inductor/test_inductor_ops.py ...s....................................................................................... [ 32%]
.....................................................................................................                            [ 66%]
tests/tensor/test_tensor_layout.py ............                                                                                  [ 70%]
tests/test_fallbacks.py ........                                                                                                 [ 72%]
tests/test_modules.py ssssss.                                                                                                    [ 75%]
tests/test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                         [ 93%]
tests/test_spyre.py .s..ss............                                                                                           [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                [100%]

======================================== 271 passed, 24 skipped, 1 xfailed in 227.80s (0:03:47) ========================================
```