### PR TITLE
Clean up compute_ops layoutDimOrder computation now that dimension are not elided

### DIFF
--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -124,7 +124,7 @@ class DimInfos:
     #
     # The list returned is
     #   - length == # operation dimensions (not # tensor dimensions)
-    #   - Values are host dimensions in the tensor that represents the tensor (op_dims_tensor)
+    #   - Values are host dimensions in the tensor that represents the operation (op_dims_tensor)
     #   - Order is the order of the dimensions as they appear in the device tensor,  followed
     #     by any remaining dimensions not in the tensor
     def get_tensor_op_index_order(self, tensor):


### PR DESCRIPTION
Reimplement compute_ops layoutDimOrder computation now that dimensions of size 1 are not elided

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
This PR does 3 things

- Reimplements compute_ops layoutDimOrder computation now that dimensions are not elided.  All previous special cases have been removed, except adjusting the scales array for layernorm.  That seems to still be required.
- Fixes a few bugs so it now executes the offline test case that reorders dimensions using `to_with_layout`
- Renames a few incorrectly chose variable names related to dim_map/scales ordering
 

#### Which issue(s) this PR is related to:
````
collected 437 items

tests/_inductor/test_building_blocks.py ....                                                                                                                         [  0%]
tests/_inductor/test_inductor_decomp.py ..                                                                                                                           [  1%]
tests/_inductor/test_inductor_ops.py ...s........................................................................................................................... [ 30%]
.................................................................................................................................................................... [ 67%]
..........                                                                                                                                                           [ 70%]
tests/tensor/test_tensor_layout.py .............                                                                                                                     [ 73%]
tests/test_fallbacks.py ........                                                                                                                                     [ 75%]
tests/test_modules.py .sssss.                                                                                                                                        [ 76%]
tests/test_ops.py .x.s..xs...s........................s.s.sss.ss......x.............................                                                                 [ 95%]
tests/test_regex.py .                                                                                                                                                [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                               [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                    [100%]

================================================== 415 passed, 19 skipped, 3 xfailed in 343.67s (0:05:43) ===============================================
````


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
