### PR TITLE
Remove hard-coded information from matmul/bmm codegen that can be computed from SpyreTensorLayout 

### DIFF
--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -35,6 +35,11 @@ class DimInfo:
         setattr(self, name, value)
 
 
+def get_scales_sdsc_format(tensor):
+    # SDSC needs non-negative scale values to be 1
+    return [1 if s >= 0 else s for s in tensor["scale"]]
+
+
 @dataclass
 class DimInfos:
     """
@@ -86,7 +91,7 @@ class DimInfos:
         )
 
     # Internal implementation functions.
-    def add_row(self, name, info_list, in_former_order=True):
+    def add_row(self, name, info_list):
         self.rows[name] = info_list
 
     def make_dim_infos(self, fields=[], index_order=None, additional_rows={}):
@@ -110,7 +115,7 @@ class DimInfos:
     # Therefore some sdsc sections require all op dimensions, but
     # with the order of a subset of the indices adjusted to match
     # the tile layout of the tensor on the device.  This
-    # function computest that reordering
+    # function computes that reordering
     def get_tensor_op_index_order(self, tensor):
         dim_indices = self.dim_indices  # op dimension order
         dev_dim_order = tensor["device_layout"].dim_map[::-1][1:]
@@ -128,10 +133,6 @@ class DimInfos:
             # Indices and order unchanged
             tensor_dim_indices = dim_indices
         return tensor_dim_indices
-
-    def get_tensor_scales(self, tensor):
-        # SDSC needs non-negative scale values to be 1
-        return [1 if s >= 0 else s for s in tensor["scale"]]
 
     def get_labels_host_order(self):
         return self.rows["label"]
@@ -154,7 +155,7 @@ class DimInfos:
 
     def get_tensor_op_infos(self, tensor):
         result = self.make_dim_infos(
-            additional_rows={"scale": self.get_tensor_scales(tensor)},
+            additional_rows={"scale": get_scales_sdsc_format(tensor)},
             index_order=self.get_tensor_op_index_order(tensor),
         )
         return result


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR uses the DimInfos improvements from #593  to simplify the matmul/bmm code.  It does the following:

- Extracts padded dimensions for the operation from tensors. Was able to unify it to a single short route `get_padded_dimensions_matmul(..)` that works for both matmul and bmm 3, 4 dims (and maybe 5+? tbd)
- Extract layout order automatically from tensors.  Eliminates the tedious manual specification for mm & bmm3, bmm4. 
- Populate primarDs names and layouts sdsc fields automatically
- Compute stick_dim labels and is_stick automatically from tensors.
- Removed all zipped tuples in matmul sdsc generation loops as they are no longer needed


#### Which issue(s) this PR is related to:

#243 

#### Special notes for your reviewer:

It wasn't obvious to me at first that the existing manual specification of layout order (ie, `["x", "in", "out"]) was so bad because it was easy to read and self documenting.  But these manual specifications became quite tedious for matmul/bmm3/bmm4 so I'm now convinced it's definitely a win to delete all that code and pull it automatically from SpyreTensorLayout.  The code might (?) also work bmm dims 5+, but it is not yet tested.

If someone feels that seeing the order explicitly somewhere is valuable for understanding the rest of the code, we can write them in documentation somewhere,  dump them with a debug flag, or even write a test that asserts we compute the expected orders.

#### Does this PR introduce a user-facing change?

#### Additional note:

