### PR TITLE
[INFRA][CI] add pre-commit hook to prevent user from adding pytest.ini

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,11 @@ repos:
         exclude: codegen/.*
   - repo: local
     hooks:
+      - id: forbid-pytest-ini
+        name: Forbid pytest.ini (use pyproject.toml instead)
+        language: fail
+        entry: pytest.ini is forbidden. Use [tool.pytest.ini_options] in pyproject.toml instead.
+        files: ^pytest\.ini$
       - id: check-requirements-dev
         name: Check requirements/dev.txt sync
         entry: tools/check-requirements.sh


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

PR #1043 removed pytest.ini as the pytest configuration is now defined in pyproject.toml. If pytest.ini exists, pytest will prefer it over pyproject.toml, leading to the new configuration being ignored.
This PR adds a guardrail to block adding pytest.ini back into the repository and clearly guides users to use pyproject.toml instead.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

The CICD for this PR won't be successful until `pytest.ini` is removed from the repo, which is the result of PR #1043. After that, any PR would fail if it add `pytest.ini` again. 