### PR TITLE
test: Suppress expected fallback warning in test_addmm_ab_bc_scaled

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -435,6 +435,7 @@ class TestOps(TestCase):
             z, torch.addmm(mat, x, y), rtol=self.rtol, atol=self.atol
         )
 
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_addmm_ab_bc_scaled(self):
         mat = torch.randn(self.mm_a * self.mm_c, dtype=self.dtype).view(
             self.mm_a, self.mm_c


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Add a pytest warning filter to test_addmm_ab_bc_scaled to suppress FallbackWarning messages during test execution.

```
tests/test_ops.py::TestOps::test_addmm_ab_bc_scaled
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:208: FallbackWarning: torch.ops.spyre.full is falling back to cpu
    warn_fallback("torch.ops.spyre.full")
```

This test uses constant/scalar arguments, which currently trigger a CPU fallback and emit an expected warning. The filter reduces noise in test output while the underlying behavior is being addressed.

Once #238 adds native support for constant arguments, this warning filter can be removed.

#### Which issue(s) this PR is related to:

- #742

#### Special notes for your reviewer:

```
(dt-inductor) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
=================================================================== test session starts ===================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: hypothesis-6.151.9
collected 509 items

tests/inductor/test_building_blocks.py ....                                                                                                         [  0%]
tests/inductor/test_inductor_decomp.py ...                                                                                                          [  1%]
tests/inductor/test_inductor_ops.py ...s........................................................................................................... [ 23%]
................................................................................................................................................... [ 52%]
................................................................................................                                                    [ 70%]
tests/inductor/test_logging.py ....                                                                                                                 [ 71%]
tests/tensor/test_tensor_layout.py ..............                                                                                                   [ 74%]
tests/test_fallbacks.py ........                                                                                                                    [ 76%]
tests/test_modules.py .sssss.                                                                                                                       [ 77%]
tests/test_ops.py ...s...s...s..............................s...sss.ss.....................                                                         [ 91%]
tests/test_regex.py .                                                                                                                               [ 91%]
tests/test_spyre.py ..s..ss............                                                                                                             [ 95%]
tests/test_spyre_lazy_silent.py .                                                                                                                   [ 95%]
tests/test_stream.py .....................                                                                                                          [100%]

==================================================================== warnings summary =====================================================================
tests/test_ops.py::TestOps::test_isin_scalar_tensor_out
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/ops/fallbacks.py:255: UserWarning: An output with one or more elements was resized since it had shape [], which does not match the required output shape [0]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (Triggered internally at /home/yohei/dt-inductor/pytorch/aten/src/ATen/native/Resize.cpp:31.)
    return torch.isin(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 491 passed, 18 skipped, 1 warning in 414.04s (0:06:54) ==================================================
```

**Note**:
DeprecationWarning is addressed by https://github.com/torch-spyre/torch-spyre/pull/1043
The resizing warning will be addressed separately https://github.com/torch-spyre/torch-spyre/issues/992#issuecomment-4080010156

#### Does this PR introduce a user-facing change?

#### Additional note:

CC: @inatatsu 