### PR TITLE
Add profiler research docs for cuda and other accelerators

### DIFF
--- a/docs/profiler/accelerator_specific_profiling.md
+++ b/docs/profiler/accelerator_specific_profiling.md
@@ -62,6 +62,7 @@ Additionally, **Google TPU** uses a completely separate profiling path via **XPr
 - No driver-level API tracing
 
 ### Chrome Trace JSON Differences (vs CUDA)
+
 ```
 CUDA kernel args:
   "registers per thread": 86, "shared memory": 32768,
@@ -100,6 +101,7 @@ The standalone `rocprof` CLI can capture hardware counters NOT available in PyTo
 - Visualization via **TensorBoard** with `tensorboard-plugin-profile`
 
 ### How to Profile
+
 ```python
 import torch_xla.debug.profiler as xp
 

--- a/docs/profiler/cuda_profiler_details.md
+++ b/docs/profiler/cuda_profiler_details.md
@@ -253,6 +253,7 @@ The correlation chain:
 
 ### With `with_stack=True`:
 Each event additionally captures Python source location:
+
 ```python
 # Example from key_averages().table(sort_by="cuda_time_total", row_limit=10)
 # Name    | Source Location
@@ -262,12 +263,14 @@ Each event additionally captures Python source location:
 
 ### With `with_flops=True`:
 FLOPS estimates for supported ops (matmul, conv2d, BMM):
+
 ```
 aten::addmm  | 81920 FLOPS  (M=32, K=128, N=10 -> 2*M*K*N)
 ```
 
 ### With `with_modules=True`:
 Module hierarchy for TorchScript models:
+
 ```
 nn.Module: Linear | aten::addmm
 ```


### PR DESCRIPTION
Resolves #855                                                                            
                                                                                           
  #### What type of PR is this?                                                            
                                                                                           
  - [ ] bug                                                                                
  - [ ] feature                                                                            
  - [x] documentation                                                                      
  - [ ] cleanup

  #### What this PR does:

  Documents PyTorch profiler capabilities across different accelerator backends:
  - Per-kernel profiler details for CUDA (trace from MLP on Tesla T4, CUDA 12.08, CUPTI
  v26)
  - CPU-GPU call trace hierarchy captured by PyTorch profiler
  - Cross-accelerator comparison (CUDA, ROCm, Intel XPU, Google TPU, Habana HPU, Meta MTIA)
   with source links to GitHub repos and documentation

  Files added:
  - `cuda_profiler_details.md` - Merged per-kernel details & CPU-CUDA call traces
  - `accelerator_specific_profiling.md` - Accelerator comparison with source references

  #### Which issue(s) this PR is related to:

  Resolves #855

  #### Special notes for your reviewer:

  Information was gathered from PyTorch/Kineto source code and official documentation for
  each accelerator's profiling backend. Source links are included for each accelerator.

  #### Does this PR introduce a user-facing change?

  No

  #### Additional note:

  None