### PR TITLE
Special case scale value for tensors shape (1,)

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -616,6 +616,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "exp": torch.exp,
             },
             "param_sets": {
+                "1d0": {cached_randn((1,), dtype=torch.float16)},
                 "2d0": {cached_randn((1, 3), dtype=torch.float16)},
                 "2d1": {cached_randn((2, 1), dtype=torch.float16)},
                 "3d0": {cached_randn((1, 3, 4), dtype=torch.float16)},

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -595,6 +595,11 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
         """
         dim_map = map_dims_to_vars(access.layout, access.index)
         var_map = {v: k for k, v in dim_map.items()}
+
+        # Special case: single dimension of size 1 is not elided by inductor
+        if len(op_dimensions) == 1 and op_dimensions[0].numel == 1:
+            return [access.layout.device_layout.dim_map[0]]
+
         return [
             -3
             if (di.var == self.wildcard)


### PR DESCRIPTION
Special case scale value for tensors shape (1,) so it is not -3.  Last dim of size 1 is not elided by inductor.  

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Ensures that tensors of shape (1,) have correct scale array

#### Which issue(s) this PR is related to:

Fixes #614

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

#### Additional note:
