### PR TITLE
Fix an exception at to_spyre()

### DIFF
--- a/tests/models/test_model_ops.py
+++ b/tests/models/test_model_ops.py
@@ -190,8 +190,10 @@ class TestSpyreModelOps(PrivateUse1TestBase):
         def to_spyre(arg):
             if isinstance(arg, list):
                 return [x.to(test_device) for x in arg]
+            elif isinstance(arg, torch.Tensor):
+                return arg.to(test_device)
             else:
-                return arg.to(device=test_device)
+                return arg
 
         test_sample = cpu_sample.transform(to_spyre)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
This PR allows to_spyre() to accept non-device value (e.g. torch.dtype) in test_device. When `arg is `torch.dtype`, an exception occurred.  

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
Fixes #1093
Fixes #1116
Fixes #1122

#### Special notes for your reviewer:

An exception does not occur in the test framework with #1063

```
$ pytest -n 1 --max-worker-restart=99999 -s -rsapd tests/models/test_model_ops.py -k test_model_ops_db_torch_arange_1_spyre__granite-3_3-8b-instruct-fms_spyre_yaml__spyre_float16
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
================================================================================================================================================================================================================ test session starts ================================================================================================================================================================================================================
platform linux -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre
configfile: pytest.ini
plugins: hypothesis-6.151.9, github-report-0.0.1, xdist-3.8.0, md-report-0.7.0
ready: 1/1 worker      /home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
1 worker [1 item]
F
===================================================================================================================================================================================================================== FAILURES ======================================================================================================================================================================================================================
________________________________________________________________________________________________________________________________________________________________ TestSpyreModelOpsCPU.test_model_ops_db_torch_arange_1_spyre__granite-3_3-8b-instruct-fms_spyre_yaml__spyre_float16 _________________________________________________________________________________________________________________________________________________________________
[gw0] linux -- Python 3.12.9 /home/ishizaki/aiu-src/dt-opfunc-verify/.venv/bin/python3

self = <test_model_ops.TestSpyreModelOpsCPU testMethod=test_model_ops_db_torch_arange_1_spyre__granite-3_3-8b-instruct-fms_spyre_yaml__spyre_float16>, device = 'spyre:0', dtype = torch.float16
op = ModelOpInfo(name='torch.arange.1_spyre__granite-3.3-8b-instruct-fms_spyre.yaml_', ref=None, aliases=(), variant_test_n...alysis=False, supports_expanded_weight=False, is_factory_function=False, skip_correctness_check_compile_vs_eager=False)

    @ops(model_ops_db)
    def test_model_ops_db(
        self,
        device,
        dtype,
        op,
    ):
        pytestconfig = shared_config._PYTEST_CONFIG
        selected_models = set(pytestconfig.getoption("--model") or [])
        dedupe_enabled = bool(pytestconfig.getoption("--dedupe", default=True))
        compile_backend = str(
            pytestconfig.getoption("--compile-backend") or "inductor"
        ).strip()
        allowed_test_names = pytestconfig.getoption("--test-name")
    
        method_name = self._testMethodName
    
        loadedCase: LoadedCase = op.loadedCase
        model = loadedCase.model
        case: Any = loadedCase.case
        defaults = loadedCase.defaults
    
        # 1) Model filtering (keeps your "only ops from granite3-speech" capability)
        if selected_models and model not in selected_models:
            pytest.skip(f"Filtered out by --model (selected={sorted(selected_models)})")
    
        # 2) Test names filtering
        if allowed_test_names:
            matched = any(test_name in method_name for test_name in allowed_test_names)
            if not matched:
                pytest.skip("Filtered out by --test-name list")
    
        # 3) Check pytest -m marker expression
        mark_expr = pytestconfig.option.markexpr
        if mark_expr:
            from _pytest.mark.expression import Expression
    
            compiled_expr = Expression.compile(mark_expr)
    
            # Get marks from YAML case
            case_marks = set()
            marks = case.get("marks")
            if isinstance(marks, str) and marks.strip():
                case_marks.add(marks.strip())
            elif isinstance(marks, (list, tuple)):
                for m in marks:
                    if isinstance(m, str) and m.strip():
                        case_marks.add(m.strip())
    
            # Evaluate if this test should run based on marks
            if not compiled_expr.evaluate(lambda m: m in case_marks):
                pytest.skip(f"Skipped by marker expression: {mark_expr}")
    
        # 4) Optional cross-model dedupe (do NOT dedupe at collection time!)
        if dedupe_enabled:
            global seen_case_keys
            k = case_key(case, defaults)
            if k in seen_case_keys:
                pytest.skip(
                    "duplicate signature already tested (enable/disable via --no-dedupe)"
                )
            seen_case_keys.add(k)
    
        test_device = torch.device(
            re.sub(r":\d+$", "", device)
        )  # remove :digit (e.g. :0)
    
        # load parameters
        seed = case.get("seed", defaults.get("seed", None))
        rtol = float(case.get("rtol", defaults.get("rtol", 5e-3)))
        atol = float(case.get("atol", defaults.get("atol", 5e-3)))
        description = case.get("description")
    
        # Build CPU args ONCE, then copy to Spyre (identical values)
        cpu_sample = make_SampleInput(case, seed, dtype)
    
        def to_spyre(arg):
            if isinstance(arg, list):
                return [x.to(test_device) for x in arg]
            elif isinstance(arg, torch.Tensor):
                return arg.to(device=test_device)
            else:
                return arg
    
        test_sample = cpu_sample.transform(to_spyre)
    
        # run target op
        try:
>           run_test(
                op,
                self,
                cpu_sample,
                test_sample,
                test_device,
                compile_backend,
                rtol,
                atol,
                description,
            )

tests/models/test_model_ops.py:202: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/models/runner.py:336: in run_test
    ref_out = op(cpu_sample.input, *cpu_sample.args, **cpu_sample.kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../.venv/lib64/python3.12/site-packages/torch/testing/_internal/opinfo/core.py:1186: in __call__
    return self.op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def _lazy_init():
        global _initialized, _queued_calls
        if is_initialized() or hasattr(_tls, "is_initializing"):
            return
        with _initialization_lock:
            # We be double-checked locking, boys!  This is OK because
            # the above test was GIL protected anyway.  The inner test
            # is for when a thread blocked on some other thread which was
            # doing the initialization; when they get the lock, they will
            # find there is nothing left to do.
            if is_initialized():
                return
            # It is important to prevent other threads from entering _lazy_init
            # immediately, while we are still guaranteed to have the GIL, because some
            # of the C calls we make below will release the GIL
            if _is_in_bad_fork():
                raise RuntimeError(
                    "Cannot re-initialize CUDA in forked subprocess. To use CUDA with "
                    "multiprocessing, you must use the 'spawn' start method"
                )
            if not hasattr(torch._C, "_cuda_getDeviceCount"):
>               raise AssertionError("Torch not compiled with CUDA enabled")
E               AssertionError: Torch not compiled with CUDA enabled
E               
E               To execute this test, run the following from the base repo dir:
E                   python test_model_ops.py TestSpyreModelOpsCPU.test_model_ops_db_torch_arange_1_spyre__granite-3_3-8b-instruct-fms_spyre_yaml__spyre_float16
E               
E               This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0

../.venv/lib64/python3.12/site-packages/torch/cuda/__init__.py:417: AssertionError
============================================================================================================================================================================================================== short test summary info ==============================================================================================================================================================================================================
FAILED tests/models/test_model_ops.py::TestSpyreModelOpsCPU::test_model_ops_db_torch_arange_1_spyre__granite-3_3-8b-instruct-fms_spyre_yaml__spyre_float16 - AssertionError: Torch not compiled with CUDA enabled
================================================================================================================================================================================================================= 1 failed in 8.91s =================================================================================================================================================================================================================
```

#### Does this PR introduce a user-facing change?

#### Additional note:
