### PR TITLE
Remove ConstantArg

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -32,7 +32,7 @@ from torch._inductor.codegen.simd import SIMDKernel
 from torch._inductor.utils import sympy_subs
 from torch._inductor.virtualized import StoreMode, V
 
-from torch_spyre.execution import ConstantArg, OpSpec, TensorArg
+from torch_spyre.execution import OpSpec, TensorArg
 from .constants import (
     MATMUL_REDUCTION_OP,
     SPYRE_FP32_OPS,
@@ -344,7 +344,7 @@ def create_op_spec(
     op: str,
     is_reduction: bool,
     dims: list[DimensionInfo],
-    args: Sequence[TensorArg | ConstantArg],
+    args: Sequence[TensorArg],
     op_info: dict[str, Any],
 ) -> OpSpec:
     for arg in args:
@@ -451,12 +451,10 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
         elif isinstance(value, PointwiseOp):
             # Pointwise compute ops are defined by the output's index
             di = self.derive_dim_info(dst)
-            args: list[TensorArg | ConstantArg] = []
+            args: list[TensorArg] = []
             for input in value.arguments:
                 if isinstance(input, TensorAccess):
                     args.append(self.create_tensor_arg(True, input.name, input, di))
-                elif isinstance(input, Constant):
-                    args.append(ConstantArg(input.value, input.dtype))
                 else:
                     raise Unsupported(f"unexpected argument {input} to {value.op}")
             args.append(self.create_tensor_arg(False, real_dst_name, dst, di))
@@ -473,32 +471,28 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
             ]
             in_stl = args[0].device_layout  # type: ignore[union-attr]
             out_stl = args[1].device_layout  # type: ignore[union-attr]
-            if isinstance(args[0], TensorArg) and isinstance(args[1], TensorArg):
-                # Determine data op based on tensor args
-                if (
-                    Counter(in_stl.dim_map) == Counter(out_stl.dim_map)
-                    and in_stl.device_size != out_stl.device_size
-                ) or (Counter(in_di) == Counter(out_di) and in_di != out_di):
-                    # Transpose:
-                    #   - check that the input / output DimensionInfo are the same, but in different order.
-                    #   - check that the dim map has the same dimensions (no duplicate dimensions), but device size differs.
-                    op = TRANSPOSE_OP
-                elif all(is_wildcard(d.var) for d in in_di) and not all(
-                    is_wildcard(d.var) for d in out_di
-                ):
-                    # Broadcast: scalar input (all dims wildcards) expanding to non-scalar output.
-                    op = CLONE_OP
-                    in_di = out_di
-                    args[0] = self.create_tensor_arg(True, value.name, value, in_di)
-                elif in_stl.device_size == out_stl.device_size:
-                    # Clone: check that device layout is the same.
-                    op = CLONE_OP
-                else:
-                    # Unsupported data operation on TensorArg
-                    raise Unsupported(f"Data operation {args[0]})=>{args[1]}")
+            # Determine data op based on tensor args
+            if (
+                Counter(in_stl.dim_map) == Counter(out_stl.dim_map)
+                and in_stl.device_size != out_stl.device_size
+            ) or (Counter(in_di) == Counter(out_di) and in_di != out_di):
+                # Transpose:
+                #   - check that the input / output DimensionInfo are the same, but in different order.
+                #   - check that the dim map has the same dimensions (no duplicate dimensions), but device size differs.
+                op = TRANSPOSE_OP
+            elif all(is_wildcard(d.var) for d in in_di) and not all(
+                is_wildcard(d.var) for d in out_di
+            ):
+                # Broadcast: scalar input (all dims wildcards) expanding to non-scalar output.
+                op = CLONE_OP
+                in_di = out_di
+                args[0] = self.create_tensor_arg(True, value.name, value, in_di)
+            elif in_stl.device_size == out_stl.device_size:
+                # Clone: check that device layout is the same.
+                op = CLONE_OP
             else:
-                # Unsupported data operation on ConstantArg
-                raise Unsupported(f"Data operation on {type(args[0])}")
+                # Unsupported data operation on TensorArg
+                raise Unsupported(f"Data operation {args[0]})=>{args[1]}")
 
             op_spec = create_op_spec(op, False, in_di, args, op_info)
             if op == TRANSPOSE_OP:

--- a/torch_spyre/_inductor/wrapper.py
+++ b/torch_spyre/_inductor/wrapper.py
@@ -52,7 +52,7 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
         super().write_header()
         self.imports.splice(
             """
-                from torch_spyre.execution import ConstantArg, TensorArg, OpSpec, UnimplementedOp
+                from torch_spyre.execution import TensorArg, OpSpec, UnimplementedOp
                 from torch_spyre.execution.async_compile import SpyreAsyncCompile
                 from torch_spyre._C import DataFormats, SpyreTensorLayout, spyre_empty_with_layout
                 import subprocess

--- a/torch_spyre/execution/__init__.py
+++ b/torch_spyre/execution/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import dataclasses
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 import torch
 from torch_spyre._C import SpyreTensorLayout
 
@@ -44,20 +44,6 @@ class TensorArg:
 
 
 @dataclasses.dataclass
-class ConstantArg:
-    """
-    A class representing a Constant argument to an OpSpec
-
-    Attributes:
-        value: The value of the constant.
-        dtype: The PyTorch (host) dtype of the constant.
-    """
-
-    value: Union[bool, float, int]
-    dtype: torch.dtype
-
-
-@dataclasses.dataclass
 class OpSpec:
     """
     A class representing a single operation to perform on the device
@@ -73,7 +59,7 @@ class OpSpec:
     op: str
     is_reduction: bool
     iteration_space: list[int]
-    args: Sequence[TensorArg | ConstantArg]
+    args: Sequence[TensorArg]
     op_info: dict[str, Any]
 
 

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -23,7 +23,7 @@ from torch_spyre._C import convert_artifacts
 from torch_spyre._inductor.codegen.superdsc import generate_sdsc
 from torch_spyre._inductor.constants import SEGMENT_OFFSETS
 from torch_spyre._inductor.logging_utils import get_inductor_logger
-from . import ConstantArg, OpSpec, UnimplementedOp
+from . import OpSpec, UnimplementedOp
 from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
 
 logger = get_inductor_logger("sdsc_compile")
@@ -62,9 +62,7 @@ class SpyreAsyncCompile:
                     if kernel_name.split("_")[-1] == k.replace("lx:", ""):
                         lx_addr = addr
 
-                if isinstance(ts, ConstantArg):
-                    raise RuntimeError("TOOO: implement SDSC generation for constants")
-                elif ts.is_input:
+                if ts.is_input:
                     inputs.append(
                         {
                             "name": _argument_names[index],


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

We've committed to lifting constants/scalars to Tensors in a compiler pass prior to generating an OpSpec.  Simplify backend code by eliminating ConstantArg to reflect this decision.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
```
================================================================================================= test session starts =================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 462 items                                                                                                                                                                                                   

tests/inductor/test_building_blocks.py ....                                                                                                                                                                     [  0%]
tests/inductor/test_inductor_decomp.py ...                                                                                                                                                                      [  1%]
tests/inductor/test_inductor_ops.py ...s....................................................................................................................................................................... [ 38%]
..................................................................................................................................................                                                              [ 70%]
tests/inductor/test_logging.py ....                                                                                                                                                                             [ 70%]
tests/tensor/test_tensor_layout.py ...............                                                                                                                                                              [ 74%]
tests/test_fallbacks.py ........                                                                                                                                                                                [ 75%]
tests/test_modules.py .sssss.                                                                                                                                                                                   [ 77%]
tests/test_ops.py .x.s..xs...s........................s...sss.ss......................................                                                                                                          [ 95%]
tests/test_regex.py .                                                                                                                                                                                           [ 95%]
tests/test_spyre.py .s..ss............                                                                                                                                                                          [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                               [100%]

=============================================================================== 442 passed, 18 skipped, 2 xfailed in 386.44s (0:06:26) ================================================================================
```
#### Does this PR introduce a user-facing change?

#### Additional note:
