### PR TITLE
Add scalar support for torch.div and torch.true_divide

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -942,6 +942,30 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "4d": (cached_randn((4, 17, 256, 128), dtype=torch.float16),),
             },
         },
+        ("test_scalar_cpu", "test_scalar_cpu"): {
+            "ops_dict": {
+                "add": torch.add,
+                "sub": torch.sub,
+                "mul": torch.mul,
+                "div": torch.div,
+                "true_divide": torch.true_divide,
+                "combined": lambda scalar, x: (
+                    a := torch.add(x, scalar),
+                    b := torch.add(scalar, a),
+                    c := torch.add(b, scalar),
+                    d := torch.sub(c, scalar),
+                    e := torch.mul(5, d),
+                    out := torch.add(e, e),
+                    out,
+                ),
+            },
+            "param_sets": {
+                "1d": (cached_randn((1024,), dtype=torch.float16), 3.0),
+                "2d": (cached_randn((512, 1024), dtype=torch.float16), 1.0),
+                "3d": (cached_randn((8, 64, 1024), dtype=torch.float16), 1.5),
+                "4d": (cached_randn((2, 4, 64, 1024), dtype=torch.float16), 2.4),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -976,18 +1000,19 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         torch.testing.assert_close(result, torch.eq(x, y))
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
-    def test_scalar_cpu(self):
-        def fn(x):
-            a = torch.add(x, 1.0)
-            b = torch.add(1.0, a)
-            c = torch.add(b, 1.0)
-            d = torch.sub(c, 2.0)
-            e = torch.mul(5, d)
-            out = torch.add(e, e)
-            return out
+    def test_scalar_cpu(self, op, *args):
+        def fn(*tensor_args):
+            # Scalar args are preserved as scalars
+            tensor_args = list(tensor_args)
+            updated_args = [
+                tensor_args.pop(0) if isinstance(arg, torch.Tensor) else arg
+                for arg in args
+            ]
+            return op(*updated_args)
 
-        x = torch.rand(512, 1024, dtype=torch.float16)
-        compare_with_cpu(fn, x)
+        tensor_args = [arg for arg in args if isinstance(arg, torch.Tensor)]
+
+        compare_with_cpu(fn, *tensor_args)
 
     def test_unary_op_cpu(self, op, x):
         compare_with_cpu(op, x)

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -52,6 +52,8 @@ def replace_scalar_with_tensor(graph: torch.fx.Graph) -> None:
         torch.ops.aten.add.Tensor,
         torch.ops.aten.sub.Tensor,
         torch.ops.aten.mul.Tensor,
+        torch.ops.aten.true_divide.Tensor,
+        torch.ops.aten.div.Tensor,
     ]
 
     # Created node cache for scalar values, and reuse the node when


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR extends `replace_scalar_with_tensor` pass to handle  `torch.div` and `torch.true_divide` operators with scalar arguments.

#### Which issue(s) this PR is related to:

- #1118 
- #915 

#### Special notes for your reviewer:

CC: @joyalbin 

#### Does this PR introduce a user-facing change?

#### Additional note:

<details>
<summary>pytest</summary>

```
(dt-inductor) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/home/yohei/dt-inductor/pytorch/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
=============================================== test session starts ================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: hypothesis-6.151.9, xdist-3.8.0
collected 532 items

tests/inductor/test_building_blocks.py ....                                                                  [  0%]
tests/inductor/test_inductor_decomp.py ...                                                                   [  1%]
tests/inductor/test_inductor_ops.py ...s.................................................................... [ 14%]
............................................................................................................ [ 35%]
............................................................................................................ [ 55%]
.........................................................................................                    [ 72%]
tests/inductor/test_logging.py ....                                                                          [ 72%]
tests/tensor/test_tensor_layout.py ..............                                                            [ 75%]
tests/test_fallbacks.py ........                                                                             [ 77%]
tests/test_modules.py .sssss.                                                                                [ 78%]
tests/test_ops.py ...s...s...s..............................s...sss.ss.....................                  [ 92%]
tests/test_regex.py .                                                                                        [ 92%]
tests/test_spyre.py ..s..ss............                                                                      [ 95%]
tests/test_spyre_lazy_silent.py .                                                                            [ 96%]
tests/test_stream.py .....................                                                                   [100%]

================================================= warnings summary =================================================
tests/test_ops.py::TestOps::test_addmm_ab_bc_scaled
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:208: FallbackWarning: torch.ops.spyre.full is falling back to cpu
    warn_fallback("torch.ops.spyre.full")

tests/test_ops.py::TestOps::test_isin_scalar_tensor_out
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/ops/fallbacks.py:255: UserWarning: An output with one or more elements was resized since it had shape [], which does not match the required output shape [0]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (Triggered internally at /home/yohei/dt-inductor/pytorch/aten/src/ATen/native/Resize.cpp:31.)
    return torch.isin(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= 514 passed, 18 skipped, 2 warnings in 419.63s (0:06:59) ==============================
```

</details>