### PR TITLE
Model-Centric Functional Verification for OpFunc Enablement

### DIFF
--- a/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
+++ b/RFCs/0186-TestFrameworks/0186-TestFrameworks.md
@@ -1,0 +1,467 @@
+
+# RFC-0186: Model-Centric Functional Verification for OpFunc Enablement
+
+**Authors:**
+- Tuan M. Hoang Trong (YKT)
+- Kazuaki Ishizaki (TRL)
+- Umamaheswari Devi (IRL)
+
+**Tracking issue:** #241
+**Target repository:** `torch-spyre/torch-spyre`
+**Related issues/PRs:** #323
+
+---
+
+## Summary
+This RFC proposes a **model-centric functional verification** framework built on **pytest** to ensure the correctness of individual **torch operations** used in target models such as GPT-OSS, Granite-4h, Granite-Vision, and Granite-Speech.
+Unlike existing PyTorch tests that rely on synthetic parameters and small tensor shapes, this RFC approach uses actual tensor shapes, parameters, and data types from the target models, delivering realistic and comprehensive coverage.
+
+This framework is essential for **OpFunc enablement**, as it verifies correctness with **model-specific parameters** rather than synthetic test cases.
+By doing so, we eliminate blind spots that existing tests **may not cover**.
+
+---
+
+## Motivation
+
+### Background
+We have repeatedly encountered cases where inference results appear mostly
+correct, yet certain **torch operations** produce incorrect outputs. These
+subtle inconsistencies block feature development (e.g., fine-tuning) and
+introduce fragility into the stack. To build a stable foundation and accelerate
+innovation, **model-centric functional verification** using **actual model
+parameters** is critical.
+
+### Problems
+In the past, we observed these issues:
+- Operations with certain **dimensions** work correctly, but operations with
+  other dimensions generate **incorrect results**.
+- Operations with specific **values** in a tensor generate **incorrect results**.
+
+These observations lead to the need for verification with **actual parameters**.
+Existing PyTorch tests are insufficient for three critical reasons:
+
+- **Unrealistic tensor dimensions**: Current tests use shapes that differ from
+  real-world workloads, failing to reflect deployment scenarios.
+- **Limited coverage of Spyre execution paths**: Small tensor sizes often avoid
+  **Spyre-relevant** multi-core/tiling/scheduling paths, leaving key behaviors
+  untested.
+- **Synthetic data limitations**: Tests do not capture edge cases arising from
+  **actual parameter distributions** in production models.
+
+These gaps can lead to undetected correctness issues that surface only with the
+target models, increasing risk and slowing development.
+
+## Goals
+- **Functional correctness**: Validate each enabled torch operation against a
+  **CPU reference** using **real shapes and data** from target models.
+- **Nightly monitoring**: Continuously track correctness of enabled OpFuncs
+  using the industry-standard **pytest** framework.
+- **Scalability**: Support multiple models (Granite-4h, GPT-OSS,
+  Granite-Vision-3, Granite-Speech) with **cross-model deduplication**.
+- **Maintainability**: Centralize test intent in descriptors (**shapes, dtypes,
+  tolerances**) for easy updates as models evolve.
+
+## Non-Goals (for now)
+- **Performance tracking**: Out of scope initially (future metrics may be
+  added).
+- **Per-PR gating**: Tests run in nightly CI/CD, not on every PR.
+
+---
+
+## Proposed Implementation
+
+### Design Concept
+Our framework delivers:
+
+- Leverage **pytest** as the de facto testing standard.
+- **Descriptor-driven** approach (currently **YAML**) to represent actual model
+  parameters for each torch operation.
+- Automated test generation from descriptors, with optional **deduplication
+  across models**.
+- Flexible test selection via **pytest markers** for skipping, expected
+  failures, and targeted runs.
+- CI integration as **nightly tests**, starting with **Spyre/AIU-backed**
+  models and expanding to canonical sets.
+
+This design ensures **realistic**, **maintainable**, and **scalable**
+correctness checks across diverse models—closing the gap between synthetic
+testing and production reality.
+
+### Overview
+We use two cooperating frameworks:
+
+1) **Model scan & codegen (existing, internal, modified):**  
+   - Scan target models and extract the set of `torch.ops` along with input shapes and/or sample inputs.  
+   - **Change:** Generate **YAML** instead of Python test files.
+
+2) **YAML test runner (the proposed one):**  
+   - Load YAML case definitions.  
+   - Codegen lightweight test functions dynamically (via `pytest`).  
+   - Execute ops, compare against CPU reference, and report results.
+   - Skip tests if needed.
+
+---
+### Execution strategy
+
+- Run all extracted ops for a model (subject to dedupe).
+- Avoid redundant runs (global cache keyed by <op, normalized_inputs>).
+- Make test parameters easy to understand for debugging (schema + description fields).
+
+---
+
+### Models & files
+We plan per-model YAML, with option for subclasses variants:
+
+- `tests/_inductor/models/template.yaml`
+- `tests/_inductor/models/gpt-oss.yaml`
+- `tests/_inductor/models/gpt-oss-spyre.yaml`  
+  *Temporary, backend-specific functional correctness checks. May relax original shapes and can be deleted once features are stable.*
+
+**Naming:** (notice to changes in internal scripts) Permanent test cases (e.g., no `_fp16`) reside in files **without** postfixes. Backend-temporary cases use the `-spyre` postfix file.
+
+---
+
+### Deduplication & selection
+- **Cross-model deduplication (default):** If `op-A(input-B)` was already tested for model-C, skip rerunning for model-D, if that test case is part of model-D.
+Deduplication is based on normalized op signature and input shapes, not model name.
+- **Disable dedupe:** `--no-dedupe` (explicit).
+- **Selective model runs:** Choose one or many models at runtime (e.g., run only `granite3-speech`).
+- **Select cases**: integrate with pytest.ini design, register custom markers for cleanliness. **Can skip tests at each input set**.
+Marker usage and registration follow pytest documentation best practices, enabling selection and skip/xfail logic
+
+**CLI Examples**
+
+```bash
+# List available models/cases
+pytest --list-models 2>&1 | tee logs_test.txt
+pytest --list-cases  2>&1 | tee logs_test.txt
+
+# Run a single case by name
+pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "mul_ok"
+
+# Run all 'torch.add' ops for GPT-oss
+pytest -q tests/_inductor/test_model_ops.py --model gpt_oss -k "torch.add"
+
+# Run all tests ignoring default marker filters
+pytest tests/_inductor/test_model_ops.py --model gpt-oss-20b -m ""
+
+# Run for multiple models
+pytest --model gpt_oss tests/
+pytest --model gpt_oss --model granite4h tests/
+
+# Show selected tests based on marks
+pytest --list-cases-by-mark
+pytest --list-cases-by-mark --model gpt-oss
+# Show excluded tests based on marks
+pytest --list-cases-by-mark --show-excluded
+pytest --list-cases-by-mark --show-excluded --model gpt-oss
+
+```
+
+**Full argument list**
+
+supported arguments: pytest
+
+```bash
+pytest \
+  [--model <model-name>]*
+  --dedupe / --no-dedupe
+  --list-models, --list-cases
+  --compile-backend "inductor"
+    TEST_COMPILE_BACKEND: env. variable to change the default backend “inductor”
+  --list-cases-by-mark [marks] [--show-excluded]
+```
+
+---
+
+### Source Layout
+
+Below is the proposed directory structure for the YAML-driven test framework:
+
+```bash
+tests/
+├── conftest.py
+└── _inductor/
+    ├── init.py
+    ├── test_model_ops.py          # Entry point for pytest-based tests
+    ├── model_cases_loader.py      # Loads and parses YAML files
+    ├── op_registry.py             # Maintains mapping of ops to test logic
+    ├── runner.py                  # Executes tests dynamically from YAML
+    └── models/                    # YAML manifests per model
+        ├── gpt_oss.yaml
+        └── granite3_speech.yaml
+```
+
+## YAML Schema
+
+Top-level structure
+
+```yaml
+
+model: <model-name>
+default:
+  dtype: <DTYPE_MAP value>
+  seed: <int>
+  rtol: <float>
+  atol: <float>
+cases:
+  - name: <case-name>
+    op: <torch.op>            # as registered via OP_REGISTRY
+    inputs:                   # map of arguments for the op
+      tensor:                 # tensor description (see below)
+      value:                  # scalar input
+      py:                     # restricted Python literal (tuples, None, Ellipsis, slice, ints, floats, lists, inf, -inf, nan)
+      tensor_list:            # sequences (list/tuple) of tensors
+      file:                   # .pt file holding values for a tensor
+    description: <text>       # e.g., trace where the op was extracted
+    expects_error:            # expected error (optional) - expected error type and message substring
+      type: <ExceptionType>
+      match: <substring>
+
+    # Test control
+    marks: <pytest marker(s)>
+    skip_if:                  # Conditional skip logic for backend/device)
+      expr: <python boolean>  # if True -> skip
+      reason: <text>
+
+    # Per-case overrides of defaults
+    dtype: <DTYPE_MAP value>
+    seed: <int>
+    rtol: <float>
+    atol: <float>
+
+```
+
+---
+
+### pytest.ini Configuration
+
+The `pytest.ini` file contains default marker expressions that filter tests:
+
+```ini
+[pytest]
+markers =
+    paddedtensor: tests for tensors requiring padding
+    largedimtensor: tests for 4D and 5D tensors
+    fp32operation: tests for fp32 operations
+    bf16operation: tests for bfloat16 operations
+    constant: tests for operations with constants
+
+addopts = -m "not largedimtensor and not fp32operation and not bf16operation and not constant"
+```
+
+By default, tests marked with largedimtensor, fp32operation, bf16operation, or constant are excluded. To run all tests regardless of markers, use `-m ""` option.
+
+---
+
+### Input to a test case
+
+A test case is generated based on the op to test, and the input sources which is a sequence of arguments, each can be one of the following
+
+- -tensor: randomly generated tensor(s) following shape, dtype, init, etc.
+- -value: scalars, lists, tuples.
+- -py: restricted Python literal expressions (tuples, None, Ellipsis, slices, ints, floats, lists, inf, -inf, nan).
+- -file: load from .pt files (torch.load("path/to/file.pt")).
+
+Rationale: Debugging error-sensitive bugs often requires specific tensor values, especially in the backward path, so YAML supports exact data (init: data) and file-based inputs (-file).
+
+### Input tensor description
+
+```yaml
+
+tensor:
+  shape: [dim0, dim1, ...]
+  init: rand | zeros | ones | arange | randint | uniform | data   # optional
+  dtype: <optional dtype>
+  preset: <optional preset for non-contiguous/layout-sensitive ops>
+  preset_args: <optional args for preset>
+
+  # init_args specify bounds for random generation
+  # If 'randint': allow 'low' (default 0), 'high'
+  # If 'uniform': allow 'low' (default 0), 'high' (default 1)
+  # If 'data': pass exact values as list(s)
+```
+
+---
+
+### Supporting Constants
+
+The framework uses predefined mappings for dtypes and error names to ensure consistency between YAML descriptors and Python runtime.
+
+#### DTYPE_MAP
+Maps string keys in YAML to actual `torch` dtypes:
+
+```python
+DTYPE_MAP = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+    "int64": torch.int64,
+    "bool": torch.bool,
+}
+```
+
+##### Error type
+
+The value in `expected_errors` is a string which is mapped to Python exception classes based on the following map:
+
+```python
+_ERR_NAME_TO_TYPE = {
+    "RuntimeError": RuntimeError,
+    "ValueError": ValueError,
+    "TypeError": TypeError,
+    "AssertionError": AssertionError,
+}
+```
+
+---
+
+### Example YAML File
+
+Below is a sample `template.yaml` illustrating the proposed schema and advanced features such as dtype overrides, skip conditions, error expectations, and presets for non-contiguous layouts.
+
+```yaml
+model: template
+default:
+  dtype: fp16        # Default dtype for all cases unless overridden
+  seed: 123          # Seed for reproducibility
+  rtol: 1.0e-3       # Default relative tolerance
+  atol: 1.0e-3       # Default absolute tolerance
+
+cases:
+  - name: add_basic
+    op: torch.add
+    inputs:
+      - tensor: {shape: [4, 128, 768], init: randn}
+      - tensor: {shape: [4, 128, 768], init: randn}
+    description: |
+      Example from GPT-oss forward path:
+      File: site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138
+      Code: next_states = next_states * routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
+
+  - name: op_bool_tensors
+    op: torch.logical_and
+    inputs:
+      - tensor: {shape: [11, 6], dtype: bool}
+      - tensor: {shape: [11, 6], dtype: bool}
+    description: |
+      Ops with randomly generated bool tensors (50% chance of True)
+
+  - name: op_different_dtypes
+    op: torch.add
+    inputs:
+      - tensor: {shape: [11, 6], dtype: fp32, init: randn}
+      - tensor: {shape: [11, 6], dtype: int64, init: randint, init_args: {high: 100}}
+    description: |
+      Ops with args of different dtypes
+
+  - name: mul_tensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: uniform, init_args: {low: -1.0, high: 1.0}}
+      - value: 3.0
+    description: |
+      Ops with tensor and scalar as args
+
+  - name: mul_inttensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: randint, init_args: {low: 1, high: 100}}
+      - value: 3
+    description: |
+      Ops with tensor and scalar as args
+
+  - name: aten_view
+    op: torch.ops.aten.view
+    inputs:
+      - tensor: {shape: [1, 64]}
+      - value: [2, 32]
+    description: |
+      Value can accept scalar, list or tuple
+
+  - name: softmax_lastdim
+    op: torch.nn.functional.softmax
+    attrs: {dim: -1}
+    inputs:
+      - tensor: {shape: [2, 4, 8], init: arange}
+
+  - name: cat_list
+    op: torch.cat
+    attrs: {dim: -1}
+    inputs:
+      - tensor_list:
+          - {shape: [2, 3, 4], init: randn}
+          - {shape: [2, 3, 5], init: randn}
+
+  - name: view_should_error_on_noncontig
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: [2, 24]
+
+  - name: view_should_error_on_noncontig_167
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: 32
+      - value: -1
+      - value: 2880
+
+  - name: contiguous_from_transpose_view
+    op: torch.contiguous
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: transpose_view
+          preset_args: {dim0: 1, dim1: 2}
+
+  - name: rsqrt_skip_example
+    op: torch.rsqrt
+    skip_if:
+      - expr: cfg.test_device.type == 'spyre' and dtype_str == 'fp16'
+        reason: Spyre fp16 rsqrt not supported yet
+    inputs:
+      - tensor: {shape: [64, 1024], init: rand}
+
+  - name: getitem_ellipsis_none_fullslice
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 5760]
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))
+```
+
+---
+## Metrics
+Initial (functional) metrics:
+
+- Pass rate per model and per-op.
+- Coverage (# distinct ops and input shapes per model; % of enabled opFuncs).
+- Deduplication efficiency (skipped duplicates vs unique executed cases).
+- Stability trend across nightly runs (failures/new regressions).
+- Runtime per case and total (optional for capacity planning).
+
+Future (performance) metrics if enabled:
+
+- Regression detection across releases (op latency deltas).
+- Impact of backend optimizations.
+- Comparison against baseline (CPU or another backend).
+
+---
+## Dependencies
+
+- Existing internal scripts for op & input extraction.
+- pytest runner (markers defined in pytest.ini). [docs.pytest.org]
+- torch for CPU reference and .pt loading (baseline correctness). [docs.pytorch.org]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+markers =
+    paddedtensor: tests for tensors requiring padding
+    largedimtensor: tests for 4D and 5D tensors
+    fp32operation: tests for fp32 operations
+    bf16operation: tests for bfloat16 operations
+    constant: tests for operations with constants
+
+addopts = -m "not fp32operation and not bf16operation and not constant"

--- a/tests/_inductor/model_cases_loader.py
+++ b/tests/_inductor/model_cases_loader.py
@@ -1,0 +1,153 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ast
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import pytest
+import regex as re
+import yaml
+
+
+@dataclass(frozen=True)
+class LoadedCase:
+    model: str
+    defaults: Dict[str, Any]
+    case: Dict[str, Any]
+    source_path: Path
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^0-9a-zA-Z_]+", "_", s)
+
+
+def models_dir(pytest_root: Path) -> Path:
+    # adjust if needed; this is robust regardless of current working directory
+    return pytest_root / "tests" / "_inductor" / "models"
+
+
+def freeze(x: Any) -> Any:
+    if isinstance(x, dict):
+        return tuple(sorted((k, freeze(v)) for k, v in x.items()))
+    if isinstance(x, (list, tuple)):
+        return tuple(freeze(v) for v in x)
+    if isinstance(x, str) and "torch." not in x:
+        try:
+            return ast.literal_eval(x)
+        except (ValueError, SyntaxError):
+            return x
+    return x
+
+
+def case_key(case: Dict[str, Any], defaults: Dict[str, Any]) -> tuple:
+    # Used for dedupe; intentionally does NOT include model name.
+    op = case["op"]
+    dtype = case.get("dtype", defaults.get("dtype", "float16"))
+    seed = case.get("seed", defaults.get("seed", None))
+    attrs = freeze(case.get("attrs", {}))
+
+    inputs_sig = []
+    for inp in case.get("inputs", []):
+        if "tensor" in inp:
+            t = inp["tensor"]
+            inputs_sig.append(
+                (
+                    "tensor",
+                    tuple(t["shape"]),
+                    t.get("init", "rand"),
+                    freeze(t.get("init_args", {})),
+                    freeze(t.get("data", None)),
+                    bool(t.get("contiguous", True)),
+                    t.get("preset", None),
+                    freeze(t.get("preset_args", {})),
+                    freeze(t.get("base_shape", None)),
+                )
+            )
+        elif "tensor_list" in inp:
+            lst = []
+            for t in inp["tensor_list"]:
+                lst.append(
+                    (
+                        tuple(t["shape"]),
+                        t.get("init", "rand"),
+                        freeze(t.get("init_args", {})),
+                        freeze(t.get("data", None)),
+                        bool(t.get("contiguous", True)),
+                        t.get("preset", None),
+                        freeze(t.get("preset_args", {})),
+                        freeze(t.get("base_shape", None)),
+                    )
+                )
+            inputs_sig.append(("tensor_list", tuple(lst)))
+        elif "value" in inp:
+            inputs_sig.append(("value", freeze(inp["value"])))
+        elif "py" in inp:
+            inputs_sig.append(("py", freeze(inp["py"])))
+        else:
+            raise ValueError(f"Unknown input entry: {inp}")
+
+    return (op, dtype, seed, attrs, tuple(inputs_sig))
+
+
+def load_all_cases(pytest_root: Path) -> List[LoadedCase]:
+    items: List[LoadedCase] = []
+    for p in sorted(models_dir(pytest_root).glob("*.yaml")):
+        if p.name.endswith("template.yaml"):  # skip template.yaml file
+            continue
+        spec = yaml.safe_load(p.read_text())
+        model = spec.get("model", p.stem)
+        defaults = dict(spec.get("defaults", {}))
+        for case in spec.get("cases", []):
+            # allow "cases" to omit "op" if the YAML provides a top-level op (optional)
+            if "op" not in case and "op" in spec:
+                case = dict(case)
+                case["op"] = spec["op"]
+            items.append(
+                LoadedCase(model=model, defaults=defaults, case=case, source_path=p)
+            )
+    return items
+
+
+def to_pytest_params(items: Iterable[LoadedCase]) -> List[Any]:
+    seen_test_ids = set()
+    params = []
+    for it in items:
+        marks = []
+
+        # auto mark per-model: -m model_granite3_speech
+        marks.append(getattr(pytest.mark, f"model_{_slug(it.model)}"))
+
+        # case-level marks
+        ms = it.case.get("marks", None)
+        if ms is not None and not isinstance(ms, list):
+            ms = [ms]
+        if isinstance(ms, list):
+            for mm in ms:
+                marks.append(getattr(pytest.mark, mm))
+
+        case_name = it.case.get("name", it.case["op"])
+        test_id = f"{it.model}::{case_name}"
+        if test_id in seen_test_ids:
+            basename = os.path.basename(it.source_path)
+            test_id = test_id + "::" + basename
+        seen_test_ids.add(test_id)
+
+        params.append(
+            pytest.param(
+                it.model, it.case, it.defaults, it.source_path, marks=marks, id=test_id
+            )
+        )
+    return params

--- a/tests/_inductor/models/gpt-oss-20b.yaml
+++ b/tests/_inductor/models/gpt-oss-20b.yaml
@@ -1,0 +1,2991 @@
+model: gpt-oss-20b
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [201088, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 199999
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:479 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.getitem.1
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32]
+          dtype: torch.float32
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.float.1
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: fp32operation
+  - name: torch.Tensor.expand.1
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.to.1
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - value: cuda:0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.getitem.2
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.amp.autocast_mode._enter_autocast.1
+    op: torch.amp.autocast_mode._enter_autocast
+    inputs:
+      - value: cuda
+      - value: null
+      - value: false
+      - value: null
+    description: ''
+    marks: constant
+  - name: torch.float.3
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.matmul.1
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.transpose.1
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 11]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.cos.1
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.mul.1
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float32
+          init: rand
+      - value: 1.3465735902799727
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.sin.1
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:205 in forward, code: sin = emb.sin() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.pow.1
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.1
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.1
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.1
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.2
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.3
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:61 in forward, code: return (self.weight * hidden_states).to(input_dtype)  #
+      main diff with Llama'
+    marks: fp32operation
+  - name: torch.nn.functional.linear.1
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [4096, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: bf16operation
+  - name: torch.Tensor.view.1
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 4096]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 11, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.2
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 11, 64, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.linear.2
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [512, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [512]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: bf16operation
+  - name: torch.Tensor.view.2
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 512]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 11, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.3
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 11, 8, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.unsqueeze.1
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:234 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.chunk.1
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.3
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.4
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.sub.1
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.add.2
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.cat.1
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.chunk.2
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 8, 11, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.4
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 8, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.5
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.sub.2
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 8, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 8, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 8, 11, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.cat.2
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 8, 11, 32]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.zeros.1
+    op: torch.zeros
+    inputs:
+      - value: (1, 8, 128, 64)
+    description: 'site-packages/transformers/cache_utils.py:282 in lazy_initialization, code: self.keys = torch.zeros('
+    marks: constant
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.index_copy_.1
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 8, 11, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:443 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.5
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.2
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 8
+      - value: 128
+      - value: 64
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.reshape.1
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 8, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 64, 128, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:219 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.transpose.4
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.matmul.2
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 64, 128]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.mul.6
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.6
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 128, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.add.4
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11, 128]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.reshape.2
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, -1, 1, 1)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:258 in eager_attention_forward, code: sinks = module.sinks.reshape(1, -1,
+      1, 1).expand(query.shape[0], -1, query.shape[-2], -1)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.expand.3
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 1]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 11
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:258 in eager_attention_forward, code: sinks = module.sinks.reshape(1, -1,
+      1, 1).expand(query.shape[0], -1, query.shape[-2], -1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.cat.3
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 11, 128]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 11, 1]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+  - name: torch.max.1
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 129]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.getitem.7
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 11, 1]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 11, 1]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sub.3
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 129]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 11, 1]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.nn.functional.softmax.1
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 129]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.8
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 129]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.dropout.1
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 128]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.3
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.transpose.5
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.1
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 11, 64, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.reshape.3
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 64, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 11, -1)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.2
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 11, 4096]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.3
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 4096]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [2880, 4096]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:342 in forward, code: attn_output = self.o_proj(attn_output)'
+    marks: bf16operation
+  - name: torch.add.5
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:381 in forward, code: hidden_states = residual + hidden_states'
+    marks: bf16operation
+  - name: torch.reshape.4
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (-1, 2880)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:153 in forward, code: hidden_states = hidden_states.reshape(-1, self.hidden_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.linear.4
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:154 in forward, code: router_logits = F.linear(hidden_states, self.weight,
+      self.bias)  # (seq_len, num_experts)'
+    marks: bf16operation
+  - name: torch.topk.1
+    op: torch.topk
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 4
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.9
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [11, 4]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [11, 4]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.softmax.2
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [11, 4]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:156 in forward, code: router_top_value = torch.nn.functional.softmax(router_top_value,
+      dim=1, dtype=router_top_value.dtype)'
+    marks:
+      - paddedtensor
+      - bf16operation
+    kwmap:
+      dim: 1
+      dtype: torch.float16
+  - name: torch.zeros_like.1
+    op: torch.zeros_like
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+    marks:
+      - paddedtensor
+      - bf16operation
+  - name: torch.scatter_.1
+    op: torch.scatter_
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - tensor:
+          shape: [11, 4]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [11, 4]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.repeat.1
+    op: torch.repeat
+    inputs:
+      - tensor:
+          shape: [11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:128 in forward, code: hidden_states = hidden_states.repeat(num_experts,
+      1)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.3
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [352, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:129 in forward, code: hidden_states = hidden_states.view(num_experts, -1,
+      self.hidden_size)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.bmm.1
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 5760]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+    marks: bf16operation
+  - name: torch.getitem.10
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 5760]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.add.6
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 11, 5760]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+    marks: bf16operation
+  - name: torch.getitem.11
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 11, 5760]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, slice(None, None, 2))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:131 in forward, code: gate, up = gate_up[..., ::2], gate_up[..., 1::2]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.clamp.1
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:132 in forward, code: gate = gate.clamp(min=None, max=self.limit)'
+    marks: bf16operation
+    kwmap:
+      min: None
+      max: 7.0
+  - name: torch.clamp.2
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:133 in forward, code: up = up.clamp(min=-self.limit, max=self.limit)'
+    marks: bf16operation
+    kwmap:
+      min: -7.0
+      max: 7.0
+  - name: torch.mul.7
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1.702
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.sigmoid.1
+    op: torch.sigmoid
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks: bf16operation
+  - name: torch.mul.8
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks: bf16operation
+  - name: torch.add.7
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.bmm.2
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+    marks: bf16operation
+  - name: torch.getitem.12
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:136 in forward, code: next_states = next_states + self.down_proj_bias[...,
+      None, :]'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.add.8
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:136 in forward, code: next_states = next_states + self.down_proj_bias[...,
+      None, :]'
+    marks: bf16operation
+  - name: torch.Tensor.view.4
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:137 in forward, code: next_states = next_states.view(num_experts, batch_size,
+      -1, self.hidden_size)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.6
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 0
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.5
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 11]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.getitem.13
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 1, 11]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.mul.9
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 1, 11, 1]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.sum.1
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [32, 1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:139 in forward, code: next_states = next_states.sum(dim=0)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: 0
+  - name: torch.zeros.2
+    op: torch.zeros
+    inputs:
+      - value: (1, 8, 2048, 64)
+    description: 'site-packages/transformers/cache_utils.py:282 in lazy_initialization, code: self.keys = torch.zeros('
+    marks: constant
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.index_copy_.2
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 8, 11, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:332 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.14
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.4
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 8
+      - value: 2048
+      - value: 64
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.reshape.5
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 8, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 64, 2048, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:219 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.transpose.7
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.matmul.4
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 64, 2048]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.mul.10
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.15
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 2048, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.add.9
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11, 2048]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.cat.4
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 11, 2048]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 11, 1]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+  - name: torch.max.2
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2049]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.sub.4
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2049]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 11, 1]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.nn.functional.softmax.3
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2049]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.16
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2049]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.dropout.2
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2048]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.5
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 11, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.getitem.17
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:683 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.linear.5
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [201088, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:683 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.embedding.2
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [201088, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 199999
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:479 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.getitem.18
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.float.4
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.float.5
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.matmul.6
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.transpose.8
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.cos.2
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.mul.11
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float32
+          init: rand
+      - value: 1.3465735902799727
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.sin.2
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:205 in forward, code: sin = emb.sin() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.pow.2
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.2
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.10
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.2
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.12
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.13
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:61 in forward, code: return (self.weight * hidden_states).to(input_dtype)  #
+      main diff with Llama'
+    marks: fp32operation
+  - name: torch.nn.functional.linear.6
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [4096, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: bf16operation
+  - name: torch.Tensor.view.6
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 1, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.9
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 64, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.linear.7
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [512, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [512]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: bf16operation
+  - name: torch.Tensor.view.7
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 512]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 1, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.10
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 8, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.unsqueeze.2
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:234 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.chunk.3
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.19
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.14
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.sub.5
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.add.11
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.cat.5
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.chunk.4
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.20
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 8, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.15
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.sub.6
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 8, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.add.12
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 8, 1, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.cat.6
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 8, 1, 32]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.index_copy_.3
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 8, 1, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:443 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.matmul.7
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 64, 128]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.mul.16
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.21
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 128, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.add.13
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.cat.7
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 1, 128]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 1, 1]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+  - name: torch.max.3
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 129]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.getitem.22
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 1, 1]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 1, 1]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sub.7
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 129]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 1, 1]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.nn.functional.softmax.4
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 129]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.23
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 129]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.dropout.3
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 128]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.8
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 128]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 128, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.transpose.11
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.3
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 64, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.reshape.6
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1, 64, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (1, 1, -1)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.4
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.8
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [2880, 4096]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:342 in forward, code: attn_output = self.o_proj(attn_output)'
+    marks: bf16operation
+  - name: torch.add.14
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:381 in forward, code: hidden_states = residual + hidden_states'
+    marks: bf16operation
+  - name: torch.reshape.7
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (-1, 2880)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:153 in forward, code: hidden_states = hidden_states.reshape(-1, self.hidden_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.linear.9
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:154 in forward, code: router_logits = F.linear(hidden_states, self.weight,
+      self.bias)  # (seq_len, num_experts)'
+    marks: bf16operation
+  - name: torch.topk.2
+    op: torch.topk
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 4
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.24
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 4]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 4]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.softmax.5
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 4]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:156 in forward, code: router_top_value = torch.nn.functional.softmax(router_top_value,
+      dim=1, dtype=router_top_value.dtype)'
+    marks:
+      - paddedtensor
+      - bf16operation
+    kwmap:
+      dim: 1
+      dtype: torch.float16
+  - name: torch.zeros_like.2
+    op: torch.zeros_like
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+    marks:
+      - paddedtensor
+      - bf16operation
+  - name: torch.scatter_.2
+    op: torch.scatter_
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+      - tensor:
+          shape: [1, 4]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 4]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.repeat.2
+    op: torch.repeat
+    inputs:
+      - tensor:
+          shape: [1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:128 in forward, code: hidden_states = hidden_states.repeat(num_experts,
+      1)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.8
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:129 in forward, code: hidden_states = hidden_states.view(num_experts, -1,
+      self.hidden_size)'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.bmm.3
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 5760]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+    marks: bf16operation
+  - name: torch.add.15
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+    marks: bf16operation
+  - name: torch.getitem.25
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, slice(None, None, 2))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:131 in forward, code: gate, up = gate_up[..., ::2], gate_up[..., 1::2]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.clamp.3
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:132 in forward, code: gate = gate.clamp(min=None, max=self.limit)'
+    marks: bf16operation
+    kwmap:
+      min: None
+      max: 7.0
+  - name: torch.clamp.4
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:133 in forward, code: up = up.clamp(min=-self.limit, max=self.limit)'
+    marks: bf16operation
+    kwmap:
+      min: -7.0
+      max: 7.0
+  - name: torch.mul.17
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1.702
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.sigmoid.2
+    op: torch.sigmoid
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks: bf16operation
+  - name: torch.mul.18
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks: bf16operation
+  - name: torch.add.16
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.bmm.4
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+    marks: bf16operation
+  - name: torch.add.17
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:136 in forward, code: next_states = next_states + self.down_proj_bias[...,
+      None, :]'
+    marks: bf16operation
+  - name: torch.Tensor.view.9
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:137 in forward, code: next_states = next_states.view(num_experts, batch_size,
+      -1, self.hidden_size)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.12
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 0
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.10
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 1]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - paddedtensor
+      - bf16operation
+      - constant
+  - name: torch.getitem.26
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 1, 1]
+          dtype: torch.bfloat16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.mul.19
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [32, 1, 1, 1]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.sum.2
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [32, 1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:139 in forward, code: next_states = next_states.sum(dim=0)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: 0
+  - name: torch.index_copy_.4
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 8, 1, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:332 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.matmul.9
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 64]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 64, 2048]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.mul.20
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.27
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 2048, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.add.18
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 2048]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.cat.8
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 64, 1, 2048]
+            dtype: torch.bfloat16
+            init: rand
+          - shape: [1, 64, 1, 1]
+            dtype: torch.bfloat16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+  - name: torch.max.4
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2049]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.sub.8
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2049]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 1, 1]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.nn.functional.softmax.6
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2049]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.28
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2049]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks:
+      - bf16operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.dropout.4
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2048]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    marks:
+      - bf16operation
+      - largedimtensor
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.10
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1, 2048]
+          dtype: torch.bfloat16
+          init: rand
+      - tensor:
+          shape: [1, 64, 2048, 64]
+          dtype: torch.bfloat16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+    marks:
+      - bf16operation
+      - largedimtensor
+  - name: torch.getitem.29
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.bfloat16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:683 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks:
+      - bf16operation
+      - constant

--- a/tests/_inductor/models/gpt-oss-20b_spyre.yaml
+++ b/tests/_inductor/models/gpt-oss-20b_spyre.yaml
@@ -1,0 +1,2496 @@
+model: gpt-oss-20b
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [201088, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 199999
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:479 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks: constant
+  - name: torch.getitem.1_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32]
+          dtype: torch.float16
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.float.1_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+  - name: torch.Tensor.expand.1_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.to.1_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - value: cuda:0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:197 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.getitem.2_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.amp.autocast_mode._enter_autocast.1_spyre
+    op: torch.amp.autocast_mode._enter_autocast
+    inputs:
+      - value: cuda
+      - value: null
+      - value: false
+      - value: null
+    description: ''
+    marks: constant
+  - name: torch.float.3_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.matmul.1_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.transpose.1_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.cos.1_spyre
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+  - name: torch.mul.1_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 1.3465735902799727
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: constant
+  - name: torch.sin.1_spyre
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:205 in forward, code: sin = emb.sin() * self.attention_scaling'
+  - name: torch.pow.1_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+  - name: torch.mean.1_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.1_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.1_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.2_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.3_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:61 in forward, code: return (self.weight * hidden_states).to(input_dtype)  #
+      main diff with Llama'
+  - name: torch.nn.functional.linear.1_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+  - name: torch.Tensor.view.1_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 11, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.2_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [11, 64, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.nn.functional.linear.2_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+  - name: torch.Tensor.view.2_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 512]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 11, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.3_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [11, 8, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.unsqueeze.1_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:234 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.chunk.1_spyre
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [64, 11, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.3_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [64, 11, 32]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+  - name: torch.mul.4_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [64, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.sub.1_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [64, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.add.2_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [64, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+  - name: torch.cat.1_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [64, 11, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [64, 11, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.chunk.2_spyre
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [8, 11, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.4_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [8, 11, 32]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+  - name: torch.mul.5_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [8, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.sub.2_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [8, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.add.3_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [8, 11, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+  - name: torch.cat.2_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 11, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 11, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.zeros.1_spyre
+    op: torch.zeros
+    inputs:
+      - value: (1, 8, 128, 64)
+    description: 'site-packages/transformers/cache_utils.py:282 in lazy_initialization, code: self.keys = torch.zeros('
+    marks: constant
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.index_copy_.1_spyre
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [8, 128, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [8, 11, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:443 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks: constant
+  - name: torch.getitem.5_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 128, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.2_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 128, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 8
+      - value: 128
+      - value: 64
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.1_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [8, 128, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (1024, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:219 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.transpose.4_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [64, 128, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks: constant
+  - name: torch.matmul.2_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 11, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+  - name: torch.mul.6_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [64, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks: constant
+  - name: torch.getitem.6_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 128, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks: constant
+  - name: torch.add.4_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [64, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+  - name: torch.reshape.2_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [64]
+          dtype: torch.float16
+          init: rand
+      - value: (1, -1, 1, 1)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:258 in eager_attention_forward, code: sinks = module.sinks.reshape(1, -1,
+      1, 1).expand(query.shape[0], -1, query.shape[-2], -1)'
+    marks: constant
+  - name: torch.Tensor.expand.3_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [64, 1, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 11
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:258 in eager_attention_forward, code: sinks = module.sinks.reshape(1, -1,
+      1, 1).expand(query.shape[0], -1, query.shape[-2], -1)'
+    marks: constant
+  - name: torch.cat.3_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [64, 11, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [64, 11, 1]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    kwmap:
+      dim: -1
+  - name: torch.max.1_spyre
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [64, 11, 129]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.getitem.7_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [64, 11, 1]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks: constant
+  - name: torch.sub.3_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [64, 11, 129]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+  - name: torch.nn.functional.softmax.1_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [64, 11, 129]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.8_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 11, 129]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks: constant
+  - name: torch.nn.functional.dropout.1_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [64, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.3_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 128, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+  - name: torch.transpose.5_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [64, 11, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.1_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [11, 64, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.reshape.3_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [11, 64, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (11, -1)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.2_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 11, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.nn.functional.linear.3_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2880, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:342 in forward, code: attn_output = self.o_proj(attn_output)'
+  - name: torch.add.5_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:381 in forward, code: hidden_states = residual + hidden_states'
+  - name: torch.reshape.4_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: (-1, 2880)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:153 in forward, code: hidden_states = hidden_states.reshape(-1, self.hidden_dim)'
+    marks: constant
+  - name: torch.nn.functional.linear.4_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:154 in forward, code: router_logits = F.linear(hidden_states, self.weight,
+      self.bias)  # (seq_len, num_experts)'
+  - name: torch.topk.1_spyre
+    op: torch.topk
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 4
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.9_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [11, 4]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks: constant
+  - name: torch.nn.functional.softmax.2_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [11, 4]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:156 in forward, code: router_top_value = torch.nn.functional.softmax(router_top_value,
+      dim=1, dtype=router_top_value.dtype)'
+    kwmap:
+      dim: 1
+      dtype: torch.float16
+  - name: torch.zeros_like.1_spyre
+    op: torch.zeros_like
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+  - name: torch.scatter_.1_spyre
+    op: torch.scatter_
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - tensor:
+          shape: [11, 4]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [11, 4]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+    marks: constant
+  - name: torch.repeat.1_spyre
+    op: torch.repeat
+    inputs:
+      - tensor:
+          shape: [11, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:128 in forward, code: hidden_states = hidden_states.repeat(num_experts,
+      1)'
+    marks: constant
+  - name: torch.Tensor.view.3_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [352, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:129 in forward, code: hidden_states = hidden_states.view(num_experts, -1,
+      self.hidden_size)'
+    marks: constant
+  - name: torch.bmm.1_spyre
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 5760]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+  - name: torch.getitem.10_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 5760]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+    marks: constant
+  - name: torch.add.6_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 11, 5760]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+  - name: torch.getitem.11_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 11, 5760]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, None, 2))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:131 in forward, code: gate, up = gate_up[..., ::2], gate_up[..., 1::2]'
+    marks: constant
+  - name: torch.clamp.1_spyre
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:132 in forward, code: gate = gate.clamp(min=None, max=self.limit)'
+    kwmap:
+      min: None
+      max: 7.0
+  - name: torch.clamp.2_spyre
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:133 in forward, code: up = up.clamp(min=-self.limit, max=self.limit)'
+    kwmap:
+      min: -7.0
+      max: 7.0
+  - name: torch.mul.7_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 1.702
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks: constant
+  - name: torch.sigmoid.1_spyre
+    op: torch.sigmoid
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+  - name: torch.mul.8_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+  - name: torch.add.7_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+    marks: constant
+  - name: torch.bmm.2_spyre
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+  - name: torch.getitem.12_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:136 in forward, code: next_states = next_states + self.down_proj_bias[...,
+      None, :]'
+    marks: constant
+  - name: torch.add.8_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:136 in forward, code: next_states = next_states + self.down_proj_bias[...,
+      None, :]'
+  - name: torch.Tensor.view.4_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:137 in forward, code: next_states = next_states.view(num_experts, batch_size,
+      -1, self.hidden_size)'
+    marks: constant
+  - name: torch.transpose.6_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [11, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks: constant
+  - name: torch.Tensor.view.5_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks: constant
+  - name: torch.getitem.13_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 1, 11]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks: constant
+  - name: torch.mul.9_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+  - name: torch.sum.1_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:139 in forward, code: next_states = next_states.sum(dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.zeros.2_spyre
+    op: torch.zeros
+    inputs:
+      - value: (1, 8, 2048, 64)
+    description: 'site-packages/transformers/cache_utils.py:282 in lazy_initialization, code: self.keys = torch.zeros('
+    marks: constant
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.index_copy_.2_spyre
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [8, 2048, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [8, 11, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:332 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks: constant
+  - name: torch.getitem.14_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 2048, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.4_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 2048, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 8
+      - value: 2048
+      - value: 64
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:218 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.5_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [8, 2048, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (16384, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:219 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.transpose.7_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [64, 2048, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks: constant
+  - name: torch.matmul.4_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 11, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 64, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+  - name: torch.mul.10_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [64, 11, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks: constant
+  - name: torch.getitem.15_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 2048]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 2048, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks: constant
+  - name: torch.add.9_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [64, 11, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+  - name: torch.cat.4_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [64, 11, 2048]
+            dtype: torch.float16
+            init: rand
+          - shape: [64, 11, 1]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    kwmap:
+      dim: -1
+  - name: torch.max.2_spyre
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [64, 11, 2049]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.sub.4_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [64, 11, 2049]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+  - name: torch.nn.functional.softmax.3_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [64, 11, 2049]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.16_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 11, 2049]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks: constant
+  - name: torch.nn.functional.dropout.2_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [64, 11, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.5_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 11, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 2048, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+  - name: torch.getitem.17_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 2880]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:683 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant
+  - name: torch.nn.functional.linear.5_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [201088, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:683 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant
+  - name: torch.nn.functional.embedding.2_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [201088, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 199999
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:479 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks: constant
+  - name: torch.getitem.18_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.4
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:198 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.float.5_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.matmul.6_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.transpose.8_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:202 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.cos.2_spyre
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+  - name: torch.mul.11_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 1.3465735902799727
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:204 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: constant
+  - name: torch.sin.2_spyre
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:205 in forward, code: sin = emb.sin() * self.attention_scaling'
+  - name: torch.pow.2_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+  - name: torch.mean.2_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:59 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.10_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.2_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.12_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:60 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.13_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:61 in forward, code: return (self.weight * hidden_states).to(input_dtype)  #
+      main diff with Llama'
+  - name: torch.nn.functional.linear.6_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+  - name: torch.Tensor.view.6_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.9_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:313 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.nn.functional.linear.7_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+  - name: torch.Tensor.view.7_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 512]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1, -1, 64)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.10_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 8, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:314 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.unsqueeze.2_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:234 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.chunk.3_spyre
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [64, 1, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.19_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [64, 1, 32]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+  - name: torch.mul.14_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [64, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.sub.5_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [64, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.add.11_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [64, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+  - name: torch.cat.5_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [64, 1, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [64, 1, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.chunk.4_spyre
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [8, 1, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.20_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [8, 1, 32]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:227 in _apply_rotary_emb, code: first_half, second_half = torch.chunk(x,
+      2, dim=-1)'
+    marks: constant
+  - name: torch.mul.15_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [8, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.sub.6_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [8, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:228 in _apply_rotary_emb, code: first_ = first_half * cos - second_half
+      * sin'
+  - name: torch.add.12_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [8, 1, 32]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:229 in _apply_rotary_emb, code: second_ = second_half * cos + first_half
+      * sin'
+  - name: torch.cat.6_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 1, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:230 in _apply_rotary_emb, code: return torch.cat((first_, second_), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.index_copy_.3_spyre
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [8, 128, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [8, 1, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:443 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks: constant
+  - name: torch.matmul.7_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 1, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+  - name: torch.mul.16_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [64, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks: constant
+  - name: torch.getitem.21_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 128, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks: constant
+  - name: torch.add.13_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [64, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+  - name: torch.cat.7_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [64, 1, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [64, 1, 1]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    kwmap:
+      dim: -1
+  - name: torch.max.3_spyre
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [64, 1, 129]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.getitem.22_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [64, 1, 1]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    marks: constant
+  - name: torch.sub.7_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [64, 1, 129]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+  - name: torch.nn.functional.softmax.4_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [64, 1, 129]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.23_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 1, 129]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks: constant
+  - name: torch.nn.functional.dropout.3_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [64, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.8_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 128, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+  - name: torch.transpose.11_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [64, 1, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.3_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 64, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:269 in eager_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.reshape.6_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 64, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (1, -1)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.4_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:341 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.nn.functional.linear.8_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2880, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:342 in forward, code: attn_output = self.o_proj(attn_output)'
+  - name: torch.add.14_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:381 in forward, code: hidden_states = residual + hidden_states'
+  - name: torch.reshape.7_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: (-1, 2880)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:153 in forward, code: hidden_states = hidden_states.reshape(-1, self.hidden_dim)'
+    marks: constant
+  - name: torch.nn.functional.linear.9_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:154 in forward, code: router_logits = F.linear(hidden_states, self.weight,
+      self.bias)  # (seq_len, num_experts)'
+  - name: torch.topk.2_spyre
+    op: torch.topk
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 4
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.24_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 4]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:155 in forward, code: router_top_value, router_indices = torch.topk(router_logits,
+      self.top_k, dim=-1)  # (seq_len, top_k)'
+    marks: constant
+  - name: torch.nn.functional.softmax.5_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 4]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:156 in forward, code: router_top_value = torch.nn.functional.softmax(router_top_value,
+      dim=1, dtype=router_top_value.dtype)'
+    kwmap:
+      dim: 1
+      dtype: torch.float16
+  - name: torch.zeros_like.2_spyre
+    op: torch.zeros_like
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+  - name: torch.scatter_.2_spyre
+    op: torch.scatter_
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - tensor:
+          shape: [1, 4]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 4]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:157 in forward, code: router_scores = torch.zeros_like(router_logits).scatter_(1,
+      router_indices, router_top_value)'
+    marks: constant
+  - name: torch.repeat.2_spyre
+    op: torch.repeat
+    inputs:
+      - tensor:
+          shape: [1, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:128 in forward, code: hidden_states = hidden_states.repeat(num_experts,
+      1)'
+    marks: constant
+  - name: torch.Tensor.view.8_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:129 in forward, code: hidden_states = hidden_states.view(num_experts, -1,
+      self.hidden_size)'
+    marks: constant
+  - name: torch.bmm.3_spyre
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 5760]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+  - name: torch.add.15_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:130 in forward, code: gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+      + self.gate_up_proj_bias[..., None, :]'
+  - name: torch.getitem.25_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 1, 5760]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, None, 2))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:131 in forward, code: gate, up = gate_up[..., ::2], gate_up[..., 1::2]'
+    marks: constant
+  - name: torch.clamp.3_spyre
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:132 in forward, code: gate = gate.clamp(min=None, max=self.limit)'
+    kwmap:
+      min: None
+      max: 7.0
+  - name: torch.clamp.4_spyre
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:133 in forward, code: up = up.clamp(min=-self.limit, max=self.limit)'
+    kwmap:
+      min: -7.0
+      max: 7.0
+  - name: torch.mul.17_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 1.702
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+    marks: constant
+  - name: torch.sigmoid.2_spyre
+    op: torch.sigmoid
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+  - name: torch.mul.18_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:134 in forward, code: glu = gate * torch.sigmoid(gate * self.alpha)'
+  - name: torch.add.16_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+    marks: constant
+  - name: torch.bmm.4_spyre
+    op: torch.bmm
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 2880, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:135 in forward, code: next_states = torch.bmm(((up + 1) * glu), self.down_proj)'
+  - name: torch.add.17_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:136 in forward, code: next_states = next_states + self.down_proj_bias[...,
+      None, :]'
+  - name: torch.Tensor.view.9_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+      - value: 2880
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:137 in forward, code: next_states = next_states.view(num_experts, batch_size,
+      -1, self.hidden_size)'
+    marks: constant
+  - name: torch.transpose.12_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: 1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks: constant
+  - name: torch.Tensor.view.10_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [32, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 32
+      - value: 1
+      - value: -1
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks: constant
+  - name: torch.getitem.26_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 1, 1]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+    marks: constant
+  - name: torch.mul.19_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0,
+      1).view(num_experts, batch_size, -1)[..., None]'
+  - name: torch.sum.2_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:139 in forward, code: next_states = next_states.sum(dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.index_copy_.4_spyre
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [8, 2048, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [8, 1, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/cache_utils.py:332 in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+    marks: constant
+  - name: torch.matmul.9_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 1, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 64, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+  - name: torch.mul.20_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [64, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 0.125
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:253 in eager_attention_forward, code: attn_weights = torch.matmul(query,
+      key_states.transpose(2, 3)) * scaling'
+    marks: constant
+  - name: torch.getitem.27_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 2048, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:255 in eager_attention_forward, code: causal_mask = attention_mask[:, :,
+      :, : key_states.shape[-2]]'
+    marks: constant
+  - name: torch.add.18_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [64, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:256 in eager_attention_forward, code: attn_weights = attn_weights + causal_mask'
+  - name: torch.cat.8_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [64, 1, 2048]
+            dtype: torch.float16
+            init: rand
+          - shape: [64, 1, 1]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:259 in eager_attention_forward, code: combined_logits = torch.cat([attn_weights,
+      sinks], dim=-1)'
+    kwmap:
+      dim: -1
+  - name: torch.max.4_spyre
+    op: torch.max
+    inputs:
+      - tensor:
+          shape: [64, 1, 2049]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.sub.8_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [64, 1, 2049]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:264 in eager_attention_forward, code: combined_logits = combined_logits
+      - combined_logits.max(dim=-1, keepdim=True).values'
+  - name: torch.nn.functional.softmax.6_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [64, 1, 2049]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:265 in eager_attention_forward, code: probs = F.softmax(combined_logits,
+      dim=-1, dtype=combined_logits.dtype)'
+    kwmap:
+      dim: -1
+      dtype: torch.float16
+  - name: torch.getitem.28_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 1, 2049]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, -1, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:266 in eager_attention_forward, code: scores = probs[..., :-1]  # we drop
+      the sink here'
+    marks: constant
+  - name: torch.nn.functional.dropout.4_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [64, 1, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:267 in eager_attention_forward, code: attn_weights = nn.functional.dropout(scores,
+      p=dropout, training=module.training)'
+    kwmap:
+      p: 0.0
+      training: false
+  - name: torch.matmul.10_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [64, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 2048, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:268 in eager_attention_forward, code: attn_output = torch.matmul(attn_weights,
+      value_states)'
+  - name: torch.getitem.29_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 2880]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:683 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant

--- a/tests/_inductor/models/gpt_oss.yaml
+++ b/tests/_inductor/models/gpt_oss.yaml
@@ -1,0 +1,29 @@
+model: gpt-oss
+
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 1.0e-2
+  rtol: 1.0e-2
+
+cases:
+  - name: mul_ok
+    op: torch.mul
+    inputs:
+    - tensor:
+        shape: [1, 64]
+    - tensor:
+        shape: [1, 64]
+
+  - name: mul_ng_fp32
+    op: torch.mul
+    marks:
+    - paddedtensor
+    - fpoperation
+    inputs:
+    - tensor:
+        shape: [1, 64]
+    - tensor:
+        shape: [1, 1]
+        dtype: torch.float32
+        init: rand

--- a/tests/_inductor/models/granite-4.0-h-tiny.yaml
+++ b/tests/_inductor/models/granite-4.0-h-tiny.yaml
@@ -1,0 +1,6968 @@
+model: granite-4.0-h-tiny
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [100352, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 100256
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1345 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.mul.1
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 12
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1347 in forward, code: inputs_embeds = inputs_embeds *
+      self.embedding_multiplier'
+    marks: constant
+  - name: torch.full.1
+    op: torch.full
+    inputs:
+      - value: (11, 11)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.triu.1
+    op: torch.triu
+    inputs:
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1537 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.triu(causal_mask, diagonal=1)'
+    marks: paddedtensor
+    kwmap:
+      diagonal: 1
+  - name: torch.arange.1
+    op: torch.arange
+    inputs:
+      - value: 11
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.reshape.1
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: (-1, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+  - name: torch.gt.1
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [11, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.1
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.1
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.1
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.1
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.2
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 11, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.3
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.1
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.1
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.1
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.1
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.setitem.1
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 11, None))
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.2
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.1
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.invert.1
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.mul.2
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.4
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in _update_mamba_mask, code: if cache_position[0]
+      > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: constant
+  - name: torch.gt.2
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in _update_mamba_mask, code: if cache_position[0]
+      > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: constant
+  - name: torch.eq.3
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in torch_dynamo_resume_in__update_mamba_mask_at_1560,
+      code: if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.all.2
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in torch_dynamo_resume_in__update_mamba_mask_at_1560,
+      code: if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: paddedtensor
+  - name: torch.pow.1
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.1
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.2
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.1
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.3
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.4
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:951 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.1
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [6448, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:650 in torch_forward, code: projected_states = self.in_proj(input_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.split.1
+    op: torch.split
+    inputs:
+      - tensor:
+          shape: [1, 11, 6448]
+          dtype: torch.float16
+          init: rand
+      - value: [3072, 3328, 48]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:651 in torch_forward, code: gate, hidden_states_B_C, dt
+      = projected_states.split('
+    kwmap:
+      dim: -1
+  - name: torch.getitem.5
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 11, 3072]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 3328]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 48]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:651 in torch_forward, code: gate, hidden_states_B_C, dt
+      = projected_states.split('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.transpose.1
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 11, 3328]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:683 in torch_forward, code: hidden_states_B_C_transposed
+      = hidden_states_B_C.transpose(1, 2)'
+    marks: constant
+  - name: torch.nn.functional.pad.1
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 3328, 11]
+          dtype: torch.float16
+          init: rand
+      - value: (-7, 0)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.Tensor.copy_.1
+    op: torch.Tensor.copy_
+    inputs:
+      - tensor:
+          shape: [1, 3328, 4]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 3328, 4]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:687 in torch_forward, code: cache_params.conv_states[self.layer_idx].copy_(conv_states)'
+  - name: torch.conv1d.1
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 3328, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [3328, 1, 4]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [3328]
+          dtype: torch.float16
+          init: rand
+      - value: (1,)
+      - value: (3,)
+      - value: (1,)
+      - value: 3328
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:689 in torch_forward, code: hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C.transpose(1,
+      2))[..., :seq_len].transpose(1, 2))'
+    marks: constant
+  - name: torch.getitem.6
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 3328, 14]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 11, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:689 in torch_forward, code: hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C.transpose(1,
+      2))[..., :seq_len].transpose(1, 2))'
+    marks: constant
+  - name: torch.transpose.2
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 3328, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:689 in torch_forward, code: hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C.transpose(1,
+      2))[..., :seq_len].transpose(1, 2))'
+    marks: constant
+  - name: torch.nn.functional.silu.1
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 11, 3328]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.functional.split.1
+    op: torch.functional.split
+    inputs:
+      - tensor:
+          shape: [1, 11, 3328]
+          dtype: torch.float16
+          init: rand
+      - value: [3072, 128, 128]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:692 in torch_forward, code: hidden_states, B, C = torch.split('
+    kwmap:
+      dim: -1
+  - name: torch.getitem.7
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 11, 3072]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 128]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:692 in torch_forward, code: hidden_states, B, C = torch.split('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.float.1
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:699 in torch_forward, code: A = -torch.exp(self.A_log.float())                            #
+      [num_heads]'
+  - name: torch.exp.1
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:699 in torch_forward, code: A = -torch.exp(self.A_log.float())                            #
+      [num_heads]'
+    marks: fp32operation
+  - name: torch.neg.1
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:699 in torch_forward, code: A = -torch.exp(self.A_log.float())                            #
+      [num_heads]'
+    marks: fp32operation
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:759 in torch_forward, code: dt = nn.functional.softplus(dt
+      + self.dt_bias)'
+  - name: torch.nn.functional.softplus.1
+    op: torch.nn.functional.softplus
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:759 in torch_forward, code: dt = nn.functional.softplus(dt
+      + self.dt_bias)'
+  - name: torch.clamp.1
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+      - value: 0.0
+      - value: .inf
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:760 in torch_forward, code: dt = torch.clamp(dt, self.time_step_limit[0],
+      self.time_step_limit[1])'
+    marks: constant
+  - name: torch.reshape.2
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 11, -1, 64)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:761 in torch_forward, code: hidden_states = hidden_states.reshape(batch_size,
+      seq_len, -1, self.head_dim).float()'
+    marks: constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 11, 48, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:761 in torch_forward, code: hidden_states = hidden_states.reshape(batch_size,
+      seq_len, -1, self.head_dim).float()'
+    marks: largedimtensor
+  - name: torch.reshape.3
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 11, -1, 128)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:762 in torch_forward, code: B = B.reshape(batch_size,
+      seq_len, -1, self.ssm_state_size).float()'
+    marks: constant
+  - name: torch.float.3
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 11, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:762 in torch_forward, code: B = B.reshape(batch_size,
+      seq_len, -1, self.ssm_state_size).float()'
+    marks: largedimtensor
+  - name: torch.repeat_interleave.1
+    op: torch.repeat_interleave
+    inputs:
+      - tensor:
+          shape: [1, 11, 1, 128]
+          dtype: torch.float32
+          init: rand
+      - value: 48
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:764 in torch_forward, code: B = B.repeat_interleave(self.num_heads
+      // self.n_groups, dim=2, output_size=self.num_heads)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: 2
+      output_size: 48
+  - name: torch.getitem.8
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:768 in torch_forward, code: D_residual = self.D[..., None]
+      * pad_tensor_by_size(hidden_states, pad_size)'
+    marks: constant
+  - name: torch.nn.functional.pad.2
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 11, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - value: (0, 0, 0, 0, 0, 245, 0, 0)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.5
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [48, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:768 in torch_forward, code: D_residual = self.D[..., None]
+      * pad_tensor_by_size(hidden_states, pad_size)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.getitem.9
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:771 in torch_forward, code: hidden_states = hidden_states
+      * dt[..., None]'
+    marks: constant
+  - name: torch.mul.6
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 11, 48, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:771 in torch_forward, code: hidden_states = hidden_states
+      * dt[..., None]'
+    marks: largedimtensor
+  - name: torch.mul.7
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:772 in torch_forward, code: A = A.to(hidden_states.dtype)
+      * dt'
+  - name: torch.reshape.4
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - value: (1, -1, 256, 48, 64)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:349 in reshape_into_chunks, code: return input_tensor.reshape('
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.pad.3
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float32
+          init: rand
+      - value: (0, 0, 0, 245, 0, 0)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.reshape.5
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 256, 48]
+          dtype: torch.float32
+          init: rand
+      - value: (1, -1, 256, 48)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:346 in reshape_into_chunks, code: return input_tensor.reshape(input_tensor.shape[0],
+      -1, chunk_size, input_tensor.shape[2])'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.nn.functional.pad.4
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 11, 48, 128]
+          dtype: torch.float32
+          init: rand
+      - value: (0, 0, 0, 0, 0, 245, 0, 0)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.reshape.6
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 256, 48, 128]
+          dtype: torch.float32
+          init: rand
+      - value: (1, -1, 256, 48, 128)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:349 in reshape_into_chunks, code: return input_tensor.reshape('
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.permute.1
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48]
+          dtype: torch.float32
+          init: rand
+      - value: (0, 3, 1, 2)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:778 in torch_forward, code: A = A.permute(0, 3, 1, 2)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.cumsum.1
+    op: torch.cumsum
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:779 in torch_forward, code: A_cumsum = torch.cumsum(A,
+      dim=-1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+  - name: torch.getitem.10
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256]
+          dtype: torch.float32
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.2
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 48
+      - value: 1
+      - value: 256
+      - value: 256
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.ones.1
+    op: torch.ones
+    inputs:
+      - value: 256
+      - value: 256
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:363 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=-1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.tril.1
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:363 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=-1)'
+    marks: paddedtensor
+    kwmap:
+      diagonal: -1
+  - name: torch.invert.2
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+    marks: paddedtensor
+  - name: torch.masked_fill.2
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256, 256]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.cumsum.2
+    op: torch.cumsum
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256, 256]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:366 in segment_sum, code: tensor_segsum = torch.cumsum(input_tensor,
+      dim=-2)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.tril.2
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:369 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=0)'
+    marks: paddedtensor
+    kwmap:
+      diagonal: 0
+  - name: torch.masked_fill.3
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256, 256]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+      - value: -.inf
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:370 in segment_sum, code: tensor_segsum = tensor_segsum.masked_fill(~mask,
+      -torch.inf)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.exp.2
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256, 256]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:783 in torch_forward, code: L = torch.exp(segment_sum(A))'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.getitem.11
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 128]
+          dtype: torch.float32
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:786 in torch_forward, code: G_intermediate = C[:, :, :,
+      None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.8
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 1, 48, 128]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 256, 48, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:786 in torch_forward, code: G_intermediate = C[:, :, :,
+      None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.sum.1
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 256, 48, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:787 in torch_forward, code: G = G_intermediate.sum(dim=-1)  #
+      shape: (b, c, l, s, h)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+  - name: torch.getitem.12
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 256, 48]
+          dtype: torch.float32
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:790 in torch_forward, code: M_intermediate = G[..., None]
+      * L.permute(0, 2, 3, 4, 1)[..., None]'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.permute.2
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256, 256]
+          dtype: torch.float32
+          init: rand
+      - value: (0, 2, 3, 4, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:790 in torch_forward, code: M_intermediate = G[..., None]
+      * L.permute(0, 2, 3, 4, 1)[..., None]'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.9
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 256, 48, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 256, 256, 48, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:790 in torch_forward, code: M_intermediate = G[..., None]
+      * L.permute(0, 2, 3, 4, 1)[..., None]'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.sum.2
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 256, 48, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:791 in torch_forward, code: M = M_intermediate.sum(dim=-1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: -1
+  - name: torch.getitem.13
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:794 in torch_forward, code: Y_diag = (M[..., None] * hidden_states[:,
+      :, None]).sum(dim=3)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.10
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 256, 48, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:794 in torch_forward, code: Y_diag = (M[..., None] * hidden_states[:,
+      :, None]).sum(dim=3)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.sum.3
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:794 in torch_forward, code: Y_diag = (M[..., None] * hidden_states[:,
+      :, None]).sum(dim=3)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: 3
+  - name: torch.sub.1
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 48, 1, 256]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:798 in torch_forward, code: decay_states = torch.exp(A_cumsum[:,
+      :, :, -1:] - A_cumsum)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.exp.3
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:798 in torch_forward, code: decay_states = torch.exp(A_cumsum[:,
+      :, :, -1:] - A_cumsum)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.permute.3
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256]
+          dtype: torch.float32
+          init: rand
+      - value: (0, -2, -1, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:799 in torch_forward, code: B_decay = B * decay_states.permute(0,
+      -2, -1, 1)[..., None]'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.14
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48]
+          dtype: torch.float32
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:799 in torch_forward, code: B_decay = B * decay_states.permute(0,
+      -2, -1, 1)[..., None]'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.11
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 128]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 256, 48, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:799 in torch_forward, code: B_decay = B * decay_states.permute(0,
+      -2, -1, 1)[..., None]'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.mul.12
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 1, 128]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 256, 48, 64, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:800 in torch_forward, code: states = (B_decay[..., None,
+      :] * hidden_states[..., None]).sum(dim=2)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.sum.4
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:800 in torch_forward, code: states = (B_decay[..., None,
+      :] * hidden_states[..., None]).sum(dim=2)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: 2
+  - name: torch.getitem.15
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+      - py: (slice(None, None, None), slice(None, 1, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:807 in torch_forward, code: previous_states = torch.zeros_like(states[:,
+      :1])'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.zeros_like.1
+    op: torch.zeros_like
+    inputs:
+      - tensor:
+          shape: [1, 1, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:807 in torch_forward, code: previous_states = torch.zeros_like(states[:,
+      :1])'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.cat.1
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1, 48, 64, 128]
+            dtype: torch.float32
+            init: rand
+          - shape: [1, 1, 48, 64, 128]
+            dtype: torch.float32
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:808 in torch_forward, code: states = torch.cat([previous_states,
+      states], dim=1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: 1
+  - name: torch.getitem.16
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 48, 1, 256]
+          dtype: torch.float32
+          init: rand
+      - py: (-1,)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:809 in torch_forward, code: decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:,
+      :, :, -1], (1, 0))))'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.pad.5
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 48, 1]
+          dtype: torch.float32
+          init: rand
+      - value: (1, 0)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.getitem.17
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 48, 2]
+          dtype: torch.float32
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.Tensor.expand.3
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 48, 2, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 48
+      - value: 2
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.tril.3
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:363 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=-1)'
+    marks: paddedtensor
+    kwmap:
+      diagonal: -1
+  - name: torch.invert.3
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+    marks: paddedtensor
+  - name: torch.masked_fill.4
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 48, 2, 2]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.cumsum.3
+    op: torch.cumsum
+    inputs:
+      - tensor:
+          shape: [1, 48, 2, 2]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:366 in segment_sum, code: tensor_segsum = torch.cumsum(input_tensor,
+      dim=-2)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.tril.4
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:369 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=0)'
+    marks: paddedtensor
+    kwmap:
+      diagonal: 0
+  - name: torch.masked_fill.5
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 48, 2, 2]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+      - value: -.inf
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:370 in segment_sum, code: tensor_segsum = tensor_segsum.masked_fill(~mask,
+      -torch.inf)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.exp.4
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [1, 48, 2, 2]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:809 in torch_forward, code: decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:,
+      :, :, -1], (1, 0))))'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.transpose.3
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 48, 2, 2]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 3
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:810 in torch_forward, code: decay_chunk = decay_chunk.transpose(1,
+      3)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.18
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 2, 2, 48]
+          dtype: torch.float32
+          init: rand
+      - value: (Ellipsis, None, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.getitem.19
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 2, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, Ellipsis)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.13
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 2, 2, 48, 1, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 2, 1, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.sum.5
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 2, 2, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dim: 1
+  - name: torch.getitem.20
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 2, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+      - py: (-1,)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:812 in torch_forward, code: states, ssm_state = new_states[:,
+      :-1], new_states[:, -1]'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.14
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 1, 128]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:817 in torch_forward, code: C_times_states = (C[..., None,
+      :] * states[:, :, None, ...])'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.sum.6
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:819 in torch_forward, code: Y_off = (C_times_states.sum(-1)
+      * state_decay_out_permuted[..., None])'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.mul.15
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 256, 48, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:819 in torch_forward, code: Y_off = (C_times_states.sum(-1)
+      * state_decay_out_permuted[..., None])'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.add.4
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:822 in torch_forward, code: y = Y_diag + Y_off'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.reshape.7
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - value: (1, -1, 48, 64)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:824 in torch_forward, code: y = y.reshape(batch_size,
+      -1, self.num_heads, self.head_dim)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.add.5
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:826 in torch_forward, code: y = y + D_residual'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.getitem.21
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 256, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - py: (slice(None, None, None), slice(None, 11, None), slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:829 in torch_forward, code: y = y[:, :seq_len, :, :]'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.reshape.8
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 48, 64]
+          dtype: torch.float32
+          init: rand
+      - value: (1, 11, -1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:830 in torch_forward, code: y = y.reshape(batch_size,
+      seq_len, -1)'
+    marks:
+      - fp32operation
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.copy_.2
+    op: torch.Tensor.copy_
+    inputs:
+      - tensor:
+          shape: [1, 48, 64, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 48, 64, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:834 in torch_forward, code: cache_params.ssm_states[self.layer_idx].copy_(ssm_state)'
+    marks:
+      - fp32operation
+      - largedimtensor
+  - name: torch.nn.functional.silu.2
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:879 in forward, code: hidden_states = hidden_states *
+      nn.functional.silu(gate.to(torch.float32))'
+    marks: fp32operation
+  - name: torch.mul.16
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:879 in forward, code: hidden_states = hidden_states *
+      nn.functional.silu(gate.to(torch.float32))'
+    marks: fp32operation
+  - name: torch.pow.2
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:880 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.2
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:880 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.mul.17
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:881 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.18
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [3072]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:883 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+    marks: fp32operation
+  - name: torch.nn.functional.linear.2
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 3072]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:841 in torch_forward, code: contextualized_states = self.out_proj(scan_output.to(dtype))  #
+      [batch, seq_len, hidden_size]'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.mul.19
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 0.22
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1197 in forward, code: hidden_states = residual + hidden_states
+      * self.residual_multiplier'
+    marks: constant
+  - name: torch.add.6
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1197 in forward, code: hidden_states = residual + hidden_states
+      * self.residual_multiplier'
+  - name: torch.reshape.9
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: (-1, 1536)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1093 in forward, code: layer_input = layer_input.reshape(-1,
+      emb_size)'
+    marks: constant
+  - name: torch.nn.functional.linear.3
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1024 in forward, code: logits = self.layer(hidden_states).float()  #
+      [batch_size x seq_len, num_experts]'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.float.4
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1024 in forward, code: logits = self.layer(hidden_states).float()  #
+      [batch_size x seq_len, num_experts]'
+    marks: paddedtensor
+  - name: torch.topk.1
+    op: torch.topk
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float32
+          init: rand
+      - value: 6
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1025 in forward, code: top_k_logits, top_k_indices = logits.topk(self.top_k,
+      dim=1)  # [num_tokens, top_k]'
+    marks:
+      - paddedtensor
+      - fp32operation
+      - constant
+    kwmap:
+      dim: 1
+  - name: torch.getitem.22
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [11, 6]
+            dtype: torch.float32
+            init: rand
+          - shape: [11, 6]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1025 in forward, code: top_k_logits, top_k_indices = logits.topk(self.top_k,
+      dim=1)  # [num_tokens, top_k]'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.softmax.1
+    op: torch.softmax
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1026 in forward, code: top_k_gates = torch.softmax(top_k_logits,
+      dim=1).type_as(hidden_states)  # [num_tokens, top_k]'
+    marks:
+      - paddedtensor
+      - fp32operation
+    kwmap:
+      dim: 1
+  - name: torch.type_as.1
+    op: torch.type_as
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1026 in forward, code: top_k_gates = torch.softmax(top_k_logits,
+      dim=1).type_as(hidden_states)  # [num_tokens, top_k]'
+    marks: paddedtensor
+  - name: torch.zeros.1
+    op: torch.zeros
+    inputs:
+      - value: [11, 64]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1029 in forward, code: zeros = torch.zeros('
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.scatter.1
+    op: torch.scatter
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 64
+      - value: 1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1032 in forward, code: gates = zeros.scatter(1, top_k_indices,
+      1)  # [num_tokens, num_experts]'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.long.1
+    op: torch.long
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1033 in forward, code: expert_size = gates.long().sum(0)  #
+      [num_experts,]'
+    marks: paddedtensor
+  - name: torch.sum.7
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1033 in forward, code: expert_size = gates.long().sum(0)  #
+      [num_experts,]'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.getitem.23
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1036 in forward, code: expert_size = expert_size.tolist()'
+    marks: constant
+  - name: torch.flatten.1
+    op: torch.flatten
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1039 in forward, code: top_k_experts = top_k_indices.flatten()  #
+      [num_tokens * top_k]'
+    marks: paddedtensor
+  - name: torch.sort.1
+    op: torch.sort
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1040 in forward, code: _, index_sorted_experts = top_k_experts.sort(0)  #
+      [num_tokens * top_k]'
+    marks: constant
+  - name: torch.getitem.24
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [66]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: [66]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1040 in forward, code: _, index_sorted_experts = top_k_experts.sort(0)  #
+      [num_tokens * top_k]'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.div.1
+    op: torch.div
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 6
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1041 in forward, code: batch_index = index_sorted_experts.div(self.top_k,
+      rounding_mode="trunc")  # [num_tokens * top_k]'
+    marks: constant
+    kwmap:
+      rounding_mode: trunc
+  - name: torch.flatten.2
+    op: torch.flatten
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1044 in forward, code: top_k_gates = top_k_gates.flatten()  #
+      [num_tokens * top_k]'
+    marks: paddedtensor
+  - name: torch.getitem.25
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 66
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1045 in forward, code: batch_gates = top_k_gates[index_sorted_experts]  #
+      [num_tokens * top_k]'
+  - name: torch.getitem.26
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 11
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1096 in forward, code: expert_inputs = layer_input[batch_index]'
+  - name: torch.getitem.27
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 1024, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: constant
+  - name: torch.getitem.28
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 1536, 512]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: constant
+  - name: torch.getitem.29
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1102 in forward, code: expert_outputs = expert_outputs
+      * batch_gates[:, None]'
+    marks: constant
+  - name: torch.zeros.2
+    op: torch.zeros
+    inputs:
+      - value: (11, 1536)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1104 in forward, code: zeros = torch.zeros((bsz * length,
+      self.input_size), dtype=expert_outputs.dtype, device=expert_outputs.device)'
+    marks: constant
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.Tensor.view.1
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: 1536
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1106 in forward, code: layer_output = layer_output.view(bsz,
+      length, self.input_size)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.4
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:905 in forward, code: hidden_states = self.input_linear(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.chunk.1
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 11, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.30
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 11, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 1024]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.silu.3
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.20
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:907 in forward, code: hidden_states = self.activation(chunked_hidden_states[0])
+      * chunked_hidden_states[1]'
+  - name: torch.nn.functional.linear.5
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:908 in forward, code: hidden_states = self.output_linear(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.6
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:189 in forward, code: query_states = self.q_proj(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.7
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:190 in forward, code: key_states = self.k_proj(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.2
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: 12
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.4
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 11, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.view.3
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 512]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: 4
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.5
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 11, 4, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.31
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.4
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 11
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.10
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 11, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.6
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.1
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 11, 12, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: largedimtensor
+  - name: torch.Tensor.view.4
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:221 in forward, code: attn_output = attn_output.view(bsz,
+      q_len, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.3
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.4
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.5
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.6
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.7
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.8
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.split.2
+    op: torch.split
+    inputs:
+      - tensor:
+          shape: [66, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: [0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 3, 2, 2, 1, 1, 0, 3, 0, 0, 1, 2, 0, 0, 0, 1, 0, 5, 0, 2, 1, 0, 0, 0, 6, 0, 1, 1, 3, 0, 0, 0, 6,
+          0, 2, 0, 1, 1, 0, 0, 0, 2, 5, 0, 2, 3, 0, 0, 1, 1, 2]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:994 in forward, code: input_list = inputs.split(expert_size,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.getitem.32
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:994 in forward, code: input_list = inputs.split(expert_size,
+      dim=0)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.8
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [0, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.9
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [2, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.10
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.11
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [3, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.12
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [5, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.13
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [6, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.cat.2
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.silu.4
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [66, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+    marks: paddedtensor
+  - name: torch.split.3
+    op: torch.split
+    inputs:
+      - tensor:
+          shape: [66, 512]
+          dtype: torch.float16
+          init: rand
+      - value: [0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 3, 2, 2, 1, 1, 0, 3, 0, 0, 1, 2, 0, 0, 0, 1, 0, 5, 0, 2, 1, 0, 0, 0, 6, 0, 1, 1, 3, 0, 0, 0, 6,
+          0, 2, 0, 1, 1, 0, 0, 0, 2, 5, 0, 2, 3, 0, 0, 1, 1, 2]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:994 in forward, code: input_list = inputs.split(expert_size,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.14
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [0, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.15
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [2, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.16
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.17
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [3, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.18
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [5, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.19
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [6, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.cat.3
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.20
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [7, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.21
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [9, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.cat.4
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [7, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [9, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.22
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [7, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.23
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [9, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.cat.5
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [7, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [9, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.24
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [4, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.cat.6
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.25
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [4, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: paddedtensor
+  - name: torch.cat.7
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.cat.8
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.cat.9
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.scaled_dot_product_attention.9
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.10
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.getitem.344
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1735 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.nn.functional.linear.26
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [100352, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1735 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.truediv.1
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [1, 1, 100352]
+          dtype: torch.float16
+          init: rand
+      - value: 6
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1736 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = logits / self.config.logits_scaling'
+    marks: constant
+  - name: torch.nn.functional.embedding.2
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [100352, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 100256
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1345 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.mul.21
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 12
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1347 in forward, code: inputs_embeds = inputs_embeds *
+      self.embedding_multiplier'
+    marks: constant
+  - name: torch.full.2
+    op: torch.full
+    inputs:
+      - value: (1, 12)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.2
+    op: torch.arange
+    inputs:
+      - value: 12
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.reshape.11
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: (-1, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+  - name: torch.gt.3
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.2
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.345
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.5
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.2
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.346
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.7
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.7
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.4
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.6
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.5
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.3
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.invert.4
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.mul.22
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.347
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in _update_mamba_mask, code: if cache_position[0]
+      > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: constant
+  - name: torch.pow.3
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.3
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.8
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.2
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.23
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.24
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:951 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.silu.5
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [6, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+    marks: paddedtensor
+  - name: torch.nn.functional.linear.27
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:905 in forward, code: hidden_states = self.input_linear(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.chunk.2
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.348
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1, 1024]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.silu.6
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.25
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:907 in forward, code: hidden_states = self.activation(chunked_hidden_states[0])
+      * chunked_hidden_states[1]'
+  - name: torch.nn.functional.linear.28
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:908 in forward, code: hidden_states = self.output_linear(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.29
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:189 in forward, code: query_states = self.q_proj(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.30
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:190 in forward, code: key_states = self.k_proj(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.5
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: 12
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.7
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.view.6
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 512]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: 4
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.8
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 4, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.349
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.6
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 12
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.12
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 12, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.11
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 12, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.9
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.2
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 12, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: largedimtensor
+  - name: torch.Tensor.view.7
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:221 in torch_dynamo_resume_in_forward_at_204, code: attn_output
+      = attn_output.view(bsz, q_len, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.350
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1735 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.full.3
+    op: torch.full
+    inputs:
+      - value: (1, 13)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.3
+    op: torch.arange
+    inputs:
+      - value: 13
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.4
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.3
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.351
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.7
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.3
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.352
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.10
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.9
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.6
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.7
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.7
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.4
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.26
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.353
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.8
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 13
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.13
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 13, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.12
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 13, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.4
+    op: torch.full
+    inputs:
+      - value: (1, 14)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.4
+    op: torch.arange
+    inputs:
+      - value: 14
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.5
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.4
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.354
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.9
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.4
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.355
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.11
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.10
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.8
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.8
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.9
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.5
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.27
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.356
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.10
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 14
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.14
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 14, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.13
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 14, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.5
+    op: torch.full
+    inputs:
+      - value: (1, 15)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.5
+    op: torch.arange
+    inputs:
+      - value: 15
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.6
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.5
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.357
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.11
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.5
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.358
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.12
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.11
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.10
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.9
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.11
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.6
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.28
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.359
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.12
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 15
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.15
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 15, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.14
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 15, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.6
+    op: torch.full
+    inputs:
+      - value: (1, 16)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.6
+    op: torch.arange
+    inputs:
+      - value: 16
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.7
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.6
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.360
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.13
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.6
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.361
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.13
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.12
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.12
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.10
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.13
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.7
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.29
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.362
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.14
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 16
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.16
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 16, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.15
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 16, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.7
+    op: torch.full
+    inputs:
+      - value: (1, 17)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.7
+    op: torch.arange
+    inputs:
+      - value: 17
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.8
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.7
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.363
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.15
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.7
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.364
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.14
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.13
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.14
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.11
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.15
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.8
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.30
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.365
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.16
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 17
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.17
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 17, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.16
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 17, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.8
+    op: torch.full
+    inputs:
+      - value: (1, 18)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.8
+    op: torch.arange
+    inputs:
+      - value: 18
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.9
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.Tensor.mul.8
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: paddedtensor
+  - name: torch.getitem.366
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.expand.17
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.clone.8
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+    marks: largedimtensor
+  - name: torch.getitem.367
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.to.15
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.14
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: largedimtensor
+  - name: torch.eq.16
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill.12
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.eq.17
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.all.9
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.31
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: largedimtensor
+  - name: torch.getitem.368
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 4, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.18
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 4, 1, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 18
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.18
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 4, 3, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 12, 18, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.17
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12, 18, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false

--- a/tests/_inductor/models/granite-4.0-h-tiny_spyre.yaml
+++ b/tests/_inductor/models/granite-4.0-h-tiny_spyre.yaml
@@ -1,0 +1,6225 @@
+model: granite-4.0-h-tiny
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [100352, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 100256
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1345 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks: constant
+  - name: torch.mul.1_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 12
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1347 in forward, code: inputs_embeds = inputs_embeds *
+      self.embedding_multiplier'
+    marks: constant
+  - name: torch.full.1_spyre
+    op: torch.full
+    inputs:
+      - value: (11, 11)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.triu.1_spyre
+    op: torch.triu
+    inputs:
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1537 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.triu(causal_mask, diagonal=1)'
+    kwmap:
+      diagonal: 1
+  - name: torch.arange.1_spyre
+    op: torch.arange
+    inputs:
+      - value: 11
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.reshape.1_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: (-1, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+  - name: torch.gt.1_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [11, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.1_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.1_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [11, 11]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.1_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.1_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.2_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 11, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.getitem.3_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.1_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.1_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.1_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.1_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.setitem.1_spyre
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 11, None))
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.2_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.1_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.invert.1_spyre
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.mul.2_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.4_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in _update_mamba_mask, code: if cache_position[0]
+      > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: constant
+  - name: torch.gt.2_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in _update_mamba_mask, code: if cache_position[0]
+      > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: constant
+  - name: torch.eq.3_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in torch_dynamo_resume_in__update_mamba_mask_at_1560,
+      code: if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: constant
+  - name: torch.all.2_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 11]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in torch_dynamo_resume_in__update_mamba_mask_at_1560,
+      code: if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+  - name: torch.pow.1_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks: constant
+  - name: torch.mean.1_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.2_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.1_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.mul.3_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.mul.4
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:951 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.1_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [6448, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:650 in torch_forward, code: projected_states = self.in_proj(input_states)'
+    marks: constant
+  - name: torch.split.1
+    op: torch.split
+    inputs:
+      - tensor:
+          shape: [1, 11, 6448]
+          dtype: torch.float16
+          init: rand
+      - value: [3072, 3328, 48]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:651 in torch_forward, code: gate, hidden_states_B_C, dt
+      = projected_states.split('
+    kwmap:
+      dim: -1
+  - name: torch.getitem.5_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 11, 3072]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 3328]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 48]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:651 in torch_forward, code: gate, hidden_states_B_C, dt
+      = projected_states.split('
+    marks: constant
+  - name: torch.transpose.1_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 11, 3328]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:683 in torch_forward, code: hidden_states_B_C_transposed
+      = hidden_states_B_C.transpose(1, 2)'
+    marks: constant
+  - name: torch.nn.functional.pad.1_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 3328, 11]
+          dtype: torch.float16
+          init: rand
+      - value: (-7, 0)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.Tensor.copy_.1
+    op: torch.Tensor.copy_
+    inputs:
+      - tensor:
+          shape: [1, 3328, 4]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 3328, 4]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:687 in torch_forward, code: cache_params.conv_states[self.layer_idx].copy_(conv_states)'
+  - name: torch.conv1d.1_spyre
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 3328, 11]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [3328, 1, 4]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [3328]
+          dtype: torch.float16
+          init: rand
+      - value: (1,)
+      - value: (3,)
+      - value: (1,)
+      - value: 3328
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:689 in torch_forward, code: hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C.transpose(1,
+      2))[..., :seq_len].transpose(1, 2))'
+    marks: constant
+  - name: torch.getitem.6_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 3328, 14]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 11, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:689 in torch_forward, code: hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C.transpose(1,
+      2))[..., :seq_len].transpose(1, 2))'
+    marks: constant
+  - name: torch.transpose.2_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 3328, 11]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:689 in torch_forward, code: hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C.transpose(1,
+      2))[..., :seq_len].transpose(1, 2))'
+    marks: constant
+  - name: torch.nn.functional.silu.1
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 11, 3328]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.functional.split.1
+    op: torch.functional.split
+    inputs:
+      - tensor:
+          shape: [1, 11, 3328]
+          dtype: torch.float16
+          init: rand
+      - value: [3072, 128, 128]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:692 in torch_forward, code: hidden_states, B, C = torch.split('
+    kwmap:
+      dim: -1
+  - name: torch.getitem.7_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 11, 3072]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 11, 128]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:692 in torch_forward, code: hidden_states, B, C = torch.split('
+    marks: constant
+  - name: torch.float.1
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:699 in torch_forward, code: A = -torch.exp(self.A_log.float())                            #
+      [num_heads]'
+  - name: torch.exp.1_spyre
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:699 in torch_forward, code: A = -torch.exp(self.A_log.float())                            #
+      [num_heads]'
+  - name: torch.neg.1_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:699 in torch_forward, code: A = -torch.exp(self.A_log.float())                            #
+      [num_heads]'
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:759 in torch_forward, code: dt = nn.functional.softplus(dt
+      + self.dt_bias)'
+  - name: torch.nn.functional.softplus.1
+    op: torch.nn.functional.softplus
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:759 in torch_forward, code: dt = nn.functional.softplus(dt
+      + self.dt_bias)'
+  - name: torch.clamp.1_spyre
+    op: torch.clamp
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+      - value: 0.0
+      - value: .inf
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:760 in torch_forward, code: dt = torch.clamp(dt, self.time_step_limit[0],
+      self.time_step_limit[1])'
+    marks: constant
+  - name: torch.reshape.2_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 11, -1, 64)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:761 in torch_forward, code: hidden_states = hidden_states.reshape(batch_size,
+      seq_len, -1, self.head_dim).float()'
+    marks: constant
+  - name: torch.float.2_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [11, 48, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:761 in torch_forward, code: hidden_states = hidden_states.reshape(batch_size,
+      seq_len, -1, self.head_dim).float()'
+  - name: torch.reshape.3_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 11, -1, 128)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:762 in torch_forward, code: B = B.reshape(batch_size,
+      seq_len, -1, self.ssm_state_size).float()'
+    marks: constant
+  - name: torch.float.3_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [11, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:762 in torch_forward, code: B = B.reshape(batch_size,
+      seq_len, -1, self.ssm_state_size).float()'
+  - name: torch.repeat_interleave.1_spyre
+    op: torch.repeat_interleave
+    inputs:
+      - tensor:
+          shape: [11, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 48
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:764 in torch_forward, code: B = B.repeat_interleave(self.num_heads
+      // self.n_groups, dim=2, output_size=self.num_heads)'
+    marks: constant
+    kwmap:
+      dim: 2
+      output_size: 48
+  - name: torch.getitem.8_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:768 in torch_forward, code: D_residual = self.D[..., None]
+      * pad_tensor_by_size(hidden_states, pad_size)'
+    marks: constant
+  - name: torch.nn.functional.pad.2_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [11, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 0, 0, 0, 0, 245, 0, 0)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.mul.5_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [48, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:768 in torch_forward, code: D_residual = self.D[..., None]
+      * pad_tensor_by_size(hidden_states, pad_size)'
+  - name: torch.getitem.9_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:771 in torch_forward, code: hidden_states = hidden_states
+      * dt[..., None]'
+    marks: constant
+  - name: torch.mul.6_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [11, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [11, 48, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:771 in torch_forward, code: hidden_states = hidden_states
+      * dt[..., None]'
+  - name: torch.mul.7
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [48]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:772 in torch_forward, code: A = A.to(hidden_states.dtype)
+      * dt'
+  - name: torch.reshape.4_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (-1, 256, 48, 64)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:349 in reshape_into_chunks, code: return input_tensor.reshape('
+    marks: constant
+  - name: torch.nn.functional.pad.3_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 11, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 0, 0, 245, 0, 0)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.reshape.5_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 256, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (1, -1, 256, 48)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:346 in reshape_into_chunks, code: return input_tensor.reshape(input_tensor.shape[0],
+      -1, chunk_size, input_tensor.shape[2])'
+    marks: constant
+  - name: torch.nn.functional.pad.4_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [11, 48, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 0, 0, 0, 0, 245, 0, 0)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.reshape.6_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [256, 48, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (-1, 256, 48, 128)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:349 in reshape_into_chunks, code: return input_tensor.reshape('
+    marks: constant
+  - name: torch.permute.1_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 256, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 1, 2)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:778 in torch_forward, code: A = A.permute(0, 3, 1, 2)'
+    marks: constant
+  - name: torch.cumsum.1_spyre
+    op: torch.cumsum
+    inputs:
+      - tensor:
+          shape: [48, 1, 256]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:779 in torch_forward, code: A_cumsum = torch.cumsum(A,
+      dim=-1)'
+    kwmap:
+      dim: -1
+  - name: torch.getitem.10_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [48, 1, 256]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks: constant
+  - name: torch.Tensor.expand.2_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 256, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 48
+      - value: 1
+      - value: 256
+      - value: 256
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks: constant
+  - name: torch.ones.1_spyre
+    op: torch.ones
+    inputs:
+      - value: 256
+      - value: 256
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:363 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=-1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.tril.1_spyre
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:363 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=-1)'
+    kwmap:
+      diagonal: -1
+  - name: torch.invert.2_spyre
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+  - name: torch.masked_fill.2_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 256, 256]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+    marks: constant
+  - name: torch.cumsum.2_spyre
+    op: torch.cumsum
+    inputs:
+      - tensor:
+          shape: [1, 256, 256]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:366 in segment_sum, code: tensor_segsum = torch.cumsum(input_tensor,
+      dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.tril.2_spyre
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:369 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=0)'
+    kwmap:
+      diagonal: 0
+  - name: torch.masked_fill.3_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 256, 256]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 256]
+          dtype: torch.bool
+      - value: -.inf
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:370 in segment_sum, code: tensor_segsum = tensor_segsum.masked_fill(~mask,
+      -torch.inf)'
+    marks: constant
+  - name: torch.exp.2_spyre
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [1, 256, 256]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:783 in torch_forward, code: L = torch.exp(segment_sum(A))'
+  - name: torch.getitem.11_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [256, 48, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:786 in torch_forward, code: G_intermediate = C[:, :, :,
+      None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)'
+    marks: constant
+  - name: torch.mul.8_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 48, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:786 in torch_forward, code: G_intermediate = C[:, :, :,
+      None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)'
+  - name: torch.sum.1_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [256, 48, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:787 in torch_forward, code: G = G_intermediate.sum(dim=-1)  #
+      shape: (b, c, l, s, h)'
+    kwmap:
+      dim: -1
+  - name: torch.getitem.12_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [256, 256, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:790 in torch_forward, code: M_intermediate = G[..., None]
+      * L.permute(0, 2, 3, 4, 1)[..., None]'
+    marks: constant
+  - name: torch.permute.2_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 256, 256]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:790 in torch_forward, code: M_intermediate = G[..., None]
+      * L.permute(0, 2, 3, 4, 1)[..., None]'
+    marks: constant
+  - name: torch.mul.9_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [256, 48, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:790 in torch_forward, code: M_intermediate = G[..., None]
+      * L.permute(0, 2, 3, 4, 1)[..., None]'
+  - name: torch.sum.2_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [256, 48, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:791 in torch_forward, code: M = M_intermediate.sum(dim=-1)'
+    kwmap:
+      dim: -1
+  - name: torch.getitem.13_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:794 in torch_forward, code: Y_diag = (M[..., None] * hidden_states[:,
+      :, None]).sum(dim=3)'
+    marks: constant
+  - name: torch.mul.10_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [256, 48, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:794 in torch_forward, code: Y_diag = (M[..., None] * hidden_states[:,
+      :, None]).sum(dim=3)'
+  - name: torch.sum.3_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:794 in torch_forward, code: Y_diag = (M[..., None] * hidden_states[:,
+      :, None]).sum(dim=3)'
+    kwmap:
+      dim: 3
+  - name: torch.sub.1_spyre
+    op: torch.sub
+    inputs:
+      - tensor:
+          shape: [48, 1, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [48, 1, 256]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:798 in torch_forward, code: decay_states = torch.exp(A_cumsum[:,
+      :, :, -1:] - A_cumsum)'
+  - name: torch.exp.3_spyre
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [48, 1, 256]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:798 in torch_forward, code: decay_states = torch.exp(A_cumsum[:,
+      :, :, -1:] - A_cumsum)'
+  - name: torch.permute.3_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [48, 1, 256]
+          dtype: torch.float16
+          init: rand
+      - value: (0, -1, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:799 in torch_forward, code: B_decay = B * decay_states.permute(0,
+      -2, -1, 1)[..., None]'
+    marks: constant
+  - name: torch.getitem.14_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 256, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:799 in torch_forward, code: B_decay = B * decay_states.permute(0,
+      -2, -1, 1)[..., None]'
+    marks: constant
+  - name: torch.mul.11_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [256, 48, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:799 in torch_forward, code: B_decay = B * decay_states.permute(0,
+      -2, -1, 1)[..., None]'
+  - name: torch.mul.12_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [48, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [48, 64, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:800 in torch_forward, code: states = (B_decay[..., None,
+      :] * hidden_states[..., None]).sum(dim=2)'
+  - name: torch.sum.4_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:800 in torch_forward, code: states = (B_decay[..., None,
+      :] * hidden_states[..., None]).sum(dim=2)'
+    kwmap:
+      dim: 2
+  - name: torch.getitem.15_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 1, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:807 in torch_forward, code: previous_states = torch.zeros_like(states[:,
+      :1])'
+    marks: constant
+  - name: torch.zeros_like.1_spyre
+    op: torch.zeros_like
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:807 in torch_forward, code: previous_states = torch.zeros_like(states[:,
+      :1])'
+  - name: torch.cat.1_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [48, 64, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [48, 64, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:808 in torch_forward, code: states = torch.cat([previous_states,
+      states], dim=1)'
+    kwmap:
+      dim: 1
+  - name: torch.getitem.16_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [48, 1, 256]
+          dtype: torch.float16
+          init: rand
+      - py: (-1,)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:809 in torch_forward, code: decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:,
+      :, :, -1], (1, 0))))'
+    marks: constant
+  - name: torch.nn.functional.pad.5_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 48, 1]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 0)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5209 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.getitem.17_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 48, 2]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks: constant
+  - name: torch.Tensor.expand.3_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [48, 2, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 48
+      - value: 2
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:361 in segment_sum, code: input_tensor = input_tensor[...,
+      None].expand(*input_tensor.size(), chunk_size)'
+    marks: constant
+  - name: torch.tril.3_spyre
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:363 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=-1)'
+    kwmap:
+      diagonal: -1
+  - name: torch.invert.3_spyre
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+  - name: torch.masked_fill.4_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [48, 2, 2]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:364 in segment_sum, code: input_tensor = input_tensor.masked_fill(~mask,
+      0)'
+    marks: constant
+  - name: torch.cumsum.3_spyre
+    op: torch.cumsum
+    inputs:
+      - tensor:
+          shape: [48, 2, 2]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:366 in segment_sum, code: tensor_segsum = torch.cumsum(input_tensor,
+      dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.tril.4_spyre
+    op: torch.tril
+    inputs:
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:369 in segment_sum, code: mask = torch.tril(torch.ones(chunk_size,
+      chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=0)'
+    kwmap:
+      diagonal: 0
+  - name: torch.masked_fill.5_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [48, 2, 2]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2, 2]
+          dtype: torch.bool
+      - value: -.inf
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:370 in segment_sum, code: tensor_segsum = tensor_segsum.masked_fill(~mask,
+      -torch.inf)'
+    marks: constant
+  - name: torch.exp.4_spyre
+    op: torch.exp
+    inputs:
+      - tensor:
+          shape: [48, 2, 2]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:809 in torch_forward, code: decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:,
+      :, :, -1], (1, 0))))'
+  - name: torch.transpose.3_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [48, 2, 2]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 3
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:810 in torch_forward, code: decay_chunk = decay_chunk.transpose(1,
+      3)'
+    marks: constant
+  - name: torch.getitem.18_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [2, 2, 48]
+          dtype: torch.float16
+          init: rand
+      - value: (Ellipsis, None, None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+    marks: constant
+  - name: torch.getitem.19_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, Ellipsis)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+    marks: constant
+  - name: torch.mul.13_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [48, 1, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+  - name: torch.sum.5_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:811 in torch_forward, code: new_states = (decay_chunk[...,
+      None, None] * states[:, :, None, ...]).sum(dim=1)'
+    kwmap:
+      dim: 1
+  - name: torch.getitem.20_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (-1,)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:812 in torch_forward, code: states, ssm_state = new_states[:,
+      :-1], new_states[:, -1]'
+    marks: constant
+  - name: torch.mul.14_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [48, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:817 in torch_forward, code: C_times_states = (C[..., None,
+      :] * states[:, :, None, ...])'
+  - name: torch.sum.6_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:819 in torch_forward, code: Y_off = (C_times_states.sum(-1)
+      * state_decay_out_permuted[..., None])'
+    marks: constant
+  - name: torch.mul.15_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:819 in torch_forward, code: Y_off = (C_times_states.sum(-1)
+      * state_decay_out_permuted[..., None])'
+  - name: torch.add.4_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:822 in torch_forward, code: y = Y_diag + Y_off'
+  - name: torch.reshape.7_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (12288, 64)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:824 in torch_forward, code: y = y.reshape(batch_size,
+      -1, self.num_heads, self.head_dim)'
+    marks: constant
+  - name: torch.add.5_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:826 in torch_forward, code: y = y + D_residual'
+  - name: torch.getitem.21_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [256, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 11, None), slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:829 in torch_forward, code: y = y[:, :seq_len, :, :]'
+    marks: constant
+  - name: torch.reshape.8_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [11, 48, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (11, -1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:830 in torch_forward, code: y = y.reshape(batch_size,
+      seq_len, -1)'
+    marks: constant
+  - name: torch.Tensor.copy_.2_spyre
+    op: torch.Tensor.copy_
+    inputs:
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [48, 64, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:834 in torch_forward, code: cache_params.ssm_states[self.layer_idx].copy_(ssm_state)'
+  - name: torch.nn.functional.silu.2_spyre
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:879 in forward, code: hidden_states = hidden_states *
+      nn.functional.silu(gate.to(torch.float32))'
+  - name: torch.mul.16_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:879 in forward, code: hidden_states = hidden_states *
+      nn.functional.silu(gate.to(torch.float32))'
+  - name: torch.pow.2_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:880 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks: constant
+  - name: torch.mean.2_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:880 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.mul.17_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:881 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.mul.18_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [3072]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:883 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.2_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 3072]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 3072]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:841 in torch_forward, code: contextualized_states = self.out_proj(scan_output.to(dtype))  #
+      [batch, seq_len, hidden_size]'
+    marks: constant
+  - name: torch.mul.19_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 0.22
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1197 in forward, code: hidden_states = residual + hidden_states
+      * self.residual_multiplier'
+    marks: constant
+  - name: torch.add.6
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1197 in forward, code: hidden_states = residual + hidden_states
+      * self.residual_multiplier'
+  - name: torch.reshape.9_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: (-1, 1536)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1093 in forward, code: layer_input = layer_input.reshape(-1,
+      emb_size)'
+    marks: constant
+  - name: torch.nn.functional.linear.3_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [64, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1024 in forward, code: logits = self.layer(hidden_states).float()  #
+      [batch_size x seq_len, num_experts]'
+    marks: constant
+  - name: torch.float.4_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1024 in forward, code: logits = self.layer(hidden_states).float()  #
+      [batch_size x seq_len, num_experts]'
+  - name: torch.topk.1_spyre
+    op: torch.topk
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 6
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1025 in forward, code: top_k_logits, top_k_indices = logits.topk(self.top_k,
+      dim=1)  # [num_tokens, top_k]'
+    marks: constant
+    kwmap:
+      dim: 1
+  - name: torch.getitem.22_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [11, 6]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1025 in forward, code: top_k_logits, top_k_indices = logits.topk(self.top_k,
+      dim=1)  # [num_tokens, top_k]'
+    marks: constant
+  - name: torch.softmax.1_spyre
+    op: torch.softmax
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1026 in forward, code: top_k_gates = torch.softmax(top_k_logits,
+      dim=1).type_as(hidden_states)  # [num_tokens, top_k]'
+    kwmap:
+      dim: 1
+  - name: torch.type_as.1_spyre
+    op: torch.type_as
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1026 in forward, code: top_k_gates = torch.softmax(top_k_logits,
+      dim=1).type_as(hidden_states)  # [num_tokens, top_k]'
+  - name: torch.zeros.1
+    op: torch.zeros
+    inputs:
+      - value: [11, 64]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1029 in forward, code: zeros = torch.zeros('
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.scatter.1_spyre
+    op: torch.scatter
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 64
+      - value: 1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1032 in forward, code: gates = zeros.scatter(1, top_k_indices,
+      1)  # [num_tokens, num_experts]'
+    marks: constant
+  - name: torch.long.1_spyre
+    op: torch.long
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1033 in forward, code: expert_size = gates.long().sum(0)  #
+      [num_experts,]'
+  - name: torch.sum.7_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [11, 64]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1033 in forward, code: expert_size = gates.long().sum(0)  #
+      [num_experts,]'
+    marks: constant
+  - name: torch.getitem.23_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1036 in forward, code: expert_size = expert_size.tolist()'
+    marks: constant
+  - name: torch.flatten.1_spyre
+    op: torch.flatten
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1039 in forward, code: top_k_experts = top_k_indices.flatten()  #
+      [num_tokens * top_k]'
+  - name: torch.sort.1_spyre
+    op: torch.sort
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1040 in forward, code: _, index_sorted_experts = top_k_experts.sort(0)  #
+      [num_tokens * top_k]'
+    marks: constant
+  - name: torch.getitem.24_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [66]
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+      - value: 1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1040 in forward, code: _, index_sorted_experts = top_k_experts.sort(0)  #
+      [num_tokens * top_k]'
+    marks: constant
+  - name: torch.div.1_spyre
+    op: torch.div
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 6
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1041 in forward, code: batch_index = index_sorted_experts.div(self.top_k,
+      rounding_mode="trunc")  # [num_tokens * top_k]'
+    marks: constant
+    kwmap:
+      rounding_mode: trunc
+  - name: torch.flatten.2_spyre
+    op: torch.flatten
+    inputs:
+      - tensor:
+          shape: [11, 6]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1044 in forward, code: top_k_gates = top_k_gates.flatten()  #
+      [num_tokens * top_k]'
+  - name: torch.getitem.25
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 66
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1045 in forward, code: batch_gates = top_k_gates[index_sorted_experts]  #
+      [num_tokens * top_k]'
+  - name: torch.getitem.26
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [66]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 11
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1096 in forward, code: expert_inputs = layer_input[batch_index]'
+  - name: torch.getitem.27_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 1024, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: constant
+  - name: torch.getitem.28_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64, 1536, 512]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+    marks: constant
+  - name: torch.getitem.29_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [66]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1102 in forward, code: expert_outputs = expert_outputs
+      * batch_gates[:, None]'
+    marks: constant
+  - name: torch.zeros.2_spyre
+    op: torch.zeros
+    inputs:
+      - value: (11, 1536)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1104 in forward, code: zeros = torch.zeros((bsz * length,
+      self.input_size), dtype=expert_outputs.dtype, device=expert_outputs.device)'
+    marks: constant
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.Tensor.view.1_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: 1536
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1106 in forward, code: layer_output = layer_output.view(bsz,
+      length, self.input_size)'
+    marks: constant
+  - name: torch.nn.functional.linear.4_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:905 in forward, code: hidden_states = self.input_linear(hidden_states)'
+    marks: constant
+  - name: torch.chunk.1_spyre
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 11, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.30_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 11, 1024]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks: constant
+  - name: torch.nn.functional.silu.3
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.20
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:907 in forward, code: hidden_states = self.activation(chunked_hidden_states[0])
+      * chunked_hidden_states[1]'
+  - name: torch.nn.functional.linear.5_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:908 in forward, code: hidden_states = self.output_linear(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.6_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:189 in forward, code: query_states = self.q_proj(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.7_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:190 in forward, code: key_states = self.k_proj(hidden_states)'
+    marks: constant
+  - name: torch.Tensor.view.2_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: 12
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.4_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [11, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.Tensor.view.3_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 11, 512]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: 4
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.5_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [11, 4, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.getitem.31_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.4_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 11
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.10_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (33, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.6_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.1_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [11, 12, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.Tensor.view.4_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [11, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 11
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:221 in forward, code: attn_output = attn_output.view(bsz,
+      q_len, -1)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.3_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.4_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.5_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.6_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.7_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.8_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.split.2_spyre
+    op: torch.split
+    inputs:
+      - tensor:
+          shape: [66, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: [0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 3, 2, 2, 1, 1, 0, 3, 0, 0, 1, 2, 0, 0, 0, 1, 0, 5, 0, 2, 1, 0, 0, 0, 6, 0, 1, 1, 3, 0, 0, 0, 6,
+          0, 2, 0, 1, 1, 0, 0, 0, 2, 5, 0, 2, 3, 0, 0, 1, 1, 2]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:994 in forward, code: input_list = inputs.split(expert_size,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.getitem.32_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:994 in forward, code: input_list = inputs.split(expert_size,
+      dim=0)'
+    marks: constant
+  - name: torch.nn.functional.linear.8_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [0, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.9_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [2, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.10_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.11_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [3, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.12_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [5, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.13_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [6, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.cat.2_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.silu.4_spyre
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [66, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.split.3_spyre
+    op: torch.split
+    inputs:
+      - tensor:
+          shape: [66, 512]
+          dtype: torch.float16
+          init: rand
+      - value: [0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 3, 2, 2, 1, 1, 0, 3, 0, 0, 1, 2, 0, 0, 0, 1, 0, 5, 0, 2, 1, 0, 0, 0, 6, 0, 1, 1, 3, 0, 0, 0, 6,
+          0, 2, 0, 1, 1, 0, 0, 0, 2, 5, 0, 2, 3, 0, 0, 1, 1, 2]
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:994 in forward, code: input_list = inputs.split(expert_size,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.14_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [0, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.15_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [2, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.16_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.17_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [3, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.18_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [5, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.19_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [6, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.cat.3_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.20_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [7, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.21_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [9, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.cat.4_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [7, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [9, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.22_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [7, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.nn.functional.linear.23_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [9, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.cat.5_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [7, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [9, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [6, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.24_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [4, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.cat.6_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.linear.25_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [4, 512]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:997 in forward, code: output_list.append(F.linear(input_list[i],
+      self.weight[i]))'
+  - name: torch.cat.7_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.cat.8_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1024]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.cat.9_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [4, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [3, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [5, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [2, 1536]
+            dtype: torch.float16
+            init: rand
+          - shape: [0, 1536]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:998 in forward, code: results = torch.cat(output_list,
+      dim=0)'
+    kwmap:
+      dim: 0
+  - name: torch.nn.functional.scaled_dot_product_attention.9_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.10_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 11, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.getitem.344_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 11, 1536]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1735 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.nn.functional.linear.26_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [100352, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1735 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.truediv.1_spyre
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [1, 1, 100352]
+          dtype: torch.float16
+          init: rand
+      - value: 6
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1736 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = logits / self.config.logits_scaling'
+    marks: constant
+  - name: torch.nn.functional.embedding.2_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [100352, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 100256
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1345 in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+    marks: constant
+  - name: torch.mul.21_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 12
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1347 in forward, code: inputs_embeds = inputs_embeds *
+      self.embedding_multiplier'
+    marks: constant
+  - name: torch.full.2_spyre
+    op: torch.full
+    inputs:
+      - value: (1, 12)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.2_spyre
+    op: torch.arange
+    inputs:
+      - value: 12
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.reshape.11_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: (-1, 1)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+  - name: torch.gt.3_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.2_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.345_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.5_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.2_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.346_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.7_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.7_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.4_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.6_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.5_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.3_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.invert.4_spyre
+    op: torch.invert
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.mul.22_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.347_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1560 in _update_mamba_mask, code: if cache_position[0]
+      > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):'
+    marks: constant
+  - name: torch.pow.3_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks: constant
+  - name: torch.mean.3_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:949 in forward, code: variance = hidden_states.pow(2).mean(-1,
+      keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.8_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.2_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.mul.23_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:950 in forward, code: hidden_states = hidden_states *
+      torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.mul.24
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:951 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.silu.5_spyre
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [6, 512]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.nn.functional.linear.27_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:905 in forward, code: hidden_states = self.input_linear(hidden_states)'
+    marks: constant
+  - name: torch.chunk.2_spyre
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.348_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 1, 1024]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:906 in forward, code: chunked_hidden_states = hidden_states.chunk(2,
+      dim=-1)'
+    marks: constant
+  - name: torch.nn.functional.silu.6
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.25
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:907 in forward, code: hidden_states = self.activation(chunked_hidden_states[0])
+      * chunked_hidden_states[1]'
+  - name: torch.nn.functional.linear.28_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:908 in forward, code: hidden_states = self.output_linear(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.29_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1536, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:189 in forward, code: query_states = self.q_proj(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.30_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:190 in forward, code: key_states = self.k_proj(hidden_states)'
+    marks: constant
+  - name: torch.Tensor.view.5_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: 12
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.7_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:193 in forward, code: query_states = query_states.view(bsz,
+      q_len, self.num_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.Tensor.view.6_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 512]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: 4
+      - value: 128
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.8_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 4, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:194 in forward, code: key_states = key_states.view(bsz,
+      q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.getitem.349_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.6_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 12
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.12_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (36, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.11_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 12, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.9_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.2_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.Tensor.view.7_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:221 in torch_dynamo_resume_in_forward_at_204, code: attn_output
+      = attn_output.view(bsz, q_len, -1)'
+    marks: constant
+  - name: torch.getitem.350_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1536]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1735 in torch_dynamo_resume_in_forward_at_1717, code:
+      logits = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.full.3_spyre
+    op: torch.full
+    inputs:
+      - value: (1, 13)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.3_spyre
+    op: torch.arange
+    inputs:
+      - value: 13
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.4_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.3_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.351_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.7_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.3_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.352_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.10_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.9_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.6_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.7_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.7_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.4_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.26_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 13]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.353_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.8_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 13
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.13_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (39, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.12_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 13, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 13, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.4_spyre
+    op: torch.full
+    inputs:
+      - value: (1, 14)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.4_spyre
+    op: torch.arange
+    inputs:
+      - value: 14
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.5_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.4_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.354_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.9_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.4_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.355_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.11_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.10_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.8_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.8_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.9_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.5_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.27_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.356_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.10_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 14
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.14_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (42, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.13_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 14, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 14, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.5_spyre
+    op: torch.full
+    inputs:
+      - value: (1, 15)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.5_spyre
+    op: torch.arange
+    inputs:
+      - value: 15
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.6_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.5_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.357_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.11_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.5_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.358_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.12_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.11_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.10_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.9_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.11_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.6_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.28_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.359_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.12_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 15
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.15_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (45, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.14_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 15, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 15, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.6_spyre
+    op: torch.full
+    inputs:
+      - value: (1, 16)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.6_spyre
+    op: torch.arange
+    inputs:
+      - value: 16
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.7_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.6_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.360_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.13_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.6_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.361_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.13_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.12_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.12_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.10_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.13_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.7_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.29_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 16]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.362_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.14_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 16
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.16_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (48, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.15_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 16, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 16, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.7_spyre
+    op: torch.full
+    inputs:
+      - value: (1, 17)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.7_spyre
+    op: torch.arange
+    inputs:
+      - value: 17
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.8_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.7_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.363_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.15_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.7_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.364_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.14_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.13_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.14_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.11_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.15_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.8_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.30_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 17]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.365_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.16_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 17
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.17_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (51, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.16_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 17, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 17, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.full.8_spyre
+    op: torch.full
+    inputs:
+      - value: (1, 18)
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1533 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = torch.full('
+    marks: constant
+    kwmap:
+      fill_value: -65504.0
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.arange.8_spyre
+    op: torch.arange
+    inputs:
+      - value: 18
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.gt.9_spyre
+    op: torch.gt
+    inputs:
+      - tensor:
+          shape: [18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.Tensor.mul.8_spyre
+    op: torch.Tensor.mul
+    inputs:
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1538 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask *= torch.arange(target_length, device=cache_position.device) > cache_position.reshape(-1, 1)'
+  - name: torch.getitem.366_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.float16
+          init: rand
+      - py: (None, None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.Tensor.expand.17_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 1
+      - value: -1
+      - value: -1
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1539 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)'
+    marks: constant
+  - name: torch.clone.8_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1541 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit'
+  - name: torch.getitem.367_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.to.15_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+    marks: constant
+  - name: torch.add.14_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1543 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to('
+  - name: torch.eq.16_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1546 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: padding_mask = padding_mask == 0'
+    marks: constant
+  - name: torch.masked_fill.12_spyre
+    op: torch.masked_fill
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py:1547 in _prepare_4d_causal_attention_mask_with_cache_position,
+      code: causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill('
+    marks: constant
+  - name: torch.eq.17_spyre
+    op: torch.eq
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    marks: constant
+  - name: torch.all.9_spyre
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+    kwmap:
+      dim: -1
+      keepdim: true
+  - name: torch.mul.31_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 18]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/modeling_attn_mask_utils.py:247 in _unmask_unattended, code: return expanded_mask.mul(~torch.all(expanded_mask
+      == min_dtype, dim=-1, keepdim=True))'
+  - name: torch.getitem.368_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [4, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.18_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 4
+      - value: 3
+      - value: 18
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.18_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [3, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (54, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.17_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [12, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 18, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12, 18, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false

--- a/tests/_inductor/models/granite-speech-3.3-8b.yaml
+++ b/tests/_inductor/models/granite-speech-3.3-8b.yaml
@@ -1,0 +1,11496 @@
+model: granite-speech-3.3-8b
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.__eq__.1
+    op: torch.__eq__
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 49159
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:401 in forward, code: is_audio_idx = input_ids == self.config.audio_token_id'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.clone.1
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:402 in forward, code: llm_input_ids = input_ids.clone()'
+    marks: paddedtensor
+  - name: torch.setitem.1
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:403 in forward, code: llm_input_ids[is_audio_idx] = 0'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.embedding.1
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [49160, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:404 in forward, code: inputs_embeds = self.get_input_embeddings()(llm_input_ids)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.1
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 160]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 160]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:270 in forward, code: hidden_states = self.input_linear(hidden_states)'
+  - name: torch.nn.functional.layer_norm.1
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1024,)
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:110 in forward, code: hidden_states = self.pre_norm(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.2
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:111 in forward, code: hidden_states = self.up_proj(hidden_states)'
+  - name: torch.nn.functional.silu.1
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 844, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:112 in forward, code: hidden_states = self.dropout(self.silu(hidden_states))'
+    kwmap:
+      inplace: false
+  - name: torch.nn.functional.dropout.1
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 844, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:112 in forward, code: hidden_states = self.dropout(self.silu(hidden_states))'
+    marks: constant
+  - name: torch.nn.functional.linear.3
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:113 in forward, code: hidden_states = self.down_proj(hidden_states)'
+  - name: torch.nn.functional.dropout.2
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:114 in forward, code: hidden_states = self.dropout(hidden_states)'
+    marks: constant
+  - name: torch.mul.1
+    op: torch.mul
+    inputs:
+      - value: 0.5
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:244 in forward, code: hidden_states = 0.5 * self.ff1(hidden_states)
+      + hidden_states'
+    marks: constant
+  - name: torch.add.1
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:244 in forward, code: hidden_states = 0.5 * self.ff1(hidden_states)
+      + hidden_states'
+  - name: torch.nn.functional.pad.1
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 0, 0, 156)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5290 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.nn.functional.linear.4
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:152 in forward, code: query_states = self.to_q(hidden_states)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.linear.5
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:153 in forward, code: key_states, value_states = self.to_kv(hidden_states).chunk(2,
+      dim=-1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.chunk.1
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 1000, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:153 in forward, code: key_states, value_states = self.to_kv(hidden_states).chunk(2,
+      dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.1
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 1000, 1024]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1000, 1024]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:153 in forward, code: key_states, value_states = self.to_kv(hidden_states).chunk(2,
+      dim=-1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.reshape.1
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 5, 200, 8, -1)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:155 in forward, code: query_states = query_states.reshape(bsz,
+      num_blocks, self.context_size, self.num_heads, -1).transpose(2, 3)'
+    marks: constant
+  - name: torch.transpose.1
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 5, 200, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:155 in forward, code: query_states = query_states.reshape(bsz,
+      num_blocks, self.context_size, self.num_heads, -1).transpose(2, 3)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.embedding.2
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [200, 200]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1025, 128]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:160 in forward, code: rel_pos_emb = self.rel_pos_emb(attention_dists)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.functional.einsum.1
+    op: torch.functional.einsum
+    inputs:
+      - value: b m h c d, c r d -> b m h c r
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [200, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:166 in forward, code: pos_attn = torch.einsum("b m h c d,
+      c r d -> b m h c r", query_states, rel_pos_emb) * self.scale'
+    marks: constant
+  - name: torch.mul.2
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 200]
+          dtype: torch.float16
+          init: rand
+      - value: 0.08838834764831845
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:166 in forward, code: pos_attn = torch.einsum("b m h c d,
+      c r d -> b m h c r", query_states, rel_pos_emb) * self.scale'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.ones.1
+    op: torch.ones
+    inputs:
+      - value: 200
+      - value: 200
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:170 in forward, code: mask = torch.ones(self.context_size,
+      self.context_size, dtype=bool, device=hidden_states.device)'
+    marks: constant
+    kwmap:
+      dtype: torch.bool
+      device: cuda:0
+  - name: torch.setitem.2
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [200, 200]
+          dtype: torch.bool
+      - py: (slice(None, 44, None), slice(None, 44, None))
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:171 in forward, code: mask[:remainder, :remainder] = 0'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.getitem.2
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 200]
+          dtype: torch.float16
+          init: rand
+      - py: (-1,)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:173 in forward, code: pos_attn[:, -1, :].masked_fill_(mask,
+      mask_value)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.masked_fill_.1
+    op: torch.masked_fill_
+    inputs:
+      - tensor:
+          shape: [1, 8, 200, 200]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [200, 200]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:173 in forward, code: pos_attn[:, -1, :].masked_fill_(mask,
+      mask_value)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.attention._backend_from_string.1
+    op: torch.nn.attention._backend_from_string
+    inputs:
+      - value: MATH
+    description: ''
+    marks: constant
+  - name: torch.nn.attention._sdpa_kernel.1
+    op: torch.nn.attention._sdpa_kernel
+    inputs:
+      - value: false
+    description: ''
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.transpose.2
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:179 in forward, code: out = out.transpose(2, 3).reshape(bsz,
+      hidden_states.shape[1], -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.2
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 5, 200, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1000, -1)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:179 in forward, code: out = out.transpose(2, 3).reshape(bsz,
+      hidden_states.shape[1], -1)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.3
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 844, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:180 in forward, code: out = self.to_out(out[:, :num_features,
+      :])'
+    marks: constant
+  - name: torch.nn.functional.linear.6
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:180 in forward, code: out = self.to_out(out[:, :num_features,
+      :])'
+  - name: torch.permute.1
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:223 in forward, code: hidden_states = self.up_conv(hidden_states.permute(0,
+      2, 1))'
+    marks: constant
+  - name: torch.conv1d.1
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 1024, 844]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1,)
+      - value: (0,)
+      - value: (1,)
+      - value: 1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:223 in forward, code: hidden_states = self.up_conv(hidden_states.permute(0,
+      2, 1))'
+    marks: constant
+  - name: torch.nn.functional.glu.1
+    op: torch.nn.functional.glu
+    inputs:
+      - tensor:
+          shape: [1, 4096, 844]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:224 in forward, code: hidden_states = self.glu(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.pad.2
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+      - value: (7, 7)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5290 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.conv1d.2
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 2048, 858]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: (1,)
+      - value: (0,)
+      - value: (1,)
+      - value: 2048
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:198 in forward, code: return self.conv(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.batch_norm.1
+    op: torch.nn.functional.batch_norm
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - value: false
+      - value: 0.1
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:226 in forward, code: hidden_states = self.silu(self.batch_norm(hidden_states))'
+    marks: constant
+  - name: torch.nn.functional.silu.2
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:226 in forward, code: hidden_states = self.silu(self.batch_norm(hidden_states))'
+    kwmap:
+      inplace: false
+  - name: torch.conv1d.3
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 2048, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1,)
+      - value: (0,)
+      - value: (1,)
+      - value: 1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:227 in forward, code: hidden_states = self.down_conv(hidden_states).permute(0,
+      2, 1)'
+    marks: constant
+  - name: torch.permute.2
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 1024, 844]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:227 in forward, code: hidden_states = self.down_conv(hidden_states).permute(0,
+      2, 1)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.3
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.4
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.5
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.6
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.7
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.8
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.clone.2
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:275 in forward, code: hidden_states_mid = hidden_states.clone()'
+  - name: torch.nn.functional.linear.7
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:276 in forward, code: hidden_states_mid = self.out(hidden_states_mid)'
+  - name: torch.nn.functional.softmax.1
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 844, 256]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:277 in forward, code: hidden_states += self.out_mid(nn.Softmax(dim=-1)(hidden_states_mid))'
+    marks: constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.linear.8
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 256]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 256]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:277 in forward, code: hidden_states += self.out_mid(nn.Softmax(dim=-1)(hidden_states_mid))'
+  - name: torch.Tensor.add.1
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:277 in forward, code: hidden_states += self.out_mid(nn.Softmax(dim=-1)(hidden_states_mid))'
+  - name: torch.nn.functional.scaled_dot_product_attention.9
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.10
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.11
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.12
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.13
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.14
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.15
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.16
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 5, 8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.pad.3
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 0, 0, 11)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5290 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.Tensor.view.1
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 855, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 15
+      - value: 1024
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:83 in forward, code: hidden_states = hidden_states.view(batch_size
+      * nblocks, self.window_size, dim)'
+    marks: constant
+  - name: torch.nn.functional.layer_norm.2
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1024,)
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-12
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1036 in forward, code: embedding_output = self.layernorm(query_embeds)'
+    marks: constant
+  - name: torch.nn.functional.dropout.3
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1037 in forward, code: embedding_output = self.dropout(embedding_output)'
+    marks: constant
+  - name: torch.ones.2
+    op: torch.ones
+    inputs:
+      - value: (1, 3)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1044 in forward, code: attention_mask = torch.ones(((batch_size, seq_length)),
+      device=device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.getitem.4
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 3]
+          dtype: torch.float32
+          init: rand
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:995 in get_extended_attention_mask, code: extended_attention_mask = attention_mask[:,
+      None, None, :]'
+    marks:
+      - paddedtensor
+      - fp32operation
+      - constant
+  - name: torch.to.3
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 3]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1006 in get_extended_attention_mask, code: extended_attention_mask = extended_attention_mask.to(dtype=self.dtype)  #
+      fp16 compatibility'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dtype: torch.float16
+  - name: torch.sub.1
+    op: torch.sub
+    inputs:
+      - value: 1.0
+      - tensor:
+          shape: [1, 1, 1, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1007 in get_extended_attention_mask, code: extended_attention_mask = (1.0
+      - extended_attention_mask) * -10000.0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.mul.3
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 3]
+          dtype: torch.float16
+          init: rand
+      - value: -10000.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1007 in get_extended_attention_mask, code: extended_attention_mask = (1.0
+      - extended_attention_mask) * -10000.0'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.ones.3
+    op: torch.ones
+    inputs:
+      - value: (57, 15)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1066 in forward, code: encoder_attention_mask = torch.ones(encoder_hidden_shape,
+      device=device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.getitem.5
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [57, 15]
+          dtype: torch.float32
+          init: rand
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/modeling_utils.py:1558 in invert_attention_mask, code: encoder_extended_attention_mask = encoder_attention_mask[:,
+      None, None, :]'
+    marks:
+      - paddedtensor
+      - fp32operation
+      - constant
+  - name: torch.to.4
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [57, 1, 1, 15]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/modeling_utils.py:1564 in invert_attention_mask, code: encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  #
+      fp16 compatibility'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dtype: torch.float16
+  - name: torch.sub.2
+    op: torch.sub
+    inputs:
+      - value: 1.0
+      - tensor:
+          shape: [57, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/modeling_utils.py:1565 in invert_attention_mask, code: encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask)
+      * torch.finfo(self.dtype).min'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.mul.4
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [57, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_utils.py:1565 in invert_attention_mask, code: encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask)
+      * torch.finfo(self.dtype).min'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.linear.9
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:596 in forward, code: key_layer = self.transpose_for_scores(self.key(hidden_states))'
+  - name: torch.Tensor.view.2
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 3
+      - value: 16
+      - value: 64
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:574 in transpose_for_scores, code: x = x.view(*new_x_shape)'
+    marks: constant
+  - name: torch.permute.3
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1, 3)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:575 in transpose_for_scores, code: return x.permute(0, 2, 1, 3)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.transpose.3
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+      - value: -2
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.matmul.1
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 16, 64, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks: largedimtensor
+  - name: torch.truediv.1
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 8.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:622 in forward, code: attention_scores = attention_scores / math.sqrt(self.attention_head_size)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.2
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:626 in forward, code: attention_scores = attention_scores + attention_mask'
+    marks: largedimtensor
+  - name: torch.nn.functional.softmax.2
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:629 in forward, code: attention_probs = nn.Softmax(dim=-1)(attention_scores)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.dropout.4
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:637 in forward, code: attention_probs_dropped = self.dropout(attention_probs)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.matmul.2
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:643 in forward, code: context_layer = torch.matmul(attention_probs_dropped,
+      value_layer)'
+    marks: largedimtensor
+  - name: torch.permute.4
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1, 3)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.1
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 3, 16, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+    marks: largedimtensor
+  - name: torch.Tensor.view.3
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 3
+      - value: 1024
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:647 in forward, code: context_layer = context_layer.view(*new_context_layer_shape)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:666 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+  - name: torch.getitem.6
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 3, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:787 in forward, code: query_attention_output = attention_output[:, :query_length,
+      :]'
+    marks: constant
+  - name: torch.nn.functional.linear.10
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 15, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:592 in forward, code: key_layer = self.transpose_for_scores(self.key(encoder_hidden_states))'
+  - name: torch.Tensor.view.4
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [57, 15, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 15
+      - value: 16
+      - value: 64
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:574 in transpose_for_scores, code: x = x.view(*new_x_shape)'
+    marks: constant
+  - name: torch.permute.5
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [57, 15, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1, 3)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:575 in transpose_for_scores, code: return x.permute(0, 2, 1, 3)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.transpose.4
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [57, 16, 15, 64]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+      - value: -2
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.matmul.3
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 16, 64, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks: largedimtensor
+  - name: torch.truediv.2
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 8.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:622 in forward, code: attention_scores = attention_scores / math.sqrt(self.attention_head_size)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.4
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 1, 1, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:626 in forward, code: attention_scores = attention_scores + attention_mask'
+    marks: largedimtensor
+  - name: torch.nn.functional.softmax.3
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:629 in forward, code: attention_probs = nn.Softmax(dim=-1)(attention_scores)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.dropout.5
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:637 in forward, code: attention_probs_dropped = self.dropout(attention_probs)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.matmul.4
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 16, 15, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:643 in forward, code: context_layer = torch.matmul(attention_probs_dropped,
+      value_layer)'
+    marks: largedimtensor
+  - name: torch.permute.6
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1, 3)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.2
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [57, 3, 16, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+    marks: largedimtensor
+  - name: torch.Tensor.view.5
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [57, 3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 3
+      - value: 1024
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:647 in forward, code: context_layer = context_layer.view(*new_context_layer_shape)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.linear.11
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:664 in forward, code: hidden_states = self.dense(hidden_states)'
+  - name: torch.nn.functional.dropout.6
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:665 in forward, code: hidden_states = self.dropout(hidden_states)'
+    marks: constant
+  - name: torch.add.5
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:666 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+  - name: torch.nn.functional.layer_norm.3
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1024,)
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-12
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:666 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+    marks: constant
+  - name: torch.nn.functional.linear.12
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:727 in forward, code: hidden_states = self.dense(hidden_states)'
+  - name: torch.nn.functional.gelu.1
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [57, 3, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:85 in forward, code: return self.act(input)'
+  - name: torch.nn.functional.linear.13
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 3, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:741 in forward, code: hidden_states = self.dense(hidden_states)'
+  - name: torch.add.6
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:743 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+  - name: torch.Tensor.view.6
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 3
+      - value: 16
+      - value: 64
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:574 in transpose_for_scores, code: x = x.view(*new_x_shape)'
+    marks: constant
+  - name: torch.permute.7
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [57, 3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1, 3)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:575 in transpose_for_scores, code: return x.permute(0, 2, 1, 3)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.transpose.5
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+      - value: -2
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.matmul.5
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 16, 64, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks: largedimtensor
+  - name: torch.truediv.3
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 8.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:622 in forward, code: attention_scores = attention_scores / math.sqrt(self.attention_head_size)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.add.7
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:626 in forward, code: attention_scores = attention_scores + attention_mask'
+    marks: largedimtensor
+  - name: torch.nn.functional.softmax.4
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:629 in forward, code: attention_probs = nn.Softmax(dim=-1)(attention_scores)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.dropout.7
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:637 in forward, code: attention_probs_dropped = self.dropout(attention_probs)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.matmul.6
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:643 in forward, code: context_layer = torch.matmul(attention_probs_dropped,
+      value_layer)'
+    marks: largedimtensor
+  - name: torch.getitem.7
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 3, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:787 in forward, code: query_attention_output = attention_output[:, :query_length,
+      :]'
+    marks: constant
+  - name: torch.matmul.7
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [57, 16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 16, 64, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks: largedimtensor
+  - name: torch.Tensor.view.7
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 171
+      - value: -1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:92 in forward, code: query_output.last_hidden_state.view(batch_size,
+      nblocks * self.window_size // self.downsample_rate, -1)'
+    marks: constant
+  - name: torch.nn.functional.linear.14
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 171, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:91 in forward, code: query_proj = self.linear('
+  - name: torch.where.1
+    op: torch.where
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - value: 0
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:511 in get_merged_audio_embeddings, code: llm_input_ids =
+      torch.where(is_audio_index, 0, input_ids)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.unsqueeze.1
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - value: -1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:515 in get_merged_audio_embeddings, code: special_audio_mask
+      = is_audio_index.unsqueeze(-1)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.int.1
+    op: torch.int
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+    marks: paddedtensor
+  - name: torch.sum.1
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int32
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+    marks: paddedtensor
+    kwmap:
+      dim: 1
+  - name: torch.int.2
+    op: torch.int
+    inputs:
+      - tensor:
+          shape: [1, 171]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+    marks: paddedtensor
+  - name: torch.sum.2
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 171]
+          dtype: torch.int32
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+    marks: paddedtensor
+    kwmap:
+      dim: 1
+  - name: torch.ne.1
+    op: torch.ne
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+  - name: torch.all.1
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+  - name: torch.masked_scatter.1
+    op: torch.masked_scatter
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.bool
+      - tensor:
+          shape: [171, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:523 in torch_dynamo_resume_in_get_merged_audio_embeddings_at_521,
+      code: inputs_embeds = inputs_embeds.masked_scatter('
+    marks: paddedtensor
+  - name: torch.mul.5
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 12.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:411 in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+      main diff with Llama'
+    marks: constant
+  - name: torch.to.6
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.1
+    op: torch.arange
+    inputs:
+      - value: 239
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.2
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.1
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 1
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.1
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 1
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.2
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 3
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.new_ones.1
+    op: torch.new_ones
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: ()
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+    kwmap:
+      dtype: torch.bool
+  - name: torch.le.1
+    op: torch.le
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.to.7
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: cuda:0
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+  - name: torch.__and__.1
+    op: torch.__and__
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - tensor:
+          shape: []
+          dtype: torch.bool
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.ops.aten.index.1
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.1
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 239
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.2
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [239]
+          dtype: torch.bool
+      - value: 3
+      - value: 239
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.3
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [239, 239]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.4
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 239, 239]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.getitem.8
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64]
+          dtype: torch.float32
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.float.1
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: fp32operation
+  - name: torch.Tensor.expand.1
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.to.8
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float32
+          init: rand
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.getitem.9
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.amp.autocast_mode._enter_autocast.1
+    op: torch.amp.autocast_mode._enter_autocast
+    inputs:
+      - value: cuda
+      - value: null
+      - value: false
+      - value: null
+    description: ''
+    marks: constant
+  - name: torch.float.3
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 239]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.matmul.8
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 239]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.transpose.6
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 239]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.cat.1
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 239, 64]
+            dtype: torch.float32
+            init: rand
+          - shape: [1, 239, 64]
+            dtype: torch.float32
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:352 in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.1
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.mul.6
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.sin.1
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:354 in forward, code: sin = emb.sin() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.to.9
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:356 in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    marks: fp32operation
+    kwmap:
+      dtype: torch.float16
+  - name: torch.pow.1
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.1
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.8
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.1
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.7
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.8
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:204 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.15
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.8
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 239, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.7
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 239, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.linear.16
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.9
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 239, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 239, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.8
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 239, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.unsqueeze.2
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:73 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.9
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.getitem.10
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.neg.1
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: largedimtensor
+  - name: torch.cat.2
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 32, 239, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 32, 239, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.add.9
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.mul.10
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.getitem.11
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.neg.2
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 8, 239, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: largedimtensor
+  - name: torch.cat.3
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 239, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 239, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.add.10
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 8, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.tensor.1
+    op: torch.tensor
+    inputs:
+      - value: []
+    description: 'site-packages/transformers/cache_utils.py:94 in lazy_initialization, code: self.keys = torch.tensor([], dtype=self.dtype, device=self.device)'
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.cat.4
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 239, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.Tensor.expand.2
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 239
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.3
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 239, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.12
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 239, 239]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 239, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.17
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.9
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.3
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 239, 32, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: largedimtensor
+  - name: torch.reshape.4
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 239, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 239, -1)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.4
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.add.11
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:288 in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+  - name: torch.nn.functional.linear.17
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12800, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.silu.3
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.11
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+  - name: torch.nn.functional.linear.18
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 12800]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.18
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.19
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.20
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.21
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.22
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.23
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.24
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.25
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.26
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.27
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.28
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.29
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.30
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.31
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.32
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.33
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.34
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.35
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.36
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.37
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.38
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.39
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.40
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.41
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.42
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.43
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.44
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.45
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.46
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.47
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.48
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.49
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.50
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.51
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.52
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.53
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.54
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.55
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.56
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.getitem.13
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:549 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant
+  - name: torch.nn.functional.linear.19
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [49160, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:549 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.truediv.4
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [1, 1, 49160]
+          dtype: torch.float16
+          init: rand
+      - value: 16.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:550 in forward, code: logits = logits / self.config.logits_scaling  # main
+      diff with Llama'
+    marks: constant
+  - name: torch.__eq__.2
+    op: torch.__eq__
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 49159
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:401 in forward, code: is_audio_idx = input_ids == self.config.audio_token_id'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.clone.3
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:402 in forward, code: llm_input_ids = input_ids.clone()'
+    marks: paddedtensor
+  - name: torch.setitem.3
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:403 in forward, code: llm_input_ids[is_audio_idx] = 0'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.embedding.3
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [49160, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:404 in forward, code: inputs_embeds = self.get_input_embeddings()(llm_input_ids)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.mul.12
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 12.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:411 in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+      main diff with Llama'
+    marks: constant
+  - name: torch.to.12
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 240]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.Tensor.add.3
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [240]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.3
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [240]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.2
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 240]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.5
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [240]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.6
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 240]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.7
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 240]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.getitem.14
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.float.4
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.float.5
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.matmul.9
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.transpose.10
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.cat.5
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1, 64]
+            dtype: torch.float32
+            init: rand
+          - shape: [1, 1, 64]
+            dtype: torch.float32
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:352 in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.2
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.mul.13
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.sin.2
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:354 in forward, code: sin = emb.sin() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.to.13
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:356 in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    marks: fp32operation
+    kwmap:
+      dtype: torch.float16
+  - name: torch.pow.2
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.2
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.12
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.2
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.14
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.15
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:204 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.20
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.10
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.11
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.linear.21
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.11
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.12
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.unsqueeze.3
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:73 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.16
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.getitem.15
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.neg.3
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: largedimtensor
+  - name: torch.cat.6
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 32, 1, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 32, 1, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.add.13
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.mul.17
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.getitem.16
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.neg.4
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: largedimtensor
+  - name: torch.cat.7
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 1, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.add.14
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 8, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.cat.8
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 239, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.getitem.17
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.3
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 240
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.5
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 240, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.18
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 240]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 240, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.57
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.13
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.5
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: largedimtensor
+  - name: torch.reshape.6
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1, -1)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.6
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.add.15
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:288 in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+  - name: torch.nn.functional.linear.22
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12800, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.silu.4
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.18
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+  - name: torch.nn.functional.linear.23
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 12800]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.58
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.59
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.60
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.61
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.62
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.63
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.64
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.65
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.66
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.67
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.68
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.69
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.70
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.71
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.72
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.73
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.74
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.75
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.76
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.77
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.78
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.79
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.80
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.81
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.82
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.83
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.84
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.85
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.86
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.87
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.88
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.89
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.90
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.91
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.92
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.93
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.94
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.95
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.96
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.getitem.19
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:549 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant
+  - name: torch.to.16
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 241]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.2
+    op: torch.arange
+    inputs:
+      - value: 241
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.4
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [241]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.2
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 241
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.4
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [241]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.3
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 241]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.8
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 241
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.9
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [241]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.10
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 241]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.11
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 241]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.9
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 240, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.getitem.20
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.4
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 241
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.7
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 241, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sym_sum.1
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 240]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.21
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 241]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.97
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.98
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.99
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.100
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.101
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.102
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.103
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.104
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.105
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.106
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.107
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.108
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.109
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.110
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.111
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.112
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.113
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.114
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.115
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.116
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.117
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.118
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.119
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.120
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.121
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.122
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.123
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.124
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.125
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.126
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.127
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.128
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.129
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.130
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.131
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.132
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.133
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.134
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.135
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.136
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.17
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 242]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.3
+    op: torch.arange
+    inputs:
+      - value: 242
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.5
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [242]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.3
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 242
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.5
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [242]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.4
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 242]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.12
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 242
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.13
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [242]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.14
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 242]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.15
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 242]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.10
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 241, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.getitem.22
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.5
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 242
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.8
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 242, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sym_sum.2
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 241]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.23
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 242]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.137
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.138
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.139
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.140
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.141
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.142
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.143
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.144
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.145
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.146
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.147
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.148
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.149
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.150
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.151
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.152
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.153
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.154
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.155
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.156
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.157
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.158
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.159
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.160
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.161
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.162
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.163
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.164
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.165
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.166
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.167
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.168
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.169
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.170
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.171
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.172
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.173
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.174
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.175
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.176
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.18
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 243]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.4
+    op: torch.arange
+    inputs:
+      - value: 243
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.6
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [243]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.4
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 243
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.6
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [243]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.5
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 243]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.16
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 243
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.17
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [243]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.18
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 243]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.19
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 243]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.11
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 242, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.getitem.24
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.6
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 243
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.9
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 243, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sym_sum.3
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 242]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.25
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 243]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.177
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.178
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.179
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.180
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.181
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.182
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.183
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.184
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.185
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.186
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.187
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.188
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.189
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.190
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.191
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.192
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.193
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.194
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.195
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.196
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.197
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.198
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.199
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.200
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.201
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.202
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.203
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.204
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.205
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.206
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.207
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.208
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.209
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.210
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.211
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.212
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.213
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.214
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.215
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.216
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.19
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 244]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.5
+    op: torch.arange
+    inputs:
+      - value: 244
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.7
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [244]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.5
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 244
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.7
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [244]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.6
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 244]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.20
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 244
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.21
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [244]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.22
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 244]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.23
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 244]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.12
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 243, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.getitem.26
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.7
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 244
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.10
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 244, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sym_sum.4
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 243]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.27
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 244]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.217
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.218
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.219
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.220
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.221
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.222
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.223
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.224
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.225
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.226
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.227
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.228
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.229
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.230
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.231
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.232
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.233
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.234
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.235
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.236
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.237
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.238
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.239
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.240
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.241
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.242
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.243
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.244
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.245
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.246
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.247
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.248
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.249
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.250
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.251
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.252
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.253
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.254
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.255
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.256
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.20
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 245]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.6
+    op: torch.arange
+    inputs:
+      - value: 245
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.8
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [245]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.6
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 245
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.8
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [245]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.7
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 245]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.24
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 245
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.25
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [245]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.26
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 245]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.27
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 245]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.13
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 244, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.getitem.28
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.8
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 245
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.11
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 245, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sym_sum.5
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 244]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.29
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 245]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.257
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.258
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.259
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.260
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.261
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.262
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.263
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.264
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.265
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.266
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.267
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.268
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.269
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.270
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.271
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.272
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.273
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.274
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.275
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.276
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.277
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.278
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.279
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.280
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.281
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.282
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.283
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.284
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.285
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.286
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.287
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.288
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.289
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.290
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.291
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.292
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.293
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.294
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.295
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.296
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.21
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 246]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.7
+    op: torch.arange
+    inputs:
+      - value: 246
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.9
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [246]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.7
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 246
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.9
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [246]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.8
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 246]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.28
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 246
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.29
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [246]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.30
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 246]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.31
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 246]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.14
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 245, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.getitem.30
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.expand.9
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 246
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.12
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 246, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.sym_sum.6
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 245]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.31
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 1, 246]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.297
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.298
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.299
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.300
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.301
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.302
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.303
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.304
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.305
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.306
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.307
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.308
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.309
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.310
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.311
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.312
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.313
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.314
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.315
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.316
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.317
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.318
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.319
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.320
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.321
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.322
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.323
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.324
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.325
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.326
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.327
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.328
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.329
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.330
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.331
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.332
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.333
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.334
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.335
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.336
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false

--- a/tests/_inductor/models/granite-speech-3.3-8b_spyre.yaml
+++ b/tests/_inductor/models/granite-speech-3.3-8b_spyre.yaml
@@ -1,0 +1,10835 @@
+model: granite-speech-3.3-8b
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.__eq__.1_spyre
+    op: torch.__eq__
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 49159
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:401 in forward, code: is_audio_idx = input_ids == self.config.audio_token_id'
+    marks: constant
+  - name: torch.clone.1_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:402 in forward, code: llm_input_ids = input_ids.clone()'
+  - name: torch.setitem.1_spyre
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:403 in forward, code: llm_input_ids[is_audio_idx] = 0'
+    marks: constant
+  - name: torch.nn.functional.embedding.1_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [49160, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:404 in forward, code: inputs_embeds = self.get_input_embeddings()(llm_input_ids)'
+    marks: constant
+  - name: torch.nn.functional.linear.1
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 160]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 160]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:270 in forward, code: hidden_states = self.input_linear(hidden_states)'
+  - name: torch.nn.functional.layer_norm.1_spyre
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1024,)
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:110 in forward, code: hidden_states = self.pre_norm(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.2
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:111 in forward, code: hidden_states = self.up_proj(hidden_states)'
+  - name: torch.nn.functional.silu.1
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 844, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:112 in forward, code: hidden_states = self.dropout(self.silu(hidden_states))'
+    kwmap:
+      inplace: false
+  - name: torch.nn.functional.dropout.1_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 844, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:112 in forward, code: hidden_states = self.dropout(self.silu(hidden_states))'
+    marks: constant
+  - name: torch.nn.functional.linear.3
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:113 in forward, code: hidden_states = self.down_proj(hidden_states)'
+  - name: torch.nn.functional.dropout.2_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:114 in forward, code: hidden_states = self.dropout(hidden_states)'
+    marks: constant
+  - name: torch.mul.1_spyre
+    op: torch.mul
+    inputs:
+      - value: 0.5
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:244 in forward, code: hidden_states = 0.5 * self.ff1(hidden_states)
+      + hidden_states'
+    marks: constant
+  - name: torch.add.1
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:244 in forward, code: hidden_states = 0.5 * self.ff1(hidden_states)
+      + hidden_states'
+  - name: torch.nn.functional.pad.1_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 0, 0, 156)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5290 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.nn.functional.linear.4_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:152 in forward, code: query_states = self.to_q(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.5_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:153 in forward, code: key_states, value_states = self.to_kv(hidden_states).chunk(2,
+      dim=-1)'
+    marks: constant
+  - name: torch.chunk.1_spyre
+    op: torch.chunk
+    inputs:
+      - tensor:
+          shape: [1, 1000, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:153 in forward, code: key_states, value_states = self.to_kv(hidden_states).chunk(2,
+      dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.getitem.1_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 1000, 1024]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:153 in forward, code: key_states, value_states = self.to_kv(hidden_states).chunk(2,
+      dim=-1)'
+    marks: constant
+  - name: torch.reshape.1_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 5, 200, 8, -1)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:155 in forward, code: query_states = query_states.reshape(bsz,
+      num_blocks, self.context_size, self.num_heads, -1).transpose(2, 3)'
+    marks: constant
+  - name: torch.transpose.1_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [200, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:155 in forward, code: query_states = query_states.reshape(bsz,
+      num_blocks, self.context_size, self.num_heads, -1).transpose(2, 3)'
+    marks: constant
+  - name: torch.nn.functional.embedding.2_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [200, 200]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1025, 128]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:160 in forward, code: rel_pos_emb = self.rel_pos_emb(attention_dists)'
+    marks: constant
+  - name: torch.functional.einsum.1_spyre
+    op: torch.functional.einsum
+    inputs:
+      - value: b m h c d, c r d -> b m h c r
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [200, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:166 in forward, code: pos_attn = torch.einsum("b m h c d,
+      c r d -> b m h c r", query_states, rel_pos_emb) * self.scale'
+    marks: constant
+  - name: torch.mul.2_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [8, 200, 200]
+          dtype: torch.float16
+          init: rand
+      - value: 0.08838834764831845
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:166 in forward, code: pos_attn = torch.einsum("b m h c d,
+      c r d -> b m h c r", query_states, rel_pos_emb) * self.scale'
+    marks: constant
+  - name: torch.ones.1_spyre
+    op: torch.ones
+    inputs:
+      - value: 200
+      - value: 200
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:170 in forward, code: mask = torch.ones(self.context_size,
+      self.context_size, dtype=bool, device=hidden_states.device)'
+    marks: constant
+    kwmap:
+      dtype: torch.bool
+      device: cuda:0
+  - name: torch.setitem.2_spyre
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [200, 200]
+          dtype: torch.bool
+      - py: (slice(None, 44, None), slice(None, 44, None))
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:171 in forward, code: mask[:remainder, :remainder] = 0'
+    marks: constant
+  - name: torch.getitem.2_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 200, 200]
+          dtype: torch.float16
+          init: rand
+      - py: (-1,)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:173 in forward, code: pos_attn[:, -1, :].masked_fill_(mask,
+      mask_value)'
+    marks: constant
+  - name: torch.masked_fill_.1_spyre
+    op: torch.masked_fill_
+    inputs:
+      - tensor:
+          shape: [8, 200, 200]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [200, 200]
+          dtype: torch.bool
+      - value: -65504.0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:173 in forward, code: pos_attn[:, -1, :].masked_fill_(mask,
+      mask_value)'
+    marks: constant
+  - name: torch.nn.attention._backend_from_string.1_spyre
+    op: torch.nn.attention._backend_from_string
+    inputs:
+      - value: MATH
+    description: ''
+    marks: constant
+  - name: torch.nn.attention._sdpa_kernel.1_spyre
+    op: torch.nn.attention._sdpa_kernel
+    inputs:
+      - value: false
+    description: ''
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.transpose.2_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+      - value: 3
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:179 in forward, code: out = out.transpose(2, 3).reshape(bsz,
+      hidden_states.shape[1], -1)'
+    marks: constant
+  - name: torch.reshape.2_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [200, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (-1,)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:179 in forward, code: out = out.transpose(2, 3).reshape(bsz,
+      hidden_states.shape[1], -1)'
+    marks: constant
+  - name: torch.getitem.3_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1000, 1024]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 844, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:180 in forward, code: out = self.to_out(out[:, :num_features,
+      :])'
+    marks: constant
+  - name: torch.nn.functional.linear.6
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:180 in forward, code: out = self.to_out(out[:, :num_features,
+      :])'
+  - name: torch.permute.1_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:223 in forward, code: hidden_states = self.up_conv(hidden_states.permute(0,
+      2, 1))'
+    marks: constant
+  - name: torch.conv1d.1_spyre
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 1024, 844]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1,)
+      - value: (0,)
+      - value: (1,)
+      - value: 1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:223 in forward, code: hidden_states = self.up_conv(hidden_states.permute(0,
+      2, 1))'
+    marks: constant
+  - name: torch.nn.functional.glu.1_spyre
+    op: torch.nn.functional.glu
+    inputs:
+      - tensor:
+          shape: [1, 4096, 844]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:224 in forward, code: hidden_states = self.glu(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.pad.2_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+      - value: (7, 7)
+      - value: constant
+      - value: null
+    description: 'site-packages/torch/nn/functional.py:5290 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.conv1d.2_spyre
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 2048, 858]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: (1,)
+      - value: (0,)
+      - value: (1,)
+      - value: 2048
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:198 in forward, code: return self.conv(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.batch_norm.1_spyre
+    op: torch.nn.functional.batch_norm
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - value: false
+      - value: 0.1
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:226 in forward, code: hidden_states = self.silu(self.batch_norm(hidden_states))'
+    marks: constant
+  - name: torch.nn.functional.silu.2
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:226 in forward, code: hidden_states = self.silu(self.batch_norm(hidden_states))'
+    kwmap:
+      inplace: false
+  - name: torch.conv1d.3_spyre
+    op: torch.conv1d
+    inputs:
+      - tensor:
+          shape: [1, 2048, 844]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 2048, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1,)
+      - value: (0,)
+      - value: (1,)
+      - value: 1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:227 in forward, code: hidden_states = self.down_conv(hidden_states).permute(0,
+      2, 1)'
+    marks: constant
+  - name: torch.permute.2_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [1, 1024, 844]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:227 in forward, code: hidden_states = self.down_conv(hidden_states).permute(0,
+      2, 1)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.3_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.4_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.5_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.6_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.7_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.8_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.clone.2
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:275 in forward, code: hidden_states_mid = hidden_states.clone()'
+  - name: torch.nn.functional.linear.7
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [256]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:276 in forward, code: hidden_states_mid = self.out(hidden_states_mid)'
+  - name: torch.nn.functional.softmax.1_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [1, 844, 256]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:277 in forward, code: hidden_states += self.out_mid(nn.Softmax(dim=-1)(hidden_states_mid))'
+    marks: constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.linear.8
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 844, 256]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 256]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:277 in forward, code: hidden_states += self.out_mid(nn.Softmax(dim=-1)(hidden_states_mid))'
+  - name: torch.Tensor.add.1
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:277 in forward, code: hidden_states += self.out_mid(nn.Softmax(dim=-1)(hidden_states_mid))'
+  - name: torch.nn.functional.scaled_dot_product_attention.9_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.10_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.11_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.12_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.13_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.14_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.15_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.scaled_dot_product_attention.16_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 200, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:176 in forward, code: out = F.scaled_dot_product_attention('
+    kwmap:
+      scale: 0.08838834764831845
+  - name: torch.nn.functional.pad.3_spyre
+    op: torch.nn.functional.pad
+    inputs:
+      - tensor:
+          shape: [1, 844, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 0, 0, 11)
+      - value: constant
+      - value: 0
+    description: 'site-packages/torch/nn/functional.py:5290 in pad, code: return torch._C._nn.pad(input, pad, mode, value)'
+    marks: constant
+  - name: torch.Tensor.view.1_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 855, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 15
+      - value: 1024
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:83 in forward, code: hidden_states = hidden_states.view(batch_size
+      * nblocks, self.window_size, dim)'
+    marks: constant
+  - name: torch.nn.functional.layer_norm.2_spyre
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1024,)
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-12
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1036 in forward, code: embedding_output = self.layernorm(query_embeds)'
+    marks: constant
+  - name: torch.nn.functional.dropout.3_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1037 in forward, code: embedding_output = self.dropout(embedding_output)'
+    marks: constant
+  - name: torch.ones.2_spyre
+    op: torch.ones
+    inputs:
+      - value: (1, 3)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1044 in forward, code: attention_mask = torch.ones(((batch_size, seq_length)),
+      device=device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.getitem.4_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 3]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:995 in get_extended_attention_mask, code: extended_attention_mask = attention_mask[:,
+      None, None, :]'
+    marks: constant
+  - name: torch.to.3_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1006 in get_extended_attention_mask, code: extended_attention_mask = extended_attention_mask.to(dtype=self.dtype)  #
+      fp16 compatibility'
+    kwmap:
+      dtype: torch.float16
+  - name: torch.sub.1_spyre
+    op: torch.sub
+    inputs:
+      - value: 1.0
+      - tensor:
+          shape: [1, 1, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1007 in get_extended_attention_mask, code: extended_attention_mask = (1.0
+      - extended_attention_mask) * -10000.0'
+    marks: constant
+  - name: torch.mul.3_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 3]
+          dtype: torch.float16
+          init: rand
+      - value: -10000.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1007 in get_extended_attention_mask, code: extended_attention_mask = (1.0
+      - extended_attention_mask) * -10000.0'
+    marks: constant
+  - name: torch.ones.3_spyre
+    op: torch.ones
+    inputs:
+      - value: (57, 15)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:1066 in forward, code: encoder_attention_mask = torch.ones(encoder_hidden_shape,
+      device=device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.getitem.5_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [57, 15]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), None, None, slice(None, None, None))
+    description: 'site-packages/transformers/modeling_utils.py:1558 in invert_attention_mask, code: encoder_extended_attention_mask = encoder_attention_mask[:,
+      None, None, :]'
+    marks: constant
+  - name: torch.to.4_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/modeling_utils.py:1564 in invert_attention_mask, code: encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  #
+      fp16 compatibility'
+    kwmap:
+      dtype: torch.float16
+  - name: torch.sub.2_spyre
+    op: torch.sub
+    inputs:
+      - value: 1.0
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/modeling_utils.py:1565 in invert_attention_mask, code: encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask)
+      * torch.finfo(self.dtype).min'
+    marks: constant
+  - name: torch.mul.4_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+      - value: -65504.0
+    description: 'site-packages/transformers/modeling_utils.py:1565 in invert_attention_mask, code: encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask)
+      * torch.finfo(self.dtype).min'
+    marks: constant
+  - name: torch.nn.functional.linear.9
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:596 in forward, code: key_layer = self.transpose_for_scores(self.key(hidden_states))'
+  - name: torch.Tensor.view.2_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 3
+      - value: 16
+      - value: 64
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:574 in transpose_for_scores, code: x = x.view(*new_x_shape)'
+    marks: constant
+  - name: torch.permute.3_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:575 in transpose_for_scores, code: return x.permute(0, 2, 1, 3)'
+    marks: constant
+  - name: torch.transpose.3_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+      - value: -2
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks: constant
+  - name: torch.matmul.1_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 64, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+  - name: torch.truediv.1_spyre
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 8.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:622 in forward, code: attention_scores = attention_scores / math.sqrt(self.attention_head_size)'
+    marks: constant
+  - name: torch.add.2_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:626 in forward, code: attention_scores = attention_scores + attention_mask'
+  - name: torch.nn.functional.softmax.2_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:629 in forward, code: attention_probs = nn.Softmax(dim=-1)(attention_scores)'
+    marks: constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.dropout.4_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:637 in forward, code: attention_probs_dropped = self.dropout(attention_probs)'
+    marks: constant
+  - name: torch.matmul.2_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:643 in forward, code: context_layer = torch.matmul(attention_probs_dropped,
+      value_layer)'
+  - name: torch.permute.4_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.1_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [3, 16, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+  - name: torch.Tensor.view.3_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 3
+      - value: 1024
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:647 in forward, code: context_layer = context_layer.view(*new_context_layer_shape)'
+    marks: constant
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:666 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+  - name: torch.getitem.6_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 3, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:787 in forward, code: query_attention_output = attention_output[:, :query_length,
+      :]'
+    marks: constant
+  - name: torch.nn.functional.linear.10
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 15, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:592 in forward, code: key_layer = self.transpose_for_scores(self.key(encoder_hidden_states))'
+  - name: torch.Tensor.view.4_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [57, 15, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 15
+      - value: 16
+      - value: 64
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:574 in transpose_for_scores, code: x = x.view(*new_x_shape)'
+    marks: constant
+  - name: torch.permute.5_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [15, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:575 in transpose_for_scores, code: return x.permute(0, 2, 1, 3)'
+    marks: constant
+  - name: torch.transpose.4_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [16, 15, 64]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+      - value: -2
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks: constant
+  - name: torch.matmul.3_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 64, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+  - name: torch.truediv.2_spyre
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 8.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:622 in forward, code: attention_scores = attention_scores / math.sqrt(self.attention_head_size)'
+    marks: constant
+  - name: torch.add.4_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:626 in forward, code: attention_scores = attention_scores + attention_mask'
+  - name: torch.nn.functional.softmax.3_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:629 in forward, code: attention_probs = nn.Softmax(dim=-1)(attention_scores)'
+    marks: constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.dropout.5_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:637 in forward, code: attention_probs_dropped = self.dropout(attention_probs)'
+    marks: constant
+  - name: torch.matmul.4_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [16, 3, 15]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 15, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:643 in forward, code: context_layer = torch.matmul(attention_probs_dropped,
+      value_layer)'
+  - name: torch.permute.6_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.2_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [3, 16, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:645 in forward, code: context_layer = context_layer.permute(0, 2, 1, 3).contiguous()'
+  - name: torch.Tensor.view.5_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 3
+      - value: 1024
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:647 in forward, code: context_layer = context_layer.view(*new_context_layer_shape)'
+    marks: constant
+  - name: torch.nn.functional.linear.11
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:664 in forward, code: hidden_states = self.dense(hidden_states)'
+  - name: torch.nn.functional.dropout.6_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:665 in forward, code: hidden_states = self.dropout(hidden_states)'
+    marks: constant
+  - name: torch.add.5
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 3, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:666 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+  - name: torch.nn.functional.layer_norm.3_spyre
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1024,)
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-12
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:666 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+    marks: constant
+  - name: torch.nn.functional.linear.12
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:727 in forward, code: hidden_states = self.dense(hidden_states)'
+  - name: torch.nn.functional.gelu.1
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [57, 3, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:85 in forward, code: return self.act(input)'
+  - name: torch.nn.functional.linear.13
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [57, 3, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:741 in forward, code: hidden_states = self.dense(hidden_states)'
+  - name: torch.add.6
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:743 in forward, code: hidden_states = self.LayerNorm(hidden_states + input_tensor)'
+  - name: torch.Tensor.view.6_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 57
+      - value: 3
+      - value: 16
+      - value: 64
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:574 in transpose_for_scores, code: x = x.view(*new_x_shape)'
+    marks: constant
+  - name: torch.permute.7_spyre
+    op: torch.permute
+    inputs:
+      - tensor:
+          shape: [3, 16, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (0, 2, 1)
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:575 in transpose_for_scores, code: return x.permute(0, 2, 1, 3)'
+    marks: constant
+  - name: torch.transpose.5_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+      - value: -2
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+    marks: constant
+  - name: torch.matmul.5_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 64, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+  - name: torch.truediv.3_spyre
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 8.0
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:622 in forward, code: attention_scores = attention_scores / math.sqrt(self.attention_head_size)'
+    marks: constant
+  - name: torch.add.7_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 3]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:626 in forward, code: attention_scores = attention_scores + attention_mask'
+  - name: torch.nn.functional.softmax.4_spyre
+    op: torch.nn.functional.softmax
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:629 in forward, code: attention_probs = nn.Softmax(dim=-1)(attention_scores)'
+    marks: constant
+    kwmap:
+      _stacklevel: 5
+  - name: torch.nn.functional.dropout.7_spyre
+    op: torch.nn.functional.dropout
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - value: 0.1
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:637 in forward, code: attention_probs_dropped = self.dropout(attention_probs)'
+    marks: constant
+  - name: torch.matmul.6_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [16, 3, 3]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:643 in forward, code: context_layer = torch.matmul(attention_probs_dropped,
+      value_layer)'
+  - name: torch.getitem.7_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, 3, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:787 in forward, code: query_attention_output = attention_output[:, :query_length,
+      :]'
+    marks: constant
+  - name: torch.matmul.7_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [16, 3, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 64, 15]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/blip_2/modeling_blip_2.py:604 in forward, code: attention_scores = torch.matmul(query_layer, key_layer.transpose(-1,
+      -2))'
+  - name: torch.Tensor.view.7_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [57, 3, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 171
+      - value: -1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:92 in forward, code: query_output.last_hidden_state.view(batch_size,
+      nblocks * self.window_size // self.downsample_rate, -1)'
+    marks: constant
+  - name: torch.nn.functional.linear.14
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 171, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 1024]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:91 in forward, code: query_proj = self.linear('
+  - name: torch.where.1_spyre
+    op: torch.where
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - value: 0
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:511 in get_merged_audio_embeddings, code: llm_input_ids =
+      torch.where(is_audio_index, 0, input_ids)'
+    marks: constant
+  - name: torch.unsqueeze.1_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - value: -1
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:515 in get_merged_audio_embeddings, code: special_audio_mask
+      = is_audio_index.unsqueeze(-1)'
+    marks: constant
+  - name: torch.int.1_spyre
+    op: torch.int
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+  - name: torch.sum.1_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int32
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+    kwmap:
+      dim: 1
+  - name: torch.int.2_spyre
+    op: torch.int
+    inputs:
+      - tensor:
+          shape: [1, 171]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+  - name: torch.sum.2_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 171]
+          dtype: torch.int32
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+    kwmap:
+      dim: 1
+  - name: torch.ne.1
+    op: torch.ne
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+  - name: torch.all.1
+    op: torch.all
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:518 in get_merged_audio_embeddings, code: if torch.all(is_audio_index.int().sum(dim=1)
+      != input_features_mask.int().sum(dim=1)).item():'
+  - name: torch.masked_scatter.1_spyre
+    op: torch.masked_scatter
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.bool
+      - tensor:
+          shape: [171, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:523 in torch_dynamo_resume_in_get_merged_audio_embeddings_at_521,
+      code: inputs_embeds = inputs_embeds.masked_scatter('
+  - name: torch.mul.5_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 12.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:411 in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+      main diff with Llama'
+    marks: constant
+  - name: torch.to.6_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.1_spyre
+    op: torch.arange
+    inputs:
+      - value: 239
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.2_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.1_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 1
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.1_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 1
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.2_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 3
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.new_ones.1_spyre
+    op: torch.new_ones
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: ()
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+    kwmap:
+      dtype: torch.bool
+  - name: torch.le.1
+    op: torch.le
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.to.7_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: cuda:0
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+  - name: torch.__and__.1
+    op: torch.__and__
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - tensor:
+          shape: []
+          dtype: torch.bool
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.ops.aten.index.1
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.1_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 239
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.2_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [239]
+          dtype: torch.bool
+      - value: 3
+      - value: 239
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.3_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [239, 239]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.4_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 239, 239]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.getitem.8_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64]
+          dtype: torch.float16
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.float.1_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+  - name: torch.Tensor.expand.1_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.to.8_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float16
+          init: rand
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.getitem.9_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 239]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.amp.autocast_mode._enter_autocast.1_spyre
+    op: torch.amp.autocast_mode._enter_autocast
+    inputs:
+      - value: cuda
+      - value: null
+      - value: false
+      - value: null
+    description: ''
+    marks: constant
+  - name: torch.float.3_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 239]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.matmul.8_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 239]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.transpose.6_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 239]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.cat.1_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 239, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 239, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:352 in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.1_spyre
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+  - name: torch.mul.6_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: constant
+  - name: torch.sin.1_spyre
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:354 in forward, code: sin = emb.sin() * self.attention_scaling'
+  - name: torch.to.9_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:356 in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    kwmap:
+      dtype: torch.float16
+  - name: torch.pow.1_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+  - name: torch.mean.1_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.8_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.1_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.7_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.8
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:204 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.15_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.Tensor.view.8_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 239, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.7_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [239, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.nn.functional.linear.16_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.Tensor.view.9_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 239, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 239, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.8_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [239, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.unsqueeze.2_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:73 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.9_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+  - name: torch.getitem.10_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.1_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [32, 239, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.2_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [32, 239, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [32, 239, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.add.9_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+  - name: torch.mul.10_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [8, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+  - name: torch.getitem.11_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.2_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [8, 239, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.3_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 239, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 239, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.add.10_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [8, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+  - name: torch.tensor.1
+    op: torch.tensor
+    inputs:
+      - value: []
+    description: 'site-packages/transformers/cache_utils.py:94 in lazy_initialization, code: self.keys = torch.tensor([], dtype=self.dtype, device=self.device)'
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.cat.4_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 239, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.Tensor.expand.2_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 239
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.3_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (956, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.getitem.12_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 239, 239]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 239, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.17_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.9_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.3_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [239, 32, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.reshape.4_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [239, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (239, -1)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.4
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.add.11
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:288 in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+  - name: torch.nn.functional.linear.17_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12800, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.silu.3
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.11
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+  - name: torch.nn.functional.linear.18_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 239, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 12800]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.18_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.19_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.20_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.21_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.22_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.23_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.24_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.25_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.26_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.27_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.28_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.29_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.30_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.31_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.32_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.33_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.34_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.35_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.36_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.37_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.38_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.39_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.40_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.41_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.42_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.43_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.44_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.45_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.46_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.47_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.48_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.49_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.50_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.51_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.52_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.53_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.54_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.55_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.56_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 239, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.getitem.13_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 239, 4096]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:549 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant
+  - name: torch.nn.functional.linear.19_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [49160, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:549 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant
+  - name: torch.truediv.4_spyre
+    op: torch.truediv
+    inputs:
+      - tensor:
+          shape: [1, 1, 49160]
+          dtype: torch.float16
+          init: rand
+      - value: 16.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:550 in forward, code: logits = logits / self.config.logits_scaling  # main
+      diff with Llama'
+    marks: constant
+  - name: torch.__eq__.2_spyre
+    op: torch.__eq__
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 49159
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:401 in forward, code: is_audio_idx = input_ids == self.config.audio_token_id'
+    marks: constant
+  - name: torch.clone.3_spyre
+    op: torch.clone
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:402 in forward, code: llm_input_ids = input_ids.clone()'
+  - name: torch.setitem.3_spyre
+    op: torch.setitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.bool
+      - value: 0
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:403 in forward, code: llm_input_ids[is_audio_idx] = 0'
+    marks: constant
+  - name: torch.nn.functional.embedding.3_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [49160, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/granite_speech/modeling_granite_speech.py:404 in forward, code: inputs_embeds = self.get_input_embeddings()(llm_input_ids)'
+    marks: constant
+  - name: torch.mul.12_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 12.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:411 in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+      main diff with Llama'
+    marks: constant
+  - name: torch.to.12_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 240]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.Tensor.add.3_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [240]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.3_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [240]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.2
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 240]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.5_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [240]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.6_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 240]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.7_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 240]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.getitem.14_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.4
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.float.5_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.matmul.9_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.transpose.10_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.cat.5_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 1, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:352 in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.2_spyre
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+  - name: torch.mul.13_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: constant
+  - name: torch.sin.2_spyre
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:354 in forward, code: sin = emb.sin() * self.attention_scaling'
+  - name: torch.to.13_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:356 in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    kwmap:
+      dtype: torch.float16
+  - name: torch.pow.2_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+  - name: torch.mean.2_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.12_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.2_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.14_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.15
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:204 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.20_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.Tensor.view.10_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.11_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.nn.functional.linear.21_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.Tensor.view.11_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.12_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 8, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.unsqueeze.3_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:73 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.16_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+  - name: torch.getitem.15_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.3_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [32, 1, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.6_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [32, 1, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [32, 1, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.add.13_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+  - name: torch.mul.17_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [8, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+  - name: torch.getitem.16_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.4_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [8, 1, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.7_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 1, 64]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.add.14_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [8, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 1, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+  - name: torch.cat.8_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 239, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.getitem.17_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.3_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 240
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.5_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (960, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.getitem.18_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 240]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 240, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.57_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.transpose.13_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.5_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 32, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.reshape.6_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 32, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (1, -1)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.6
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.add.15
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:288 in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+  - name: torch.nn.functional.linear.22_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [12800, 4096]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.silu.4
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.18
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+  - name: torch.nn.functional.linear.23_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 12800]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4096, 12800]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.58_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.59_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.60_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.61_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.62_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.63_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.64_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.65_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.66_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.67_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.68_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.69_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.70_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.71_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.72_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.73_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.74_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.75_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.76_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.77_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.78_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.79_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.80_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.81_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.82_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.83_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.84_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.85_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.86_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.87_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.88_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.89_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.90_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.91_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.92_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.93_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.94_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.95_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.96_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 240, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.getitem.19_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:549 in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+      :])'
+    marks: constant
+  - name: torch.to.16_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 241]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.2_spyre
+    op: torch.arange
+    inputs:
+      - value: 241
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.4_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [241]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.2_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 241
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.4_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [241]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.3
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 241]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.8_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 241
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.9_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [241]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.10_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 241]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.11_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 241]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.9_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 240, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.getitem.20_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.4_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 241
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.7_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (964, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.sym_sum.1
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 240]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.21_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 241]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.97_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.98_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.99_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.100_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.101_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.102_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.103_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.104_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.105_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.106_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.107_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.108_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.109_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.110_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.111_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.112_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.113_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.114_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.115_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.116_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.117_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.118_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.119_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.120_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.121_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.122_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.123_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.124_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.125_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.126_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.127_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.128_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.129_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.130_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.131_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.132_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.133_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.134_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.135_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.136_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 241, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.17_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 242]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.3_spyre
+    op: torch.arange
+    inputs:
+      - value: 242
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.5_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [242]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.3_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 242
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.5_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [242]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.4
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 242]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.12_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 242
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.13_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [242]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.14_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 242]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.15_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 242]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.10_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 241, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.getitem.22_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.5_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 242
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.8_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (968, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.sym_sum.2
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 241]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.23_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 242]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.137_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.138_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.139_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.140_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.141_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.142_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.143_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.144_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.145_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.146_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.147_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.148_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.149_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.150_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.151_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.152_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.153_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.154_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.155_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.156_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.157_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.158_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.159_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.160_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.161_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.162_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.163_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.164_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.165_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.166_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.167_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.168_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.169_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.170_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.171_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.172_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.173_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.174_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.175_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.176_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 242, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.18_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 243]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.4_spyre
+    op: torch.arange
+    inputs:
+      - value: 243
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.6_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [243]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.4_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 243
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.6_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [243]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.5
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 243]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.16_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 243
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.17_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [243]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.18_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 243]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.19_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 243]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.11_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 242, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.getitem.24_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.6_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 243
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.9_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (972, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.sym_sum.3
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 242]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.25_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 243]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.177_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.178_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.179_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.180_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.181_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.182_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.183_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.184_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.185_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.186_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.187_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.188_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.189_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.190_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.191_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.192_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.193_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.194_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.195_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.196_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.197_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.198_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.199_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.200_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.201_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.202_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.203_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.204_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.205_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.206_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.207_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.208_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.209_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.210_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.211_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.212_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.213_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.214_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.215_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.216_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 243, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.19_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 244]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.5_spyre
+    op: torch.arange
+    inputs:
+      - value: 244
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.7_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [244]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.5_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 244
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.7_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [244]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.6
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 244]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.20_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 244
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.21_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [244]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.22_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 244]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.23_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 244]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.12_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 243, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.getitem.26_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.7_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 244
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.10_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (976, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.sym_sum.4
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 243]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.27_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 244]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.217_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.218_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.219_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.220_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.221_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.222_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.223_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.224_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.225_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.226_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.227_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.228_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.229_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.230_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.231_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.232_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.233_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.234_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.235_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.236_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.237_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.238_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.239_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.240_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.241_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.242_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.243_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.244_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.245_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.246_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.247_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.248_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.249_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.250_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.251_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.252_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.253_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.254_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.255_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.256_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 244, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.20_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 245]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.6_spyre
+    op: torch.arange
+    inputs:
+      - value: 245
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.8_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [245]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.6_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 245
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.8_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [245]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.7
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 245]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.24_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 245
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.25_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [245]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.26_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 245]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.27_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 245]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.13_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 244, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.getitem.28_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.8_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 245
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.11_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (980, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.sym_sum.5
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 244]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.29_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 245]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.257_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.258_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.259_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.260_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.261_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.262_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.263_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.264_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.265_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.266_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.267_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.268_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.269_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.270_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.271_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.272_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.273_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.274_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.275_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.276_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.277_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.278_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.279_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.280_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.281_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.282_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.283_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.284_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.285_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.286_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.287_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.288_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.289_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.290_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.291_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.292_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.293_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.294_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.295_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.296_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 245, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.to.21_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 246]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.7_spyre
+    op: torch.arange
+    inputs:
+      - value: 246
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.9_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [246]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.7_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 246
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.9_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [246]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 4
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.ops.aten.index.8
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 246]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.28_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 246
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.29_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [246]
+          dtype: torch.bool
+      - value: 3
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.30_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 246]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.31_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 1, 246]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.cat.14_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 245, 128]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 1, 128]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.getitem.30_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.9_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 246
+      - value: 128
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.12_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - value: (984, 128)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.sym_sum.6
+    op: torch.sym_sum
+    inputs:
+      - value: [1, 245]
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:23 in repeat_kv, code: batch, num_key_value_heads, slen, head_dim = hidden_states.shape'
+  - name: torch.getitem.31_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 246]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, add, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.297_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.298_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.299_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.300_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.301_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.302_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.303_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.304_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.305_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.306_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.307_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.308_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.309_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.310_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.311_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.312_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.313_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.314_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.315_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.316_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.317_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.318_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.319_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.320_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.321_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.322_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.323_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.324_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.325_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.326_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.327_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.328_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.329_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.330_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.331_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.332_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.333_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.334_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.335_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.336_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 1, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 246, 128]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.0078125
+      is_causal: false

