### PR TITLE
Add batch_norm decomposition for Spyre

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -880,6 +880,38 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "4d": (cached_randn((4, 17, 256, 128), dtype=torch.float16),),
             },
         },
+        ("test_batchnorm", "test_batchnorm_cpu"): {
+            # TODO: Using eps=1e-4 instead of default 1e-5 because our batch_norm
+            # implementation operates internally in float16 (unlike the original which uses
+            # float32). Once float16/float32 type conversion is implemented, this can be
+            # decreased. See #937
+            "param_sets": {
+                "2d": (
+                    cached_randn((2, 2048), dtype=torch.float16),  # input
+                    cached_randn(2048, scale=1.00, dtype=torch.float16),  # mean
+                    cached_randn(2048, abs=True, dtype=torch.float16),  # var
+                    cached_randn(2048, scale=0.99, dtype=torch.float16),  # weight
+                    cached_randn(2048, scale=1.01, dtype=torch.float16),  # bias
+                    1e-4,  # eps
+                ),
+                "3d": (
+                    cached_randn((2, 2048, 896), dtype=torch.float16),  # input
+                    cached_randn(2048, scale=1.00, dtype=torch.float16),  # mean
+                    cached_randn(2048, abs=True, dtype=torch.float16),  # var
+                    cached_randn(2048, scale=0.99, dtype=torch.float16),  # weight
+                    cached_randn(2048, scale=1.01, dtype=torch.float16),  # bias
+                    1e-4,  # eps
+                ),
+                "4d": (
+                    cached_randn((2, 2048, 64, 64), dtype=torch.float16),  # input
+                    cached_randn(2048, scale=1.00, dtype=torch.float16),  # mean
+                    cached_randn(2048, abs=True, dtype=torch.float16),  # var
+                    cached_randn(2048, scale=0.99, dtype=torch.float16),  # weight
+                    cached_randn(2048, scale=1.01, dtype=torch.float16),  # bias
+                    1e-4,  # eps
+                ),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -1086,6 +1118,15 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return torch.nn.functional.rms_norm(input, [input.shape[-1]], eps=1e-6)
 
         compare_with_cpu(fn, x)
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_batchnorm_cpu(self, input, mean, var, weight, bias, eps):
+        def fn(input, mean, var, weight, bias):
+            return torch.nn.functional.batch_norm(
+                input, mean, var, weight, bias, eps=eps
+            )
+
+        compare_with_cpu(fn, input, mean, var, weight, bias)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_implicit_loading(self):

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -362,3 +362,46 @@ def logical_not_decomp(input: torch.Tensor) -> torch.Tensor:
     else:
         zero = torch.zeros_like(input)
     return torch.eq(input, zero)
+
+
+@register_spyre_decomposition(
+    [torch.ops.aten._native_batch_norm_legit_no_training.default]
+)
+def batch_norm_decomp(
+    input: torch.Tensor,
+    weight: Optional[torch.Tensor],
+    bias: Optional[torch.Tensor],
+    running_mean: torch.Tensor,
+    running_var: torch.Tensor,
+    momentum: float,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Based on upstream PyTorch decomposition:
+    # https://github.com/pytorch/pytorch/blob/v2.10.0/torch/_decomp/decompositions.py#L1932-L1969
+
+    # TODO: Upstream uses float32 internally. Add float16/float32 type conversion
+    # once implemented. See #937
+
+    # TODO: Replace full_like CPU-fallback with scalar constant once constant
+    # arguments are supported. See #238
+    e = torch.full_like(running_var, eps)
+
+    invstd = running_var.add(e).sqrt().reciprocal()
+
+    # TODO: Using transpose instead of unsqueeze because unsqueeze requires
+    # restickify. See #738
+    input = input.transpose(1, -1).contiguous()
+
+    output = (input - running_mean) * invstd
+
+    if weight is not None:
+        weight = weight.flatten()
+        output = output * weight
+
+    if bias is not None:
+        bias = bias.flatten()
+        output = output + bias
+
+    output = output.transpose(1, -1).contiguous()
+
+    return (output, running_mean, invstd)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Implements custom batch normalization decomposition for Spyre based on upstream PyTorch's implementation.

- Based on [upstream PyTorch v2.10.0](https://github.com/pytorch/pytorch/blob/v2.10.0/torch/_decomp/decompositions.py#L1932-L1969)
- Operates in float16 (vs upstream's float32) due to pending type conversion support
    - See #937
- Uses `transpose` instead of `unsqueeze` to avoid restickify requirement
- Uses `eps=1e-4` in tests instead of default `1e-5` for float16 precision

#### Which issue(s) this PR is related to:

Fixes  #149 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

```
(dt-inductor) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 460 items

tests/_inductor/test_building_blocks.py ....                                                                                                                     [  0%]
tests/_inductor/test_inductor_decomp.py ...                                                                                                                      [  1%]
tests/_inductor/test_inductor_ops.py ...s....................................................................................................................... [ 28%]
................................................................................................................................................................ [ 63%]
................................                                                                                                                                 [ 70%]
tests/_inductor/test_logging.py ....                                                                                                                             [ 70%]
tests/tensor/test_tensor_layout.py ...............                                                                                                               [ 74%]
tests/test_fallbacks.py ........                                                                                                                                 [ 75%]
tests/test_modules.py .sssss.                                                                                                                                    [ 77%]
tests/test_ops.py .x.s..xs...s........................s...sss.ss......................................                                                           [ 95%]
tests/test_regex.py .                                                                                                                                            [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                           [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                [100%]

======================================================== 440 passed, 18 skipped, 2 xfailed in 411.34s (0:06:51) ========================================================
```