### PR TITLE
Feat: Add torch.any support

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -832,6 +832,25 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "4d": (cached_randn((4, 17, 256, 128), dtype=torch.float16),),
             },
         },
+        ("test_any", "test_any_cpu"): {
+            "param_sets": {
+                "2d_dim0": (
+                    0,
+                    False,
+                    torch.randint(0, 2, (512, 1024), dtype=torch.float16),
+                ),
+                "2d_dim0_keepdim": (
+                    0,
+                    True,
+                    torch.randint(0, 2, (256, 128), dtype=torch.float16),
+                ),
+                "2d_all_true": (
+                    0,
+                    False,
+                    torch.ones(256, 128, dtype=torch.float16),
+                ),
+            }
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -1021,6 +1040,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return torch.nn.functional.rms_norm(input, [input.shape[-1]], eps=1e-6)
 
         compare_with_cpu(fn, x)
+
+    def test_any_cpu(self, dim, keepdim, x):
+        compare_with_cpu(lambda x: torch.any(x, dim=dim, keepdim=keepdim), x)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.fallbacks.FallbackWarning")
     def test_implicit_loading(self):

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -470,6 +470,37 @@ class TestOps(TestCase):
             y0, torch.sum(x, dim=[0]), rtol=self.rtol, atol=self.atol
         )
 
+    def test_any_basic(self):
+        x = torch.randint(0, 2, (512, 1024), dtype=self.dtype)
+        x_spyre = x.to("spyre")
+        y0 = torch.any(x_spyre, dim=0).to("cpu")
+        torch.testing.assert_close(y0, torch.any(x, dim=0))
+
+    def test_any_keepdim(self):
+        x = torch.randint(0, 2, (256, 128), dtype=self.dtype)
+        x_spyre = x.to("spyre")
+        y0 = torch.any(x_spyre, dim=0, keepdim=True).to("cpu")
+        torch.testing.assert_close(y0, torch.any(x, dim=0, keepdim=True))
+
+    def test_any_dim1(self):
+        x = torch.randint(0, 2, (512, 1024), dtype=self.dtype)
+        x_spyre = x.to("spyre")
+        y1 = torch.any(x_spyre, dim=1).to("cpu")
+        torch.testing.assert_close(y1, torch.any(x, dim=1))
+
+    def test_any_all_true(self):
+        x = torch.ones(256, 128, dtype=self.dtype)
+        x_spyre = x.to("spyre")
+        y0 = torch.any(x_spyre, dim=0).to("cpu")
+        torch.testing.assert_close(y0, torch.any(x, dim=0))
+
+    def test_any_all_false(self):
+        # Test with all zero values
+        x = torch.zeros(256, 128, dtype=self.dtype)
+        x_spyre = x.to("spyre")
+        y0 = torch.any(x_spyre, dim=0).to("cpu")
+        torch.testing.assert_close(y0, torch.any(x, dim=0))
+
     def test_softmax(self):
         x = torch.arange(0, 64, dtype=self.dtype).unsqueeze(0).repeat(3, 1)
         x_spyre = x.to("spyre")

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -14,6 +14,7 @@
 
 
 from contextlib import contextmanager
+from types import SimpleNamespace
 
 import torch
 
@@ -405,6 +406,43 @@ def lower_mean(x, axis=None, keepdim=False, *, dtype=None):
         reduction_type="mean", input_node=x, op_info=op_info, **kwargs
     )
     result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.aten.any.default)