--- a/tests/_inductor/models/granite-vision-3.3-2b.yaml
+++ b/tests/_inductor/models/granite-vision-3.3-2b.yaml
@@ -1,0 +1,2346 @@
+model: granite-vision-3.3-2b
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [49156, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:492 in forward, code: inputs_embeds = self.get_input_embeddings()(input_ids)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.getitem.1
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [2]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:95 in image_size_to_num_patches, code: image_size = image_size.tolist()'
+    marks: constant
+  - name: torch.to.1
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [10, 3, 384, 384]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:278 in forward, code: patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  #
+      shape = [*, width, grid, grid]'
+    marks:
+      - fp32operation
+      - largedimtensor
+    kwmap:
+      dtype: torch.float16
+  - name: torch.conv2d.1
+    op: torch.conv2d
+    inputs:
+      - tensor:
+          shape: [10, 3, 384, 384]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152, 3, 14, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - value: (14, 14)
+      - value: valid
+      - value: (1, 1)
+      - value: 1
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:278 in forward, code: patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  #
+      shape = [*, width, grid, grid]'
+    marks: constant
+  - name: torch.flatten.1
+    op: torch.flatten
+    inputs:
+      - tensor:
+          shape: [10, 1152, 27, 27]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:279 in forward, code: embeddings = patch_embeds.flatten(2).transpose(1, 2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.transpose.1
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 1152, 729]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:279 in forward, code: embeddings = patch_embeds.flatten(2).transpose(1, 2)'
+    marks: constant
+  - name: torch.nn.functional.embedding.2
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 729]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:284 in forward, code: embeddings = embeddings + self.position_embedding(self.position_ids)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.add.1
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 729, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:284 in forward, code: embeddings = embeddings + self.position_embedding(self.position_ids)'
+  - name: torch.nn.functional.layer_norm.1
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: (1152,)
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-06
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:448 in forward, code: hidden_states = self.layer_norm1(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.1
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:385 in forward, code: queries = self.q_proj(hidden_states)'
+  - name: torch.Tensor.view.1
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 10
+      - value: 729
+      - value: 16
+      - value: 72
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:389 in forward, code: queries = queries.view(batch_size, seq_length, self.num_heads,
+      self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.2
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 729, 16, 72]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:389 in forward, code: queries = queries.view(batch_size, seq_length, self.num_heads,
+      self.head_dim).transpose(1, 2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [10, 16, 729, 72]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [10, 16, 729, 72]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [10, 16, 729, 72]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.11785113019775792
+      is_causal: false
+  - name: torch.transpose.3
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 16, 729, 72]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.1
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [10, 729, 16, 72]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: largedimtensor
+  - name: torch.reshape.1
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [10, 729, 16, 72]
+          dtype: torch.float16
+          init: rand
+      - value: (10, 729, 1152)
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:408 in forward, code: attn_output = attn_output.reshape(batch_size, seq_length,
+      embed_dim).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.2
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:408 in forward, code: attn_output = attn_output.reshape(batch_size, seq_length,
+      embed_dim).contiguous()'
+  - name: torch.add.2
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:454 in forward, code: hidden_states = residual + hidden_states'
+  - name: torch.nn.functional.linear.2
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:424 in forward, code: hidden_states = self.fc1(hidden_states)'
+  - name: torch.nn.functional.gelu.1
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [10, 729, 4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:51 in forward, code: return self.act(input)'
+    kwmap:
+      approximate: tanh
+  - name: torch.nn.functional.linear.3
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:426 in forward, code: hidden_states = self.fc2(hidden_states)'
+  - name: torch.repeat.1
+    op: torch.repeat
+    inputs:
+      - tensor:
+          shape: [1, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 10
+      - value: 1
+      - value: 1
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:729 in forward, code: probe = self.probe.repeat(batch_size, 1, 1)'
+    marks: constant
+  - name: torch.transpose.4
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+  - name: torch.transpose.5
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+  - name: torch.nn.functional.multi_head_attention_forward.1
+    op: torch.nn.functional.multi_head_attention_forward
+    inputs:
+      - tensor:
+          shape: [1, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [729, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [729, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1152
+      - value: 16
+      - tensor:
+          shape: [3456, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [3456]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: null
+      - value: false
+      - value: 0.0
+      - tensor:
+          shape: [1152, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+    kwmap:
+      training: false
+      key_padding_mask: None
+      need_weights: true
+      average_attn_weights: true
+      is_causal: false
+  - name: torch.getitem.2
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [1, 10, 1152]
+            dtype: torch.float16
+            init: rand
+          - shape: [10, 1, 729]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.transpose.6
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+  - name: torch.nn.functional.layer_norm.2
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: (1152,)
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-06
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:734 in forward, code: hidden_state = self.layernorm(hidden_state)'
+    marks: constant
+  - name: torch.nn.functional.linear.4
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:424 in forward, code: hidden_states = self.fc1(hidden_states)'
+  - name: torch.nn.functional.gelu.2
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [10, 1, 4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:51 in forward, code: return self.act(input)'
+    kwmap:
+      approximate: tanh
+  - name: torch.nn.functional.linear.5
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 1, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:426 in forward, code: hidden_states = self.fc2(hidden_states)'
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:735 in forward, code: hidden_state = residual + self.mlp(hidden_state)'
+  - name: torch.getitem.3
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - py: (0,)
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:737 in forward, code: return hidden_state[:, 0]'
+    marks: constant
+  - name: torch.nn.functional.linear.6
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 4608]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 4608]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:216 in forward, code: hidden_states = self.linear_1(image_features)'
+  - name: torch.nn.functional.gelu.3
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [10, 729, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:85 in forward, code: return self.act(input)'
+  - name: torch.nn.functional.linear.7
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:218 in forward, code: hidden_states = self.linear_2(hidden_states)'
+  - name: torch.cat.1
+    op: torch.cat
+    inputs:
+      - tensor:
+          shape: [6237, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:501 in torch_dynamo_resume_in_forward_at_495, code: image_features
+      = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)'
+    marks: paddedtensor
+    kwmap:
+      dim: 0
+  - name: torch.__eq__.1
+    op: torch.__eq__
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 49155
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:438 in get_placeholder_mask, code: special_image_mask = input_ids
+      == self.config.image_token_id'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.sum.1
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:440 in get_placeholder_mask, code: n_image_tokens = special_image_mask.sum()'
+    marks: paddedtensor
+  - name: torch.unsqueeze.1
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.bool
+      - value: -1
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:441 in get_placeholder_mask, code: special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.expand_as.1
+    op: torch.expand_as
+    inputs:
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.bool
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:441 in get_placeholder_mask, code: special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)'
+  - name: torch.to.3
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.bool
+      - value: cuda:0
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:441 in get_placeholder_mask, code: special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)'
+    marks: constant
+  - name: torch.masked_scatter.1
+    op: torch.masked_scatter
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.bool
+      - tensor:
+          shape: [6237, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:505 in torch_dynamo_resume_in_forward_at_502, code: inputs_embeds
+      = inputs_embeds.masked_scatter(special_image_mask, image_features)'
+    marks: paddedtensor
+  - name: torch.mul.1
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 12.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:411 in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+      main diff with Llama'
+    marks: constant
+  - name: torch.to.4
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    marks: paddedtensor
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.1
+    op: torch.arange
+    inputs:
+      - value: 6301
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.1
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.1
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 1
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.1
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 1
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.2
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 3
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.new_ones.1
+    op: torch.new_ones
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: ()
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+    kwmap:
+      dtype: torch.bool
+  - name: torch.le.1
+    op: torch.le
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.to.5
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: cuda:0
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+  - name: torch.__and__.1
+    op: torch.__and__
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - tensor:
+          shape: []
+          dtype: torch.bool
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.ops.aten.index.1
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.1
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 6301
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.2
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [6301]
+          dtype: torch.bool
+      - value: 3
+      - value: 6301
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.3
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [6301, 6301]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch._C._functorch._remove_batch_dim.4
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 6301, 6301]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.getitem.4
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32]
+          dtype: torch.float32
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.float.1
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: fp32operation
+  - name: torch.Tensor.expand.1
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.to.6
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.getitem.5
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.amp.autocast_mode._enter_autocast.1
+    op: torch.amp.autocast_mode._enter_autocast
+    inputs:
+      - value: cuda
+      - value: null
+      - value: false
+      - value: null
+    description: ''
+    marks: constant
+  - name: torch.float.3
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 6301]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.matmul.1
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 1, 6301]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: fp32operation
+  - name: torch.transpose.7
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301]
+          dtype: torch.float32
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.cat.2
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 6301, 32]
+            dtype: torch.float32
+            init: rand
+          - shape: [1, 6301, 32]
+            dtype: torch.float32
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:352 in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.1
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.mul.2
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.sin.1
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:354 in forward, code: sin = emb.sin() * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.to.7
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:356 in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    marks: fp32operation
+    kwmap:
+      dtype: torch.float16
+  - name: torch.pow.1
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float32
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.1
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float32
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.4
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.float32
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.1
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.3
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float32
+          init: rand
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.float32
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.4
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:204 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.8
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.2
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 6301, -1, 64)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.8
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 6301, 32, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.linear.9
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.Tensor.view.3
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 6301, 512]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 6301, -1, 64)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.9
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 6301, 8, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.unsqueeze.2
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:73 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.5
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.getitem.6
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 32, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.neg.1
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: largedimtensor
+  - name: torch.cat.3
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 32, 6301, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 32, 6301, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.add.5
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.mul.6
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.getitem.7
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 32, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.neg.2
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 8, 6301, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: largedimtensor
+  - name: torch.cat.4
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 6301, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 6301, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - largedimtensor
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.add.6
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+    marks: largedimtensor
+  - name: torch.tensor.1
+    op: torch.tensor
+    inputs:
+      - value: []
+    description: 'site-packages/transformers/cache_utils.py:94 in lazy_initialization, code: self.keys = torch.tensor([], dtype=self.dtype, device=self.device)'
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.cat.5
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 8, 6301, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    marks: largedimtensor
+    kwmap:
+      dim: -2
+  - name: torch.Tensor.expand.2
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 6301
+      - value: 64
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.reshape.2
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 32, 6301, 64)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.getitem.8
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 6301, 6301]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 6301, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.transpose.10
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.3
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 6301, 32, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: largedimtensor
+  - name: torch.reshape.3
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 6301, 32, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 6301, -1)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks:
+      - largedimtensor
+      - constant
+  - name: torch.Tensor.contiguous.4
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.add.7
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:288 in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+  - name: torch.nn.functional.linear.10
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8192, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.silu.1
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.7
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+  - name: torch.nn.functional.linear.11
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 8192]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks:
+      - paddedtensor
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.3
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.4
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.5
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.6
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.7
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.8
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.9
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.10
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.11
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.12
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.13
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.14
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.15
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.16
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.17
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.18
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.19
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.20
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.21
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.22
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.23
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.24
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.25
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.26
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.27
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.28
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.29
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.30
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.31
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.32
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.33
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.34
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.35
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.36
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.37
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.38
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.39
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.40
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.41
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: largedimtensor
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.getitem.9
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:687 in torch_dynamo_resume_in_forward_at_666, code: logits = self.lm_head(hidden_states[:,
+      slice_indices, :])'
+    marks: constant
+  - name: torch.nn.functional.linear.12
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [49156, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:687 in torch_dynamo_resume_in_forward_at_666, code: logits = self.lm_head(hidden_states[:,
+      slice_indices, :])'
+    marks:
+      - paddedtensor
+      - constant

--- a/tests/_inductor/models/granite-vision-3.3-2b_spyre.yaml
+++ b/tests/_inductor/models/granite-vision-3.3-2b_spyre.yaml
@@ -1,0 +1,2206 @@
+model: granite-vision-3.3-2b
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [49156, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 0
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:492 in forward, code: inputs_embeds = self.get_input_embeddings()(input_ids)'
+    marks: constant
+  - name: torch.getitem.1_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [2]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:95 in image_size_to_num_patches, code: image_size = image_size.tolist()'
+    marks: constant
+  - name: torch.to.1_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [3, 384, 384]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:278 in forward, code: patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  #
+      shape = [*, width, grid, grid]'
+    kwmap:
+      dtype: torch.float16
+  - name: torch.conv2d.1_spyre
+    op: torch.conv2d
+    inputs:
+      - tensor:
+          shape: [3, 384, 384]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [3, 14, 14]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - value: (14, 14)
+      - value: valid
+      - value: (1, 1)
+      - value: 1
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:278 in forward, code: patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  #
+      shape = [*, width, grid, grid]'
+    marks: constant
+  - name: torch.flatten.1_spyre
+    op: torch.flatten
+    inputs:
+      - tensor:
+          shape: [1152, 27, 27]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:279 in forward, code: embeddings = patch_embeds.flatten(2).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.1_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 1152, 729]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:279 in forward, code: embeddings = patch_embeds.flatten(2).transpose(1, 2)'
+    marks: constant
+  - name: torch.nn.functional.embedding.2_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 729]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:284 in forward, code: embeddings = embeddings + self.position_embedding(self.position_ids)'
+    marks: constant
+  - name: torch.add.1
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 729, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:284 in forward, code: embeddings = embeddings + self.position_embedding(self.position_ids)'
+  - name: torch.nn.functional.layer_norm.1_spyre
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: (1152,)
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-06
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:448 in forward, code: hidden_states = self.layer_norm1(hidden_states)'
+    marks: constant
+  - name: torch.nn.functional.linear.1
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:385 in forward, code: queries = self.q_proj(hidden_states)'
+  - name: torch.Tensor.view.1_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 10
+      - value: 729
+      - value: 16
+      - value: 72
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:389 in forward, code: queries = queries.view(batch_size, seq_length, self.num_heads,
+      self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.2_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [729, 16, 72]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:389 in forward, code: queries = queries.view(batch_size, seq_length, self.num_heads,
+      self.head_dim).transpose(1, 2)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [16, 729, 72]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 729, 72]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [16, 729, 72]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.11785113019775792
+      is_causal: false
+  - name: torch.transpose.3_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [16, 729, 72]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.1_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [729, 16, 72]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.reshape.1_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [729, 16, 72]
+          dtype: torch.float16
+          init: rand
+      - value: (729, 1152)
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:408 in forward, code: attn_output = attn_output.reshape(batch_size, seq_length,
+      embed_dim).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.2
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:408 in forward, code: attn_output = attn_output.reshape(batch_size, seq_length,
+      embed_dim).contiguous()'
+  - name: torch.add.2
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:454 in forward, code: hidden_states = residual + hidden_states'
+  - name: torch.nn.functional.linear.2
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:424 in forward, code: hidden_states = self.fc1(hidden_states)'
+  - name: torch.nn.functional.gelu.1
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [10, 729, 4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:51 in forward, code: return self.act(input)'
+    kwmap:
+      approximate: tanh
+  - name: torch.nn.functional.linear.3
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:426 in forward, code: hidden_states = self.fc2(hidden_states)'
+  - name: torch.repeat.1_spyre
+    op: torch.repeat
+    inputs:
+      - tensor:
+          shape: [1, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 10
+      - value: 1
+      - value: 1
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:729 in forward, code: probe = self.probe.repeat(batch_size, 1, 1)'
+    marks: constant
+  - name: torch.transpose.4_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+  - name: torch.transpose.5_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [10, 729, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+  - name: torch.nn.functional.multi_head_attention_forward.1_spyre
+    op: torch.nn.functional.multi_head_attention_forward
+    inputs:
+      - tensor:
+          shape: [1, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [729, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [729, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1152
+      - value: 16
+      - tensor:
+          shape: [3456, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [3456]
+          dtype: torch.float16
+          init: rand
+      - value: null
+      - value: null
+      - value: false
+      - value: 0.0
+      - tensor:
+          shape: [1152, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+    kwmap:
+      training: false
+      key_padding_mask: None
+      need_weights: true
+      average_attn_weights: true
+      is_causal: false
+  - name: torch.getitem.2_spyre
+    op: torch.getitem
+    inputs:
+      - tensor_list:
+          - shape: [10, 1, 729]
+            dtype: torch.float16
+            init: rand
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+  - name: torch.transpose.6_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 10, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 0
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:731 in forward, code: hidden_state = self.attention(probe, hidden_state, hidden_state)[0]'
+    marks: constant
+  - name: torch.nn.functional.layer_norm.2_spyre
+    op: torch.nn.functional.layer_norm
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - value: (1152,)
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-06
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:734 in forward, code: hidden_state = self.layernorm(hidden_state)'
+    marks: constant
+  - name: torch.nn.functional.linear.4
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:424 in forward, code: hidden_states = self.fc1(hidden_states)'
+  - name: torch.nn.functional.gelu.2
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [10, 1, 4304]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:51 in forward, code: return self.act(input)'
+    kwmap:
+      approximate: tanh
+  - name: torch.nn.functional.linear.5
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 1, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152, 4304]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:426 in forward, code: hidden_states = self.fc2(hidden_states)'
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:735 in forward, code: hidden_state = residual + self.mlp(hidden_state)'
+  - name: torch.getitem.3_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [10, 1, 1152]
+          dtype: torch.float16
+          init: rand
+      - py: (0,)
+    description: 'site-packages/transformers/models/siglip/modeling_siglip.py:737 in forward, code: return hidden_state[:, 0]'
+    marks: constant
+  - name: torch.nn.functional.linear.6
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 4608]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 4608]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:216 in forward, code: hidden_states = self.linear_1(image_features)'
+  - name: torch.nn.functional.gelu.3
+    op: torch.nn.functional.gelu
+    inputs:
+      - tensor:
+          shape: [10, 729, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:85 in forward, code: return self.act(input)'
+  - name: torch.nn.functional.linear.7
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [10, 729, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:218 in forward, code: hidden_states = self.linear_2(hidden_states)'
+  - name: torch.cat.1_spyre
+    op: torch.cat
+    inputs:
+      - tensor:
+          - shape: [6237, 2048]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:501 in torch_dynamo_resume_in_forward_at_495, code: image_features
+      = torch.cat(image_features, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)'
+    kwmap:
+      dim: 0
+  - name: torch.__eq__.1_spyre
+    op: torch.__eq__
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 49155
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:438 in get_placeholder_mask, code: special_image_mask = input_ids
+      == self.config.image_token_id'
+    marks: constant
+  - name: torch.sum.1_spyre
+    op: torch.sum
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.bool
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:440 in get_placeholder_mask, code: n_image_tokens = special_image_mask.sum()'
+  - name: torch.unsqueeze.1_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.bool
+      - value: -1
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:441 in get_placeholder_mask, code: special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)'
+    marks: constant
+  - name: torch.expand_as.1
+    op: torch.expand_as
+    inputs:
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.bool
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:441 in get_placeholder_mask, code: special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)'
+  - name: torch.to.3_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.bool
+      - value: cuda:0
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:441 in get_placeholder_mask, code: special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)'
+    marks: constant
+  - name: torch.masked_scatter.1_spyre
+    op: torch.masked_scatter
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.bool
+      - tensor:
+          shape: [6237, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:505 in torch_dynamo_resume_in_forward_at_502, code: inputs_embeds
+      = inputs_embeds.masked_scatter(special_image_mask, image_features)'
+  - name: torch.mul.1_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 12.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:411 in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+      main diff with Llama'
+    marks: constant
+  - name: torch.to.4_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/masking_utils.py:723 in _preprocess_mask_arguments, code: attention_mask = attention_mask.to(device=cache_position.device,
+      dtype=torch.bool)'
+    kwmap:
+      device: cuda:0
+      dtype: torch.bool
+  - name: torch.arange.1_spyre
+    op: torch.arange
+    inputs:
+      - value: 6301
+    description: 'site-packages/transformers/masking_utils.py:379 in sdpa_mask_recent_torch, code: kv_arange = torch.arange(kv_length, device=cache_position.device)'
+    marks: constant
+    kwmap:
+      device: cuda:0
+  - name: torch.Tensor.add.1_spyre
+    op: torch.Tensor.add
+    inputs:
+      - tensor:
+          shape: [6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+    description: 'site-packages/transformers/masking_utils.py:380 in sdpa_mask_recent_torch, code: kv_arange += kv_offset'
+    marks: constant
+  - name: torch._C._functorch._vmap_increment_nesting.1_spyre
+    op: torch._C._functorch._vmap_increment_nesting
+    inputs:
+      - value: 1
+      - value: error
+    description: ''
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.1_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [1]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 1
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch._C._functorch._add_batch_dim.2_spyre
+    op: torch._C._functorch._add_batch_dim
+    inputs:
+      - tensor:
+          shape: [6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: 0
+      - value: 3
+    description: 'site-packages/torch/_functorch/vmap.py:159 in _create_batched_inputs, code: arg if in_dim is None else _add_batch_dim(arg, in_dim, vmap_level)'
+    marks: constant
+  - name: torch.new_ones.1_spyre
+    op: torch.new_ones
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - value: ()
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+    kwmap:
+      dtype: torch.bool
+  - name: torch.le.1
+    op: torch.le
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: []
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.to.5_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: cuda:0
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+    marks: constant
+  - name: torch.__and__.1
+    op: torch.__and__
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - tensor:
+          shape: []
+          dtype: torch.bool
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:142 in __torch_function__, code: return func(*args, **(kwargs or {}))'
+  - name: torch.ops.aten.index.1
+    op: torch.ops.aten.index
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.bool
+      - tensor_list:
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+          - shape: []
+            dtype: torch.int64
+            init: randint
+            init_args:
+              high: 1000
+    description: 'site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py:100 in forward, code: return torch.ops.aten.index(x, indices)'
+  - name: torch._C._functorch._remove_batch_dim.1_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: []
+          dtype: torch.bool
+      - value: 4
+      - value: 6301
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.2_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [6301]
+          dtype: torch.bool
+      - value: 3
+      - value: 6301
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.3_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [6301, 6301]
+          dtype: torch.bool
+      - value: 2
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch._C._functorch._remove_batch_dim.4_spyre
+    op: torch._C._functorch._remove_batch_dim
+    inputs:
+      - tensor:
+          shape: [1, 6301, 6301]
+          dtype: torch.bool
+      - value: 1
+      - value: 1
+      - value: 0
+    description: 'site-packages/torch/_functorch/vmap.py:184 in _maybe_remove_batch_dim, code: return _remove_batch_dim(batched_output, vmap_level, batch_size,
+      out_dim)'
+    marks: constant
+  - name: torch.getitem.4_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32]
+          dtype: torch.float16
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.float.1_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+  - name: torch.Tensor.expand.1_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.to.6_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - value: cuda:0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:346 in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+      -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.getitem.5_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 6301]
+          dtype: torch.int64
+          init: randint
+          init_args:
+            high: 1000
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:347 in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+  - name: torch.amp.autocast_mode._enter_autocast.1_spyre
+    op: torch.amp.autocast_mode._enter_autocast
+    inputs:
+      - value: cuda
+      - value: null
+      - value: false
+      - value: null
+    description: ''
+    marks: constant
+  - name: torch.float.3_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 6301]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.matmul.1_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 1, 6301]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+  - name: torch.transpose.7_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 6301]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:351 in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.cat.2_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 6301, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [1, 6301, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:352 in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.1_spyre
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+  - name: torch.mul.2_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:353 in forward, code: cos = emb.cos() * self.attention_scaling'
+    marks: constant
+  - name: torch.sin.1_spyre
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:354 in forward, code: sin = emb.sin() * self.attention_scaling'
+  - name: torch.to.7_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:356 in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    kwmap:
+      dtype: torch.float16
+  - name: torch.pow.1_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+  - name: torch.mean.1_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: -1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:202 in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.4_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.float16
+          init: rand
+      - value: 1.0e-05
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.1_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.3_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 1]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:203 in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+      + self.variance_epsilon)'
+  - name: torch.mul.4
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:204 in forward, code: return self.weight * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.8_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.Tensor.view.2_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 6301, -1, 64)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.8_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [6301, 32, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:157 in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.nn.functional.linear.9_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [512, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.Tensor.view.3_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 6301, 512]
+          dtype: torch.float16
+          init: rand
+      - value: (1, 6301, -1, 64)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.transpose.9_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [6301, 8, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:158 in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+      2)'
+    marks: constant
+  - name: torch.unsqueeze.2_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:73 in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.5_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+  - name: torch.getitem.6_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 32, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.1_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [32, 6301, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.3_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [32, 6301, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [32, 6301, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.add.5_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:75 in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+      * sin)'
+  - name: torch.mul.6_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+  - name: torch.getitem.7_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - py: (Ellipsis, slice(None, 32, None))
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:48 in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.2_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [8, 6301, 32]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.4_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [8, 6301, 32]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 6301, 32]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:50 in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.add.6_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:76 in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+      * sin)'
+  - name: torch.tensor.1
+    op: torch.tensor
+    inputs:
+      - value: []
+    description: 'site-packages/transformers/cache_utils.py:94 in lazy_initialization, code: self.keys = torch.tensor([], dtype=self.dtype, device=self.device)'
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.cat.5_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [0]
+            dtype: torch.float16
+            init: rand
+          - shape: [8, 6301, 64]
+            dtype: torch.float16
+            init: rand
+    description: 'site-packages/transformers/cache_utils.py:119 in update, code: self.keys = torch.cat([self.keys, key_states], dim=-2)'
+    kwmap:
+      dim: -2
+  - name: torch.Tensor.expand.2_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 6301
+      - value: 64
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:26 in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+      num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.2_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [4, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (25204, 64)
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:27 in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+      * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.getitem.8_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 6301, 6301]
+          dtype: torch.bool
+      - py: (slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, 6301, None))
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:73 in sdpa_attention_forward, code: attention_mask = attention_mask[:, :, :,
+      : key.shape[-2]]'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.transpose.10_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.3_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [6301, 32, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:106 in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+      2).contiguous()'
+  - name: torch.reshape.3_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [6301, 32, 64]
+          dtype: torch.float16
+          init: rand
+      - value: (6301, -1)
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.4
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:184 in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.add.7
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:288 in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+  - name: torch.nn.functional.linear.10_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [8192, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.silu.1
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/activations.py:99 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.7
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+  - name: torch.nn.functional.linear.11_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 6301, 8192]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [2048, 8192]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/granite/modeling_granite.py:222 in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+      * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.3_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.4_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.5_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.6_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.7_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.8_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.9_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.10_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.11_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.12_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.13_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.14_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.15_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.16_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.17_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.18_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.19_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.20_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.21_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.22_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.23_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.24_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.25_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.26_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.27_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.28_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.29_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.30_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.31_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.32_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.33_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.34_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.35_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.36_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.37_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.38_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.39_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.40_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.nn.functional.scaled_dot_product_attention.41_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [32, 6301, 64]
+          dtype: torch.float16
+          init: rand
+    description: 'site-packages/transformers/integrations/sdpa_attention.py:96 in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.015625
+      is_causal: false
+  - name: torch.getitem.9_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 6301, 2048]
+          dtype: torch.float16
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:687 in torch_dynamo_resume_in_forward_at_666, code: logits = self.lm_head(hidden_states[:,
+      slice_indices, :])'
+    marks: constant
+  - name: torch.nn.functional.linear.12_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 2048]
+          dtype: torch.float16
+          init: rand
+      - tensor:
+          shape: [49156, 2048]
+          dtype: torch.float16
+          init: rand
+      - value: null
+    description: 'site-packages/transformers/models/llava_next/modeling_llava_next.py:687 in torch_dynamo_resume_in_forward_at_666, code: logits = self.lm_head(hidden_states[:,
+      slice_indices, :])'
+    marks: constant

--- a/tests/_inductor/models/template.yaml
+++ b/tests/_inductor/models/template.yaml
@@ -1,0 +1,115 @@
+model: template
+
+default:
+  dtype: fp16
+  seed: 123
+  rtol: 5.0e-3
+  atol: 5.0e-3
+
+cases:
+  - name: add_basic
+    op: torch.add
+    inputs:
+      - tensor: {shape: [4, 128, 768], init: randn}
+      - tensor: {shape: [4, 128, 768], init: randn}
+    description: |
+      This is some of the text File: site-packages/transformers/models/gpt_oss/modeling_gpt_oss.py:138 in forward, code: next_states = next_states * routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
+
+  - name: op_bool_tensors
+    op: torch.logical_and
+    inputs:
+      - tensor: {shape: [11, 6], dtype: bool}
+      - tensor: {shape: [11, 6], dtype: bool}
+    description: |
+      ops with args of randomly generated bool tensors (50% chance of True)
+
+  - name: op_different_dtypes
+    op: torch.add
+    inputs:
+      - tensor: {shape: [11, 6], dtype: fp32, init: randn}
+      - tensor: {shape: [11, 6], dtype: int64, init: randint, init_args: {high: 100}}
+    description: |
+      ops with args of different dtypes
+
+  - name: mul_tensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: uniform, init_args: {low: -1.0, high: 1.0}}
+      - value: 3.0
+    description: |
+      ops with tensor and scalar as args 
+
+  - name: mul_inttensor_scalar
+    op: torch.mul
+    inputs:
+      - tensor: {shape: [1, 64], init: randint, init_args: {low: 1, high: 100}}
+      - value: 3
+    description: |
+      ops with tensor and scalar as args 
+
+  - name: aten_view
+    op: torch.ops.aten.view
+    inputs:
+      - tensor: {shape: [1, 64]}
+      - value: [2, 32]
+    description: |
+      value can accept scalar, list or tuple
+
+  - name: softmax_lastdim
+    op: torch.nn.functional.softmax
+    attrs: {dim: -1}
+    inputs:
+      - tensor: {shape: [2, 4, 8], init: arange}
+
+  - name: cat_list
+    op: torch.cat
+    attrs: {dim: -1}
+    inputs:
+      - tensor_list:
+          - {shape: [2, 3, 4], init: randn}
+          - {shape: [2, 3, 5], init: randn}
+
+  - name: view_should_error_on_noncontig
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: [2, 24]
+
+  - name: view_should_error_on_noncontig_167
+    op: torch.view
+    expects_error: {type: RuntimeError, match: view}
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: noncontig_slice
+          preset_args: {dim: 1, step: 2}
+      - value: 32
+      - value: -1
+      - value: 2880
+
+  - name: contiguous_from_transpose_view
+    op: torch.contiguous
+    inputs:
+      - tensor:
+          shape: [2, 3, 8]
+          preset: transpose_view
+          preset_args: {dim0: 1, dim1: 2}
+
+  - name: rsqrt_skip_example
+    op: torch.rsqrt
+    skip_if:
+      - expr: cfg.test_device.type == 'spyre' and dtype_str == 'fp16'
+        reason: Spyre fp16 rsqrt not supported yet
+    inputs:
+      - tensor: {shape: [64, 1024], init: rand}
+  - name: getitem_ellipsis_none_fullslice
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [32, 5760]
+          init: rand
+      - py: (Ellipsis, None, slice(None, None, None))

