### PR TITLE
Suppress making an exponent a scalar tensor

### DIFF
--- a/codegen/utils/template_tools.py
+++ b/codegen/utils/template_tools.py
@@ -37,8 +37,10 @@ def extract_scalar_arg_names(schema_string: str) -> List[str]:
     # Pattern: Scalar (optionally ?) followed by whitespace and name
     pattern = r"Scalar\??[\s]+([a-zA-Z_][a-zA-Z0-9_]*)"
     all_scalar_names = re.findall(pattern, args_str)
-    # Filter out alpha and beta
-    return [name for name in all_scalar_names if name not in ["alpha", "beta"]]
+    # Filter out alpha, beta, and exponent to allow upstream decompositions
+    return [
+        name for name in all_scalar_names if name not in ["alpha", "beta", "exponent"]
+    ]
 
 
 def get_args_with_default_vals(schema_string):

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -273,6 +273,12 @@ class TestOps(TestCase):
         y = torch.tanh(x_spyre).to("cpu")
         torch.testing.assert_close(y, torch.tanh(x), rtol=self.rtol, atol=self.atol)
 
+    def test_pow_scalar_exponent(self):
+        x = torch.randn((1, 1, 4096), dtype=self.dtype)
+        x_spyre = x.to("spyre")
+        y = torch.pow(x_spyre, 2).to("cpu")
+        torch.testing.assert_close(y, torch.pow(x, 2), rtol=self.rtol, atol=self.atol)
+
     @unittest.skip("TODO: Needs more debug")
     def test_clone(self):
         x = torch.tensor([-2, -1, 0, 1, 2], dtype=self.dtype)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Suppress converting an exponent a scalar tensor so that the upstream decomposition successfully converts `pow(x, 2)` into `x * x`.

#### Which issue(s) this PR is related to:
Fixes #145.

#### Special notes for your reviewer:
This PR reimplements the idea of https://github.com/torch-spyre/torch-spyre/pull/437 based on the latest main by Bob.

**Test results**
```
======================================================== test session starts =========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/inagaki/dt-inductor/torch-spyre
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: hypothesis-6.151.9
collected 450 items

tests/inductor/test_building_blocks.py ....                                                                                    [  0%]
tests/inductor/test_inductor_decomp.py ...                                                                                     [  1%]
tests/inductor/test_inductor_ops.py ...s...................................................................................... [ 21%]
.............................................................................................................................. [ 49%]
..........................................................................................................                     [ 73%]
tests/inductor/test_logging.py ....                                                                                            [ 74%]
tests/tensor/test_tensor_layout.py ..............                                                                              [ 77%]
tests/test_fallbacks.py ........                                                                                               [ 78%]
tests/test_modules.py .sssss.                                                                                                  [ 80%]
tests/test_ops.py .x.s..xs...s........................s...sss.ss.....................                                          [ 95%]
tests/test_regex.py .                                                                                                          [ 95%]
tests/test_spyre.py ..s..ss............                                                                                        [ 99%]
tests/test_spyre_lazy_silent.py .                                                                                              [100%]

======================================= 430 passed, 18 skipped, 2 xfailed in 366.49s (0:06:06) =======================================
```

cc: @gkumbhat @ani300 @raghukiran1224 
#### Does this PR introduce a user-facing change?
No.

#### Additional note (from Bob):
Fixed the issue with `torch.pow` operator in eager mode by modifying `codegen/utils/template_tools.py`.

**Change Made:**
In the `extract_scalar_arg_names()` function (line 41), added `"exponent"` to the exclusion list alongside `"alpha"` and `"beta"`:

```python
# Filter out alpha, beta, and exponent to allow upstream decompositions
return [name for name in all_scalar_names if name not in ["alpha", "beta", "exponent"]]
```

**Why This Fixes The Issue:**
- The base template converts scalar arguments to tensors on the Spyre device
- For `pow.Tensor_Scalar`, the `exponent` parameter was being converted to a tensor
- This prevented PyTorch's upstream decomposition from converting `pow(x, 2)` into `x * x`
- By excluding `exponent` from tensor conversion (like `alpha` and `beta`), the scalar exponent remains a scalar
- This allows the decomposition to work, which can then be handled by the Spyre backend

This is the smallest change that solves the problem without modifying the template or other parts of the codebase.