+@register_spyre_lowering(torch.ops.aten.any.dim)
+@register_spyre_lowering(torch.ops.aten.any.out)
+def reduce_any(x, dim=None, keepdim=False, *, out=None):
+    origin = x.get_origin_node()
+    if origin is None:
+        origin = SimpleNamespace(
+            target=torch.ops.aten.abs.default,
+            name="any_abs_fallback",
+            args=(),
+            kwargs={},
+        )
+    x_abs = Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
+        inner_fn=lambda index: lowering.ops.abs(x.make_loader()(index)),
+        ranges=x.get_size(),
+        origin_node=origin,
+        traceback=x.get_traceback(),
+    )
+    x_abs.realize()
+
+    kwargs = lowering._make_reduction_inner(
+        x_abs,
+        axis=dim,
+        keepdims=keepdim,
+        dtype=x.get_dtype(),
+        override_return_dtype=torch.bool,
+    )
+    result = SpyreReduction.create(
+        reduction_type="max", input_node=x_abs, op_info={}, **kwargs
+    )
+    result.realize()
+
     return result
 
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -274,7 +274,6 @@ class SpyreKernelOpsHandler(DefaultHandler):
         if reduction_type in [
             "welford_reduce",
             "welford_combine",
-            "any",
             "prod",
             "xor_sum",
         ]:

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -333,7 +333,13 @@ auto create_dma_graph(const at::Tensor& self, const at::Tensor& dst,
   sendnn::SubGraph exec_graph;
   {  // add above subgraph as part of SenFusedDeviceCompute node
     flex::FlexGraphBuilder gb;
-    auto dci = generate_dci(dev_tensor, stl, host2device);
+    // For bool tensors, cpu_tensor, fp16 staging buffer is used to avoid broken
+    // DL16→bool conversion
+    const at::Tensor* dci_tensor =
+        (cpu_tensor->scalar_type() != (host2device ? self : dst).scalar_type())
+            ? cpu_tensor
+            : dev_tensor;
+    auto dci = generate_dci(dci_tensor, stl, host2device);
     if (host2device) {
       auto inp_node = gb.PrimaryInput("Input", cpu_ti);
       auto dci_node = gb.SenHostCompute("Host2Sen-HostPrep", {dci_ti},
@@ -420,16 +426,28 @@ auto copy_host_to_device(const at::Tensor& self, const at::Tensor& dst) {
   SEN_THROW_NOK(gl->Copy(sendnn::Outputs(), {inp_tensor}, sn_idx));
 }
 auto copy_device_to_host(const at::Tensor& self, const at::Tensor& dst) {
-  std::shared_ptr<sendnn::GraphLoader> gl = create_dma_graph(self, dst, false);
-  // execute
+  at::Tensor dma_dst =
+      (dst.scalar_type() == at::kBool)
+          ? at::empty(self.sizes(),
+                      at::TensorOptions().dtype(at::kHalf).device(at::kCPU))
+          : dst;
+
+  std::shared_ptr<sendnn::GraphLoader> gl =
+      create_dma_graph(self, dma_dst, false);
+
   constexpr int sn_idx = 0;
   constexpr int tensor_idx = 0;
-  auto out_tensor = createOutputTensor(*gl, dst.storage().data_ptr().get(),
+  auto out_tensor = createOutputTensor(*gl, dma_dst.storage().data_ptr().get(),
                                        tensor_idx, sn_idx);
   auto* ctx =
       static_cast<SharedOwnerCtx*>(self.storage().data_ptr().get_context());
   out_tensor.SetSpyreData(ctx->owner);
   SEN_THROW_NOK(gl->Copy({out_tensor}, sendnn::Inputs(), sn_idx));
+
+  // Post-copy cast only needed for bool
+  if (dst.scalar_type() == at::kBool) {
+    dst.copy_(dma_dst.to(at::kBool));
+  }
 }
 
 // A custom allocator for our custom device, what returns is a handle to the

--- a/torch_spyre/ops.py
+++ b/torch_spyre/ops.py
@@ -223,4 +223,10 @@ def spyre__unsqueeze(self: torch.Tensor, dim: int) -> torch.Tensor:
     return result
 
 
+@torch.library.register_kernel("aten::any.dim", ["spyre"])
+def spyre__any_dim(self: torch.Tensor, dim: int, keepdim: bool = False) -> torch.Tensor:
+    compiled_any = torch.compile(torch.any, dynamic=False)
+    return compiled_any(self, dim=dim, keepdim=keepdim)
+
+
 # INSERT_CODEGEN_HERE


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Adds support for `torch.any` on the Spyre backend.

### Implementation Details
- Added `reduce_any()` lowering in `torch_spyre/_inductor/lowering.py`
- Uses `abs()` followed by `max` reduction with `override_return_dtype=torch.bool`
- Registers lowerings for `aten.any.default`, `aten.any.dim`, and `aten.any.out`

### Approach
1. Apply `abs()` pointwise operation to handle negative values
2. Perform `max` reduction across specified dimension(s)
3. Override return dtype to `torch.bool`

### Known Issues
1. Conversion from 0.0 to bool is broken, its converting `0.0` to `True` instead of `False`
#### Which issue(s) this PR is related to:

Fixes #600 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
