### PR TITLE
Test torch.permute

### DIFF
--- a/tests/_inductor/test_inductor_ops.py
+++ b/tests/_inductor/test_inductor_ops.py
@@ -524,6 +524,18 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             },
         },
         (
+            "test_permute",
+            "test_permute",
+        ): {
+            "param_sets": {
+                "4d_0_2_1_3": ((2, 3, 16, 64), (0, 2, 1, 3)),
+                "3d_0_2_1": ((2, 1024, 844), (0, 2, 1)),
+                "4d_0_3_1_2": ((2, 2, 256, 48), (0, 3, 1, 2)),
+                "4d_0_m2_m1_1": ((2, 48, 2, 256), (0, -2, -1, 1)),
+                "5d_0_2_3_4_1": ((2, 48, 2, 256, 265), (0, 2, 3, 4, 1)),
+            },
+        },
+        (
             "test_fallback",
             "test_fallback_cpu",
         ): {
@@ -966,6 +978,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     )
     def test_clone(self, x):
         compare_with_cpu(lambda a: torch.clone(a).contiguous(), x)
+
+    def test_permute(self, input_dims, dims):
+        compare_with_cpu(
+            lambda input: torch.permute(input, dims),
+            cached_randn(input_dims, dtype=torch.float16),
+        )
 
     def test_dropout_functional(self, input, kwargs):
         compare_with_cpu(lambda a: torch.nn.functional.dropout(a, **kwargs), input)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Tests [torch.permute](https://docs.pytorch.org/docs/stable/generated/torch.permute.html) by using inductor.

#### Which issue(s) this PR is related to:

Closes #230.

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
No.

#### Additional note:
```
((dti-venv) ) [inagaki@inagaki-pod torch-spyre]$ pytest
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/inagaki/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 462 items

tests/_inductor/test_building_blocks.py ....                                                                                                                                                                [  0%]
tests/_inductor/test_inductor_decomp.py ...                                                                                                                                                                 [  1%]
tests/_inductor/test_inductor_ops.py ...s.................................................................................................................................................................. [ 37%]
.......................................................................................................................................................                                                     [ 70%]
tests/_inductor/test_logging.py ....                                                                                                                                                                        [ 70%]
tests/tensor/test_tensor_layout.py ...............                                                                                                                                                          [ 74%]
tests/test_fallbacks.py ........                                                                                                                                                                            [ 75%]
tests/test_modules.py .sssss.                                                                                                                                                                               [ 77%]
tests/test_ops.py .x.s..xs...s........................s...sss.ss......................................                                                                                                      [ 95%]
tests/test_regex.py .                                                                                                                                                                                       [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                                                                      [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                           [100%]

============================================================================= 442 passed, 18 skipped, 2 xfailed in 342.98s (0:05:42) ==============================================================================
((dti-venv) ) [inagaki@inagaki-pod torch-spyre]$
```