### PR TITLE
fix: protect empty ops for unsupported dtypes

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -271,6 +271,27 @@ class TestSpyre(TestCase):
             t2 = t.to(device="spyre")  # noqa: F841
         assert len(rec) == 0
 
+    def test_allocation_and_copy_dtypes(self):
+        # allocation and device to host cases
+        for dtype in [torch.float16, torch.float32, torch.bool, torch.int8]:
+            x = torch.empty(64, dtype=dtype, device="spyre")
+            x.cpu()
+
+        for dtype in [torch.bfloat16, torch.float64]:
+            with self.assertRaises(RuntimeError):
+                x = torch.empty(64, dtype=dtype, device="spyre")
+                x.cpu()
+
+        # allocation and host to device cases
+        for dtype in [torch.float16, torch.float32, torch.bool, torch.int8]:
+            x = torch.empty(64, dtype=dtype)
+            x.to("spyre")
+
+        for dtype in [torch.bfloat16, torch.float64]:
+            with self.assertRaises(RuntimeError):
+                x = torch.empty(64, dtype=dtype)
+                x.to("spyre")
+
     def test_hooks_on_import(self):
         import torch
 

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -234,6 +234,15 @@ DataFormats get_device_dtype(c10::ScalarType torch_dtype) {
   return sen_dtype_dev;
 }
 
+bool is_supported_dtype(c10::ScalarType dtype) {
+  // TODO(kmehant,yoheiueda): Replace this heuristic with a reliable method to
+  // determine supported dtypes. Using elems_per_stick can miss certain
+  // unsupported dtypes. See #950
+  DataFormats sen_dtype_dev = get_device_dtype(dtype);
+  return sen_dtype_dev != DataFormats::INVALID &&
+         elems_per_stick(sen_dtype_dev) > 0;
+}
+
 }  // namespace spyre
 
 PYBIND11_MODULE(_C, m) {

--- a/torch_spyre/csrc/module.h
+++ b/torch_spyre/csrc/module.h
@@ -52,5 +52,6 @@ class GlobalRuntime {
   }
 };
 bool get_downcast_warn_enabled();
+bool is_supported_dtype(c10::ScalarType dtype);
 
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -424,7 +424,6 @@ auto copy_host_to_device(const at::Tensor& self, const at::Tensor& dst) {
     DEBUGINFO("GraphLoader is null!");
     return;
   }
-
   // execute
   constexpr int sn_idx = 0;
   constexpr int tensor_idx = 0;
@@ -539,6 +538,8 @@ at::Tensor spyre_empty(c10::IntArrayRef size,
               "Non strided layout not supported");
   TORCH_CHECK(!c10::pinned_memory_or_default(pin_memory_opt),
               "Pin memory can only be on CPU");
+  TORCH_CHECK(spyre::is_supported_dtype(dtype),
+              "Spyre backend does not support dtype ", dtype);
   const c10::DeviceGuard device_guard(device);
 
   auto device_layout = SpyreTensorLayout(size.vec(), dtype);
@@ -577,6 +578,8 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
   // SETUP FOR Spyre TENSOR
   at::detail::check_size_nonnegative(size);
   const auto scalar_type = c10::dtype_or_default(dtype_opt);
+  TORCH_CHECK(spyre::is_supported_dtype(scalar_type),
+              "Spyre backend does not support dtype ", scalar_type);
   caffe2::TypeMeta dtype = c10::scalarTypeToTypeMeta(scalar_type);
   c10::Device device = device_opt.value_or(
       c10::impl::VirtualGuardImpl{c10::DeviceType::PrivateUse1}.getDevice());
@@ -732,6 +735,8 @@ at::Tensor empty_with_layout(
               "Non strided layout not supported");
   TORCH_CHECK(!c10::pinned_memory_or_default(pin_memory_opt),
               "Pin memory can only be on CPU");
+  TORCH_CHECK(spyre::is_supported_dtype(dtype),
+              "Spyre backend does not support dtype ", dtype);
   const c10::DeviceGuard device_guard(device);
 
   size_t size_bytes = get_device_size_in_bytes(device_layout);


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug (protects from crashes when using ops with unsupported dtypes)
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Empty operations currently fail without proper handling when used with unsupported dtypes, this PR handles this by protecting the empty aten ops with dtype checks which otherwise crashes. This is essential for forthcoming testing effort and avoiding abrupt crashes. 


cc: @ashokponkumar @ChanderG 