### PR TITLE
Fix KernelSpec generation for BMM with dims of size 1

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -551,7 +551,33 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
             y = value.arguments[1]
             di_x = self.derive_dim_info(x)
             di_y = self.derive_dim_info(y)
-            di = di_x[0:3] + di_y[2:]
+            if len(di_x) == 4 and len(di_y) == 4:
+                di = di_x[0:3] + di_y[2:]
+            elif len(di_x) == 3 and len(di_y) == 3:
+                di = di_x[0:3] + di_y[2:]
+            elif len(di_x) == 2 and len(di_y) == 3:
+                if di_x == di_y[0:2]:
+                    di = [di_x[0], DimensionInfo(self.wildcard, 1), di_x[1], di_y[2]]
+                elif di_x[0] == di_y[0]:
+                    di = [di_x[0], di_x[1], DimensionInfo(self.wildcard, 1), di_y[2]]
+                else:
+                    di = [DimensionInfo(self.wildcard, 1), di_x[0], di_x[1], di_y[2]]
+            elif len(di_x) == 3 and len(di_y) == 2:
+                di = [di_x[0], di_x[1], di_x[2], DimensionInfo(self.wildcard, 1)]
+            elif len(di_x) == 2 and len(di_y) == 2:
+                if di_x == di_y:
+                    di = [
+                        di_x[0],
+                        DimensionInfo(self.wildcard, 1),
+                        di_x[1],
+                        DimensionInfo(self.wildcard, 1),
+                    ]
+                elif di_x[0] == di_y[0]:
+                    di = [di_x[0], di_x[1], DimensionInfo(self.wildcard, 1), di_y[1]]
+                else:
+                    di = [DimensionInfo(self.wildcard, 1), di_x[0], di_x[1], di_y[1]]
+            else:
+                raise Unsupported(f"malformed bmm {di_x} {di_y}")
             args = [
                 create_tensor_arg(True, actuals.index(x.name), x.layout),
                 create_tensor_arg(True, actuals.index(y.name), y.layout),


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Generalizes KernelSpec generation to handle BMMs on tensors with dimensions of size 1.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
(dti-venv) [dgrove@groved-dev torch-spyre]$ pytest tests 
============================================================================================================================= test session starts =============================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.1, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.148.2
collected 392 items                                                                                                                                                                                                                                                           

tests/_inductor/test_building_blocks.py .s..                                                                                                                                                                                                                            [  1%]
tests/_inductor/test_inductor_ops.py ...s.............................................................................................................................................................................................................................. [ 58%]
..............................................................                                                                                                                                                                                                          [ 74%]
tests/tensor/test_tensor_layout.py ............                                                                                                                                                                                                                         [ 77%]
tests/test_fallbacks.py ........                                                                                                                                                                                                                                        [ 79%]
tests/test_modules.py ssssss.                                                                                                                                                                                                                                           [ 81%]
tests/test_ops.py .x.ssss.s........................s..s.s..s.......ss.ss                                                                                                                                                                                                [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                                                                                                                                  [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                                       [100%]

=========================================================================================================== 367 passed, 24 skipped, 1 xfailed in 150.77s (0:02:30) ============================================================================================================

```

#### Does this PR introduce a user-facing change?

#### Additional note:
