### PR TITLE
Enable multi KernelSpec inductor kernels on SDSC path

### DIFF
--- a/torch_spyre/_inductor/runtime/async_compile.py
+++ b/torch_spyre/_inductor/runtime/async_compile.py
@@ -22,11 +22,14 @@ from torch._inductor.runtime.runtime_utils import cache_dir
 from torch_spyre._C import convert_artifacts
 from torch_spyre._inductor.codegen.superdsc import generate_sdsc
 from torch_spyre._inductor.constants import SEGMENT_OFFSETS
+from torch_spyre._inductor.logging_utils import get_inductor_logger
 from . import KernelSpec, ConstantArg, UnimplementedOp
 from .kernel_runner import (
     SpyreSDSCKernelRunner,
     SpyreUnimplementedRunner,
 )
+
+logger = get_inductor_logger("sdsc_compile")
 
 _argument_names = ["arg0", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6"]
 
@@ -42,67 +45,78 @@ class SpyreAsyncCompile:
     def __init__(self) -> None:
         pass
 
-    def sdsc(self, kernel_name: str, ks: Union[KernelSpec | UnimplementedOp]):
-        if isinstance(ks, UnimplementedOp):
-            print(f"WARNING: Compiling unimplemented {ks.op} to runtime exception")
-            return SpyreUnimplementedRunner(kernel_name, ks.op)
+    def sdsc(self, kernel_name: str, specs: list[Union[KernelSpec | UnimplementedOp]]):
+        # 1. Generate SDSC.json for each KernelSpec
+        sdsc_dirs = []
+        arg_mappings = []
+        for ks in specs:
+            if isinstance(ks, UnimplementedOp):
+                print(f"WARNING: Compiling unimplemented {ks.op} to runtime exception")
+                return SpyreUnimplementedRunner(kernel_name, ks.op)
 
-        inputs = []
-        outputs = []
-        arg_mapping = []
-        for index, ts in enumerate(ks.args):
-            # use node seq (idx in nodes) to verify whether to reuse lx for this buffer,
-            # in case same Op used twice in sequence and only want pin 1 of them
-            lx_addr = None
-            for k, addr in getattr(ts, "allocation", {}).items():
-                if kernel_name.split("_")[-1] == k.replace("lx:", ""):
-                    lx_addr = addr
+            inputs = []
+            outputs = []
+            arg_map = []
+            for index, ts in enumerate(ks.args):
+                # use node seq (idx in nodes) to verify whether to reuse lx for this buffer,
+                # in case same Op used twice in sequence and only want pin 1 of them
+                lx_addr = None
+                for k, addr in getattr(ts, "allocation", {}).items():
+                    if kernel_name.split("_")[-1] == k.replace("lx:", ""):
+                        lx_addr = addr
 
-            if isinstance(ts, ConstantArg):
-                raise RuntimeError("TOOO: implement SDSC generation for constants")
-            elif ts.is_input:
-                inputs.append(
-                    {
-                        "name": _argument_names[index],
-                        "scale": ts.it_dim_map,
-                        "device_layout": ts.device_layout,
-                        "host_size": ts.host_size,
-                        "lx_addr": lx_addr,
-                    }
-                )
-                arg_mapping.append(ts.arg_index)
-            else:
-                outputs.append(
-                    {
-                        "name": _argument_names[index],
-                        "scale": ts.it_dim_map,
-                        "device_layout": ts.device_layout,
-                        "host_size": ts.host_size,
-                        "lx_addr": lx_addr,
-                    }
-                )
-                arg_mapping.append(ts.arg_index)
-        kernel_descriptor = {
-            "name": kernel_name,
-            "reduction": ks.is_reduction,
-            "op": ks.op,
-            "dimensions": ks.iteration_space,
-            "inputs": inputs,
-            "outputs": outputs,
-        }
-        if ks.op_info is not None:
-            kernel_descriptor["op_info"] = ks.op_info
-        pointers = dict(zip(_argument_names, SEGMENT_OFFSETS))
-        dt_sdsc = generate_sdsc(pointers, **kernel_descriptor)
-        kernel_output_dir = get_output_dir(kernel_name)
-        subdir = os.path.join(kernel_output_dir, "execute", kernel_name)
-        os.makedirs(subdir, exist_ok=True)
-        with open(os.path.join(subdir, "sdsc.json"), "w") as file:
-            print(f"Generating {file.name}")
-            json.dump(dt_sdsc, file, indent=2)
-        subprocess.run(["dxp_standalone", "-d", kernel_output_dir], check=True)
-        convert_artifacts(kernel_output_dir)
-        return SpyreSDSCKernelRunner(kernel_name, kernel_output_dir, arg_mapping)
+                if isinstance(ts, ConstantArg):
+                    raise RuntimeError("TOOO: implement SDSC generation for constants")
+                elif ts.is_input:
+                    inputs.append(
+                        {
+                            "name": _argument_names[index],
+                            "scale": ts.it_dim_map,
+                            "device_layout": ts.device_layout,
+                            "host_size": ts.host_size,
+                            "lx_addr": lx_addr,
+                        }
+                    )
+                    arg_map.append(ts.arg_index)
+                else:
+                    outputs.append(
+                        {
+                            "name": _argument_names[index],
+                            "scale": ts.it_dim_map,
+                            "device_layout": ts.device_layout,
+                            "host_size": ts.host_size,
+                            "lx_addr": lx_addr,
+                        }
+                    )
+                    arg_map.append(ts.arg_index)
+            kernel_descriptor = {
+                "name": kernel_name,
+                "reduction": ks.is_reduction,
+                "op": ks.op,
+                "dimensions": ks.iteration_space,
+                "inputs": inputs,
+                "outputs": outputs,
+            }
+            if ks.op_info is not None:
+                kernel_descriptor["op_info"] = ks.op_info
+            pointers = dict(zip(_argument_names, SEGMENT_OFFSETS))
+            dt_sdsc = generate_sdsc(pointers, **kernel_descriptor)
+            kernel_output_dir = get_output_dir(kernel_name)
+            subdir = os.path.join(kernel_output_dir, "execute", kernel_name)
+            os.makedirs(subdir, exist_ok=True)
+            with open(os.path.join(subdir, "sdsc.json"), "w") as file:
+                logger.info(f"Generating {file.name}")
+                json.dump(dt_sdsc, file, indent=2)
+            sdsc_dirs.append(kernel_output_dir)
+            arg_mappings.append(arg_map)
+
+        # 2. Invoke the backend compiler on each sdsc.json
+        for dir in sdsc_dirs:
+            subprocess.run(["dxp_standalone", "-d", dir], check=True)
+            convert_artifacts(dir)
+
+        # 3. Construct the KernelRunner
+        return SpyreSDSCKernelRunner(kernel_name, sdsc_dirs, arg_mappings)
 
     def wait(self, scope: dict[str, Any]) -> None:
         pass

--- a/torch_spyre/_inductor/runtime/kernel_runner.py
+++ b/torch_spyre/_inductor/runtime/kernel_runner.py
@@ -31,13 +31,14 @@ class SpyreUnimplementedRunner:
 
 
 class SpyreSDSCKernelRunner:
-    def __init__(self, name: str, code_dir: str, arg_mapping: list[int]):
+    def __init__(self, name: str, code_dirs: list[str], arg_mappings: list[list[int]]):
         self.kernel_name = name
-        self.code_dir = code_dir
-        self.arg_mapping = arg_mapping
+        self.code_dirs = code_dirs
+        self.arg_mappings = arg_mappings
 
     def run(self, *args, **kw_args):
-        g2 = os.path.join(self.code_dir, "g2.graph.cbor")
-        logger.info(f"RUN: {self.kernel_name} {g2}")
-        actuals = [args[i] for i in self.arg_mapping]
-        return launch_kernel(g2, actuals)
+        for i in range(len(self.code_dirs)):
+            g2 = os.path.join(self.code_dirs[i], "g2.graph.cbor")
+            logger.info(f"RUN: {self.kernel_name}_{i} {g2}")
+            actuals = [args[i] for i in self.arg_mappings[i]]
+            launch_kernel(g2, actuals)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -711,37 +711,36 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
             return [DimensionInfo(wildcard_symbol(0), 1)]
 
     def codegen_kernel(self):
-        """Codegen the body of this kernel by pretty printing its KernelSpec"""
+        """Codegen the body of this kernel by pretty printing its list of KernelSpecs"""
         buf = IndentedBuffer()
-        if len(self.kernel_specs) != 1:
-            raise Unsupported(f"found {len(self.kernel_specs)} KernelSpecs")
-        ks = self.kernel_specs[0]
+        buf.writeline("[")
+        with buf.indent():
+            for ks in self.kernel_specs:
+                if logger.isEnabledFor(logging.DEBUG):
+                    if isinstance(ks, UnimplementedOp):
+                        logger.debug(f"kernel_spec: UnimplementedOp({ks.op})")
+                    else:
+                        logger.debug(
+                            f"kernel_spec: {ks.op}, is_reduction={ks.is_reduction}, "
+                            f"iteration_space={ks.iteration_space}, op_info={ks.op_info}"
+                        )
 
-        if logger.isEnabledFor(logging.DEBUG):
-            if isinstance(ks, UnimplementedOp):
-                logger.debug(f"kernel_spec: UnimplementedOp({ks.op})")
-            else:
-                logger.debug(
-                    f"kernel_spec: {ks.op}, is_reduction={ks.is_reduction}, "
-                    f"iteration_space={ks.iteration_space}, op_info={ks.op_info}"
-                )
-
-        if isinstance(ks, UnimplementedOp):
-            buf.writeline(f"UnimplementedOp(op='{ks.op}')")
-        else:
-            buf.writeline("KernelSpec(")
-            with buf.indent():
-                buf.writeline(f"op='{ks.op}',")
-                buf.writeline(f"is_reduction={ks.is_reduction},")
-                buf.writeline(f"iteration_space={ks.iteration_space!r},")
-                buf.writeline(f"op_info={ks.op_info!r},")
-                buf.writeline("args=[")
-                with buf.indent():
-                    for arg in ks.args:
-                        buf.writeline(f"{arg!r},")
-                buf.writeline("]")
-            buf.writeline(")")
-
+                if isinstance(ks, UnimplementedOp):
+                    buf.writeline(f"UnimplementedOp(op='{ks.op}')")
+                else:
+                    buf.writeline("KernelSpec(")
+                    with buf.indent():
+                        buf.writeline(f"op='{ks.op}',")
+                        buf.writeline(f"is_reduction={ks.is_reduction},")
+                        buf.writeline(f"iteration_space={ks.iteration_space!r},")
+                        buf.writeline(f"op_info={ks.op_info!r},")
+                        buf.writeline("args=[")
+                        with buf.indent():
+                            for arg in ks.args:
+                                buf.writeline(f"{arg!r},")
+                        buf.writeline("]")
+                    buf.writeline("),")
+        buf.writeline("]")
         return buf.getvalue()
 
     def call_kernel(self, name: str, node=None):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Unblocks the inductor level work on enabling fusion by allowing a single Kernel to be compiled into multiple KernelSpecs. At the async_compile/KernelRunner level, we use a sequence of dxp_standalone and launch_kernel operations to compile and run using an unchanged SDSC-based backend compiler and runtime.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Fixes #349 

#### Special notes for your reviewer:
```
===================================================================================================================== test session starts ======================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 445 items                                                                                                                                                                                                                                            

tests/_inductor/test_building_blocks.py ....                                                                                                                                                                                                             [  0%]
tests/_inductor/test_inductor_decomp.py ..                                                                                                                                                                                                               [  1%]
tests/_inductor/test_inductor_ops.py ...s............................................................................................................................................................................................................... [ 48%]
...........................................................................................                                                                                                                                                              [ 69%]
tests/_inductor/test_logging.py ....                                                                                                                                                                                                                     [ 70%]
tests/tensor/test_tensor_layout.py ...............                                                                                                                                                                                                       [ 73%]
tests/test_fallbacks.py ........                                                                                                                                                                                                                         [ 75%]
tests/test_modules.py .sssss.                                                                                                                                                                                                                            [ 76%]
tests/test_ops.py .x.s..xs...s........................s...sss.ss.....................................                                                                                                                                                    [ 95%]
tests/test_regex.py .                                                                                                                                                                                                                                    [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                                                                                                                   [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                        [100%]

==================================================================================================== 425 passed, 18 skipped, 2 xfailed in 381.90s (0:06:21) ====================================================================================================


```
#### Does this PR introduce a user-facing change?

#### Additional note:
