### PR TITLE
:bug: don't duplicate decompositions

### DIFF
--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -93,6 +93,9 @@ def enable_spyre_compile_fx_wrapper():
         def _wrapper(gm, example_inputs, *args, **kwargs):
             from torch._inductor.decomposition import decompositions
 
+            if "decompositions" in kwargs:
+                kwargs.pop("decompositions")
+
             if _uses_spyre(gm, example_inputs):
                 import torch
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR fixes an issue where vllm fails to compile a granite model when torch-spyre is installed.

Running the vanilla vllm+cpu server like so crashes:
```
VLLM_PLUGINS="" vllm serve ibm-granite/granite-3.3-8b-instruct
```

But disabling the autoloading of torch-spyre does not crash:
```
VLLM_PLUGINS="" TORCH_DEVICE_BACKEND_AUTOLOAD=0 vllm serve ibm-granite/granite-3.3-8b-instruct
```

A snippet of the stack trace:
```
(EngineCore_DP0 pid=116782)   File "/home/senuser/install-testing/vllm-spyre/vllm_spyre_next/.venv/lib64/python3.12/site-packages/torch/_inductor/compile_fx.py", line 2486, in compile_fx
(EngineCore_DP0 pid=116782)     return compile_fx(
(EngineCore_DP0 pid=116782)            ^^^^^^^^^^^
(EngineCore_DP0 pid=116782)   File "/home/senuser/install-testing/vllm-spyre/vllm_spyre_next/.venv/lib64/python3.12/site-packages/torch_spyre/_inductor/__init__.py", line 108, in _wrapper
(EngineCore_DP0 pid=116782)     return _orig(
(EngineCore_DP0 pid=116782)            ^^^^^^
(EngineCore_DP0 pid=116782) torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
(EngineCore_DP0 pid=116782) TypeError: torch._inductor.compile_fx.compile_fx() got multiple values for keyword argument 'decompositions'
```

The wrapper here doesn't check if `decompositions` is already in the keyword args, causing this crash. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
