### PR TITLE
Support BMM with 3d input and 2d kernel BMK @ KN -> BMN

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -166,6 +166,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     ((3, 1, 256), (3, 256, 128)),
                     ((3, 17, 256), (3, 256, 128)),
                     ((3, 17, 128, 256), (3, 17, 256, 128)),
+                    ((2, 64, 128), (128, 16384)),
                 ]
             ),
         },

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -100,8 +100,6 @@ class DimInfos:
         self.rows[name] = info_list
 
     def make_dim_infos(self, fields=[], index_order=None, additional_rows={}):
-        print(f"{additional_rows=}")
-        print(f"{index_order=}")
         rows = self.rows | additional_rows
         if not index_order:
             index_order = self.dim_indices

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -100,6 +100,8 @@ class DimInfos:
         self.rows[name] = info_list
 
     def make_dim_infos(self, fields=[], index_order=None, additional_rows={}):
+        print(f"{additional_rows=}")
+        print(f"{index_order=}")
         rows = self.rows | additional_rows
         if not index_order:
             index_order = self.dim_indices
@@ -123,20 +125,23 @@ class DimInfos:
     # function computes that reordering
     def get_tensor_op_index_order(self, tensor):
         dim_indices = self.dim_indices  # op dimension order
-        dev_dim_order = tensor["device_layout"].dim_map[::-1][1:]
-        missing_dims = list(set(dim_indices) - set(dev_dim_order))
-        if len(missing_dims) > 0 and len(dim_indices) >= 3 and tensor["scale"][0] == -1:
-            if missing_dims[0] == 0:
-                # Add missing dimensions to end of device dimension order
-                # Compute the number of leading missing dims (-1)
-                tensor_dim_indices = dev_dim_order + list(
-                    set(dim_indices) - set(dev_dim_order)
-                )
-            else:  # keepdim=0 case
-                tensor_dim_indices = [idx + 1 for idx in dev_dim_order] + [0]
-        else:
-            # Indices and order unchanged
-            tensor_dim_indices = dim_indices
+
+        # FIXME: Need to do this properly
+        # dev_dim_order = tensor["device_layout"].dim_map[::-1][1:]
+        # missing_dims = list(set(dim_indices) - set(dev_dim_order))
+        # if len(missing_dims) > 0 and len(dim_indices) >= 3 and tensor["scale"][0] == -1:
+        #     if missing_dims[0] == 0:
+        #         # Add missing dimensions to end of device dimension order
+        #         # Compute the number of leading missing dims (-1)
+        #         tensor_dim_indices = dev_dim_order + list(
+        #             set(dim_indices) - set(dev_dim_order)
+        #         )
+        #     else:  # keepdim=0 case
+        #         tensor_dim_indices = [idx + 1 for idx in dev_dim_order] + [0]
+        # else:
+        #     # Indices and order unchanged
+
+        tensor_dim_indices = dim_indices
         return tensor_dim_indices
 
     def get_labels_host_order(self):

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -121,7 +121,7 @@ class DimInfos:
     # with the order of a subset of the indices adjusted to match
     # the tile layout of the tensor on the device.  This
     # function computes that reordering
-    def get_tensor_op_index_order(self, tensor, op):
+    def get_tensor_op_index_order(self, tensor):
         dim_indices = self.dim_indices  # op dimension order
 
         dev_dim_order = tensor["device_layout"].dim_map[::-1][1:]
@@ -166,7 +166,7 @@ class DimInfos:
     def get_tensor_op_infos(self, tensor, op):
         result = self.make_dim_infos(
             additional_rows={"scale": get_scales_sdsc_format(tensor, op)},
-            index_order=self.get_tensor_op_index_order(tensor, op),
+            index_order=self.get_tensor_op_index_order(tensor),
         )
         return result
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -126,12 +126,10 @@ class DimInfos:
 
         dev_dim_order = tensor["device_layout"].dim_map[::-1][1:]
         missing_dims = list(set(dim_indices) - set(dev_dim_order))
-        # HACK: avoid special case handling for batchmatmul
         if (
-            len(missing_dims) > 0
+            len(missing_dims) == 1
             and len(dim_indices) >= 3
             and tensor["scale"][0] == -1
-            and op != "batchmatmul"
         ):
             if missing_dims[0] == 0:
                 # Add missing dimensions to end of device dimension order

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -197,34 +197,6 @@ def ensure_default_handler(op_name):
         setattr(cls, op_name, method)
 
 
-# @register_spyre_lowering(torch.ops.aten.mm.default)
-# def lower_mm(x, y):
-#     def inner_fn(index, reduction_index):
-#         i0, i1 = index
-#         (r0,) = reduction_index
-#         return (x_loader([i0, r0]), y_loader([r0, i1]))
-
-#     x = V.graph.get_buffer(x.realize())
-#     y = V.graph.get_buffer(y.realize())
-#     x_loader = x.make_loader()
-#     y_loader = y.make_loader()
-
-#     result = Reduction.create(
-#         reduction_type=MATMUL_REDUCTION_OP,
-#         input_node=[x, y],
-#         device=x.get_device(),
-#         dst_dtype=x.get_dtype(),
-#         src_dtype=x.get_dtype(),
-#         inner_fn=inner_fn,
-#         ranges=[x.get_size()[0], y.get_size()[1]],
-#         reduction_ranges=[x.get_size()[1]],
-#     )
-
-#     result.realize()
-
-#     return result
-
-
 @register_spyre_lowering(torch.ops.aten.mm.default)
 def lower_mm(x, y):
     x = V.graph.get_buffer(x.realize())

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -197,31 +197,89 @@ def ensure_default_handler(op_name):
         setattr(cls, op_name, method)
 
 
+# @register_spyre_lowering(torch.ops.aten.mm.default)
+# def lower_mm(x, y):
+#     def inner_fn(index, reduction_index):
+#         i0, i1 = index
+#         (r0,) = reduction_index
+#         return (x_loader([i0, r0]), y_loader([r0, i1]))
+
+#     x = V.graph.get_buffer(x.realize())
+#     y = V.graph.get_buffer(y.realize())
+#     x_loader = x.make_loader()
+#     y_loader = y.make_loader()
+
+#     result = Reduction.create(
+#         reduction_type=MATMUL_REDUCTION_OP,
+#         input_node=[x, y],
+#         device=x.get_device(),
+#         dst_dtype=x.get_dtype(),
+#         src_dtype=x.get_dtype(),
+#         inner_fn=inner_fn,
+#         ranges=[x.get_size()[0], y.get_size()[1]],
+#         reduction_ranges=[x.get_size()[1]],
+#     )
+
+#     result.realize()
+
+#     return result
+
+
 @register_spyre_lowering(torch.ops.aten.mm.default)
 def lower_mm(x, y):
-    def inner_fn(index, reduction_index):
-        i0, i1 = index
-        (r0,) = reduction_index
-        return (x_loader([i0, r0]), y_loader([r0, i1]))
-
     x = V.graph.get_buffer(x.realize())
     y = V.graph.get_buffer(y.realize())
     x_loader = x.make_loader()
     y_loader = y.make_loader()
 
-    result = Reduction.create(
-        reduction_type=MATMUL_REDUCTION_OP,
-        input_node=[x, y],
-        device=x.get_device(),
-        dst_dtype=x.get_dtype(),
-        src_dtype=x.get_dtype(),
-        inner_fn=inner_fn,
-        ranges=[x.get_size()[0], y.get_size()[1]],
-        reduction_ranges=[x.get_size()[1]],
-    )
+    x_size = x.get_size()
+    y_size = y.get_size()
+    x_ndim = len(x_size)
+    y_ndim = len(y_size)
+
+    # Handle 3D input with 2D weight (batched matmul)
+    if x_ndim == 3 and y_ndim == 2:
+
+        def inner_fn(index, reduction_index):
+            i0, i1, i2 = index  # batch, row, col
+            (r0,) = reduction_index
+            return (x_loader([i0, i1, r0]), y_loader([r0, i2]))
+
+        result = Reduction.create(
+            reduction_type=BATCH_MATMUL_OP,  # Use BATCH_MATMUL_OP for 3D×2D
+            input_node=[x, y],
+            device=x.get_device(),
+            dst_dtype=x.get_dtype(),
+            src_dtype=x.get_dtype(),
+            inner_fn=inner_fn,
+            ranges=[x_size[0], x_size[1], y_size[1]],  # [B, M, N]
+            reduction_ranges=[x_size[2]],  # K
+        )
+    # Standard 2D × 2D matrix multiplication
+    elif x_ndim == 2 and y_ndim == 2:
+
+        def inner_fn(index, reduction_index):
+            i0, i1 = index
+            (r0,) = reduction_index
+            return (x_loader([i0, r0]), y_loader([r0, i1]))
+
+        result = Reduction.create(
+            reduction_type=MATMUL_REDUCTION_OP,  # Use MATMUL_REDUCTION_OP for 2D×2D
+            input_node=[x, y],
+            device=x.get_device(),
+            dst_dtype=x.get_dtype(),
+            src_dtype=x.get_dtype(),
+            inner_fn=inner_fn,
+            ranges=[x_size[0], y_size[1]],
+            reduction_ranges=[x_size[1]],
+        )
+    else:
+        raise ValueError(
+            f"Unsupported tensor dimensions for mm: x.shape={x_size}, y.shape={y_size}. "
+            f"Expected (2D, 2D) or (3D, 2D), got ({x_ndim}D, {y_ndim}D)"
+        )
 
     result.realize()
-
     return result
 
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -617,7 +617,12 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
                         di_y[2],
                     ]
             elif len(di_x) == 3 and len(di_y) == 2:
-                di = [di_x[0], di_x[1], di_x[2], DimensionInfo(wildcard_symbol(1), 1)]
+                if di_x[:2] == di_y:
+                    di = [di_x[0], di_x[1], di_x[2], DimensionInfo(self.wildcard, 1)]
+                elif di_x[2] == di_y[0]:
+                    di = [di_x[0], di_x[1], di_x[2], di_y[1]]
+                else:
+                    raise Unsupported(f"malformed bmm {di_x} {di_y}")
             elif len(di_x) == 2 and len(di_y) == 2:
                 if di_x == di_y:
                     di = [


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR attempts to add the missing support of BMM in the form of
`BMK @ KN -> BMN`

#### Which issue(s) this PR is related to:

#631 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

- I had to hack `get_tensor_op_index_order` in compute_ops.py. Need to come up with a proper fix.
- the fix applies to only BMK @ KN and not other similar cases like MK @ BKN or 4d cases