### PR TITLE
Enable data type conversion with to.dtype operator

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1460,6 +1460,25 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             },
         },
+        (
+            "test_mixed_dtype_cmp_op",
+            "test_mixed_dtype_cmp_ops",
+        ): {
+            "ops_dict": {
+                "ge": torch.ge,
+                "le": torch.le,
+            },
+            "param_sets": {
+                "float16_bool_1d": (
+                    cached_randn((64,), dtype=torch.float16, scale=10.0),
+                    torch.randint(0, 2, (64,), dtype=torch.bool),
+                ),
+                "float16_bool_2d": (
+                    cached_randn((32, 64), dtype=torch.float16, scale=10.0),
+                    torch.randint(0, 2, (32, 64), dtype=torch.bool),
+                ),
+            },
+        },
         ("test_dtype_convenience_methods", "test_dtype_convenience_cpu"): {
             "param_sets": {
                 "half_1d": (cached_randn((256,), dtype=torch.float32), torch.float16),
@@ -2012,13 +2031,13 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_mixed_dtype_binary_op_cpu(self, op, a, b):
-        # tests binary ops for mixed dtype
-        # TODO: Division by 0 or near-zero differs on Spyre from CPU, sidestep for now.
+        """Test binary ops for mixed dtype
+        TODO: Division by 0 or near-zero differs on Spyre from CPU, sidestep for now"""
         if op == torch.div:
             pytest.skip(
-                "div excluded for mixed dtype — Division by 0 or near-zero differs on Spyre from CPU, sidestep for now."
+                "div excluded for mixed dtype — Division by 0 or near-zero differs on Spyre from CPU,"
+                "sidestep for now."
             )
-
         expected_dtype = torch.result_type(a, b)
         target = _compile_and_run(op, (a, b), device=torch.device("spyre"))
 
@@ -2028,19 +2047,30 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             expected_dtype,
             f"dtype mismatch: got {target.dtype}, expected {expected_dtype}",
         )
-        compare_with_cpu(
-            op, a, b, atol=FP16_EPS * 10, rtol=FP16_EPS * 10, target=target
-        )
+        compare_with_cpu(op, a, b, target=target)
 
-    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_mixed_dtype_cmp_ops(self, op, a, b):
+        """Test comparison ops for mixed dtype"""
+        target = _compile_and_run(op, (a, b), device=torch.device("spyre"))
+        expected_dtype = torch.bool
+
+        # dtype check
+        self.assertEqual(
+            target.dtype,
+            expected_dtype,
+            f"dtype mismatch: got {target.dtype}, expected {expected_dtype}",
+        )
+        compare_with_cpu(op, a, b, target=target)
+
     def test_dtype_convenience_cpu(self, x, target_dtype):
-        # tests .half() and .float() convenience methods specifically
+        """Test .half() and .float() convenience methods specifically"""
+
         def fn(x):
             return x.half() if target_dtype == torch.float16 else x.float()
 
         target = _compile_and_run(fn, (x,), device=torch.device("spyre"))
         self.assertEqual(target.dtype, target_dtype)
-        compare_with_cpu(fn, x, atol=FP16_EPS, rtol=FP16_EPS, target=target)
+        compare_with_cpu(fn, x, target=target)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -21,8 +21,10 @@ from utils_inductor import (
     cached_randn,
     make_param_dict,
     unique_randn_along_dim,
+    compare,
+    compare_with_cpu,
+    _compile_and_run,
 )
-from utils_inductor import compare, compare_with_cpu
 
 POINTWISE_UNARY_OPS_DICT = {
     "abs": torch.abs,
@@ -1437,6 +1439,41 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 # ),
             }
         },
+        (
+            "test_mixed_dtype_binary_op",
+            "test_mixed_dtype_binary_op_cpu",
+        ): {
+            "ops_dict": POINTWISE_BINARY_OPS_DICT,
+            "param_sets": {
+                # fp32 + fp16 (cast fp16 → fp32)
+                "fp32_fp16_1d": (
+                    cached_randn((256,), dtype=torch.float32),
+                    cached_randn((256,), dtype=torch.float16),
+                ),
+                "fp32_fp16_2d": (
+                    cached_randn((67, 256), dtype=torch.float32),
+                    cached_randn((67, 256), dtype=torch.float16),
+                ),
+                "fp32_fp16_3d": (
+                    cached_randn((67, 71, 256), dtype=torch.float32),
+                    cached_randn((67, 71, 256), dtype=torch.float16),
+                ),
+            },
+        },
+        ("test_dtype_convenience_methods", "test_dtype_convenience_cpu"): {
+            "param_sets": {
+                "half_1d": (cached_randn((256,), dtype=torch.float32), torch.float16),
+                "half_2d": (
+                    cached_randn((67, 256), dtype=torch.float32),
+                    torch.float16,
+                ),
+                "float_1d": (cached_randn((256,), dtype=torch.float16), torch.float32),
+                "float_2d": (
+                    cached_randn((67, 256), dtype=torch.float16),
+                    torch.float32,
+                ),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -1972,6 +2009,38 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 return result.item()
 
             compare_with_cpu(fn, x, y, cpu_compile=False)
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_mixed_dtype_binary_op_cpu(self, op, a, b):
+        # tests binary ops for mixed dtype
+        # TODO: Division by 0 or near-zero differs on Spyre from CPU, sidestep for now.
+        if op == torch.div:
+            pytest.skip(
+                "div excluded for mixed dtype — Division by 0 or near-zero differs on Spyre from CPU, sidestep for now."
+            )
+
+        expected_dtype = torch.result_type(a, b)
+        target = _compile_and_run(op, (a, b), device=torch.device("spyre"))
+
+        # dtype check
+        self.assertEqual(
+            target.dtype,
+            expected_dtype,
+            f"dtype mismatch: got {target.dtype}, expected {expected_dtype}",
+        )
+        compare_with_cpu(
+            op, a, b, atol=FP16_EPS * 10, rtol=FP16_EPS * 10, target=target
+        )
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_dtype_convenience_cpu(self, x, target_dtype):
+        # tests .half() and .float() convenience methods specifically
+        def fn(x):
+            return x.half() if target_dtype == torch.float16 else x.float()
+
+        target = _compile_and_run(fn, (x,), device=torch.device("spyre"))
+        self.assertEqual(target.dtype, target_dtype)
+        compare_with_cpu(fn, x, atol=FP16_EPS, rtol=FP16_EPS, target=target)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -205,3 +205,16 @@ def _ones_scalar_fake(
     dtype: Optional[torch.dtype] = None,
 ):
     return torch.empty(1, dtype=dtype, device="spyre")
+
+
+@torch.library.custom_op("spyre::cpu_dtype_cast", mutates_args=(), device_types="spyre")
+def _cpu_dtype_cast(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Custom op to do type conversion on CPU
+    TODO: Develop type conversion as a Spyre operator and avoid CPU fallback:
+    https://github.com/torch-spyre/torch-spyre/issues/1153"""
+    return tensor.cpu().to(dtype=dtype).to(tensor.device)
+
+
+@_cpu_dtype_cast.register_fake
+def _(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    return tensor.to(dtype=dtype)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -58,7 +58,7 @@ class CustomPrePasses(CustomGraphPass):
     """
     The list of custom passes to run
     """
-    passes: List[Callable[[torch.fx.graph.Graph], None]] = [insert_dtype_casts]
+    passes: List[Callable[[torch.fx.graph.Graph], None]] = []
 
     def __call__(self, graph: torch.fx.graph.Graph) -> None:
         for p in CustomPrePasses.passes:
@@ -83,6 +83,7 @@ class CustomPostPasses(CustomGraphPass):
         relayout_linear_weights,
         mm_to_bmm_pass.apply,
         bmm_unflatten_pass.apply,
+        insert_dtype_casts,
     ]
 
     def __call__(self, graph: torch.fx.graph.Graph) -> None:

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -29,6 +29,7 @@ from .temp_passes import (
     mm_to_bmm_pass,
     relayout_linear_weights,
     replace_scalar_with_tensor,
+    insert_dtype_casts,
 )
 from .stickify import propagate_spyre_tensor_layouts
 from .core_division import core_division_planning
@@ -57,7 +58,7 @@ class CustomPrePasses(CustomGraphPass):
     """
     The list of custom passes to run
     """
-    passes: List[Callable[[torch.fx.graph.Graph], None]] = []
+    passes: List[Callable[[torch.fx.graph.Graph], None]] = [insert_dtype_casts]
 
     def __call__(self, graph: torch.fx.graph.Graph) -> None:
         for p in CustomPrePasses.passes:

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -25,6 +25,7 @@ from torch._inductor.pattern_matcher import (
 )
 
 aten = torch.ops.aten
+import torch.fx
 
 
 def relayout_linear_weights(graph: torch.fx.Graph) -> None:
@@ -312,3 +313,52 @@ def replace_scalar_with_tensor(graph: torch.fx.Graph) -> None:
                         )
                         const_node_map[scalar_val] = full_node
                     node.update_arg(idx, full_node)
+
+
+def get_node_dtype(node: torch.fx.Node):
+    """
+    Return the expected output dtype of this node (used as the cast target).
+    """
+    val = node.meta.get("val", None)
+    if isinstance(val, torch.Tensor):
+        return val.dtype
+    return None
+
+
+def insert_dtype_casts(graph: torch.fx.Graph) -> None:
+    """
+    FX graph pass that inserts explicit CPU dtype casts before any op whose
+    tensor inputs have mismatched dtypes.
+    """
+    for node in list(graph.nodes):
+        if node.op != "call_function":
+            continue
+        # Get the result dtype
+        target_dtype = get_node_dtype(node)
+        if target_dtype is None:
+            continue
+
+        # Collect tensor args with mismatched dtypes
+        mismatched = []
+        for i, arg in enumerate(node.args):
+            if not isinstance(arg, torch.fx.Node):
+                continue
+            # Get the dtype of input tensors
+            src_dtype = get_node_dtype(arg)
+            if src_dtype is not None and src_dtype != target_dtype:
+                mismatched.append((i, arg, src_dtype))
+
+        if not mismatched:
+            continue
+
+        with graph.inserting_before(node):
+            for i, arg, src_dtype in mismatched:
+                cast_node = graph.call_function(
+                    torch.ops.aten.to.dtype,
+                    args=(arg, target_dtype),
+                )
+                cast_node.name = graph._graph_namespace.create_name(
+                    f"cpu_cast_{arg.name}_to_{str(target_dtype).split('.')[-1]}", None
+                )
+                node.update_arg(i, cast_node)
+    graph.lint()

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -16,6 +16,7 @@
 
 from typing import cast
 import torch
+import torch.fx
 from torch._inductor.pattern_matcher import (
     Arg,
     CallFunction,
@@ -25,7 +26,6 @@ from torch._inductor.pattern_matcher import (
 )
 
 aten = torch.ops.aten
-import torch.fx
 
 
 def relayout_linear_weights(graph: torch.fx.Graph) -> None:
@@ -315,36 +315,43 @@ def replace_scalar_with_tensor(graph: torch.fx.Graph) -> None:
                     node.update_arg(idx, full_node)
 
 
-def get_node_dtype(node: torch.fx.Node):
-    """
-    Return the expected output dtype of this node (used as the cast target).
-    """
-    val = node.meta.get("val", None)
-    if isinstance(val, torch.Tensor):
-        return val.dtype
-    return None
-
-
 def insert_dtype_casts(graph: torch.fx.Graph) -> None:
     """
-    FX graph pass that inserts explicit CPU dtype casts before any op whose
-    tensor inputs have mismatched dtypes.
+    Combined pass that:
+    1. Detects mismatched dtype in nodes
+    2. Inserts Spyre custom cast op (cpu_dtype_cast)
+        node for type conversion except for bool dtype which
+        has separate handling.
+    TODO: To be revisted once https://github.com/torch-spyre/torch-spyre/issues/1153 resolved
     """
+
+    def get_node_dtype(node: torch.fx.Node):
+        val = node.meta.get("val", None)
+        if isinstance(val, torch.Tensor):
+            return val.dtype
+        return None
+
     for node in list(graph.nodes):
         if node.op != "call_function":
             continue
+
         # Get the result dtype
         target_dtype = get_node_dtype(node)
         if target_dtype is None:
             continue
+        # skip conversion for bool dtype
+        if target_dtype == torch.bool:
+            continue
 
-        # Collect tensor args with mismatched dtypes
         mismatched = []
         for i, arg in enumerate(node.args):
             if not isinstance(arg, torch.fx.Node):
                 continue
             # Get the dtype of input tensors
             src_dtype = get_node_dtype(arg)
+            # skip conversion for bool dtype
+            if src_dtype == torch.bool:
+                continue
             if src_dtype is not None and src_dtype != target_dtype:
                 mismatched.append((i, arg, src_dtype))
 
@@ -354,11 +361,13 @@ def insert_dtype_casts(graph: torch.fx.Graph) -> None:
         with graph.inserting_before(node):
             for i, arg, src_dtype in mismatched:
                 cast_node = graph.call_function(
-                    torch.ops.aten.to.dtype,
+                    torch.ops.spyre.cpu_dtype_cast.default,
                     args=(arg, target_dtype),
                 )
+
                 cast_node.name = graph._graph_namespace.create_name(
-                    f"cpu_cast_{arg.name}_to_{str(target_dtype).split('.')[-1]}", None
+                    f"cast_{arg.name}_to_{str(target_dtype).split('.')[-1]}", None
                 )
                 node.update_arg(i, cast_node)
+
     graph.lint()

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -317,13 +317,25 @@ def replace_scalar_with_tensor(graph: torch.fx.Graph) -> None:
 
 def insert_dtype_casts(graph: torch.fx.Graph) -> None:
     """
-    Combined pass that:
+    A pass that:
     1. Detects mismatched dtype in nodes
     2. Inserts Spyre custom cast op (cpu_dtype_cast)
         node for type conversion except for bool dtype which
         has separate handling.
     TODO: To be revisted once https://github.com/torch-spyre/torch-spyre/issues/1153 resolved
     """
+    SDSC_SUPPORT = {
+        (torch.bool, torch.float16),
+        (torch.float16, torch.bool),
+    }
+    COMPARISON_OPS = {
+        torch.ops.aten.le.Tensor,
+        torch.ops.aten.ge.Tensor,
+        torch.ops.aten.lt.Tensor,
+        torch.ops.aten.gt.Tensor,
+        torch.ops.aten.eq.Tensor,
+        torch.ops.aten.ne.Tensor,
+    }
 
     def get_node_dtype(node: torch.fx.Node):
         val = node.meta.get("val", None)
@@ -331,16 +343,26 @@ def insert_dtype_casts(graph: torch.fx.Graph) -> None:
             return val.dtype
         return None
 
+    def get_cast_target_dtype(node: torch.fx.Node) -> torch.dtype | None:
+        """Dtype that inputs should be cast to.
+        For cmp ops, use non-bool input dtype instead of output dtype
+        fp16,bool --> fp16,fp16"""
+        if node.target in COMPARISON_OPS:
+            for arg in node.args:
+                if isinstance(arg, torch.fx.Node):
+                    dtype = get_node_dtype(arg)
+                    if dtype is not None and dtype != torch.bool:
+                        return dtype
+            return None
+        return get_node_dtype(node)
+
     for node in list(graph.nodes):
         if node.op != "call_function":
             continue
 
-        # Get the result dtype
-        target_dtype = get_node_dtype(node)
+        # Get the target dtype
+        target_dtype = get_cast_target_dtype(node)
         if target_dtype is None:
-            continue
-        # skip conversion for bool dtype
-        if target_dtype == torch.bool:
             continue
 
         mismatched = []
@@ -349,8 +371,12 @@ def insert_dtype_casts(graph: torch.fx.Graph) -> None:
                 continue
             # Get the dtype of input tensors
             src_dtype = get_node_dtype(arg)
-            # skip conversion for bool dtype
-            if src_dtype == torch.bool:
+
+            # Skip if float16 to bool conversion through convert_element_type
+            if (
+                node.target == torch.ops.prims.convert_element_type.default
+                and (src_dtype, target_dtype) in SDSC_SUPPORT
+            ):
                 continue
             if src_dtype is not None and src_dtype != target_dtype:
                 mismatched.append((i, arg, src_dtype))
@@ -360,6 +386,9 @@ def insert_dtype_casts(graph: torch.fx.Graph) -> None:
 
         with graph.inserting_before(node):
             for i, arg, src_dtype in mismatched:
+                # where operation does not need casting as first arg is cond
+                if node.target == torch.ops.aten.where.self and i == 0:
+                    continue
                 cast_node = graph.call_function(
                     torch.ops.spyre.cpu_dtype_cast.default,
                     args=(arg, target_dtype),
@@ -369,5 +398,10 @@ def insert_dtype_casts(graph: torch.fx.Graph) -> None:
                     f"cast_{arg.name}_to_{str(target_dtype).split('.')[-1]}", None
                 )
                 node.update_arg(i, cast_node)
+
+        # remove the redundant prims.convert_element_type
+        if node.target == torch.ops.prims.convert_element_type.default:
+            node.replace_all_uses_with(cast_node)
+            graph.erase_node(node)
 
     graph.lint()

--- a/torch_spyre/ops/fallbacks.py
+++ b/torch_spyre/ops/fallbacks.py
@@ -272,8 +272,3 @@ def spyre__tril(input, diagonal=0, **kwargs):
 @register_fallback([aten.triu.default, aten.triu.out])
 def spyre__triu(input, diagonal=0, **kwargs):
     return torch.triu(input, diagonal, **kwargs)
-
-
-@register_fallback([aten.to.dtype])
-def spyre__to_dtype(input, dtype, **kwargs):
-    return aten.to(input, dtype=dtype)

--- a/torch_spyre/ops/fallbacks.py
+++ b/torch_spyre/ops/fallbacks.py
@@ -272,3 +272,8 @@ def spyre__tril(input, diagonal=0, **kwargs):
 @register_fallback([aten.triu.default, aten.triu.out])
 def spyre__triu(input, diagonal=0, **kwargs):
     return torch.triu(input, diagonal, **kwargs)
+
+
+@register_fallback([aten.to.dtype])
+def spyre__to_dtype(input, dtype, **kwargs):
+    return aten.to(input, dtype=dtype)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:


This change allows compile time data type conversion of Spyre Tensors by falling back to CPU for the type conversion. Binary operations like Addition, subtraction and multiplication of Spyre Tensors of different data types will be casted to the suitable resultant data type n CPU without the introduction of a Pointwise `to_dtype` node which otherwise fails. 

Data type conversion operations like `.float()`, `.half()` can be executed and suitable data conversion is taken care of.

This change allows converting spyre tensors from one data type to another by adding a custom spyre operator.

#### Which issue(s) this PR is related to:

Helps in unblocking #395  as it is needed for RMSNorm and RoPe
Temporary fix for #41 
Handles #1154

#### Special notes for your reviewer: None

#### Does this PR introduce a user-facing change? No

#### Additional note: None
