### PR TITLE
Make SENCORES=32 default and remove compare_with_eager

### DIFF
--- a/tests/_inductor/utils_inductor.py
+++ b/tests/_inductor/utils_inductor.py
@@ -168,23 +168,6 @@ class ParameterizedTestMeta(type):
         return super().__new__(mcs, name, bases, namespace)
 
 
-# compare with eager
-def compare_with_eager(fn, *args, atol=0, rtol=0, needs_device=False):
-    torch._dynamo.reset_code_caches()  # kernel caching workaround
-    device_args = [arg.to(DEVICE) for arg in args]
-    device_kwargs = {"device": DEVICE} if needs_device else {}
-    result = torch.compile(fn)(*device_args, **device_kwargs).cpu()
-    eager_result = fn(*device_args, **device_kwargs).cpu()
-    torch.testing.assert_close(
-        result,
-        eager_result,
-        equal_nan=True,
-        atol=atol,
-        rtol=rtol,
-        msg=lambda msg: f"eager mismatch\n\n{msg}\n",
-    )
-
-
 # compare with cpu
 def compare_with_cpu(
     fn, *args, atol=0.1, rtol=0.1, needs_device=False, cpu_compile=True
@@ -260,7 +243,7 @@ def compare_with_sendnn(fn, *args, atol=0.0, rtol=0.0, needs_device=False):
     )
 
 
-# 4-way comparison
+# 3-way comparison
 def compare(
     fn, *args, atol=0.0, rtol=0.0, cpu_atol=0.1, cpu_rtol=0.1, needs_device=False
 ):
@@ -269,15 +252,6 @@ def compare(
     device_kwargs = {"device": DEVICE} if needs_device else {}
     result = torch.compile(fn)(*device_args, **device_kwargs).cpu()
 
-    eager_result = fn(*device_args, **device_kwargs).cpu()
-    torch.testing.assert_close(
-        result,
-        eager_result,
-        equal_nan=True,
-        atol=atol,
-        rtol=rtol,
-        msg=lambda msg: f"eager mismatch\n\n{msg}\n",
-    )
     cpu_result = fn(*args)
     torch.testing.assert_close(
         result,

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -258,7 +258,7 @@ def core_division_planning(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
     # Nodes are in topological order (guarenteed by caller).
-    max_cores = int(os.getenv("SENCORES", "1"))
+    max_cores = int(os.getenv("SENCORES", "32"))
     if max_cores > 32 or max_cores < 1:
         raise Unsupported(f"invalid SENCORES value {max_cores}")
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

- Change SENCORES default to 32 if env variable is not set
- Remove eager result comparison from inductor op tests

#### Which issue(s) this PR is related to:

#533 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

##Before
```
======================================================== test session starts ========================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/ccyang/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 392 items                                                                                                                 

_inductor/test_building_blocks.py .s..                                                                                        [  1%]
_inductor/test_inductor_ops.py ...s.......................................................................................... [ 25%]
............................................................................................................................. [ 56%]
.....................................................................                                                         [ 74%]
tensor/test_tensor_layout.py ............                                                                                     [ 77%]
test_fallbacks.py ........                                                                                                    [ 79%]
test_modules.py ssssss.                                                                                                       [ 81%]
test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                            [ 95%]
test_spyre.py .s..ss............                                                                                              [ 99%]
test_spyre_lazy_silent.py .                                                                                                   [100%]

====================================== 367 passed, 24 skipped, 1 xfailed in 163.70s (0:02:43) =======================================
```

## After
Note the reduced test time
```
======================================================== test session starts ========================================================
platform linux -- Python 3.12.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/ccyang/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 392 items                                                                                                                 

_inductor/test_building_blocks.py .s..                                                                                        [  1%]
_inductor/test_inductor_ops.py ...s.......................................................................................... [ 25%]
............................................................................................................................. [ 56%]
.....................................................................                                                         [ 74%]
tensor/test_tensor_layout.py ............                                                                                     [ 77%]
test_fallbacks.py ........                                                                                                    [ 79%]
test_modules.py ssssss.                                                                                                       [ 81%]
test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                            [ 95%]
test_spyre.py .s..ss............                                                                                              [ 99%]
test_spyre_lazy_silent.py .                                                                                                   [100%]

====================================== 367 passed, 24 skipped, 1 xfailed in 136.64s (0:02:16) =======================================
```