### PR TITLE
Remove host size from check for data operations

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -479,7 +479,7 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
                 if (
                     Counter(in_stl.dim_map) == Counter(out_stl.dim_map)
                     and in_stl.device_size != out_stl.device_size
-                ) or in_di != out_di:
+                ) or (Counter(in_di) == Counter(out_di) and in_di != out_di):
                     # Transpose:
                     #   - check that the input / output DimensionInfo are the same, but in different order.
                     #   - check that the dim map has the same dimensions (no duplicate dimensions), but device size differs.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR removes the use of the CPU size when determining which data operation to use. With the right STLs (i.e., dim maps that reflect the transposition), we could remove the comparison of the input/output `DimensionInfos`. However, this check is required currently as the `SpyreTensorLayouts` for the input and output are currently identical when the transposed dimensions are the same size.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
```
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/avery/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 462 items                                                                                                                                                                                                                                                                                                                                                      

torch-spyre/tests/_inductor/test_building_blocks.py ....                                                                                                                                                                                                                                                                                                           [  0%]
torch-spyre/tests/_inductor/test_inductor_decomp.py ...                                                                                                                                                                                                                                                                                                            [  1%]
torch-spyre/tests/_inductor/test_inductor_ops.py ...s............................................................................................................................................................................................................................................................................................................. [ 67%]
............                                                                                                                                                                                                                                                                                                                                                       [ 70%]
torch-spyre/tests/_inductor/test_logging.py ....                                                                                                                                                                                                                                                                                                                   [ 70%]
torch-spyre/tests/tensor/test_tensor_layout.py ...............                                                                                                                                                                                                                                                                                                     [ 74%]
torch-spyre/tests/test_fallbacks.py ........                                                                                                                                                                                                                                                                                                                       [ 75%]
torch-spyre/tests/test_modules.py .sssss.                                                                                                                                                                                                                                                                                                                          [ 77%]
torch-spyre/tests/test_ops.py .x.s..xs...s........................s...sss.ss......................................                                                                                                                                                                                                                                                 [ 95%]
torch-spyre/tests/test_regex.py .                                                                                                                                                                                                                                                                                                                                  [ 95%]
torch-spyre/tests/test_spyre.py .s..ss............                                                                                                                                                                                                                                                                                                                 [ 99%]
torch-spyre/tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                                                                                                                      [100%]

========================================================================================================================================================= 442 passed, 18 skipped, 2 xfailed in 356.58s (0:05:56) =========================================================================================================================================================
```