### PR TITLE
move compiler-specific logic to _inductor package

### DIFF
--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from typing import Any
+
 from torch_spyre._inductor.constants import (
     MATMUL_REDUCTION_OP,
     BATCH_MATMUL_OP,
@@ -20,7 +23,8 @@ from torch_spyre._inductor.constants import (
 )
 from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.logging_utils import get_inductor_logger
-import logging
+from torch_spyre._inductor.op_spec import OpSpec
+from torch_spyre._inductor.constants import SEGMENT_OFFSETS
 from .compute_ops import generate_sfp_op, generate_matmul, generate_bmm
 from .data_ops import (
     generate_slice,
@@ -31,6 +35,55 @@ from .data_ops import (
 )
 
 logger = get_inductor_logger("codegen.superdsc")
+
+_argument_names = ["arg0", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6"]
+
+
+def compile_op_spec(kernel_name: str, op_spec: OpSpec) -> tuple[Any, list[int]]:
+    inputs = []
+    outputs = []
+    arg_map = []
+    for index, ts in enumerate(op_spec.args):
+        # use node seq (idx in nodes) to verify whether to reuse lx for this buffer,
+        # in case same Op used twice in sequence and only want pin 1 of them
+        lx_addr = None
+        for k, addr in getattr(ts, "allocation", {}).items():
+            if kernel_name.split("_")[-1] == k.replace("lx:", ""):
+                lx_addr = addr
+
+        if ts.is_input:
+            inputs.append(
+                {
+                    "name": _argument_names[index],
+                    "it_dim_map": ts.it_dim_map,
+                    "device_layout": ts.device_layout,
+                    "lx_addr": lx_addr,
+                }
+            )
+            arg_map.append(ts.arg_index)
+        else:
+            outputs.append(
+                {
+                    "name": _argument_names[index],
+                    "it_dim_map": ts.it_dim_map,
+                    "device_layout": ts.device_layout,
+                    "lx_addr": lx_addr,
+                }
+            )
+            arg_map.append(ts.arg_index)
+    kernel_descriptor = {
+        "name": kernel_name,
+        "reduction": op_spec.is_reduction,
+        "op": op_spec.op,
+        "dimensions": op_spec.iteration_space,
+        "inputs": inputs,
+        "outputs": outputs,
+    }
+    if op_spec.op_info is not None:
+        kernel_descriptor["op_info"] = op_spec.op_info
+    pointers = dict(zip(_argument_names, SEGMENT_OFFSETS))
+    dt_sdsc = generate_sdsc(pointers, **kernel_descriptor)
+    return dt_sdsc, arg_map
 
 
 def generate_sdsc(pointers, *, op, dimensions, inputs, outputs, reduction, **kwargs):

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -20,15 +20,12 @@ import subprocess
 
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch_spyre._C import convert_artifacts
-from torch_spyre._inductor.codegen.superdsc import generate_sdsc
-from torch_spyre._inductor.constants import SEGMENT_OFFSETS
+from torch_spyre._inductor.codegen.superdsc import compile_op_spec
 from torch_spyre._inductor.logging_utils import get_inductor_logger, _get_env_bool
 from torch_spyre._inductor.op_spec import OpSpec, UnimplementedOp
 from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
 
 logger = get_inductor_logger("sdsc_compile")
-
-_argument_names = ["arg0", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6"]
 
 _SDSC_BUNDLE = _get_env_bool("SPYRE_SUPERDSC_BUNDLE")
 
@@ -53,49 +50,7 @@ class SpyreAsyncCompile:
                 print(f"WARNING: Compiling unimplemented {ks.op} to runtime exception")
                 return SpyreUnimplementedRunner(kernel_name, ks.op)
 
-            inputs = []
-            outputs = []
-            arg_map = []
-            for index, ts in enumerate(ks.args):
-                # use node seq (idx in nodes) to verify whether to reuse lx for this buffer,
-                # in case same Op used twice in sequence and only want pin 1 of them
-                lx_addr = None
-                for k, addr in getattr(ts, "allocation", {}).items():
-                    if kernel_name.split("_")[-1] == k.replace("lx:", ""):
-                        lx_addr = addr
-
-                if ts.is_input:
-                    inputs.append(
-                        {
-                            "name": _argument_names[index],
-                            "it_dim_map": ts.it_dim_map,
-                            "device_layout": ts.device_layout,
-                            "lx_addr": lx_addr,
-                        }
-                    )
-                    arg_map.append(ts.arg_index)
-                else:
-                    outputs.append(
-                        {
-                            "name": _argument_names[index],
-                            "it_dim_map": ts.it_dim_map,
-                            "device_layout": ts.device_layout,
-                            "lx_addr": lx_addr,
-                        }
-                    )
-                    arg_map.append(ts.arg_index)
-            kernel_descriptor = {
-                "name": kernel_name,
-                "reduction": ks.is_reduction,
-                "op": ks.op,
-                "dimensions": ks.iteration_space,
-                "inputs": inputs,
-                "outputs": outputs,
-            }
-            if ks.op_info is not None:
-                kernel_descriptor["op_info"] = ks.op_info
-            pointers = dict(zip(_argument_names, SEGMENT_OFFSETS))
-            dt_sdsc = generate_sdsc(pointers, **kernel_descriptor)
+            dt_sdsc, arg_map = compile_op_spec(kernel_name, ks)
             sdscs.append(dt_sdsc)
             arg_mappings.append(arg_map)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
Aligns code with codeownership by moving  compiler internal logic into the _inductor package so that `async_compile`
simply passes through the op_spec to the compiler to process.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
