### PR TITLE
Implement torch.ones via identity broadcast

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -567,6 +567,18 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             },
         },
         (
+            "test_ones",
+            "test_ones_cpu",
+        ): {
+            "param_sets": {
+                "1d": ((64,),),
+                "2d_square": ((64, 64),),
+                "2d": ((64, 128),),
+                "3d": ((4, 3, 64),),
+                "2d_padded": ((3, 50),),
+            },
+        },
+        (
             "test_numel",
             "test_numel_cpu",
         ): {
@@ -1023,8 +1035,18 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         compare_with_cpu(fn, needs_device=True)
 
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_new_ones_cpu(self, x, y):
         compare_with_cpu(lambda x: x.new_ones((x.size())), x)
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_ones_cpu(self, size):
+        """Compiled torch.ones(size) on Spyre (identity broadcast) matches CPU."""
+
+        def fn(device=None):
+            return torch.ones(size, dtype=torch.float16, device=device)
+
+        compare_with_cpu(fn, needs_device=True, cpu_compile=False)
 
     def test_numel_cpu(self, x):
         compare_with_cpu(lambda x: torch.numel(x), x)

--- a/torch_spyre/_inductor/codegen/data_ops.py
+++ b/torch_spyre/_inductor/codegen/data_ops.py
@@ -941,7 +941,7 @@ def generate_identity(pointers, *, op, dimensions, inputs, outputs, **kwargs):
     cores = 1
 
     # Get operation dim map from the tensor that represents the operation space
-    op_dims_tensor = inputs[0]
+    op_dims_tensor = outputs[0]
     dl = op_dims_tensor["device_layout"]
     dim_map = dl.dim_map[::-1][1:]
     dim_labels = INPUT_DIM_LABELS[: ndim - 1] + OUTPUT_DIM_LABELS[:1]
@@ -1038,11 +1038,11 @@ def generate_identity(pointers, *, op, dimensions, inputs, outputs, **kwargs):
                                 "component_": "hbm"
                                 if tensor["lx_addr"] is None
                                 else "lx",
-                                "layoutDimOrder_": dim_infos.get_tensor_layout_order(
-                                    tensor
+                                "layoutDimOrder_": dim_infos.get_tensor_op_layout_order(
+                                    tensor, op
                                 ),
                                 "maxDimSizes_": [-1]
-                                * len(dim_infos.get_tensor_layout_order(tensor)),
+                                * len(dim_infos.get_tensor_op_layout_order(tensor, op)),
                                 "startAddressCoreCorelet_": {
                                     "dim_prop_func": [
                                         {"Map": {}},

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -228,3 +228,23 @@ def logical_not(input: torch.Tensor) -> torch.Tensor:
 @logical_not.register_fake
 def _(input: torch.Tensor):
     return input.new_empty(input.size())
+
+
+@torch.library.custom_op("spyre::ones_scalar", mutates_args=(), device_types="spyre")
+def spyre_ones_scalar(
+    device: torch.device,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """Return a 1-element tensor containing 1 on Spyre. Used for ones via identity broadcast."""
+    warn_fallback("torch.ops.spyre.ones_scalar")
+    out = torch.empty(1, dtype=dtype, device=device)
+    out.fill_(1)
+    return out
+
+
+@spyre_ones_scalar.register_fake
+def _ones_scalar_fake(
+    device: torch.device,
+    dtype: Optional[torch.dtype] = None,
+):
+    return torch.empty(1, dtype=dtype, device="spyre")

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -32,12 +32,8 @@ spyre_decompositions: dict = {}
 # Some Inductor decompositions do not work reliably on the Spyre backend yet.
 # We disable them here and rely on implicit fallbacks to eager ops instead. Once
 # the blocking issues are resolved, these exclusions can be removed.
-spyre_decompositions_to_exclude = [
-    # The default decomposition for torch.new_ones (defined in pytorch/torch/refs/__init__.py)
-    # uses torch.full, which is not yet supported in Spyre eager mode.
-    # See: https://github.com/torch-spyre/torch-spyre/issues/128#issuecomment-3576168221
-    torch.ops.aten.new_ones,
-]
+#
+spyre_decompositions_to_exclude: list = []
 
 
 def register_spyre_decomposition(
@@ -212,6 +208,43 @@ def rmsnorm_decomp(
 # single-element tensors well.
 # Ref: https://github.com/pytorch/pytorch/blob/v2.9.1/torch/_inductor/fx_passes/joint_graph.py#L324-L335
 #
+# Implement ones via identity broadcast: create a size-1 tensor (ones_scalar), expand to
+# target size, then clone (identity) to materialize. Clone op with identity is merged.
+@register_spyre_decomposition([torch.ops.aten.ones.default])
+def ones_decomp(
+    size: Union[list, tuple],
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: Optional[torch.layout] = None,
+    device: Optional[torch.device] = None,
+    pin_memory: Optional[bool] = None,
+) -> torch.Tensor:
+    assert layout in (torch.strided, None), f"doesn't support layout={layout}"
+    assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    scalar = torch.ops.spyre.ones_scalar(device, dtype=dtype)
+    expanded = scalar.expand(size)
+    return expanded.clone()
+
+
+@register_spyre_decomposition([torch.ops.aten.new_ones.default])
+def new_ones_decomp(
+    self: torch.Tensor,
+    size: Union[list, tuple],
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: Optional[torch.layout] = None,
+    device: Optional[torch.device] = None,
+    pin_memory: Optional[bool] = None,
+) -> torch.Tensor:
+    assert layout in (torch.strided, None), f"doesn't support layout={layout}"
+    assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
+    dev = device if device is not None else self.device
+    dt = dtype if dtype is not None else self.dtype
+    scalar = torch.ops.spyre.ones_scalar(dev, dtype=dt)
+    expanded = scalar.expand(size)
+    return expanded.clone()
+
+
 # To avoid constant folding, we introduce a custom op `spyre::full` that runs
 # torch.full on CPU and copies the result to Spyre. Remove this workaround once
 # Spyre supports one-element tensors.

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -42,7 +42,7 @@ from .constants import (
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .pass_utils import map_dims_to_vars, wildcard_symbol
+from .pass_utils import is_wildcard, map_dims_to_vars, wildcard_symbol
 from .stickify import is_sparse
 from .logging_utils import get_inductor_logger
 import logging
@@ -483,6 +483,13 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
                     #   - check that the input / output DimensionInfo are the same, but in different order.
                     #   - check that the dim map has the same dimensions (no duplicate dimensions), but device size differs.
                     op = TRANSPOSE_OP
+                elif all(is_wildcard(d.var) for d in in_di) and not all(
+                    is_wildcard(d.var) for d in out_di
+                ):
+                    # Broadcast: scalar input (all dims wildcards) expanding to non-scalar output.
+                    op = CLONE_OP
+                    in_di = out_di
+                    args[0] = self.create_tensor_arg(True, value.name, value, in_di)
                 elif in_stl.device_size == out_stl.device_size:
                     # Clone: check that device layout is the same.
                     op = CLONE_OP


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Implements torch.ones and tensor.new_ones on Spyre via identity broadcast: decompose to clone(expand(ones_scalar(), size)), add spyre.ones_scalar, handle expand-from-size-1 in stickify, and use existing clone/identity when input numel is 1 and output is full size. 

#### Which issue(s) this PR is related to:
Fixes https://github.com/torch-spyre/torch-spyre/issues/584

#### Special notes for your reviewer:
Reuses the existing clone/identity path (PR #812); only adds a broadcast variant (size-1 → full size).

#### Does this PR introduce a user-facing change?
Yes. torch.ones(..., device="spyre") and tensor.new_ones(...) work in eager and compiled mode on Spyre.

#### Additional note:
