### PR TITLE
Remove generic stick assumption in SDSC reduction codegen

### DIFF
--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -519,7 +519,8 @@ def generate_sfp_op(pointers, *, op, dimensions, inputs, outputs, reduction, **k
         cores = 1
         dim_splits = [1] * ndim
 
-    if reduction and tensors[-1]["scale"][-1] >= 0:
+    # If the output tensor is sparse, then this is a stick reduction.
+    if reduction and tensors[-1]["device_layout"].host_stick_dim() is not None:
         op += "nonstick"
 
     # Get operation dim map from the tensor that represents the operation space


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

Fixes #944 

#### Special notes for your reviewer:
```
============================================================================================================================================ test session starts ============================================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 457 items                                                                                                                                                                                                                                                                                         

tests/_inductor/test_building_blocks.py ....                                                                                                                                                                                                                                                          [  0%]
tests/_inductor/test_inductor_decomp.py ...                                                                                                                                                                                                                                                           [  1%]
tests/_inductor/test_inductor_ops.py ...s............................................................................................................................................................................................................................................................ [ 57%]
........................................................                                                                                                                                                                                                                                              [ 69%]
tests/_inductor/test_logging.py ....                                                                                                                                                                                                                                                                  [ 70%]
tests/tensor/test_tensor_layout.py ...............                                                                                                                                                                                                                                                    [ 73%]
tests/test_fallbacks.py ........                                                                                                                                                                                                                                                                      [ 75%]
tests/test_modules.py .sssss.                                                                                                                                                                                                                                                                         [ 77%]
tests/test_ops.py .x.s..xs...s........................s...sss.ss......................................                                                                                                                                                                                                [ 95%]
tests/test_regex.py .                                                                                                                                                                                                                                                                                 [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                                                                                                                                                                [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                                                                     [100%]

========================================================================================================================== 437 passed, 18 skipped, 2 xfailed in 362.68s (0:06:02) ===========================================================================================================================

```
#### Does this PR introduce a user-facing change?

#### Additional note:
