### PR TITLE
Add pr-review and debug-compilation skills

### DIFF
--- a/.claude/skills/debug-compilation/SKILL.md
+++ b/.claude/skills/debug-compilation/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: debug-compilation
+description: "Systematic debugging of torch.compile failures on the Spyre backend. Covers each pipeline stage from Dynamo tracing through runtime execution, with diagnostic env vars and common error patterns. Use when torch.compile fails, operations are unsupported, or compilation produces incorrect results."
+---
+
+# Debugging Spyre Compilation Failures
+
+When `torch.compile()` fails on Spyre, the error originates from one of eight
+pipeline stages. This skill helps identify which stage failed and how to fix it.
+
+See `common-errors.md` for an error-message → cause → fix lookup table.
+
+---
+
+## Diagnostic Environment Variables
+
+Set these before reproducing the failure:
+
+```bash
+export TORCH_SPYRE_DEBUG=1          # C++ debug logging, -O0 build
+export SENCORES=1                   # Single core (simplifies debugging)
+export TORCH_LOGS="+inductor"       # Verbose Inductor logging
+export TORCH_COMPILE_DEBUG=1        # Dump debug artifacts to torch_compile_debug/
+```
+
+Additional logging:
+
+```bash
+export DT_DEEPRT_VERBOSE=-1        # Reduce runtime noise
+export TORCH_SPYRE_DOWNCAST_WARN=0  # Suppress dtype warnings
+```
+
+---
+
+## Pipeline Stages (in order)
+
+### Stage 1: Dynamo Tracing
+
+**File:** PyTorch core (`torch._dynamo`)
+
+**What happens:** Dynamo captures an FX graph from the Python model.
+
+**Failure symptoms:**
+- `torch._dynamo.exc.Unsupported`
+- Graph breaks
+- `TorchDynamoException`
+
+**Debugging:**
+- Check `TORCH_LOGS="+dynamo"` output
+- Look for unsupported Python constructs or dynamic control flow
+- This is a PyTorch-core issue, not Spyre-specific
+
+---
+
+### Stage 2: Decompositions
+
+**File:** `torch_spyre/_inductor/decompositions.py`
+
+**What happens:** FX graph ops are rewritten into simpler ops that Spyre
+supports.
+
+**Failure symptoms:**
+- Op appears in the graph that has no lowering
+- Unexpected op composition after decomposition
+
+**Debugging:**
+- Check if the op has a `@register_spyre_decomposition`
+- Check `spyre_decompositions_to_exclude` for intentionally excluded ops
+- Use `TORCH_COMPILE_DEBUG=1` to inspect the pre/post-decomposition graph
+
+---
+
+### Stage 3: Lowering
+
+**File:** `torch_spyre/_inductor/lowering.py`
+
+**What happens:** FX graph ops are lowered to Inductor's LoopLevelIR.
+
+**Failure symptoms:**
+- `LoweringException`
+- Missing lowering for an op
+- `Unsupported("...")` from lowering code
+
+**Debugging:**
+- Check if the op has a `@register_spyre_lowering`
+- For custom ops, verify the lowering is registered for `torch.ops.spyre.*`
+- Check the fallback registry in `torch_spyre/ops/fallbacks.py`
+
+---
+
+### Stage 4: Stickify (Layout Propagation)
+
+**File:** `torch_spyre/_inductor/stickify.py`
+
+**What happens:** `SpyreTensorLayout` is assigned to each IR node, converting
+from standard PyTorch layouts to tiled stick layouts.
+
+**Failure symptoms:**
+- `"does not have FixedTiledLayout"` errors
+- Layout mismatch assertions
+- `dim_map` errors
+
+**Debugging:**
+- Check that all input tensors have compatible shapes
+- Verify stick alignment (innermost dim should be padded to multiples of 64
+  for fp16)
+- Look for unsupported reshape/view operations
+
+---
+
+### Stage 5: SpyreKernel Codegen
+
+**File:** `torch_spyre/_inductor/spyre_kernel.py`
+
+**What happens:** LoopLevelIR is translated to `KernelSpec` objects via
+`SpyreOpFuncs`.
+
+**Failure symptoms:**
+- `AttributeError: 'SpyreOpFuncs' has no attribute '<op_name>'`
+- Missing `@staticmethod` for an op
+- Wrong `op_info` dict structure
+
+**Debugging:**
+- Check `SpyreOpFuncs` class for the missing method
+- Compare with existing methods (e.g., `add`, `softplus`) for the pattern
+- Verify the method name matches what the lowering produces
+
+---
+
+### Stage 6: SuperDSC Generation
+
+**File:** `torch_spyre/_inductor/codegen/superdsc.py`
+
+**What happens:** `KernelSpec` → SuperDSC JSON descriptor for the backend
+compiler.
+
+**Failure symptoms:**
+- KeyError in `generate_sdsc()`
+- Invalid SuperDSC JSON structure
+- Op dispatch failure
+
+**Debugging:**
+- Check `generate_sdsc()` dispatch logic
+- Verify op handlers in `codegen/compute_ops.py` or `codegen/data_ops.py`
+- Use `TORCH_COMPILE_DEBUG=1` to inspect the generated JSON
+
+---
+
+### Stage 7: Backend Compiler
+
+**File:** External `dxp_standalone` binary
+
+**What happens:** SuperDSC JSON → `g2.graph.cbor` binary.
+
+**Failure symptoms:**
+- `dxp_standalone` exit code != 0
+- Compilation timeout
+- Invalid CBOR output
+
+**Debugging:**
+- Check `TORCH_COMPILE_DEBUG=1` output for the input JSON
+- Run `dxp_standalone` manually on the JSON to get detailed errors
+- Check `torch_spyre/execution/async_compile.py` for the invocation
+
+---
+
+### Stage 8: Runtime Execution
+
+**File:** `torch_spyre/execution/kernel_runner.py`
+
+**What happens:** `SpyreSDSCKernelRunner` calls `_C.launch_kernel()` to
+execute the compiled binary.
+
+**Failure symptoms:**
+- `launch_kernel` failure
+- Runtime segfault
+- Wrong results (numerics)
+
+**Debugging:**
+- Use `TORCH_SPYRE_DEBUG=1` for C++ runtime logging
+- Check tensor shapes and layouts at the kernel boundary
+- For numeric issues, compare with `compare_with_cpu()` using tighter
+  tolerances
+
+---
+
+## Common Debugging Workflow
+
+1. **Reproduce** with minimal model and `SENCORES=1`
+2. **Set env vars**: `TORCH_SPYRE_DEBUG=1 TORCH_COMPILE_DEBUG=1 TORCH_LOGS="+inductor"`
+3. **Identify the stage** from the error traceback
+4. **Check the relevant file** listed above
+5. **Inspect debug artifacts** in `torch_compile_debug/` directory
+6. **Fix or report** — see `common-errors.md` for known patterns

--- a/.claude/skills/debug-compilation/common-errors.md
+++ b/.claude/skills/debug-compilation/common-errors.md
@@ -1,0 +1,138 @@
+# Common Compilation Errors
+
+Error message → likely cause → fix.
+
+---
+
+## "Spyre backend does not support: ..."
+
+**Source:** `torch_spyre/_inductor/errors.py` — `Unsupported()` class
+
+**Cause:** An operation reached a code path that explicitly raises
+`Unsupported`. This means the op is recognized but not yet implemented.
+
+**Fix:**
+- Check which file raised it (traceback will show)
+- Implement the missing support (see `add-spyre-operation` skill)
+- Or register a CPU fallback in `torch_spyre/ops/fallbacks.py`
+
+---
+
+## "does not have FixedTiledLayout"
+
+**Source:** `torch_spyre/_inductor/stickify.py`
+
+**Cause:** The stickify pass could not assign a `FixedTiledLayout` to a node.
+Usually means an unsupported op or reshape produced a layout that cannot be
+tiled.
+
+**Fix:**
+- Check if the op needs a custom stickify handler
+- Verify input tensor shapes are compatible with stick alignment
+- Check for unsupported view/reshape operations in the graph
+
+---
+
+## AttributeError on SpyreOpFuncs
+
+**Error:** `AttributeError: type object 'SpyreOpFuncs' has no attribute '<op>'`
+
+**Source:** `torch_spyre/_inductor/spyre_kernel.py`
+
+**Cause:** The lowering produced an op that has no corresponding method in
+`SpyreOpFuncs`.
+
+**Fix:**
+- Add a `@staticmethod` method to `SpyreOpFuncs` in `spyre_kernel.py`
+- Method name must match the op name from the lowering
+
+---
+
+## Dtype Errors
+
+**Error:** Variations of dtype mismatch, unexpected float32, or
+`"expected float16 but got float32"`
+
+**Cause:** Spyre default dtype is `float16`. Operations may receive
+`float32` inputs from PyTorch defaults.
+
+**Fix:**
+- Ensure inputs are cast to `float16` before compilation
+- Check `TORCH_SPYRE_DOWNCAST_WARN=0` to see if downcasting warnings
+  appear
+- Add explicit `to_dtype` handling in the lowering if needed
+- Check `SPYRE_FP32_OPS` in `constants.py` for ops that run in fp32
+
+---
+
+## Shape Mismatch in Work Division
+
+**Error:** Assertions in `core_division.py` or dimension label mismatches
+
+**Cause:** The work division planning cannot split the operation's
+iteration space across cores.
+
+**Fix:**
+- Check `docs/work_division_planning.md` for dimension label rules
+- Verify the op's `dimensions` and `scales` in its `KernelSpec`
+- Try `SENCORES=1` to bypass multi-core splitting for debugging
+
+---
+
+## Graph Break
+
+**Error:** `torch._dynamo` reports a graph break
+
+**Cause:** Dynamo cannot trace through certain Python constructs. Not
+Spyre-specific but affects what reaches the Spyre backend.
+
+**Fix:**
+- Check `TORCH_LOGS="+dynamo"` for the break reason
+- Restructure the model code to avoid the unsupported construct
+- Use `torch._dynamo.allow_in_graph` if appropriate
+
+---
+
+## dxp_standalone Compilation Failure
+
+**Error:** Non-zero exit code from `dxp_standalone`, timeout, or CBOR
+errors
+
+**Cause:** The generated SuperDSC JSON is invalid or uses unsupported
+features.
+
+**Fix:**
+- Use `TORCH_COMPILE_DEBUG=1` to find the JSON in `torch_compile_debug/`
+- Run `dxp_standalone` manually with the JSON to get detailed output
+- Check `codegen/superdsc.py` for the generated descriptor
+- Verify op parameters in `codegen/compute_ops.py` or `codegen/data_ops.py`
+
+---
+
+## launch_kernel Runtime Failure
+
+**Error:** Errors from `_C.launch_kernel()` or segfaults during execution
+
+**Cause:** The compiled binary is valid but runtime state is incorrect
+(wrong tensor sizes, misaligned memory, missing constants).
+
+**Fix:**
+- Use `TORCH_SPYRE_DEBUG=1` for C++ debug output
+- Check tensor argument layouts in `KernelSpec.args`
+- Verify constant encoding in `torch_spyre/execution/kernel_runner.py`
+- Check `SENCORES` matches the core division in the compiled binary
+
+---
+
+## Numeric Mismatches
+
+**Error:** `torch.testing.assert_close` failures in tests
+
+**Cause:** Floating-point precision differences between CPU and Spyre,
+often due to fp16 precision limits.
+
+**Fix:**
+- Increase tolerances: `atol=0.1, rtol=0.1` is standard for fp16
+- Check if the op accumulates in fp16 vs fp32
+- Use `compare_with_sendnn()` for bit-exact reference comparison
+- Check for numerically unstable operations (division by near-zero, etc.)

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: pr-review
+description: "Review pull requests for the torch-spyre project. Checks license headers, pre-commit compliance, signed commits, tensor layout correctness, test coverage, and documentation. Use when asked to review a PR or check code quality."
+---
+
+# PR Review for torch-spyre
+
+When asked to review a PR, follow this systematic process. Use `gh pr diff`
+and `gh pr view` to inspect the changes.
+
+See `review-checklist.md` in this directory for a quick reference checklist.
+
+---
+
+## Review Process
+
+### Step 1: Fetch PR Information
+
+```bash
+gh pr view <number>
+gh pr diff <number>
+gh pr checks <number>
+```
+
+### Step 2: Run Through Checklist
+
+Work through each category below. Flag issues with severity:
+
+- **BLOCKER** — Must fix before merge
+- **SUGGESTION** — Improvement, not blocking
+- **QUESTION** — Needs clarification from author
+
+---
+
+## Review Categories
+
+### 1. License Headers
+
+Every source file must have the Apache 2.0 license header.
+
+**Python** (14 lines):
+
+```python
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# ...
+```
+
+**C++** (`/* */` block):
+
+```cpp
+/* Copyright 2025 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 ...
+ */
+```
+
+### 2. Pre-commit Compliance
+
+The PR must pass all pre-commit hooks:
+
+- **ruff** — Python linting and formatting (line length 88)
+- **clang-format** — C++ formatting
+- **cpplint** — C++ linting
+- **mypy** — Type checking
+- **pymarkdown** — Markdown linting
+- **yamlfmt** — YAML formatting
+- **enforce-import-regex** — Must use `import regex`, never `import re`
+
+### 3. Signed Commits (DCO)
+
+Every commit must have a `Signed-off-by:` line. Check with:
+
+```bash
+gh pr view <number> --json commits --jq '.commits[].messageBody'
+```
+
+### 4. Tensor Layout Correctness
+
+For changes touching layout-related code, verify:
+
+- `SpyreTensorLayout` `dim_map` values are correct
+- Stick dimension padding is handled (64 elements for fp16)
+- `FixedTiledLayout` usage includes proper `device_layout`
+- No assumptions about contiguous memory where tiled layout applies
+
+### 5. Dual Path Impact
+
+Check whether the change affects eager mode, compiled mode, or both:
+
+- **Eager-only** changes: `torch_spyre/ops/`, `codegen/`, `torch_spyre/ops/fallbacks.py`
+- **Compiled-only** changes: `torch_spyre/_inductor/`, `torch_spyre/execution/`
+- **Both paths**: `torch_spyre/csrc/`, `torch_spyre/__init__.py`
+
+Ensure tests cover the affected path(s).
+
+### 6. Test Coverage
+
+- New ops must have tests using `compare_with_cpu()` or `compare()`
+- Shape variety: 1D through 4D, stick-aligned and non-aligned sizes
+- Default dtype should be `torch.float16`
+- Tests use `ParameterizedTestMeta` for parameterized cases
+- Building-block tests for module-level changes
+
+### 7. Work Division
+
+For changes to `core_division.py` or related scheduling code:
+
+- Validate against `docs/work_division_planning.md`
+- Check dimension label correctness
+- Verify multi-core splitting logic
+
+### 8. Error Handling
+
+- Use `Unsupported()` from `torch_spyre/_inductor/errors.py` for
+  unsupported operations (not generic `RuntimeError`)
+- Error messages should be descriptive: `Unsupported("thing that failed")`
+  produces `"Spyre backend does not support: thing that failed"`
+
+### 9. Documentation
+
+- User-facing behavior changes need `docs/` updates
+- New ops should be mentioned in relevant documentation
+- Complex logic should have inline comments
+
+---
+
+## Output Format
+
+Structure your review as:
+
+```
+## PR #<number>: <title>
+
+### Summary
+<1-2 sentence summary of what the PR does>
+
+### Review
+
+#### BLOCKERs
+- [ ] <issue description> (file:line)
+
+#### SUGGESTIONs
+- [ ] <improvement> (file:line)
+
+#### QUESTIONs
+- [ ] <question for author>
+
+### Verdict
+<APPROVE / REQUEST_CHANGES / COMMENT>
+```

--- a/.claude/skills/pr-review/review-checklist.md
+++ b/.claude/skills/pr-review/review-checklist.md
@@ -1,0 +1,49 @@
+# PR Review Checklist
+
+Quick reference for reviewing torch-spyre pull requests.
+
+## Mandatory Checks (BLOCKERs if Missing)
+
+- [ ] **Apache 2.0 headers** on all new source files (Python: 14-line block,
+  C++: `/* */` block)
+- [ ] **Signed commits** — every commit has `Signed-off-by:` (DCO)
+- [ ] **Pre-commit passes** — ruff, clang-format, cpplint, mypy, pymarkdown
+- [ ] **`import regex`** — never `import re` in Python files
+- [ ] **Tests exist** for new/changed functionality
+- [ ] **`Unsupported()`** used for unsupported-op errors (not bare
+  `RuntimeError`)
+
+## Code Quality
+
+- [ ] Follows Google Python / C++ style guide
+- [ ] Line length ≤ 88 characters (Python)
+- [ ] No commented-out code left behind
+- [ ] Clear variable and function names
+
+## Tensor Layout
+
+- [ ] `dim_map` values correct for any new layout logic
+- [ ] Stick padding handled (64 fp16 elements per 128-byte stick)
+- [ ] `FixedTiledLayout` includes `device_layout`
+- [ ] No raw stride assumptions on tiled tensors
+
+## Test Coverage
+
+- [ ] `compare_with_cpu()` or `compare()` used for compiled-path tests
+- [ ] Shape variety: 1D, 2D, 3D, 4D
+- [ ] Stick-aligned and non-aligned sizes tested
+- [ ] `torch.float16` as default dtype
+- [ ] `ParameterizedTestMeta` for parameterized tests
+- [ ] `torch.manual_seed(0xAFFE)` set at class level
+
+## Path Impact
+
+- [ ] Eager path changes have `tests/test_ops.py` coverage
+- [ ] Compiled path changes have `tests/inductor/` coverage
+- [ ] Cross-path changes tested in both suites
+
+## Documentation
+
+- [ ] `docs/` updated for user-facing changes
+- [ ] Complex logic has inline comments
+- [ ] New ops documented in relevant places


