### PR TITLE
[FEAT] new copyAsync

### DIFF
--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "logging.h"
+#include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_sendnn_utils.h"
 #include "spyre_stream.h"
@@ -70,8 +71,19 @@ static void init_from_env() {
 
 void _startRuntime() {
   DEBUGINFO("starting runtime");
+  // Determine logical device index with priority:
+  //   1. tls_idx (non-zero) — set via explicit set_device() call
+  //   2. LOCAL_RANK env var — set by torchrun per process
+  //   3. 0 — single-device / non-torchrun default
+  int logical_device_id = 0;
+  int tls_idx = static_cast<int>(SpyreGuardImpl::tls_idx);
+  if (tls_idx != 0) {
+    logical_device_id = tls_idx;
+  } else if (const char *lr = std::getenv("LOCAL_RANK")) {
+    logical_device_id = std::atoi(lr);
+  }
   std::shared_ptr<Runtime> runtime;
-  auto s = flex::initializeRuntime(&runtime);
+  auto s = flex::initializeRuntime(&runtime, logical_device_id);
   init_from_env();
   if (runtime) {
     GlobalRuntime::set(runtime);
@@ -351,4 +363,9 @@ PYBIND11_MODULE(_C, m) {
                std::to_string(stream.device().index()) +
                " id=" + std::to_string(stream.id()) + ">";
       });
+  m.def("set_device", [](int idx) {
+    c10::impl::getDeviceGuardImpl(c10::DeviceType::PrivateUse1)
+        ->setDevice(c10::Device(c10::DeviceType::PrivateUse1,
+                                static_cast<c10::DeviceIndex>(idx)));
+  });
 }

--- a/torch_spyre/csrc/module.h
+++ b/torch_spyre/csrc/module.h
@@ -28,7 +28,7 @@ using DataConversionInfo = data_conversion_info;
 
 namespace spyre {
 
-using Runtime = flex::StreamRuntime;
+using Runtime = flex::RuntimeEntry;
 
 struct SharedOwnerCtx {
   flex::DeviceMemoryAllocationPtr owner;

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "spyre_allocator.h"
+
+#include <utility>
+
+#include "logging.h"
+#include "spyre_mem.h"
+#include "spyre_stream.h"
+#include "spyre_tensor_impl.h"
+
+namespace spyre {
+
+SpyreAllocator::SpyreAllocator() = default;
+
+flex::DeviceMemoryAllocatorPtr SpyreAllocator::getAllocator(
+    unsigned int dev_id) {
+  return GlobalRuntime::get()
+      ->GetDeviceHandle(dev_id)
+      ->GetDeviceMemoryAllocator();
+}
+
+SpyreAllocator& SpyreAllocator::instance() {
+  static SpyreAllocator allocator;
+  return allocator;
+}
+
+at::DataPtr SpyreAllocator::allocate(size_t nbytes) {
+  c10::Device curr_device =
+      c10::impl::getDeviceGuardImpl(c10::DeviceType::PrivateUse1)->getDevice();
+
+  auto device_id = curr_device.index();
+  auto current_stream = getCurrentStream(curr_device);
+
+  DEBUGINFO("allocating ", nbytes, " (bytes) on Spyre", curr_device);
+  if (nbytes <= 0) {
+    return {nullptr, nullptr, &ReportAndDelete, curr_device};
+  }
+  auto allocator = getAllocator(device_id);
+  flex::DeviceMemoryAllocationPtr data;  // a smart-pointer object
+  // NOTE: last argument should be set to 0
+  allocator->TryAllocate(&data, nbytes, 0);
+  TORCH_CHECK(data, "Failed to allocate ", nbytes, " bytes on Spyre device.");
+  auto* ctx = new SharedOwnerCtx{std::move(data), device_id};
+  void* ctx_void = static_cast<void*>(ctx);
+
+  void* data_void = static_cast<void*>(ctx->owner.get());
+
+  auto data_ptr_result =
+      at::DataPtr(data_void, ctx_void, &ReportAndDelete, curr_device);
+
+  return data_ptr_result;
+}
+
+void SpyreAllocator::ReportAndDelete(void* ctx_void) {
+  if (!ctx_void) {
+    return;
+  }
+  auto* ctx = static_cast<SharedOwnerCtx*>(ctx_void);
+  delete ctx;
+}
+
+at::DeleterFnPtr SpyreAllocator::raw_deleter() const {
+  return nullptr;
+}
+
+void SpyreAllocator::copy_data(void* dest, const void* src,
+                               std::size_t count) const {
+  py::gil_scoped_acquire acquire;
+  DEBUGINFO("entering allocator->copy_data method");
+  // do nothing -- look into when this is called
+  // spyre_copy_from(reinterpret_cast<spyre_ptr_t>(dest),
+  // reinterpret_cast<spyre_ptr_t>(src));
+}
+
+// Register our custom allocator
+REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &SpyreAllocator::instance());
+
+}  // namespace spyre

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -19,7 +19,6 @@
 
 #include "logging.h"
 #include "spyre_mem.h"
-#include "spyre_stream.h"
 #include "spyre_tensor_impl.h"
 
 namespace spyre {
@@ -43,7 +42,6 @@ at::DataPtr SpyreAllocator::allocate(size_t nbytes) {
       c10::impl::getDeviceGuardImpl(c10::DeviceType::PrivateUse1)->getDevice();
 
   auto device_id = curr_device.index();
-  auto current_stream = getCurrentStream(curr_device);
 
   DEBUGINFO("allocating ", nbytes, " (bytes) on Spyre", curr_device);
   if (nbytes <= 0) {

--- a/torch_spyre/csrc/spyre_allocator.h
+++ b/torch_spyre/csrc/spyre_allocator.h
@@ -19,7 +19,7 @@
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
 
-#include <flex/device_memory_allocator.hpp>
+#include <flex/device_types/device_memory_allocator.hpp>
 
 namespace spyre {
 

--- a/torch_spyre/csrc/spyre_allocator.h
+++ b/torch_spyre/csrc/spyre_allocator.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <c10/core/Allocator.h>
+#include <c10/core/Device.h>
+#include <c10/core/Stream.h>
+
+#include <flex/device_memory_allocator.hpp>
+
+namespace spyre {
+
+// A custom allocator for our custom device, which returns a handle to the
+// allocated memory, not the actual pointer.
+struct SpyreAllocator final : public at::Allocator {
+ private:
+  SpyreAllocator();
+
+  flex::DeviceMemoryAllocatorPtr getAllocator(unsigned int dev_id);
+
+ public:
+  static SpyreAllocator& instance();
+
+  at::DataPtr allocate(size_t nbytes) override;
+
+  static void ReportAndDelete(void* ctx_void);
+
+  at::DeleterFnPtr raw_deleter() const override;
+
+  void copy_data(void* dest, const void* src, std::size_t count) const final;
+};
+
+}  // namespace spyre

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -25,43 +25,22 @@
 #include <c10/core/TensorOptions.h>
 #include <c10/util/ArrayRef.h>
 #include <torch/library.h>
-#include <util/sen_data_convert.h>
 
 #include <algorithm>
-#include <cassert>
-#include <flex/graph/graph_builder/flex_graph_builder.hpp>
-#include <memory>
-#include <sendnn/graph/graph_builder.hpp>
-#include <sendnn/interface/graph_loader.hpp>
-#include <sendnn/runtime/runtime_interface.hpp>
-#include <sendnn/tensor/sentensor_info.hpp>
-#include <sendnn/util/status.hpp>
-#include <string>
 #include <utility>
 #include <vector>
 
 #include "logging.h"
 #include "module.h"
+#include "spyre_allocator.h"
 #include "spyre_sendnn_utils.h"
 #include "spyre_storage_impl.h"
+#include "spyre_stream.h"
 #include "spyre_tensor_impl.h"
 #include "types_mapping.h"
 
 namespace spyre {
 
-using DataConversionStrideInfo = data_conversion_stride_info;
-using DataConversionInfo = data_conversion_info;
-
-/* struct holding the parameters for DMA-based copy
-   size_bytes: number of bytes to transfer
-   src_offset: offset from src base pointer
-   dst_offset: offset from destination base pointer
- */
-struct DMAParameters {
-  const int64_t size_bytes;
-  const off64_t src_offset;
-  const off64_t dst_offset;
-};
 /*
  * CPU stride for a dimension.
  *
@@ -241,16 +220,15 @@ auto get_device_stride_infos(c10::IntArrayRef sizes, c10::IntArrayRef strides,
  * Generate description of data conversion for a tensor.
  *
  * @param tensor: tensor to convert
- * @return data conversion information in string
+ * @return data conversion information
  */
 auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
-                  bool host2device) -> std::string {
+                  bool host2device) -> DataConversionInfo {
   /*   host2device = true : then 'tensor' is CPU-tensor
    *   host2device = false: then 'tensor' is Spyre-tensor
    */
   auto str_type = torchScalarToString[tensor->scalar_type()];
   const auto [dtype_cpu, dtype_dev] = stringToDTDataFormatPair(str_type);
-  std::stringstream s;
 
   DataConversionInfo dci{};
   dci.dci_dsName_ = "DCI-Tensor-0";
@@ -283,244 +261,8 @@ auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
 
   dci.input_shape_ = host2device ? cpu_shape : dev_shape;
   dci.output_shape_ = host2device ? dev_shape : cpu_shape;
-  dci.exportJson(s);
-  DEBUGINFO("DataConversionInfo: ", s.str());
-  return s.str();
+  return dci;
 }
-
-auto create_dma_graph(const at::Tensor& self, const at::Tensor& dst,
-                      bool host2device)
-    -> std::shared_ptr<sendnn::GraphLoader> {
-  /* self = source
-   * dst  = destination
-   */
-  const at::Tensor* dev_tensor;
-  const at::Tensor* cpu_tensor;
-  if (host2device) {
-    cpu_tensor = &self;
-    dev_tensor = &dst;
-  } else {
-    cpu_tensor = &dst;
-    dev_tensor = &self;
-  }
-
-  auto str_type = torchScalarToString[cpu_tensor->scalar_type()];
-  const auto [sen_dtype_cpu, sen_dtype_dev] = stringToSenDatatypePair(str_type);
-  auto layout = sendnn::TensorLayout::NHWC;
-  SpyreTensorLayout stl = get_spyre_tensor_layout(host2device ? dst : self);
-  sendnn::TensorShape dev_tensor_shape(stl.device_size);
-
-  // ti = transfer info
-  // dci = data conversion info
-  sendnn::TensorInfo cpu_ti(sen_dtype_cpu,
-                            sendnn::TensorShape(cpu_tensor->sizes().vec()),
-                            layout, sendnn::TensorLocation::HOST());
-  sendnn::TensorInfo dev_ti(sen_dtype_dev, dev_tensor_shape, layout,
-                            sendnn::TensorLocation::DEVICE());
-  sendnn::TensorInfo dci_ti(sen_dtype_dev, dev_tensor_shape, layout,
-                            sendnn::TensorLocation::HOST());
-  //  STAGE 1: execution graph
-  sendnn::SubGraph sub_graph;
-  const auto [elem_bytes_cpu, elem_bytes_spyre] =
-      spyre::elementSize(cpu_tensor->scalar_type());
-  int64_t xfer_size = dev_tensor_shape.Volume() * elem_bytes_spyre;
-  {
-    flex::FlexGraphBuilder gb;
-    DMAParameters dma_param{xfer_size, 0, 0};
-    if (host2device) {
-      auto inp_node = gb.PrimaryInput("Input", dci_ti);
-      auto xfer_node = gb.SenDataTransfer(
-          "Host2Sen-Transfer",
-          dev_ti,    // output (holding shape, type, and location DEVICE)
-          inp_node,  // input (node created using PrimaryInput and on HOST)
-          dev_ti.DataSize(), dma_param.src_offset, dma_param.dst_offset);
-      auto out_node = gb.PrimaryOutput("Output", xfer_node);
-    } else {
-      auto inp_node = gb.PrimaryInput("Input", dev_ti);
-      auto xfer_node = gb.SenDataTransfer(
-          "Sen2Host-Transfer",
-          dci_ti,    // output (holding shape, type and location HOST)
-          inp_node,  // input (node created as a result of SenDataTransfer)
-          dev_ti.DataSize(), dma_param.src_offset, dma_param.dst_offset);
-      auto out_node = gb.PrimaryOutput("Output", xfer_node);
-    }
-
-    SEN_THROW_NOK(gb.Finalize(&sub_graph));
-  }
-  sendnn::SubGraph exec_graph;
-  {  // add above subgraph as part of SenFusedDeviceCompute node
-    flex::FlexGraphBuilder gb;
-    auto dci = generate_dci(dev_tensor, stl, host2device);
-    if (host2device) {
-      auto inp_node = gb.PrimaryInput("Input", cpu_ti);
-      auto dci_node = gb.SenHostCompute("Host2Sen-HostPrep", {dci_ti},
-                                        {inp_node}, "SenDataConvert", dci);
-
-      auto dev_node = gb.SenFusedDeviceCompute("SenFusedDeviceNode_0", {dci_ti},
-                                               {dci_node}, sub_graph);
-      gb.PrimaryOutput("Output", dev_node->OutputPort(0));
-    } else {
-      sendnn::Node* inp_node = gb.PrimaryInput("Input", dci_ti);
-      auto dev_node = gb.SenFusedDeviceCompute("SenFusedDeviceNode_0", {dci_ti},
-                                               {inp_node}, sub_graph);
-      auto dci_node = gb.SenHostCompute("Sen2Host-HostPrep", cpu_ti, dev_node,
-                                        "SenDataConvert", dci);
-
-      gb.PrimaryOutput("Output", dci_node->OutputPort(0));
-    }
-
-    SEN_THROW_NOK(gb.Finalize(&exec_graph));
-  }
-
-  sendnn::SegmentTable segment_table = {
-      sendnn::Segment::PRIMARY_OUT(xfer_size),
-      sendnn::Segment::PRIMARY_IN(xfer_size),
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::PROGRAM(128),
-  };
-  // STAGE 2: SenSuperNodeV2 graph
-  sendnn::Graph sn_graph;  // sn = supernode
-  {                        // SenSuperNodeV2 graph
-    flex::FlexGraphBuilder gb;
-
-    sendnn::TensorInfo inp_ti =
-        sendnn::TensorInfo(exec_graph.input_ops_.front()->OutputAt(0));
-    sendnn::TensorInfo out_ti =
-        sendnn::TensorInfo(exec_graph.output_ops_.front()->InputAt(0));
-    sendnn::NodeOrIndexedNode inp_node = gb.PrimaryInput("Input", inp_ti);
-
-    std::string k_uuid = "dma-network";
-    sendnn::attributes::SenPartitionInit part_init;
-    part_init.network_uuid_ = k_uuid;
-    part_init.partition_idx_ = 0;
-    part_init.segment_table_ = segment_table;
-
-    auto sn =
-        gb.SenSuperNodeV2("SenSuperNodeV2_0", {out_ti}, {inp_node}, k_uuid, 0,
-                          1, part_init, exec_graph, {}, false, true, true);
-    gb.PrimaryOutput("Output", {0, sn});
-
-    SEN_THROW_NOK(gb.Finalize(&sn_graph));
-  }
-
-  // STAGE 3:
-  std::shared_ptr<sendnn::GraphLoader> gl;
-  gl = std::make_shared<sendnn::GraphLoader>(GlobalRuntime::get());
-  {
-    SEN_THROW_NOK(gl->LoadGraph(sn_graph));
-    SEN_THROW_NOK(gl->CompileGraph());
-    SEN_THROW_NOK(gl->ParseGraph());
-  }
-  return gl;
-}
-
-auto copy_host_to_device(const at::Tensor& self, const at::Tensor& dst) {
-  std::shared_ptr<sendnn::GraphLoader> gl = create_dma_graph(self, dst, true);
-  if (!gl) {
-    DEBUGINFO("GraphLoader is null!");
-    return;
-  }
-  // execute
-  constexpr int sn_idx = 0;
-  constexpr int tensor_idx = 0;
-  auto inp_tensor = createInputTensor(*gl, self.storage().data_ptr().get(),
-                                      tensor_idx, sn_idx);
-  auto* ctx =
-      static_cast<SharedOwnerCtx*>(dst.storage().data_ptr().get_context());
-  flex::DeviceMemoryAllocationPtr& dev_data = ctx->owner;
-  inp_tensor.SetSpyreData(dev_data);  // ctx->owner;
-
-  SEN_THROW_NOK(gl->Copy(sendnn::Outputs(), {inp_tensor}, sn_idx));
-}
-
-auto copy_device_to_host(const at::Tensor& self, const at::Tensor& dst) {
-  std::shared_ptr<sendnn::GraphLoader> gl = create_dma_graph(self, dst, false);
-  // execute
-  constexpr int sn_idx = 0;
-  constexpr int tensor_idx = 0;
-  auto out_tensor = createOutputTensor(*gl, dst.storage().data_ptr().get(),
-                                       tensor_idx, sn_idx);
-  auto* ctx =
-      static_cast<SharedOwnerCtx*>(self.storage().data_ptr().get_context());
-  out_tensor.SetSpyreData(ctx->owner);
-  SEN_THROW_NOK(gl->Copy({out_tensor}, sendnn::Inputs(), sn_idx));
-}
-
-// A custom allocator for our custom device, what returns is a handle to the
-// allocated memory not the actual pointer
-struct SpyreAllocator final : public at::Allocator {
- private:
-  SpyreAllocator() = default;
-  flex::DeviceMemoryAllocatorPtr getAllocator(unsigned int dev_id) {
-    return GlobalRuntime::get()
-        ->GetDeviceHandle(dev_id)
-        ->GetDeviceMemoryAllocator();
-  }
-
- public:
-  static SpyreAllocator& instance() {
-    static SpyreAllocator allocator;
-    return allocator;
-  }
-
-  at::DataPtr allocate(size_t nbytes) override {
-    c10::Device curr_device =
-        c10::impl::getDeviceGuardImpl(c10::DeviceType::PrivateUse1)
-            ->getDevice();
-
-    auto device_id = curr_device.index();
-    DEBUGINFO("allocating ", nbytes, " (bytes) on Spyre", curr_device);
-    if (nbytes <= 0) {
-      return {nullptr, nullptr, &ReportAndDelete, curr_device};
-    }
-    auto allocator = getAllocator(device_id);
-    flex::DeviceMemoryAllocationPtr data;  // a smart-pointer object
-    // NOTE: last argument should be set to 0
-    allocator->TryAllocate(&data, nbytes, 0);
-    TORCH_CHECK(data, "Failed to allocate ", nbytes, " bytes on Spyre device.");
-    auto* ctx = new SharedOwnerCtx{std::move(data), device_id};
-    void* ctx_void = static_cast<void*>(ctx);
-
-    void* data_void = static_cast<void*>(ctx->owner.get());
-
-    auto data_ptr_result =
-        at::DataPtr(data_void, ctx_void, &ReportAndDelete, curr_device);
-
-    return data_ptr_result;
-  }
-
-  static void ReportAndDelete(void* ctx_void) {
-    if (!ctx_void) {
-      return;
-    }
-    auto* ctx = static_cast<SharedOwnerCtx*>(ctx_void);
-    delete ctx;
-  }
-
-  // The raw deleter only gets passed the data ptr, no context, so
-  // it would not work right now. To implement this, we first need to
-  // create a runtime interface that can correctly free an allocation
-  // only based on the data ptr, without the allocation idx from the
-  // context
-  at::DeleterFnPtr raw_deleter() const override {
-    return nullptr;
-  }
-
-  void copy_data(void* dest, const void* src, std::size_t count) const final {
-    py::gil_scoped_acquire acquire;
-    DEBUGINFO("entering allocator->copy_data method");
-    // do nothing -- look into when this is called
-    // spyre_copy_from(reinterpret_cast<spyre_ptr_t>(dest),
-    // reinterpret_cast<spyre_ptr_t>(src));
-  }
-};
-
-// Register our custom allocator
-REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &SpyreAllocator::instance());
 
 // Empty op needs C++ code and cannot be handled by python side fallback
 at::Tensor spyre_empty(c10::IntArrayRef size,
@@ -664,46 +406,17 @@ at::Tensor& spyre_set_storage(at::Tensor& result, at::Storage storage,
  */
 at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
                            bool non_blocking) {
-  DEBUGINFO("self (", self.scalar_type(), ") is on:", self.device());
-  DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
-  at::Storage source_storage;
-  at::Storage dest_storage;
-
-  // TODO(tmhoangt): add type conversion node
-  TORCH_CHECK(
-      self.scalar_type() == dst.scalar_type(),
-      "Spyre backend does not support type conversion yet during copy.");
-
-  if (self.is_cpu() && dst.is_privateuseone()) {
-    if (self.dim() == 0) {
-      at::Tensor tmp_tensor = self.reshape({1});
-      copy_host_to_device(tmp_tensor, dst);
-    } else {
-      copy_host_to_device(self, dst);
-    }
-    return dst;
-
-  } else if (self.is_privateuseone() && dst.is_cpu()) {
-    copy_device_to_host(self, dst);
-    return dst;
-
-  } else if (self.is_privateuseone() && dst.is_privateuseone()) {
-    // Copy from Spyre to Spyre
-    // FIXME: This will need to be addressed for proper spyre to spyre copy
-    source_storage =
-        (static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl()))->storage();
-    dest_storage =
-        (static_cast<SpyreTensorImpl*>(dst.unsafeGetTensorImpl()))->storage();
-    DEBUGINFO("Copying", source_storage.nbytes(), "bytes from",
-              source_storage.device(), "to", dest_storage.device());
-    std::memcpy(dest_storage.data_ptr().get(), source_storage.data_ptr().get(),
-                source_storage.nbytes());
-    DEBUGINFO("Finished Copying ");
-    return dst;
+  SpyreStream stream;
+  if (dst.is_privateuseone()) {
+    stream = getCurrentStream(dst.device());
   } else {
-    // For all other cases fallback to the upstream implementation
-    return at::_copy_from(self, dst, non_blocking);
+    stream = getCurrentStream(self.device());
   }
+  stream.copyAsync(self, dst);
+  if (!non_blocking) {
+    stream.synchronize();
+  }
+  return dst;
 }
 
 at::Tensor to_with_layout(const at::Tensor& self,

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -19,6 +19,8 @@
 #include <ATen/ATen.h>
 #include <c10/util/intrusive_ptr.h>
 
+#include "module.h"
+
 namespace spyre {
 
 at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
@@ -52,4 +54,6 @@ at::Tensor py_empty_with_layout(
     std::optional<c10::Device> device_opt, std::optional<bool> pin_memory_opt,
     std::optional<c10::MemoryFormat> memory_format_opt);
 
+auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
+                  bool host2device) -> DataConversionInfo;
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -290,7 +290,7 @@ SpyreStream getStreamFromPool(c10::Device device, int priority) {
   if (pool.stream_handle_map.find(stream_id) == pool.stream_handle_map.end()) {
     auto runtime = GlobalRuntime::get();
     flex::StreamHandle flex_handle =
-        runtime->createStream(device.index(), priority);
+        runtime->createStream(device.index(), runtime->toPriority(priority));
     pool.stream_handle_map[stream_id] = flex_handle;
   }
 

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -76,7 +76,8 @@ constexpr int kHighPriorityStreamsPerDevice = 32;
 
 // Constructor
 SpyreStream::SpyreStream()
-    : stream_(getCurrentStream(c10::Device(c10::DeviceType::PrivateUse1, 0))
+    : stream_(getCurrentStream(c10::Device(c10::DeviceType::PrivateUse1,
+                                           SpyreGuardImpl::tls_idx))
                   .unwrap()) {}
 SpyreStream::SpyreStream(c10::Stream stream) : stream_(stream) {
   TORCH_CHECK(stream_.device_type() == c10::DeviceType::PrivateUse1,
@@ -174,15 +175,11 @@ flex::StreamHandle SpyreStream::getRuntimeHandle() const {
   auto& pool = getStreamPool();
   std::lock_guard<std::mutex> lock(pool.mutex);
 
-  // Look up the flex handle using this stream's ID
   auto it = pool.stream_handle_map.find(id());
-
-  if (it != pool.stream_handle_map.end()) {
-    return it->second;
-  }
-
-  // Default stream (ID 0) returns nullptr
-  return flex::DEFAULT_STREAM;
+  TORCH_CHECK(it != pool.stream_handle_map.end(),
+              "SpyreStream: no flex handle for stream id ", id(),
+              " — was the stream pool initialized for this device?");
+  return it->second;
 }
 
 void SpyreStream::copyAsyncImpl(
@@ -200,6 +197,12 @@ void SpyreStream::copyAsyncImpl(
 void initializeStreamPoolImpl(c10::DeviceIndex device_index) {
   auto& pool = getStreamPool();
   std::lock_guard<std::mutex> lock(pool.mutex);
+
+  // Register the default stream (ID 0) using the concrete flex handle.
+  // This ensures getRuntimeHandle() resolves stream 0 to the real RuntimeStream
+  // instance owned by RuntimeContext.
+  auto runtime = GlobalRuntime::get();
+  pool.stream_handle_map[0] = runtime->getDefaultStream(device_index);
 
   // Initialize low priority streams (IDs 1 to kStreamsPerDevice)
   pool.low_priority_streams[device_index].reserve(kStreamsPerDevice);
@@ -225,14 +228,15 @@ void initializeStreamPool(c10::DeviceIndex device_index) {
 
 SpyreStream getDefaultStream(c10::Device device) {
   if (device.index() == -1) {
-    device = c10::Device(c10::DeviceType::PrivateUse1, 0);
+    device = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
   }
+  initializeStreamPool(device.index());
   return SpyreStream(c10::Stream(c10::Stream::DEFAULT, device));
 }
 
 SpyreStream getCurrentStream(c10::Device device) {
   if (device.index() == -1) {
-    device = c10::Device(c10::DeviceType::PrivateUse1, 0);
+    device = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
   }
 
   auto it = current_streams.find(device.index());
@@ -252,7 +256,7 @@ SpyreStream setCurrentStream(SpyreStream stream) {
 
 SpyreStream getStreamFromPool(c10::Device device, int priority) {
   if (device.index() == -1) {
-    device = c10::Device(c10::DeviceType::PrivateUse1, 0);
+    device = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
   }
 
   // Ensure runtime is initialized before creating streams
@@ -305,8 +309,11 @@ void synchronizeDevice(c10::optional<c10::Device> device) {
       auto& pool = getStreamPool();
       std::lock_guard<std::mutex> lock(pool.mutex);
 
-      // Default stream is always present
-      handles_to_sync.push_back(flex::DEFAULT_STREAM);
+      // Default stream (ID 0) is always present when the pool is initialized
+      auto default_it = pool.stream_handle_map.find(0);
+      if (default_it != pool.stream_handle_map.end()) {
+        handles_to_sync.push_back(default_it->second);
+      }
 
       auto collect = [&](auto& stream_map) {
         auto it = stream_map.find(device_index);

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -157,7 +157,7 @@ void SpyreStream::copyAsync(const at::Tensor& src,
       dev_tensor->storage().data_ptr().get_context());
   dci = generate_dci(&src, stl, host2device);
   if (host2device || device2host) {
-    copyAsyncImpl(cpu_ptr, ctx->owner, ctx->device_id, dci, host2device);
+    copyAsyncImpl(cpu_ptr, ctx->owner, dci, host2device);
   } else if (src.is_privateuseone() && dst.is_privateuseone()) {
     // Device to device copy - for now, we can just do a device to host copy
     // followed by a host to device copy
@@ -184,13 +184,13 @@ flex::StreamHandle SpyreStream::getRuntimeHandle() const {
 
 void SpyreStream::copyAsyncImpl(
     void* cpu_ptr, flex::DeviceMemoryAllocationPtr& device_allocation,
-    int device_id, const DataConversionInfo& dci, bool host2device) const {
+    const DataConversionInfo& dci, bool host2device) const {
   auto runtime = GlobalRuntime::get();
   flex::StreamHandle handle = getRuntimeHandle();
   if (host2device) {
-    runtime->copyAsync(cpu_ptr, device_allocation, device_id, dci, handle);
+    runtime->copyAsync(cpu_ptr, device_allocation, dci, handle);
   } else {
-    runtime->copyAsync(device_allocation, cpu_ptr, device_id, dci, handle);
+    runtime->copyAsync(device_allocation, cpu_ptr, dci, handle);
   }
 }
 

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -25,6 +25,7 @@
 
 #include "logging.h"
 #include "module.h"
+#include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_tensor_impl.h"
 
@@ -295,7 +296,7 @@ SpyreStream getStreamFromPool(c10::Device device, int priority) {
 void synchronizeDevice(c10::optional<c10::Device> device) {
   auto sync_one_device = [](c10::Device dev) {
     if (dev.index() == -1) {
-      dev = c10::Device(c10::DeviceType::PrivateUse1, 0);
+      dev = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
     }
     const auto device_index = dev.index();
 
@@ -330,10 +331,8 @@ void synchronizeDevice(c10::optional<c10::Device> device) {
   if (device.has_value()) {
     sync_one_device(device.value());
   } else {
-    // Synchronize all devices
-    for (int i = 0; i < device_count(); ++i) {
-      sync_one_device(c10::Device(c10::DeviceType::PrivateUse1, i));
-    }
+    sync_one_device(
+        c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx));
   }
 }
 

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -107,7 +107,7 @@ bool SpyreStream::query() const {
             device().index());
 
   auto runtime = GlobalRuntime::get();
-  flex::StreamHandle handle = get_flex_handle();
+  flex::StreamHandle handle = getRuntimeHandle();
   return runtime->queryStream(handle);
 }
 
@@ -118,7 +118,7 @@ void SpyreStream::synchronize() const {
             device().index());
 
   auto runtime = GlobalRuntime::get();
-  flex::StreamHandle handle = get_flex_handle();
+  flex::StreamHandle handle = getRuntimeHandle();
   runtime->synchronizeStream(handle);
 }
 
@@ -126,12 +126,50 @@ c10::Stream SpyreStream::unwrap() const {
   return stream_;
 }
 
-void SpyreStream::copy_async(const at::Tensor& src,
-                             const at::Tensor& dst) const {
-  // TODO(tmhoangt): place-holder to be implemented in the next PR
+void SpyreStream::copyAsync(const at::Tensor& src,
+                            const at::Tensor& dst) const {
+  DEBUGINFO("src (", src.scalar_type(), ") is on:", src.device());
+  DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
+
+  // TODO(tmhoangt): add type conversion node
+  TORCH_CHECK(
+      src.scalar_type() == dst.scalar_type(),
+      "Spyre backend does not support type conversion yet during copy.");
+  bool host2device = src.is_cpu() && dst.is_privateuseone();
+  bool device2host = src.is_privateuseone() && dst.is_cpu();
+
+  const at::Tensor* dev_tensor = host2device ? &dst : &src;
+  const at::Tensor* cpu_tensor = host2device ? &src : &dst;
+  at::Tensor tmp_tensor;
+  if (cpu_tensor->dim() == 0) {
+    tmp_tensor = cpu_tensor->unsqueeze(0);
+    cpu_tensor = &tmp_tensor;
+  }
+
+  void* cpu_ptr = cpu_tensor->data_ptr();
+  void* dev_ptr = dev_tensor->data_ptr();
+  DataConversionInfo dci;
+
+  SpyreTensorLayout stl = get_spyre_tensor_layout(*dev_tensor);
+  auto* ctx = static_cast<SharedOwnerCtx*>(
+      dev_tensor->storage().data_ptr().get_context());
+  dci = generate_dci(&src, stl, host2device);
+  if (host2device || device2host) {
+    copyAsyncImpl(cpu_ptr, ctx->owner, ctx->device_id, dci, host2device);
+  } else if (src.is_privateuseone() && dst.is_privateuseone()) {
+    // Device to device copy - for now, we can just do a device to host copy
+    // followed by a host to device copy
+    // TODO(tmhoangt): optimize this by doing a direct device to device copy
+    // once flex runtime supports it
+    const at::Tensor cpu_tensor = src.cpu();
+    copyAsync(cpu_tensor, dst);
+  } else {
+    TORCH_CHECK(false, "Unsupported copy types: src on ", src.device(),
+                " dst on ", dst.device());
+  }
 }
 
-flex::StreamHandle SpyreStream::get_flex_handle() const {
+flex::StreamHandle SpyreStream::getRuntimeHandle() const {
   auto& pool = getStreamPool();
   std::lock_guard<std::mutex> lock(pool.mutex);
 
@@ -146,10 +184,16 @@ flex::StreamHandle SpyreStream::get_flex_handle() const {
   return flex::DEFAULT_STREAM;
 }
 
-void SpyreStream::copy_async_impl(
+void SpyreStream::copyAsyncImpl(
     void* cpu_ptr, flex::DeviceMemoryAllocationPtr& device_allocation,
     int device_id, const DataConversionInfo& dci, bool host2device) const {
-  // TODO(tmhoangt): place-holder to be implemented in the next PR
+  auto runtime = GlobalRuntime::get();
+  flex::StreamHandle handle = getRuntimeHandle();
+  if (host2device) {
+    runtime->copyAsync(cpu_ptr, device_allocation, device_id, dci, handle);
+  } else {
+    runtime->copyAsync(device_allocation, cpu_ptr, device_id, dci, handle);
+  }
 }
 
 void initializeStreamPoolImpl(c10::DeviceIndex device_index) {

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -19,8 +19,6 @@
 #include <ATen/ATen.h>
 #include <c10/core/Stream.h>
 
-#include <flex/stream/stream_handle.hpp>
-
 #include "module.h"
 
 namespace spyre {
@@ -41,17 +39,17 @@ class SpyreStream {
   bool query() const;        // Check if work completed
   void synchronize() const;  // Block until work done
 
-  void copy_async(const at::Tensor& src, const at::Tensor& dst) const;
+  void copyAsync(const at::Tensor& src, const at::Tensor& dst) const;
 
   // Conversions
   c10::Stream unwrap() const;
 
  private:
-  flex::StreamHandle get_flex_handle() const;
-  void copy_async_impl(void* cpu_ptr,
-                       flex::DeviceMemoryAllocationPtr& device_allocation,
-                       int device_id, const DataConversionInfo& dci,
-                       bool host2device) const;
+  flex::StreamHandle getRuntimeHandle() const;
+  void copyAsyncImpl(void* cpu_ptr,
+                     flex::DeviceMemoryAllocationPtr& device_allocation,
+                     int device_id, const DataConversionInfo& dci,
+                     bool host2device) const;
 };
 
 /**

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -48,8 +48,7 @@ class SpyreStream {
   flex::StreamHandle getRuntimeHandle() const;
   void copyAsyncImpl(void* cpu_ptr,
                      flex::DeviceMemoryAllocationPtr& device_allocation,
-                     int device_id, const DataConversionInfo& dci,
-                     bool host2device) const;
+                     const DataConversionInfo& dci, bool host2device) const;
 };
 
 /**


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).


This PR refactors the host ↔ device memory copy path to use the Flex StreamRuntime’s
`copyAsync` API. This replaces the previous approach, which built and compiled a sendnn graph for **every** copy operation.

A companion PR is included in the Flex repository to support this change.


#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

**`spyre_mem.cpp` / `spyre_mem.h`**

- Remove `create_dma_graph`, `copy_host_to_device`, and `copy_device_to_host`
  — the old mechanism that constructed a full sendnn execution graph
  (`FlexGraphBuilder` → `SenFusedDeviceCompute` → `SenSuperNodeV2` →
  `GraphLoader::CompileGraph`) for each copy call. This incurred compilation
  overhead on every copy and pulled in `flex/flex_graph_builder.hpp`.
- Remove `DMAParameters` struct and the local `using` aliases for
  `DataConversionStrideInfo` / `DataConversionInfo` (now provided by headers).
- Change `generate_dci()` return type from `std::string` (a JSON export) to
  `DataConversionInfo`. The function now returns the structured conversion
  descriptor directly, which is what callers need.
- Export `generate_dci()` in `spyre_mem.h` so `SpyreStream` can use it.
- Add includes for `spyre_allocator.h` and `spyre_stream.h`; remove
  `flex/flex_graph_builder.hpp`.
- Simplify `spyre_copy_from()` to delegate entirely to
  `SpyreStream::copyAsync()` + optional `synchronize()` for blocking copies.

**`spyre_stream.cpp` / `spyre_stream.h`**

- Implement `copyAsync()` (previously a placeholder): handles host→device,
  device→host, and device→device (via CPU round-trip) copy cases using
  `generate_dci` to build the data-conversion descriptor and then dispatching
  to `copyAsyncImpl`.
- Implement `copyAsyncImpl()` (previously a placeholder): calls
  `runtime->copyAsync(cpu_ptr, device_allocation, …)` or the reverse,
  dispatching through the current `flex::StreamHandle`.
- Rename private helpers to follow naming conventions defined in clang-format (a subsequent PR will enforce this style at pre-commit hooks):
  - `copy_async` → `copyAsync`
  - `copy_async_impl` → `copyAsyncImpl`
  - `get_flex_handle` → `getRuntimeHandle`
  - `_initializeStreamPool` → `initializeStreamPoolImpl`
  

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

Issue https://github.com/torch-spyre/torch-spyre/issues/209

It also replaces PR #222 when switching to fork repo model.

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
