### PR TITLE
Project llir index to host/device coordinates

### DIFF
--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -19,7 +19,7 @@ from typing import Sequence
 
 
 def compute_relative_stride(
-    rank: int, device_size: Sequence[int], dim_map: Sequence[int]
+    rank: int, device_size: Sequence[sympy.Expr], dim_map: Sequence[int]
 ) -> list[sympy.Expr]:
     """
     Compute strides of device dimensions with respect to host dimensions

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -14,22 +14,32 @@
 
 # Helper methods to handle views
 
+import sympy
+from typing import Sequence
 
-def compute_relative_stride(rank, device_size, dim_map):
+
+def compute_relative_stride(
+    rank: int, device_size: Sequence[int], dim_map: Sequence[int]
+) -> list[sympy.Expr]:
     """
     Compute strides of device dimensions with respect to host dimensions
     """
     acc = [1] * rank
-    rel_stride = [None] * len(dim_map)
+    rel_stride = [-1] * len(dim_map)
     for device_dim in range(len(dim_map) - 1, -1, -1):
         dim = dim_map[device_dim]
-        if dim is not None:
+        if dim != -1:
             rel_stride[device_dim] = acc[dim]
             acc[dim] *= device_size[device_dim]
     return rel_stride
 
 
-def compute_coordinates(size, stride, var_ranges, index):
+def compute_coordinates(
+    size: Sequence[sympy.Expr],
+    stride: Sequence[sympy.Expr],
+    var_ranges: dict[sympy.Symbol, sympy.Expr],
+    index: sympy.Expr,
+) -> list[sympy.Expr]:
     """
     Derive an array of coordinate expressions into a tensor from an index
     """
@@ -42,7 +52,7 @@ def compute_coordinates(size, stride, var_ranges, index):
         step = term.subs(var, 1)
         limit = term.subs(var, var_ranges[var])
         primary_stride = 0
-        primary_dim = None
+        primary_dim = -1
         for dim in range(len(size)):
             if size[dim] == 1:
                 continue
@@ -56,7 +66,14 @@ def compute_coordinates(size, stride, var_ranges, index):
     return coordinates
 
 
-def compute_device_coordinates(size, stride, device_size, dim_map, var_ranges, index):
+def compute_device_coordinates(
+    size: Sequence[sympy.Expr],
+    stride: Sequence[sympy.Expr],
+    device_size: Sequence[sympy.Expr],
+    dim_map: Sequence[int],
+    var_ranges: dict[sympy.Symbol, sympy.Expr],
+    index: sympy.Expr,
+) -> list[sympy.Expr]:
     """
     Derive an array of coordinate expressions into a device tensor from an index
     """
@@ -64,6 +81,8 @@ def compute_device_coordinates(size, stride, device_size, dim_map, var_ranges, i
     host_coordinates = compute_coordinates(size, stride, var_ranges, index)
     coordinates = [0] * len(device_size)
     for dim in range(len(device_size)):
+        if dim_map[dim] == -1:
+            continue
         expr = host_coordinates[dim_map[dim]]
         vars = expr.free_symbols
         for var in vars:

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -1,0 +1,75 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper methods to handle views
+
+
+def compute_relative_stride(rank, device_size, dim_map):
+    """
+    Compute strides of device dimensions with respect to host dimensions
+    """
+    acc = [1] * rank
+    rel_stride = [None] * len(dim_map)
+    for device_dim in range(len(dim_map) - 1, -1, -1):
+        dim = dim_map[device_dim]
+        if dim is not None:
+            rel_stride[device_dim] = acc[dim]
+            acc[dim] *= device_size[device_dim]
+    return rel_stride
+
+
+def compute_coordinates(size, stride, var_ranges, index):
+    """
+    Derive an array of coordinate expressions into a tensor from an index
+    """
+    coordinates = [0] * len(size)
+    vars = index.free_symbols
+    for var in vars:
+        if var_ranges[var] <= 1:
+            continue
+        term = index.subs({v: 0 for v in vars - {var}})
+        step = term.subs(var, 1)
+        limit = term.subs(var, var_ranges[var])
+        primary_stride = 0
+        primary_dim = None
+        for dim in range(len(size)):
+            if size[dim] == 1:
+                continue
+            st = stride[dim]
+            if st > step and st < limit:
+                coordinates[dim] += var * step // st
+            elif st <= step and st > primary_stride:
+                primary_stride = st
+                primary_dim = dim
+        coordinates[primary_dim] += var * step // primary_stride
+    return coordinates
+
+
+def compute_device_coordinates(size, stride, device_size, dim_map, var_ranges, index):
+    """
+    Derive an array of coordinate expressions into a device tensor from an index
+    """
+    rel_stride = compute_relative_stride(len(size), device_size, dim_map)
+    host_coordinates = compute_coordinates(size, stride, var_ranges, index)
+    coordinates = [0] * len(device_size)
+    for dim in range(len(device_size)):
+        expr = host_coordinates[dim_map[dim]]
+        vars = expr.free_symbols
+        for var in vars:
+            term = expr.subs({v: 0 for v in vars - {var}})
+            step = term.subs(var, 1)
+            limit = term.subs(var, var_ranges[var])
+            if limit > rel_stride[dim] and step < rel_stride[dim] * device_size[dim]:
+                coordinates[dim] += term // rel_stride[dim]
+    return coordinates


### PR DESCRIPTION
#### What type of PR is this?

- [X] feature

#### What this PR does:

Loop-level IR uses index expressions to load and store tensor elements. An index maps a point in a range to an offset into the host tensor memory. This PR derives from this index:
- a list of coordinate expressions that resolve to the same offset,
- a list of device coordinate expressions that resolve to the device offset for the same tensor element.

#### Which issue(s) this PR is related to:

This PR is a step toward the implementation of views #573. 

#### Does this PR introduce a user-facing change?

No