### PR DESCRIPTION
## Summary

- **`pr-review`** skill (2 files): SKILL.md with a systematic 9-category review process (license headers, pre-commit, DCO, tensor layout, dual path impact, test coverage, work division, error handling, documentation) using BLOCKER/SUGGESTION/QUESTION severity tagging, plus a quick-reference review checklist.
- **`debug-compilation`** skill (2 files): SKILL.md with an 8-stage pipeline debugging guide (Dynamo → decompositions → lowering → stickify → SpyreKernel → SuperDSC → dxp_standalone → runtime), diagnostic env vars, plus a common-errors lookup table mapping error messages to causes and fixes.

## Context

This is **PR 3 of 4** in a planned rollout of Claude Code skills for torch-spyre:

| PR | Content | Status |
|---|---|---|
| PR 1 | `CLAUDE.md` + `project-overview` skill | [#886](https://github.com/torch-spyre/torch-spyre/pull/886) (merged) |
| PR 2 | `add-spyre-operation` + `write-spyre-op-test` skills | [#888](https://github.com/torch-spyre/torch-spyre/pull/888) |
| **PR 3 (this)** | `pr-review` + `debug-compilation` skills | Ready for review |
| PR 4 | `write-rfc` skill | Pending |

## Test plan

- [ ] Verify `pr-review` skill auto-activates on "Review PR #123" / "Check this PR"
- [ ] Verify `debug-compilation` skill auto-activates on "torch.compile is failing" / "Unsupported operation error"
- [ ] Confirm file paths in skills match current repo structure (post-restructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)