### PR TITLE
Suppress PyTorch 2.10.0+ DeprecationWarning in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,14 @@ exclude=["tests/_inductor"]
 module = ["torch_spyre._inductor.*"]
 disable_error_code = ["attr-defined"]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    # PyTorch 2.10.0+: Suppress torch.jit.script_method DeprecationWarning triggered by
+    # importing torch._inductor.compile_fx (which transitively imports torch.utils.mkldnn).
+    # https://github.com/pytorch/pytorch/blob/v2.10.0/torch/jit/_script.py#L363
+    "ignore::DeprecationWarning:torch.jit._script",
+]
+
 [tool.uv]
 required-version = ">=0.9.0"
 index-strategy = "unsafe-best-match"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

When running pytest, a DeprecationWarning is displayed from PyTorch's torch.jit.script_method decorator. This warning appears in PyTorch 2.10.0+ and is triggered during torch_spyre's autoload when importing torch._inductor.compile_fx, which transitively imports torch.utils.mkldnn.

The warning originates from upstream PyTorch code and is not actionable by torch_spyre developers.

Note: Python ignores DeprecationWarning by default in normal execution, but pytest explicitly enables all warnings during test runs. This means the warning only appears when running tests, not during regular usage.

https://docs.pytest.org/en/stable/how-to/capture-warnings.html#deprecationwarning-and-pendingdeprecationwarning

This PR added pytest configuration in pyproject.toml to suppress this specific deprecation warning.

The warning message:
```
dt-inductor) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
============================================================ test session starts =============================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 428 items

tests/_inductor/test_building_blocks.py ....                                                                                           [  0%]
tests/_inductor/test_inductor_decomp.py ..                                                                                             [  1%]
tests/_inductor/test_inductor_ops.py ...s............................................................................................. [ 24%]
...................................................................................................................................... [ 55%]
.................................................................                                                                      [ 70%]
tests/tensor/test_tensor_layout.py .............                                                                                       [ 73%]
tests/test_fallbacks.py ........                                                                                                       [ 75%]
tests/test_modules.py .sssss.                                                                                                          [ 77%]
tests/test_ops.py .x.s..xs...s........................s..s.s.......x.............................                                      [ 95%]
tests/test_spyre.py .s..ss............                                                                                                 [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                      [100%]

============================================================== warnings summary ==============================================================
../pytorch/torch/jit/_script.py:364: 14 warnings
  /home/yohei/dt-inductor/pytorch/torch/jit/_script.py:364: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== 410 passed, 15 skipped, 3 xfailed, 14 warnings in 326.78s (0:05:26) =====================================
```

Originated from:
```
../pytorch/torch/__init__.py:2937: in _import_device_backends
    entrypoint()
torch_spyre/__init__.py:180: in _autoload
    _light_autoload()
torch_spyre/_inductor/__init__.py:117: in _light_autoload
    enable_spyre_compile_fx_wrapper()
torch_spyre/_inductor/__init__.py:25: in enable_spyre_compile_fx_wrapper
    import torch._inductor.compile_fx as cfx
../pytorch/torch/_inductor/compile_fx.py:114: in <module>
    from .fx_passes.post_grad import post_grad_passes, view_to_reshape
../pytorch/torch/_inductor/fx_passes/post_grad.py:64: in <module>
    from .pre_grad import is_same_dict, save_inductor_dict
../pytorch/torch/_inductor/fx_passes/pre_grad.py:13: in <module>
    from torch.fx.experimental.optimization import (
../pytorch/torch/fx/experimental/optimization.py:15: in <module>
    import torch.utils.mkldnn as th_mkldnn
../pytorch/torch/utils/mkldnn.py:5: in <module>
    class MkldnnLinear(torch.jit.ScriptModule):
../pytorch/torch/utils/mkldnn.py:19: in MkldnnLinear
    @torch.jit.script_method
     ^^^^^^^^^^^^^^^^^^^^^^^
```

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

The DeprecationWarning is not shown.


#### Additional note:

```
(dt-inductor) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
============================================================ test session starts =============================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 428 items

tests/_inductor/test_building_blocks.py ....                                                                                           [  0%]
tests/_inductor/test_inductor_decomp.py ..                                                                                             [  1%]
tests/_inductor/test_inductor_ops.py ...s............................................................................................. [ 24%]
...................................................................................................................................... [ 55%]
.................................................................                                                                      [ 70%]
tests/tensor/test_tensor_layout.py .............                                                                                       [ 73%]
tests/test_fallbacks.py ........                                                                                                       [ 75%]
tests/test_modules.py .sssss.                                                                                                          [ 77%]
tests/test_ops.py .x.s..xs...s........................s..s.s.......x.............................                                      [ 95%]
tests/test_spyre.py .s..ss............                                                                                                 [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                      [100%]

=========================================== 410 passed, 15 skipped, 3 xfailed in 326.65s (0:05:26) ===========================================
```