### PR TITLE
Fix check for supported data formats

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -20,7 +20,7 @@ from collections import Counter
 import torch
 import sympy
 
-from torch_spyre._C import compute_view_layout
+from torch_spyre._C import compute_view_layout, DataFormats
 
 from torch._inductor.codegen.common import (
     CSEVariable,
@@ -348,13 +348,14 @@ def create_op_spec(
     op_info: dict[str, Any],
 ) -> OpSpec:
     for arg in args:
-        if arg.dtype == torch.float32 and op not in SPYRE_FP32_OPS:
+        if (
+            arg.device_layout.device_dtype == DataFormats.IEEE_FP32
+            and op not in SPYRE_FP32_OPS
+        ):
             raise Unsupported(f"{op} on {arg.dtype} dtype")
-        elif arg.dtype not in [
-            torch.bool,
-            torch.float16,
-            torch.float32,
-            torch.int64,
+        elif arg.device_layout.device_dtype not in [
+            DataFormats.IEEE_FP32,
+            DataFormats.SEN169_FP16,
         ]:
             raise Unsupported(f"operations on {arg.dtype} dtype")
     return OpSpec(op, is_reduction, [d.numel for d in dims], args, op_info)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR fixes the check for the currently supported data formats for compute/data operations.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
```
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/avery/dt-inductor/torch-spyre
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: hypothesis-6.151.9
collected 479 items                                                                                                                                                                                                                                                                                                                                                      

tests/inductor/test_building_blocks.py ....                                                                                                                                                                                                                                                                                                                        [  0%]
tests/inductor/test_inductor_decomp.py ...                                                                                                                                                                                                                                                                                                                         [  1%]
tests/inductor/test_inductor_ops.py ...s.......................................................................................................................................................................................................................................................................................................................... [ 67%]
................                                                                                                                                                                                                                                                                                                                                                   [ 71%]
tests/inductor/test_logging.py ....                                                                                                                                                                                                                                                                                                                                [ 72%]
tests/tensor/test_tensor_layout.py ...............                                                                                                                                                                                                                                                                                                                 [ 75%]
tests/test_fallbacks.py ........                                                                                                                                                                                                                                                                                                                                   [ 76%]
tests/test_modules.py .sssss.                                                                                                                                                                                                                                                                                                                                      [ 78%]
tests/test_ops.py .x.s..xs...s........................s...sss.ss......................................                                                                                                                                                                                                                                                             [ 95%]
tests/test_regex.py .                                                                                                                                                                                                                                                                                                                                              [ 96%]
tests/test_spyre.py .s..ss............                                                                                                                                                                                                                                                                                                                             [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                                                                                                                                  [100%]

========================================================================================================================================================= 459 passed, 18 skipped, 2 xfailed in 424.97s (0:07:04) =========================================================================================================================================================
```