--- a/tests/_inductor/op_registry.py
+++ b/tests/_inductor/op_registry.py
@@ -1,0 +1,505 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import torch
+
+
+@dataclass(frozen=True)
+class OpAdapter:
+    name: str
+    fn: Callable[..., Any]
+    is_inplace: bool = False
+    # pre hook may normalize (args, attrs) (e.g., set dropout(training=False))
+    pre: Optional[Callable[[list, dict], Tuple[list, dict]]] = None
+
+
+# -----------------------------
+# Helpers: resolve paths lazily
+# -----------------------------
+def _resolve_attr_path(root: Any, path: str) -> Any:
+    cur = root
+    for part in path.split("."):
+        cur = getattr(cur, part)
+    return cur
+
+
+def lazy_torch(path: str) -> Callable[..., Any]:
+    """
+    Returns a callable that resolves torch.<path> at runtime and calls it.
+
+    Example: lazy_torch("amp.autocast_mode._enter_autocast")
+    """
+
+    def _fn(*args, **kwargs):
+        target = _resolve_attr_path(torch, path)
+        return target(*args, **kwargs)
+
+    _fn.__name__ = f"lazy_torch__{path.replace('.', '_')}"
+    return _fn
+
+
+def _dropout_pre(args: list, attrs: dict) -> tuple[list, dict]:
+    # default deterministic behavior unless case overrides
+    attrs = dict(attrs)
+    attrs.setdefault("training", False)
+    return args, attrs
+
+
+# -----------------------------
+# Wrappers for Tensor methods
+# -----------------------------
+def _tensor_contiguous(x: torch.Tensor) -> torch.Tensor:
+    return x.contiguous()
+
+
+def _tensor_expand(x: torch.Tensor, shape, *args) -> torch.Tensor:
+    if isinstance(shape, (list, tuple)):
+        final_shape = list(shape)
+    elif args:
+        final_shape = [shape] + list(args)
+    else:
+        final_shape = [shape]
+    return x.expand(final_shape)
+
+
+def _tensor_expand_as(x: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+    return x.expand_as(other)
+
+
+def _tensor_float(x: torch.Tensor) -> torch.Tensor:
+    return x.float()
+
+
+def _tensor_int(x: torch.Tensor) -> torch.Tensor:
+    return x.int()
+
+
+def _tensor_long(x: torch.Tensor) -> torch.Tensor:
+    return x.long()
+
+
+def _tensor_to(x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    # allow YAML to pass (dtype/device/etc.) via args/kwargs
+    return x.to(*args, **kwargs)
+
+
+def _tensor_repeat(x: torch.Tensor, rep, *args) -> torch.Tensor:
+    if isinstance(rep, (list, tuple)):
+        final_reps = list(rep)
+    elif args:
+        final_reps = [rep] + list(args)
+    else:
+        final_reps = [rep]
+    return x.repeat(final_reps)
+
+
+def _tensor_repeat_interleave(x: torch.Tensor, rep, **kwargs) -> torch.Tensor:
+    return x.repeat_interleave(x, rep, **kwargs)
+
+
+def _tensor_view(x: torch.Tensor, shape, *args) -> torch.Tensor:
+    if isinstance(shape, (list, tuple)):
+        final_shape = list(shape)
+    elif args:
+        final_shape = [shape] + list(args)
+    else:
+        final_shape = [shape]
+    return x.view(final_shape)
+
+
+def _tensor_permute(x: torch.Tensor, dims, *args) -> torch.Tensor:
+    if isinstance(dims, (list, tuple)):
+        final_dims = list(dims)
+    elif args:
+        final_dims = [dims] + list(args)
+    else:
+        final_dims = [dims]
+    return x.permute(final_dims)
+
+
+def _tensor_transpose(x: torch.Tensor, dim0: int, dim1: int) -> torch.Tensor:
+    return x.transpose(dim0, dim1)
+
+
+def _tensor_squeeze(x: torch.Tensor, dim: int) -> torch.Tensor:
+    return x.squeeze(dim)
+
+
+def _tensor_unsqueeze(x: torch.Tensor, dim: int) -> torch.Tensor:
+    return x.unsqueeze(dim)
+
+
+def _tensor_item(x: torch.Tensor):
+    return x.item()
+
+
+def _tensor_numel(x: torch.Tensor) -> int:
+    return x.numel()
+
+
+def _tensor_new_ones(x: torch.Tensor, size, *args, **kwargs) -> torch.Tensor:
+    # size can be list/tuple/int; forward to Tensor.new_ones
+    if isinstance(size, (list, tuple)):
+        return x.new_ones(tuple(size), *args, **kwargs)
+    return x.new_ones(size, *args, **kwargs)
+
+
+def _tensor_getitem(x: torch.Tensor, idx):
+    return x.__getitem__(idx)
+
+
+def _tensor_setitem_(x: torch.Tensor, idx, value):
+    x.__setitem__(idx, value)
+    return x  # treat as in-place op returning mutated tensor
+
+
+# -----------------------------
+# Wrappers for Python operator-like torch names
+# -----------------------------
+def _torch___and__(a, b):
+    return a.__and__(b)
+
+
+def _torch___eq__(a, b):
+    return a.__eq__(b)
+
+
+def _torch_eq(a, b):
+    return a.__eq__(b)
+
+
+def _torch_le(a, b):
+    return a.__le__(b)
+
+
+def _torch_ne(a, b):
+    return a.__ne__(b)
+
+
+def _torch_gt(a, b):
+    return a.__gt__(b)
+
+
+def _torch_neg(a):
+    return -a
+
+
+def _torch_truediv(a, b):
+    return a.__truediv__(b)
+
+
+# -----------------------------
+# Special / internal wrappers
+# -----------------------------
+def _aten_index(x, indices):
+    """
+    torch.ops.aten.index has overloads; prefer .Tensor then .default if present.
+    Typical signature: aten::index(Tensor self, Tensor?[] indices) -> Tensor
+    """
+    pkt = torch.ops.aten.index
+    if hasattr(pkt, "Tensor"):
+        return pkt.Tensor(x, indices)
+    if hasattr(pkt, "default"):
+        return pkt.default(x, indices)
+    # last resort: try calling packet itself
+    return pkt(x, indices)
+
+
+def _scalar_tensor(val, *, dtype=None, device=None):
+    # torch.scalar_tensor exists in recent versions
+    return torch.scalar_tensor(val, dtype=dtype, device=device)
+
+
+def _sym_sum(x, dim=None):
+    # torch.sym_sum exists for SymInt/SymFloat paths; fall back to torch.sum if absent
+    if hasattr(torch, "sym_sum"):
+        return torch.sym_sum(x, dim=dim) if dim is not None else torch.sym_sum(x)
+    return torch.sum(x, dim=dim) if dim is not None else torch.sum(x)
+
+
+def _vmap_lazy_load_decompositions():
+    # torch._functorch.vmap.lazy_load_decompositions
+    return _resolve_attr_path(torch, "_functorch.vmap.lazy_load_decompositions")()
+
+
+# SDPA / attention internals (these often return context managers or control flags)
+def _attn_backend_from_string(s: str):
+    return _resolve_attr_path(torch, "nn.attention._backend_from_string")(s)
+
+
+def _attn_sdpa_kernel(*args, **kwargs):
+    return _resolve_attr_path(torch, "nn.attention._sdpa_kernel")(*args, **kwargs)
+
+
+# -----------------------------
+# In-place wrappers (Tensor methods)
+# -----------------------------
+def _tensor_add_(x: torch.Tensor, other, alpha=1):
+    return x.add_(other, alpha=alpha)
+
+
+def _tensor_copy_(x: torch.Tensor, source: torch.Tensor):
+    return x.copy_(source)
+
+
+def _tensor_scatter_(x: torch.Tensor, dim: int, index: torch.Tensor, src):
+    # src can be tensor or scalar
+    return x.scatter_(dim, index, src)
+
+
+def _tensor_masked_fill_(x: torch.Tensor, mask: torch.Tensor, value):
+    return x.masked_fill_(mask, value)
+
+
+def _tensor_index_copy_(
+    x: torch.Tensor, dim: int, index: torch.Tensor, source: torch.Tensor
+):
+    return x.index_copy_(dim, index, source)
+
+
+# -----------------------------
+# OP_REGISTRY: unique ops only
+# -----------------------------
+OP_REGISTRY: Dict[str, OpAdapter] = {
+    "torch.cat": OpAdapter("torch.cat", torch.cat),
+    "torch.chunk": OpAdapter("torch.chunk", torch.chunk),
+    # Basic math / reductions
+    "torch.add": OpAdapter("torch.add", torch.add),
+    "torch.Tensor.add": OpAdapter("torch.add", torch.add),
+    "operator.__add__": OpAdapter("torch.add", torch.add),
+    "torch.sub": OpAdapter("torch.sub", torch.sub),
+    "operator.__sub__": OpAdapter("torch.sub", torch.sub),
+    "torch.mul": OpAdapter("torch.mul", torch.mul),
+    "torch.Tensor.mul": OpAdapter("torch.mul", torch.mul),
+    "operator.__mul__": OpAdapter("torch.mul", torch.mul),
+    "torch.invert": OpAdapter("torch.bitwise_not", torch.bitwise_not),
+    "torch.pow": OpAdapter("torch.pow", torch.pow),
+    "torch.div": OpAdapter("torch.div", torch.div),
+    "torch.truediv": OpAdapter("torch.truediv", _torch_truediv),
+    "torch.neg": OpAdapter("torch.neg", _torch_neg),
+    "torch.sum": OpAdapter("torch.sum", torch.sum),
+    "torch.mean": OpAdapter("torch.mean", torch.mean),
+    "torch.max": OpAdapter("torch.max", torch.max),
+    "torch.softmax": OpAdapter("torch.softmax", torch.max),
+    "torch.cumsum": OpAdapter("torch.cumsum", torch.cumsum),
+    "torch.all": OpAdapter("torch.all", torch.all),
+    "torch.numel": OpAdapter("torch.numel", _tensor_numel),
+    "torch.exp": OpAdapter("torch.exp", torch.exp),
+    "torch.rsqrt": OpAdapter("torch.rsqrt", torch.rsqrt),
+    "torch.sigmoid": OpAdapter("torch.sigmoid", torch.sigmoid),
+    "torch.sin": OpAdapter("torch.sin", torch.sin),
+    "torch.cos": OpAdapter("torch.cos", torch.cos),
+    "torch.clamp": OpAdapter("torch.clamp", torch.clamp),
+    "torch.where": OpAdapter("torch.where", torch.where),
+    "torch.tril": OpAdapter("torch.tril", torch.tril),
+    "torch.triu": OpAdapter("torch.triu", torch.triu),
+    # Linear algebra
+    "torch.matmul": OpAdapter("torch.matmul", torch.matmul),
+    "operator.__matmul__": OpAdapter("torch.matmul", torch.matmul),
+    "torch.bmm": OpAdapter("torch.bmm", torch.bmm),
+    "torch.functional.einsum": OpAdapter(
+        "torch.functional.einsum", torch.functional.einsum
+    ),
+    # Shape / view / layout
+    # stride-sensitive ops
+    "torch.contiguous": OpAdapter("torch.contiguous", _tensor_contiguous),
+    "torch.Tensor.contiguous": OpAdapter("torch.contiguous", _tensor_contiguous),
+    "torch.reshape": OpAdapter("torch.reshape", torch.reshape),
+    "torch.view": OpAdapter("torch.view", _tensor_view),
+    "torch.Tensor.view": OpAdapter("torch.view", _tensor_view),
+    "torch.aten.view": OpAdapter("torch.view", _tensor_view),
+    "torch.transpose": OpAdapter("torch.transpose", _tensor_transpose),
+    "torch.permute": OpAdapter("torch.permute", _tensor_permute),
+    "torch.squeeze": OpAdapter("torch.squeeze", _tensor_squeeze),
+    "torch.unsqueeze": OpAdapter("torch.unsqueeze", _tensor_unsqueeze),
+    "torch.flatten": OpAdapter("torch.flatten", torch.flatten),
+    "torch.expand": OpAdapter("torch.expand", _tensor_expand),
+    "torch.Tensor.expand": OpAdapter("torch.expand", _tensor_expand),
+    "torch.expand_as": OpAdapter("torch.expand_as", _tensor_expand_as),
+    "torch.repeat": OpAdapter("torch.repeat", _tensor_repeat),
+    "torch.repeat_interleave": OpAdapter(
+        "torch.repeat_interleave", _tensor_repeat_interleave
+    ),
+    "torch.clone": OpAdapter("torch.clone", torch.clone),
+    "torch.split": OpAdapter("torch.split", torch.split),
+    "torch.functional.split": OpAdapter(
+        "torch.functional.split", torch.functional.split
+    ),
+    "torch.Tensor.copy_": OpAdapter("torch.copy_", _tensor_copy_, is_inplace=True),
+    # Indexing / getitem / setitem
+    "torch.getitem": OpAdapter("torch.getitem", _tensor_getitem),
+    "operator.__getitem__": OpAdapter("torch.getitem", _tensor_getitem),
+    "torch.setitem": OpAdapter("torch.setitem", _tensor_setitem_, is_inplace=True),
+    "_operator.setitem": OpAdapter(
+        "_operator.setitem", _tensor_setitem_, is_inplace=True
+    ),
+    "torch.ops.aten.index": OpAdapter("torch.ops.aten.index", _aten_index),
+    # Scatter / copy / masking
+    "torch.scatter": OpAdapter("torch.scatter", torch.scatter),
+    "torch.scatter_": OpAdapter("torch.scatter_", _tensor_scatter_, is_inplace=True),
+    # "torch.scatter_": OpAdapter("torch.scatter_", torch.Tensor.scatter_, is_inplace=True),
+    "torch.index_copy_": OpAdapter(
+        "torch.index_copy_", _tensor_index_copy_, is_inplace=True
+    ),
+    "torch.masked_fill": OpAdapter("torch.masked_fill", torch.masked_fill),
+    "torch.masked_fill_": OpAdapter(
+        "torch.masked_fill_", _tensor_masked_fill_, is_inplace=True
+    ),
+    "torch.masked_scatter": OpAdapter("torch.masked_scatter", torch.masked_scatter),
+    # Comparisons / bitwise
+    "torch.__and__": OpAdapter("torch.__and__", _torch___and__),
+    "torch.__eq__": OpAdapter("torch.__eq__", _torch___eq__),
+    "torch.eq": OpAdapter("torch.le", _torch_eq),
+    "torch.le": OpAdapter("torch.le", _torch_le),
+    "torch.ne": OpAdapter("torch.ne", _torch_ne),
+    "torch.gt": OpAdapter("torch.gt", _torch_gt),
+    "torch.logical_and": OpAdapter("torch.logical_and", torch.logical_and),
+    # Type/device conversions
+    "torch.float": OpAdapter("torch.float", _tensor_float),
+    "float": OpAdapter("torch.float", _tensor_float),
+    "torch.int": OpAdapter("torch.int", _tensor_int),
+    "torch.long": OpAdapter("torch.long", _tensor_long),
+    "torch.to": OpAdapter("torch.to", _tensor_to),
+    "torch.type_as": OpAdapter("torch.Tensor.type_as", torch.Tensor.type_as),
+    # Creation
+    "torch.zeros": OpAdapter("torch.zeros", torch.zeros),
+    "torch.zeros_like": OpAdapter("torch.zeros_like", torch.zeros_like),
+    "torch.ones": OpAdapter("torch.ones", torch.ones),
+    "torch.arange": OpAdapter("torch.arange", torch.arange),
+    "torch.tensor": OpAdapter("torch.tensor", torch.tensor),
+    "torch.scalar_tensor": OpAdapter("torch.scalar_tensor", _scalar_tensor),
+    "torch.new_ones": OpAdapter("torch.new_ones", _tensor_new_ones),
+    "torch.full": OpAdapter("torch.full", torch.full),
+    # Sort / Topk
+    "torch.sort": OpAdapter("torch.sort", torch.sort),
+    "torch.topk": OpAdapter("torch.topk", torch.topk),
+    # NNs / functionals (use F.* where appropriate)
+    "torch.nn.functional.dropout": OpAdapter(
+        "torch.nn.functional.dropout", torch.nn.functional.dropout, pre=_dropout_pre
+    ),
+    "torch.nn.functional.embedding": OpAdapter(
+        "torch.nn.functional.embedding", torch.nn.functional.embedding
+    ),
+    "torch.nn.functional.softmax": OpAdapter(
+        "torch.nn.functional.softmax", torch.nn.functional.softmax
+    ),
+    "torch.nn.functional.layer_norm": OpAdapter(
+        "torch.nn.functional.layer_norm", torch.nn.functional.layer_norm
+    ),
+    "torch.nn.functional.batch_norm": OpAdapter(
+        "torch.nn.functional.batch_norm", torch.nn.functional.batch_norm
+    ),
+    "torch.nn.functional.gelu": OpAdapter(
+        "torch.nn.functional.gelu", torch.nn.functional.gelu
+    ),
+    "torch.nn.functional.glu": OpAdapter(
+        "torch.nn.functional.glu", torch.nn.functional.glu
+    ),
+    "torch.nn.functional.silu": OpAdapter(
+        "torch.nn.functional.silu", torch.nn.functional.silu
+    ),
+    "torch.nn.functional.softplus": OpAdapter(
+        "torch.nn.functional.softplus", torch.nn.functional.softplus
+    ),
+    # gelu has both torch.nn.functional.gelu and torch.nn.gelu depending on version
+    "torch.nn.gelu": OpAdapter(
+        "torch.nn.gelu",
+        getattr(torch.nn, "gelu", torch.nn.functional.gelu),
+    ),
+    # linear: prefer torch.nn.functional.linear; torch.nn.linear may exist in some builds
+    "torch.nn.linear": OpAdapter(
+        "torch.nn.linear",
+        getattr(torch.nn, "linear", torch.nn.functional.linear),
+    ),
+    "torch.nn.functional.linear": OpAdapter(
+        "torch.nn.functional.linear", torch.nn.functional.linear
+    ),
+    "torch.nn.pad": OpAdapter(
+        "torch.nn.pad",
+        getattr(torch.nn, "pad", torch.nn.functional.pad),
+    ),
+    "torch.nn.functional.pad": OpAdapter(
+        "torch.nn.functional.pad", torch.nn.functional.pad
+    ),
+    # Attention / SDPA
+    "torch.nn.scaled_dot_product_attention": OpAdapter(
+        "torch.nn.scaled_dot_product_attention",
+        getattr(
+            torch.nn,
+            "scaled_dot_product_attention",
+            torch.nn.functional.scaled_dot_product_attention,
+        ),
+    ),
+    "torch.nn.functional.scaled_dot_product_attention": OpAdapter(
+        "torch.nn.functional.scaled_dot_product_attention",
+        torch.nn.functional.scaled_dot_product_attention,
+    ),
+    "torch.nn.functional.multi_head_attention_forward": OpAdapter(
+        "torch.nn.functional.multi_head_attention_forward",
+        torch.nn.functional.multi_head_attention_forward,
+    ),
+    "torch.nn.attention._backend_from_string": OpAdapter(
+        "torch.nn.attention._backend_from_string",
+        _attn_backend_from_string,
+    ),
+    "torch.nn.attention._sdpa_kernel": OpAdapter(
+        "torch.nn.attention._sdpa_kernel",
+        _attn_sdpa_kernel,
+    ),
+    # Conv
+    "torch.conv1d": OpAdapter("torch.conv1d", torch.conv1d),
+    "torch.conv2d": OpAdapter("torch.conv2d", torch.conv2d),
+    # Autocast internal enter/exit (kept for completeness; not usually unit-tested directly)
+    "torch.amp.autocast_mode._enter_autocast": OpAdapter(
+        "torch.amp.autocast_mode._enter_autocast",
+        lazy_torch("amp.autocast_mode._enter_autocast"),
+    ),
+    "torch.amp.autocast_mode._exit_autocast": OpAdapter(
+        "torch.amp.autocast_mode._exit_autocast",
+        lazy_torch("amp.autocast_mode._exit_autocast"),
+    ),
+    # Functorch internal vmap plumbing (kept for completeness)
+    "torch._functorch.vmap.lazy_load_decompositions": OpAdapter(
+        "torch._functorch.vmap.lazy_load_decompositions",
+        _vmap_lazy_load_decompositions,
+    ),
+    "torch._C._functorch._add_batch_dim": OpAdapter(
+        "torch._C._functorch._add_batch_dim",
+        lazy_torch("_C._functorch._add_batch_dim"),
+    ),
+    "torch._C._functorch._remove_batch_dim": OpAdapter(
+        "torch._C._functorch._remove_batch_dim",
+        lazy_torch("_C._functorch._remove_batch_dim"),
+    ),
+    "torch._C._functorch._vmap_increment_nesting": OpAdapter(
+        "torch._C._functorch._vmap_increment_nesting",
+        lazy_torch("_C._functorch._vmap_increment_nesting"),
+    ),
+    "torch._C._functorch._vmap_decrement_nesting": OpAdapter(
+        "torch._C._functorch._vmap_decrement_nesting",
+        lazy_torch("_C._functorch._vmap_decrement_nesting"),
+    ),
+    # Symbolic sum (present in some builds; fallback provided)
+    "torch.sym_sum": OpAdapter("torch.sym_sum", _sym_sum),
+    # Misc
+    "torch.item": OpAdapter("torch.item", _tensor_item),
+    # In-place add_ listed separately
+    "torch.add_": OpAdapter("torch.add_", _tensor_add_, is_inplace=True),
+    # "torch.add_": OpAdapter("torch.add_", torch.Tensor.add_, is_inplace=True),
+}
+
+# Handy set if you want it:
+INPLACE_OPS = {name for (name, a) in OP_REGISTRY.items() if a.is_inplace}

--- a/tests/_inductor/runner.py
+++ b/tests/_inductor/runner.py
@@ -1,0 +1,494 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ast
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import pytest
+import regex as re
+import torch
+import torch.nn as nn
+
+from op_registry import OP_REGISTRY
+
+DTYPE_MAP = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+    "int64": torch.int64,
+    "bool": torch.bool,
+}
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    test_device: torch.device
+    ref_device: torch.device = torch.device("cpu")
+    compile_backend: Optional[str] = None  # if set, run Spyre through torch.compile
+
+
+# ---------- safe skip/xfail condition evaluation ----------
+_ALLOWED_AST = (
+    ast.Expression,
+    ast.BoolOp,
+    ast.UnaryOp,
+    ast.Compare,
+    ast.Name,
+    ast.Load,
+    ast.Attribute,
+    ast.Constant,
+    ast.And,
+    ast.Or,
+    ast.Not,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+)
+
+
+def _safe_eval_bool(expr: str, ctx: dict) -> bool:
+    tree = ast.parse(expr, mode="eval")
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_AST):
+            raise ValueError(
+                f"Disallowed syntax in expr: {expr} (node={type(node).__name__})"
+            )
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            raise ValueError("Dunder attribute access is not allowed")
+    return bool(eval(compile(tree, "<expr>", "eval"), {"__builtins__": {}}, ctx))
+
+
+def _maybe_skip_or_xfail(
+    case: Dict[str, Any], defaults: Dict[str, Any], ctx: dict
+) -> None:
+    skip_if = case.get("skip_if", defaults.get("skip_if", None))
+    if skip_if:
+        if isinstance(skip_if, str):
+            if _safe_eval_bool(skip_if, ctx):
+                pytest.skip("skip_if matched")
+        elif isinstance(skip_if, list):
+            for item in skip_if:
+                expr = item["expr"]
+                reason = item.get("reason", "skip_if matched")
+                if _safe_eval_bool(expr, ctx):
+                    pytest.skip(reason)
+
+    xfail_reason = case.get("xfail_reason", defaults.get("xfail_reason", None))
+    if xfail_reason:
+        xfail_if = case.get("xfail_if", defaults.get("xfail_if", None))
+        if xfail_if is None or _safe_eval_bool(str(xfail_if), ctx):
+            pytest.xfail(str(xfail_reason))
+
+
+def parse_py_value(expr: str):
+    """
+    Safely parse a restricted Python literal expression used in YAML.
+    Supports: tuples, None, Ellipsis, slice(None/ints), ints, floats, lists.
+    Disallows function calls and attribute access.
+    """
+    allowed_names = {
+        "None": None,
+        "Ellipsis": Ellipsis,
+        "slice": slice,
+        "inf": float("inf"),
+        "-inf": float("-inf"),
+        "nan": float("nan"),
+    }
+    node = ast.parse(expr, mode="eval")
+
+    for n in ast.walk(node):
+        if isinstance(n, ast.Call):
+            # only allow calling slice(...)
+            if not (isinstance(n.func, ast.Name) and n.func.id == "slice"):
+                raise ValueError(f"Only slice(...) calls are allowed in py: {expr}")
+        if isinstance(n, ast.Attribute):
+            raise ValueError(f"Attributes not allowed in py: {expr}")
+        if isinstance(n, ast.Name) and n.id not in allowed_names:
+            raise ValueError(f"Name {n.id} not allowed in py: {expr}")
+
+    return eval(compile(node, "<py>", "eval"), {"__builtins__": {}}, allowed_names)
+
+
+# ---------- tensor construction (deterministic) ----------
+def _fork_seed(seed: Optional[int]):
+    if seed is None:
+        return torch.random.fork_rng(devices=[])
+    # fork_rng keeps global RNG clean
+    ctx = torch.random.fork_rng(devices=[])
+    ctx.__enter__()
+    torch.manual_seed(int(seed))
+    return ctx
+
+
+def _numel(shape) -> int:
+    if len(shape) == 0:
+        return 1
+    n = 1
+    for d in shape:
+        n *= int(d)
+    return n
+
+
+def _make_base(shape, dtype, seed):
+    with torch.random.fork_rng(devices=[]):
+        if seed is not None:
+            torch.manual_seed(int(seed))
+        return torch.randn(tuple(shape), device="cpu", dtype=dtype)
+
+
+def make_tensor_from_conf(
+    tconf: Dict[str, Any], *, dtype: torch.dtype, seed: Optional[int]
+) -> torch.Tensor:
+    shape = list(tconf["shape"])
+    init = tconf.get("init", "rand")
+    init_args = dict(tconf.get("init_args", {}))
+    preset = tconf.get("preset", None)
+    preset_args = dict(tconf.get("preset_args", {}))
+    base_shape = tconf.get("base_shape", None)
+
+    # presets create noncontig/aliasing views
+    if preset is None:
+        with torch.random.fork_rng(devices=[]):
+            if seed is not None:
+                torch.manual_seed(int(seed))
+            if init == "rand" and dtype is torch.bool:
+                threshold = 0.5  # 50% chance of True
+                t = torch.rand(tuple(shape), device="cpu") < threshold
+            elif init == "rand":
+                t = torch.rand(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "randn":
+                t = torch.randn(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "zeros":
+                t = torch.zeros(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "ones":
+                t = torch.ones(tuple(shape), dtype=dtype, device="cpu")
+            elif init == "arange":
+                t = torch.arange(_numel(shape), dtype=dtype, device="cpu").reshape(
+                    shape
+                )
+            elif init == "randint":
+                low = int(init_args.get("low", 0))
+                high = int(init_args.get("high", -1))
+                if high < 0:
+                    raise ValueError(
+                        "Invalid value (high for randint): must be provided (via init_args) and must be positive"
+                    )
+                t = torch.randint(size=tuple(shape), low=low, high=high, device="cpu")
+            elif init == "uniform":
+                low = float(init_args.get("low", 0.0))
+                high = float(init_args.get("high", 1.0))
+                t = torch.empty(tuple(shape), dtype=dtype, device="cpu").uniform_(
+                    low, high
+                )
+            elif init == "data":
+                data = tconf["data"]
+                t = torch.tensor(data, dtype=dtype, device="cpu").reshape(shape)
+            else:
+                raise ValueError(f"Unknown init: {init}")
+    else:
+        # build a base then view it
+        if preset == "noncontig_slice":
+            dim = int(preset_args.get("dim", 1 if len(shape) > 1 else 0))
+            step = int(preset_args.get("step", 2))
+            if base_shape is None:
+                base_shape = shape[:]
+                base_shape[dim] = shape[dim] * step
+            base = _make_base(base_shape, dtype, seed)
+            slc = [slice(None)] * base.ndim
+            slc[dim] = slice(0, base.shape[dim], step)
+            t = base[tuple(slc)]
+        elif preset == "transpose_view":
+            dim0 = int(preset_args.get("dim0", 0))
+            dim1 = int(preset_args.get("dim1", 1))
+            if base_shape is None:
+                base_shape = shape[:]
+                base_shape[dim0], base_shape[dim1] = shape[dim1], shape[dim0]
+            base = _make_base(base_shape, dtype, seed)
+            t = base.transpose(dim0, dim1)
+        elif preset == "expand_view0":
+            if base_shape is None:
+                raise ValueError("expand_view0 requires base_shape")
+            base = _make_base(base_shape, dtype, seed)
+            t = base.expand(*shape)
+        else:
+            raise ValueError(f"Unknown preset: {preset}")
+
+        if list(t.shape) != shape:
+            raise ValueError(
+                f"Preset {preset} produced shape {list(t.shape)} != expected {shape}"
+            )
+
+    if tconf.get("contiguous", True):
+        t = t.contiguous()
+    return t
+
+
+def confirm_device(x: Any, expected_device: str) -> bool:
+    if torch.is_tensor(x):
+        return expected_device in str(x.device)
+    if isinstance(x, (tuple, list)):
+        return all(confirm_device(item, expected_device) for item in x)
+    return True
+
+
+def to_device(x: Any, device: torch.device) -> Any:
+    if torch.is_tensor(x):
+        return x.to(device)
+    if isinstance(x, (tuple, list)):
+        return type(x)(to_device(y, device) for y in x)
+    return x
+
+
+def _normalize_out(out: Any) -> Any:
+    if torch.is_tensor(out):
+        return out
+    if isinstance(out, (tuple, list)):
+        return tuple(_normalize_out(x) for x in out)
+    return out
+
+
+def _assert_same(
+    ref_out: Any, test_out: Any, *, rtol: float, atol: float, case_name: str
+) -> None:
+    ref_out = _normalize_out(ref_out)
+    test_out = _normalize_out(test_out)
+
+    if torch.is_tensor(ref_out):
+        try:
+            torch.testing.assert_close(test_out, ref_out, rtol=rtol, atol=atol)
+        except AssertionError as e:
+            raise AssertionError(
+                f"{case_name} FAILED since output is not close to an expected result\n"
+                f"{e}\n"
+                f"shape={tuple(ref_out.shape)} dtype={ref_out.dtype}\n"
+            ) from e
+        return
+
+    if isinstance(ref_out, tuple):
+        assert isinstance(test_out, tuple) and len(test_out) == len(ref_out)
+        for r, d in zip(ref_out, test_out):
+            _assert_same(r, d, rtol=rtol, atol=atol, case_name=case_name)
+        return
+
+    assert test_out == ref_out
+
+
+# ---------- expects_error ----------
+_ERR_NAME_TO_TYPE = {
+    "RuntimeError": RuntimeError,
+    "ValueError": ValueError,
+    "TypeError": TypeError,
+    "AssertionError": AssertionError,
+}
+
+
+def _exc_type(name: Optional[str]):
+    if not name:
+        return Exception
+    return _ERR_NAME_TO_TYPE.get(str(name), Exception)
+
+
+def _run_and_capture(fn, args, attrs):
+    try:
+        out = fn(*args, **attrs)
+        return False, None, out
+    except BaseException as e:
+        return True, e, None
+
+
+def _assert_raised(label: str, raised: bool, exc: BaseException, spec: dict):
+    assert raised, f"{label} expected to raise but did not"
+    want_t = _exc_type(spec.get("type", "RuntimeError"))
+    assert isinstance(exc, want_t), f"{label} raised {type(exc)} expected {want_t}"
+    m = spec.get("match", None)
+    if m:
+        assert re.search(m, str(exc)), f"{label} message did not match /{m}/. msg={exc}"
+
+
+# ---------- optional torch.compile path ----------
+class _OpModule(nn.Module):
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+
+def _maybe_compile_call(
+    fn, args, attrs, device: torch.device, compile_backend: Optional[str]
+):
+    if compile_backend is None or device.type == "cpu":
+        return fn(*args, **attrs)
+    mod = _OpModule(fn).to(device)
+    torch._dynamo.reset_code_caches()  # kernel caching workaround
+    compiled = torch.compile(mod, backend=compile_backend)
+    return compiled(*args, **attrs)
+
+
+def parse_dtype(spec) -> torch.dtype:
+    # already a torch dtype?
+    if isinstance(spec, torch.dtype):
+        return spec
+
+    if not isinstance(spec, str):
+        raise TypeError(f"dtype must be str or torch.dtype, got {type(spec)}")
+
+    s = spec.strip()
+
+    # allow "torch.float16" (or "Torch.Float16" if you choose lower())
+    if s.startswith("torch."):
+        attr = s.split(".", 1)[1]
+        dt = getattr(torch, attr, None)
+        if isinstance(dt, torch.dtype):
+            return dt
+        raise ValueError(f"Unknown torch dtype: {spec}")
+
+    # allow your aliases (optionally case-insensitive)
+    key = s.lower()
+    if key in DTYPE_MAP:
+        return DTYPE_MAP[key]
+
+    # optionally: allow bare torch attribute names beyond your whitelist
+    # (e.g., "float64") if you want:
+    dt = getattr(torch, s, None) or getattr(torch, key, None)
+    if isinstance(dt, torch.dtype):
+        return dt
+
+    raise ValueError(
+        f"Unsupported dtype: {spec!r}. Supported: {sorted(DTYPE_MAP)} and torch.<dtype>"
+    )
+
+
+# ---------- main entry ----------
+def run_case(case: Dict[str, Any], defaults: Dict[str, Any], cfg: RunConfig) -> None:
+    op_name = case["op"]
+    adapter = OP_REGISTRY[op_name]
+
+    case_name = case.get("name", op_name)
+
+    dtype_str = case.get("dtype", defaults.get("dtype", "fp16"))
+    dtype = parse_dtype(dtype_str)
+    dtype_str = str(dtype)
+    seed = case.get("seed", defaults.get("seed", None))
+
+    rtol = float(case.get("rtol", defaults.get("rtol", 5e-3)))
+    atol = float(case.get("atol", defaults.get("atol", 5e-3)))
+    attrs = dict(case.get("attrs", {}))
+
+    ctx = {
+        "cfg": cfg,
+        "op_name": op_name,
+        "dtype_str": dtype_str,
+        "env": dict(os.environ),
+        "torch": torch,
+    }
+    _maybe_skip_or_xfail(case, defaults, ctx)
+
+    # Build CPU args ONCE, then copy to Spyre (identical values)
+    cpu_args = []
+    for i, inp in enumerate(case.get("inputs", [])):
+        # derive per-input seed so tensors differ deterministically
+        inp_seed = None if seed is None else int(seed) + i * 1000
+
+        if "tensor" in inp:
+            tensor_conf = inp["tensor"]
+            tensor_dtype = parse_dtype(tensor_conf.get("dtype", dtype_str))
+            cpu_args.append(
+                make_tensor_from_conf(tensor_conf, dtype=tensor_dtype, seed=inp_seed)
+            )
+        elif "tensor_list" in inp:
+            lst = [
+                make_tensor_from_conf(
+                    t,
+                    dtype=parse_dtype(t.get("dtype", dtype_str)),
+                    seed=(None if seed is None else int(seed) + i * 1000 + j),
+                )
+                for j, t in enumerate(inp["tensor_list"])
+            ]
+            cpu_args.append(lst)
+        elif "value" in inp:
+            val = inp["value"]
+            if isinstance(val, str):
+                try:
+                    val = ast.literal_eval(val)
+                except (ValueError, SyntaxError):
+                    pass
+            cpu_args.append(val)  # python scalar or list, etc.
+        elif "py" in inp:
+            cpu_args.append(parse_py_value(inp["py"]))
+        else:
+            raise ValueError(f"Unknown input entry: {inp}")
+
+    for key, value in case.get("kwmap", {}).items():
+        if key == "dtype":
+            value = parse_dtype(value)
+        else:
+            if isinstance(value, str):
+                try:
+                    value = ast.literal_eval(value)
+                except (ValueError, SyntaxError):
+                    pass
+        attrs[key] = value
+
+    test_args = []
+    for a in cpu_args:
+        # also move tensors inside lists (cat)
+        if isinstance(a, list):
+            test_args.append([to_device(x, cfg.test_device) for x in a])
+        else:
+            test_args.append(to_device(a, cfg.test_device))
+
+    if adapter.pre:
+        cpu_args, attrs = adapter.pre(cpu_args, attrs)
+        test_args, _ = adapter.pre(test_args, attrs)
+
+    # expects_error: both must raise
+    expects_error = case.get("expects_error", None)
+    if expects_error:
+        if "ref" in expects_error or "spyre" in expects_error:
+            ref_spec = expects_error.get("ref", {})
+            test_spec = expects_error.get("spyre", {})
+        else:
+            ref_spec = test_spec = expects_error
+
+        ref_raised, ref_exc, _ = _run_and_capture(adapter.fn, cpu_args, attrs)
+        test_raised, test_exc, _ = _run_and_capture(adapter.fn, test_args, attrs)
+        _assert_raised("CPU", ref_raised, ref_exc, ref_spec)
+        _assert_raised("Spyre", test_raised, test_exc, test_spec)
+        return
+
+    # Run
+    with torch.no_grad():
+        ref_out = adapter.fn(*cpu_args, **attrs)
+        test_out = _maybe_compile_call(
+            adapter.fn, test_args, attrs, cfg.test_device, cfg.compile_backend
+        )
+
+        if adapter.is_inplace:
+            # compare mutated arg0
+            ref_out = cpu_args[0]
+            test_out = test_args[0]
+
+    ref_out_cpu = to_device(ref_out, torch.device("cpu"))
+    assert confirm_device(test_out, "spyre"), "this result must be on spyre"
+    test_out_cpu = to_device(test_out, torch.device("cpu"))
+    _assert_same(ref_out_cpu, test_out_cpu, rtol=rtol, atol=atol, case_name=case_name)

--- a/tests/_inductor/test_model_ops.py
+++ b/tests/_inductor/test_model_ops.py
@@ -1,0 +1,184 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+import pytest
+import torch
+
+from model_cases_loader import LoadedCase, case_key, load_all_cases
+from runner import RunConfig, run_case
+import shared_config
+
+from typing import Any, Dict, List
+
+from torch.testing._internal.opinfo.core import (
+    OpInfo,
+)
+from torch.testing._internal.common_device_type import (
+    PrivateUse1TestBase,
+    ops,
+    instantiate_device_type_tests,
+)
+from op_registry import OP_REGISTRY, OpAdapter
+
+
+class ModelOpInfo(OpInfo):
+    """operator information for model-centric verification."""
+
+    def __init__(
+        self,
+        name,
+        *,
+        dtypes,
+        sample_inputs_func=None,
+        reference_inputs_func=None,
+        model="",
+        defaults: Dict[str, Any] = {},
+        loadedCase: LoadedCase,
+        adapter: OpAdapter,
+        description: str = "",
+        # Options from the OpInfo base class
+        **kwargs,
+    ):
+        super().__init__(
+            name,
+            dtypes=dtypes,
+            sample_inputs_func=sample_inputs_func,
+            reference_inputs_func=reference_inputs_func,
+            op=adapter.fn,
+            **kwargs,
+        )
+        self.loadedCase = loadedCase
+        self.adapter = adapter
+        self.defaults = defaults
+        self.description = description
+
+
+model_ops_db: list[ModelOpInfo] = []
+
+
+def add_model_ops_db(loadedCases: List[LoadedCase]):
+    seen_test_names = set()
+    for loadedCase in loadedCases:
+        test_name = loadedCase.case["name"]
+        op_name = loadedCase.case["op"]
+        adapter = OP_REGISTRY[op_name]
+        basename = os.path.basename(loadedCase.source_path)
+        test_name = f"{test_name}__{basename}_"
+        assert test_name not in seen_test_names
+        seen_test_names.add(test_name)
+        model_ops_db.append(
+            ModelOpInfo(
+                test_name,
+                # variant_test_name="",
+                dtypes=(torch.float16,),
+                loadedCase=loadedCase,
+                adapter=adapter,
+            )
+        )
+
+
+def _init_model_ops_db():
+    """Initialize model_ops_db at module import time."""
+    global model_ops_db
+    if len(model_ops_db) > 0:
+        return
+
+    if "pytest" in sys.modules:
+        root = shared_config._PYTEST_CONFIG.rootpath
+        loadedCases = load_all_cases(root)
+        add_model_ops_db(loadedCases)
+
+
+_init_model_ops_db()
+
+
+class TestSpyre(PrivateUse1TestBase):
+    @ops(model_ops_db)
+    def test_model_ops_db(
+        self,
+        device,
+        dtype,
+        op,
+    ):
+        pytestconfig = shared_config._PYTEST_CONFIG
+        selected_models = set(pytestconfig.getoption("--model") or [])
+        dedupe_enabled = bool(pytestconfig.getoption("dedupe", True))
+        compile_backend = str(
+            pytestconfig.getoption("--compile-backend") or "inductor"
+        ).strip()
+        allowed_test_names = pytestconfig.getoption("--test-names")
+        test_device_str = "spyre"
+        seen_case_keys = set()
+
+        method_name = self._testMethodName
+
+        loadedCase: LoadedCase = op.loadedCase
+        model = loadedCase.model
+        case: Any = loadedCase.case
+        defaults = loadedCase.defaults
+
+        # 1) Model filtering (keeps your "only ops from granite3-speech" capability)
+        if selected_models and model not in selected_models:
+            pytest.skip(f"Filtered out by --model (selected={sorted(selected_models)})")
+
+        # 2) Test names filtering
+        if allowed_test_names:
+            matched = any(test_name in method_name for test_name in allowed_test_names)
+            if not matched:
+                pytest.skip("Filtered out by --test-names list")
+
+        # 3) Check pytest -m marker expression
+        mark_expr = pytestconfig.option.markexpr
+        if mark_expr:
+            from _pytest.mark.expression import Expression
+
+            compiled_expr = Expression.compile(mark_expr)
+
+            # Get marks from YAML case
+            case_marks = set()
+            marks = case.get("marks")
+            if isinstance(marks, str) and marks.strip():
+                case_marks.add(marks.strip())
+            elif isinstance(marks, (list, tuple)):
+                for m in marks:
+                    if isinstance(m, str) and m.strip():
+                        case_marks.add(m.strip())
+
+            # Evaluate if this test should run based on marks
+            if not compiled_expr.evaluate(lambda m: m in case_marks):
+                pytest.skip(f"Skipped by marker expression: {mark_expr}")
+        # 4) Optional cross-model dedupe (do NOT dedupe at collection time!)
+        if dedupe_enabled:
+            k = case_key(case, defaults)
+            if k in seen_case_keys:
+                pytest.skip(
+                    "duplicate signature already tested (enable/disable via --no-dedupe)"
+                )
+            seen_case_keys.add(k)
+
+        cfg = RunConfig(
+            test_device=torch.device(test_device_str),
+            compile_backend=compile_backend,
+        )
+        try:
+            run_case(case, defaults, cfg)
+        finally:
+            torch._dynamo.reset()
+
+
+# Instantiate device type tests for the TestSpyre class
+# This is required for @ops decorator to work properly
+instantiate_device_type_tests(TestSpyre, globals())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,32 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
+import yaml
+import pytest
+
+
+import shared_config
+
+
+def _get_case_marks(case: dict) -> set[str]:
+    """
+    Support either:
+      marks: paddedtensor
+      marks: [paddedtensor, fpoperation]
+    """
+    marks = set()
+    m = case.get("marks")
+    if isinstance(m, str) and m.strip():
+        marks.add(m.strip())
+
+    ms = case.get("marks")
+    if isinstance(ms, (list, tuple)):
+        for x in ms:
+            if isinstance(x, str) and x.strip():
+                marks.add(x.strip())
+
+    return marks
 
 
 def pytest_sessionstart(session):
@@ -20,5 +46,277 @@ def pytest_sessionstart(session):
     Called after the Session object has been created and
     before performing collection and entering the run test loop.
     """
+
+    # avoid circular imports when using xdist
+    import torch  # noqa: F401
+
     os.environ.setdefault("DTLOG_LEVEL", "error")
     os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")
+
+    cfg = session.config
+    root = cfg.rootpath
+
+    selected = set(cfg.getoption("--model") or [])
+
+    if cfg.getoption("--list-models"):
+        models = sorted({m for (m, _, __, ___, _case) in _iter_yaml_cases(root)})
+        for m in models:
+            print(m)
+        pytest.exit("listed models", returncode=0)
+
+    if cfg.getoption("--list-cases"):
+        for model, name, op, p, _case in _iter_yaml_cases(root):
+            if selected and model not in selected:
+                continue
+            print(f"{model}::{name}::{op}  ({p})")
+        pytest.exit("listed cases", returncode=0)
+
+    opt = cfg.getoption("--list-cases-by-mark")
+    if opt is not None:
+        if opt == "__USE_PYTEST_M__":
+            # This is the *effective* -m expression after addopts + CLI parsing.
+            expr = (cfg.option.markexpr or "").strip()
+            # If no -m anywhere, treat as "select all"
+            if not expr:
+                expr = "True"
+        else:
+            expr = opt.strip()
+        from _pytest.mark.expression import Expression
+
+        compiled = Expression.compile(expr)
+
+        show_excluded = cfg.getoption("--show-excluded")
+        chosen = []
+        excluded = []
+
+        def case_selected(case: dict) -> bool:
+            marks = _get_case_marks(case)  # set[str]
+            return compiled.evaluate(lambda m: m in marks)
+
+        for model, name, op, p, case in _iter_yaml_cases(root):
+            if selected and model not in selected:
+                continue
+
+            rec = f"{model}::{name}::{op}  ({p})"
+            if case_selected(case):
+                chosen.append(rec)
+            else:
+                excluded.append(rec)
+
+        if show_excluded:
+            for r in excluded:
+                print(r)
+            pytest.exit(f"listed excluded cases by mark (NOT {expr})", returncode=0)
+        else:
+            for r in chosen:
+                print(r)
+            pytest.exit(f"listed selected cases by mark ({expr})", returncode=0)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--model",
+        action="append",
+        default=[],
+        help="Run only these models (repeatable). Example: --model granite3-speech",
+    )
+    parser.addoption(
+        "--dedupe",
+        dest="dedupe",
+        action="store_true",
+        default=True,  # default ON
+        help="Skip duplicate op+input signatures across models (runtime).",
+    )
+    parser.addoption(
+        "--no-dedupe",
+        action="store_false",
+        dest="dedupe",
+        help="Disable deduplication.",
+    )
+
+    # NEW: inventory modes
+    parser.addoption(
+        "--list-models",
+        action="store_true",
+        default=False,
+        help="List models found in tests/_inductor/models/*.yaml and exit.",
+    )
+    parser.addoption(
+        "--list-cases",
+        action="store_true",
+        default=False,
+        help="List cases found in tests/_inductor/models/*.yaml and exit. Use --model to filter.",
+    )
+    parser.addoption(
+        "--compile-backend",
+        action="store",
+        default=os.environ.get("TEST_COMPILE_BACKEND", "inductor"),
+        help="If set, run test via torch.compile(..., backend=...).",
+    )
+    group = parser.getgroup("yaml-cases")
+    group.addoption(
+        "--list-cases-by-mark",
+        action="store",
+        const="__USE_PYTEST_M__",
+        default=None,
+        nargs="?",
+        metavar="EXPR",
+        help=(
+            "List YAML test cases whose mark(s) match a pytest -m style expression. "
+            "Examples: paddedtensor | 'paddedtensor and not fpoperation'"
+            "If EXPR is omitted, uses the effective pytest -m expression (including pytest.ini addopts)."
+        ),
+    )
+    group.addoption(
+        "--show-excluded",
+        action="store_true",
+        default=False,
+        help="With --list-cases-by-mark, list cases excluded by the mark expression (i.e., NOT matching).",
+    )
+    group.addoption(
+        "--show-skipped",
+        action="store_true",
+        default=False,
+        help="List cases skipped by model filtering or duplications",
+    )
+    parser.addoption(
+        "--test-names",
+        action="append",
+        default=[],
+        help="Run only tests matching these test names",
+    )
+
+
+def _models_dir(rootpath: Path) -> Path:
+    return rootpath / "tests" / "_inductor" / "models"
+
+
+def load_yaml_or_fail(path: Path) -> dict:
+    text = path.read_text()
+    try:
+        data = yaml.safe_load(text)
+        if data is None:
+            raise pytest.UsageError(f"{path}: YAML is empty")
+        return data
+    except yaml.YAMLError as e:
+        # Build a nice error message with file + location + snippet
+        msg = [f"Invalid YAML in {path}"]
+
+        mark = getattr(e, "problem_mark", None)
+        if mark is not None:
+            # PyYAML lines are 0-based internally; show 1-based to humans
+            line = mark.line + 1
+            col = mark.column + 1
+            msg.append(f"Location: line {line}, column {col}")
+
+            lines = text.splitlines()
+            start = max(0, mark.line - 2)
+            end = min(len(lines), mark.line + 3)
+
+            msg.append("Context:")
+            for i in range(start, end):
+                prefix = ">>" if i == mark.line else "  "
+                msg.append(f"{prefix} {i + 1:4d}: {lines[i]}")
+                if i == mark.line:
+                    msg.append(f"     {' ' * (col - 1)}^")
+
+        # Include the underlying YAML error message too
+        msg.append(f"YAML error: {e}")
+
+        # Fail pytest configuration cleanly (instead of INTERNALERROR)
+        raise pytest.UsageError("\n".join(msg)) from e
+
+
+def _iter_yaml_cases(rootpath: Path):
+    """
+    Yields tuples: (model, case_name, op_name, yaml_path, case)
+    Supports either:
+      - per-case 'op'
+      - or top-level 'op' applied to cases that don't specify 'op'
+    """
+    for p in sorted(_models_dir(rootpath).glob("*.yaml")):
+        if p.name.endswith("template.yaml"):  # skip template.yaml file
+            continue
+        spec = load_yaml_or_fail(p)
+        model = spec.get("model", p.stem)
+        top_op = spec.get("op", None)
+        for case in spec.get("cases", []):
+            op = case.get("op", top_op)
+            name = case.get("name", op or "<unnamed>")
+            yield model, name, op, p, case
+
+
+@pytest.fixture(scope="session")
+def selected_models(pytestconfig):
+    return set(pytestconfig.getoption("--model") or [])
+
+
+@pytest.fixture(scope="session")
+def dedupe_enabled(pytestconfig):
+    return bool(pytestconfig.getoption("dedupe"))
+
+
+@pytest.fixture(scope="session")
+def test_device_str(pytestconfig):
+    return "spyre"
+
+
+@pytest.fixture(scope="session")
+def seen_case_keys():
+    # track which case has been run to avoid rerun again
+    return set()
+
+
+@pytest.fixture(scope="session")
+def compile_backend(pytestconfig):
+    s = str(pytestconfig.getoption("--compile-backend") or "").strip()
+    return s or None
+
+
+def pytest_configure(config):
+    shared_config._PYTEST_CONFIG = config
+    # auto-register model_<name> markers based on YAML files
+    mdir = config.rootpath / "tests" / "_inductor" / "models"
+    for p in mdir.glob("*.yaml"):
+        spec = load_yaml_or_fail(p)
+        model = spec.get("model", p.stem)
+        mark = "model_" + "".join(
+            ch if ch.isalnum() or ch == "_" else "_" for ch in model
+        )
+        config.addinivalue_line(
+            "markers", f"{mark}: auto-generated mark for model {model}"
+        )
+
+
+def pytest_collection_modifyitems(config, items):
+    selected_models = config.getoption("--model") or []
+    if not selected_models:
+        return  # normal behavior
+
+    # Keep only model-yaml runner tests
+    keep = []
+    deselect = []
+
+    for item in items:
+        # item.nodeid includes the file path, e.g. "tests/_inductor/test_model_ops.py::test_model_ops[...]"
+        if "tests/_inductor/test_model_ops.py::" in item.nodeid:
+            keep.append(item)
+        else:
+            deselect.append(item)
+
+    if deselect:
+        config.hook.pytest_deselected(items=deselect)
+        items[:] = keep
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if not config.getoption("--show-skipped"):
+        return
+    skipped = terminalreporter.stats.get("skipped", [])
+    if not skipped:
+        return
+
+    terminalreporter.section("Skipped tests (full list)")
+    for rep in skipped:
+        # terminalreporter.write_line(rep)
+        terminalreporter.write_line(rep.nodeid)

--- a/tests/shared_config.py
+++ b/tests/shared_config.py
@@ -1,0 +1,1 @@
+_PYTEST_CONFIG = None


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This PR introduces a model-centric functional verification framework, built on pytest, to validate the correctness of individual Torch operators exercised by target models. The goal is to provide a more meaningful readiness signal for Spyre card support than existing PyTorch operator tests.

The operators under test, along with input arguments info (e.g. tensor shapes, and types), possibly with actual input values are extracted during model execution using an internal operator-extraction framework (out of scope for this PR). Additional design details and motivation are described in the [RFC document](https://github.com/torch-spyre/torch-spyre/blob/9631b9d130f5d1895f04d858db8eb5fc8cdb6ddf/RFCs/0186-TestFrameworks/0186-TestFrameworks.md)

- supported arguments: pass to pytest

```
--model <model-name>
--dedupe
--no-dedupe
--list-models
--list-cases
--compile-backend “inductor”
```

- structure of YAML file: to be added correspondingly

The test cases will be defined as part of YAML files under tests/_inductor/models. Currently, we have two files:

- gpt_oss.yaml _ which holds two test cases extracted from the GPT-oss model.
- template.yaml _ which holds examples that can be used in a YAML file. This file is not part of the test cases.

#### Which issue(s) this PR is related to:

This work builds on discussions with @thoangtrvn, @umacdevi, and @kiszk to analyze the core requirements for addressing the issue raised in https://github.com/torch-spyre/torch-spyre/issues/186. This PR introduces a YAML-based test framework that will serve as the foundation for a series of PRs adding extracted operations later. The new approach replaces PR https://github.com/torch-spyre/torch-spyre/pull/241, which is based on running hundreds of generated Python files. The existing method resulted in significant code duplication and an unmanageable volume of added code, making review impractical.

#### Special notes for your reviewer:

Using this framework, we have been able to quickly identify bugs that have not been detected by existing tests.
https://github.com/torch-spyre/torch-spyre/issues?q=state%3Aopen%20label%3A%22op%20coverage%20(models)%22

This framework is updated by exploiting `@ops` test framework in PyTorch

#### Does this PR introduce a user-facing change?

Yes, for running certain tests related to ops from models, we can make use of the new arguments to pytest shared above.

#### Additional note:

This PR is a follow-up of https://github.com/torch-spyre/torch-spyre/pull/323 since the branch is moved to at a cloned repository.
