### PR TITLE
cleanup: remove host_size from TensorArg

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -387,7 +387,6 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
             is_input,
             -1,
             tensor.layout.dtype,
-            tensor.layout.size,
             scales,
             tensor.layout.allocation,
             tensor.layout.device_layout,

--- a/torch_spyre/execution/__init__.py
+++ b/torch_spyre/execution/__init__.py
@@ -27,12 +27,10 @@ class TensorArg:
         is_input: Is the Tensor used as an input to the operation?
         arg_index: The index of the Tensor in the argument array of the Kernel.
         dtype: The PyTorch (host) dtype of the tensor elements.
-        host_size: The PyTorch (host) size of the Tensor.
         it_dim_map: A mapping between the op's iteration_space and the PyTorch (host) dimensions of the Tensor.
             it_dim_map[d] is an integer that is interpreted as follows:
                 -1 indicates the the d-th dimension of ks.iteration_space is a broadcast or reduction dimension for this Tensor.
                 A non-negative value is the PyTorch (host) dimension of the Tensor that corresponds to the d-th dimension of ks.iteration_space.
-                For non-negative values it must be true that ks.iteration_space[d] == host_size[it_dim_map[d]].
         allocation: If present, the offset in scratchpad memory assigned to the Tensor.
         device_layout: The SpyreTensorLayout describe the device shape of the Tensor.
     """
@@ -40,7 +38,6 @@ class TensorArg:
     is_input: bool
     arg_index: int
     dtype: torch.dtype
-    host_size: torch.Size
     it_dim_map: list[int]
     allocation: Any
     device_layout: SpyreTensorLayout


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Remove the `host_size` field from TensorArg.  This field is not needed for codegen and in the presence of views
is confusing as it describes the `size` of the tensor as it exists in memory/scratchpad not as it is used in the operation.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
