### PR TITLE
Add dgrove-oss and tardieu as CODEOWNERS for tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,7 @@
 /torch_spyre/ops/        @JRosenkranz @thoangtrvn
 
 # Tests
-/tests/                  @avery-blanchard @moriohara @ashokponkumar @JRosenkranz
+/tests/                  @avery-blanchard @moriohara @ashokponkumar @JRosenkranz @dgrove-oss @tardieu
 
 # Documentation
 /docs/                   @kaoutar55 @dgrove-oss


### PR DESCRIPTION
## Summary
- Add `@dgrove-oss` and `@tardieu` as code owners for the `/tests/` directory

## Test plan
- No code changes; CODEOWNERS-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)