### PR TITLE
bug fix for SpyreTensorLayout of scalar

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -31,8 +31,12 @@ class TestSpyreTensorLayout(TestCase):
     def test_initializes(self):
         self.assertEqual(torch._C._get_privateuse1_backend_name(), "spyre")
 
-    # Test generic stick shorthands
-    def test_generic_stick(self):
+    def test_default_layout(self):
+        stl = SpyreTensorLayout([], torch.float16)
+        self.assertEqual(stl.device_size, [1, 64])
+        self.assertEqual(stl.dim_map, [-1, -1])
+        self.assertEqual(stl.host_stick_dim(), None)
+
         stl = SpyreTensorLayout([128], torch.float16)
         self.assertEqual(stl.device_size, [2, 64])
         self.assertEqual(stl.dim_map, [0, 0])

--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -115,7 +115,7 @@ void SpyreTensorLayout::init(std::vector<int64_t> host_size,
     // Degenerate case of 0-dimension tensor (ie, a scalar)
     this->device_size.resize(2);
     this->dim_map.resize(2);
-    this->device_size[0] = this->elems_per_stick();
+    this->device_size[0] = 1;
     this->device_size[1] = this->elems_per_stick();
     this->dim_map[0] = -1;
     this->dim_map[1] = -1;


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The STL for a scalar should be the same as sparse 1-D tensor of size 1.
This avoids the need for any additional special case handling. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
