### PR TITLE
Generalize stickification pass for pointwise ops

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -103,7 +103,7 @@ def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
                 stl = SpyreTensorLayout(output.size, output.dtype, [0, -1])
 
             case aten.clone.default:
-                # Clone puts its output into the default device layoout.
+                # Clone puts its output into the default device layout.
                 stl = SpyreTensorLayout(output.size, output.dtype)
 
             case _:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x] bug
- [ x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Generalizes the logic of stickification for pointwise operations to enable more combinations of input layouts.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

A useful checkpoint in the work for #534 

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
====================================================================================================== test session starts ======================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 389 items                                                                                                                                                                                                             

tests/_inductor/test_building_blocks.py .s..                                                                                                                                                                              [  1%]
tests/_inductor/test_inductor_ops.py ...s................................................................................................................................................................................ [ 47%]
.........................................................................................................                                                                                                                 [ 74%]
tests/tensor/test_tensor_layout.py ............                                                                                                                                                                           [ 77%]
tests/test_fallbacks.py ........                                                                                                                                                                                          [ 79%]
tests/test_modules.py ssssss.                                                                                                                                                                                             [ 81%]
tests/test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                                                                                                                  [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                                                                                    [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                                         [100%]

==================================================================================== 364 passed, 24 skipped, 1 xfailed in 171.88s (0:02:51) =====================================================================================

```
#### Does this PR introduce a user-facing change?

#### Additional note:
