### PR TITLE
Add CPU fallback for unsupported to_dtype conversions

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1432,6 +1432,74 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 # ),
             }
         },
+        ("test_to_dtype", "test_to_dtype_cpu"): {
+            "param_sets": {
+                # Test parameters: (src_dtype, dst_dtype, is_fallback)
+                # conversion from float16
+                "float16_to_float16": (torch.float16, torch.float16, False),
+                "float16_to_float32": (torch.float16, torch.float32, True),
+                "float16_to_float8_e4m3fn": (torch.float16, torch.float8_e4m3fn, True),
+                # TODO: Copying bool tensors to host is not working yet. See #488
+                # "float16_to_bool": (torch.float16, torch.bool, False),
+                "float16_to_int8": (torch.float16, torch.int8, True),
+                "float16_to_int64": (torch.float16, torch.int64, True),
+                # conversion from float32
+                "float32_to_float16": (torch.float32, torch.float16, True),
+                "float32_to_float32": (torch.float32, torch.float32, False),
+                "float32_to_float8_e4m3fn": (torch.float32, torch.float8_e4m3fn, True),
+                "float32_to_bool": (torch.float32, torch.bool, True),
+                "float32_to_int8": (torch.float32, torch.int8, True),
+                "float32_to_int64": (torch.float32, torch.int64, True),
+                # conversion from float8_e4m3fn
+                "float8_e4m3fn_to_float16": (torch.float8_e4m3fn, torch.float16, True),
+                "float8_e4m3fn_to_float32": (torch.float8_e4m3fn, torch.float32, True),
+                "float8_e4m3fn_to_float8_e4m3fn": (
+                    torch.float8_e4m3fn,
+                    torch.float8_e4m3fn,
+                    False,
+                ),
+                "float8_e4m3fn_to_bool": (torch.float8_e4m3fn, torch.bool, True),
+                "float8_e4m3fn_to_int8": (torch.float8_e4m3fn, torch.int8, True),
+                "float8_e4m3fn_to_int64": (torch.float8_e4m3fn, torch.int64, True),
+                # conversion from bool
+                "bool_to_float16": (torch.bool, torch.float16, False),
+                "bool_to_float32": (torch.bool, torch.float32, True),
+                "bool_to_float8_e4m3fn": (torch.bool, torch.float8_e4m3fn, True),
+                "bool_to_bool": (torch.bool, torch.bool, False),
+                "bool_to_int8": (torch.bool, torch.int8, True),
+                "bool_to_int64": (torch.bool, torch.int64, True),
+                # conversion from int8
+                "int8_to_float16": (torch.int8, torch.float16, True),
+                "int8_to_float32": (torch.int8, torch.float32, True),
+                "int8_to_float8_e4m3fn": (torch.int8, torch.float8_e4m3fn, True),
+                "int8_to_bool": (torch.int8, torch.bool, True),
+                "int8_to_int8": (torch.int8, torch.int8, False),
+                "int8_to_int64": (torch.int8, torch.int64, True),
+                # conversion from int64
+                "int64_to_float16": (torch.int64, torch.float16, True),
+                "int64_to_float32": (torch.int64, torch.float32, True),
+                "int64_to_float8_e4m3fn": (torch.int64, torch.float8_e4m3fn, True),
+                "int64_to_bool": (torch.int64, torch.bool, True),
+                "int64_to_int8": (torch.int64, torch.int8, True),
+                "int64_to_int64": (torch.int64, torch.int64, False),
+            },
+        },
+        ("test_to_dtype_chained", "test_fallback_unary_op_cpu_no_eager"): {
+            "ops_dict": {
+                "case1": lambda x: (
+                    x.to(dtype=torch.float32).exp().to(dtype=torch.float16).log()
+                ),
+                "case2": lambda x: (
+                    torch.ge(x, torch.full_like(x, 0.0)).to(dtype=torch.float16).exp()
+                ),
+            },
+            "param_sets": {
+                "1d": (cached_randn((1024,), dtype=torch.float16),),
+                "2d": (cached_randn((512, 1024), dtype=torch.float16),),
+                "3d": (cached_randn((8, 64, 1024), dtype=torch.float16),),
+                "4d": (cached_randn((2, 4, 64, 1024), dtype=torch.float16),),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -1486,6 +1554,10 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_fallback_unary_op_cpu(self, op, x):
         compare_with_cpu(op, x)
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_fallback_unary_op_cpu_no_eager(self, op, x):
+        compare_with_cpu(op, x, run_eager=False)
 
     def test_binary_op(self, op, a, b):
         if op == torch.div:
@@ -1967,6 +2039,51 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 return result.item()
 
             compare_with_cpu(fn, x, y, cpu_compile=False)
+
+    def test_to_dtype_cpu(self, src_dtype, dst_dtype, is_fallback):
+        import warnings
+        from contextlib import nullcontext
+        from torch_spyre.ops.fallbacks import FallbackWarning
+
+        def fn(x):
+            return x.to(dst_dtype)
+
+        if dst_dtype == torch.bool or src_dtype == torch.bool:
+            src = torch.randint(0, 2, (64,)).to(dtype=src_dtype)
+        elif src_dtype == torch.float8_e4m3fn:
+            src = torch.randint(0, 16, (64,), dtype=torch.float16).to(dtype=src_dtype)
+        else:
+            src = torch.randint(0, 64, (64,), dtype=src_dtype)
+
+        if src_dtype == torch.bool and dst_dtype == torch.float8_e4m3fn:
+            # Inductor CPU backend compilation fails for this case.
+            # See: https://github.com/pytorch/pytorch/issues/178095
+            cpu_compile = False
+        else:
+            cpu_compile = True
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", ".*Backend Spyre does not support int64.*", UserWarning
+            )
+            if is_fallback:
+                # Expect fallback warning
+                warnings.simplefilter("always", FallbackWarning)
+                ctx = pytest.warns(FallbackWarning)
+            else:
+                # Expect no warning
+                warnings.simplefilter("error")
+                ctx = nullcontext()
+
+            with ctx:
+                compare_with_cpu(
+                    fn,
+                    src,
+                    atol=0.0,
+                    rtol=0.0,
+                    cpu_compile=cpu_compile,
+                    run_eager=False,
+                )
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -18,6 +18,7 @@ import os
 import torch
 from torch._inductor.ir import (
     ComputedBuffer,
+    DeviceCopy,
     FallbackKernel,
     MultiOutput,
     Pointwise,
@@ -345,6 +346,8 @@ def core_division_planning(
                     raise RuntimeError("FallbackKernel must be followed by MultiOutput")
 
                 # Core division not supported on fallback kernels
+                pass
+            elif isinstance(n.node, DeviceCopy):
                 pass
             else:
                 logger.warning(f"unhandled node type {type(n.node)}")

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -19,12 +19,13 @@ import torch
 
 from torch._inductor.ir import Reduction, Pointwise
 import torch._inductor.lowering as lowering
+import torch._inductor.config as config
 
 from typing import Any, Callable, Union
 
 from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 import torch_spyre._inductor.customops  # noqa: F401
-from torch_spyre.ops.fallbacks import fallback_ops
+from torch_spyre.ops.fallbacks import fallback_ops, warn_fallback
 from .ir import SpyreReduction
 from torch._inductor.virtualized import V
 from .errors import Unsupported
@@ -198,6 +199,24 @@ def ensure_default_handler(op_name):
     if op_name not in cls.__dict__:
         method = cls._call_default(op_name)
         setattr(cls, op_name, method)
+
+
+def cpu_fallback(op, *args, **kwargs):
+    handler = lowering.fallback_handler(op, add_to_fallback_set=False)
+    return handler(*args, **kwargs)
+
+
+def to_device(x, device):
+    # Suppress noisy DeviceCopy warnings. Comprehensive fallback warning shown separately.
+    # https://github.com/pytorch/pytorch/blob/v2.10.0/torch/_inductor/ir.py#L7457
+    old = config.developer_warnings
+    if old:
+        config.developer_warnings = False
+    try:
+        return lowering.to_device(x, device)
+    finally:
+        if old:
+            config.developer_warnings = old
 
 
 @register_spyre_lowering(torch.ops.aten.mm.default)
@@ -553,3 +572,27 @@ def clone(x, *, memory_format=None):
         result.realize()
         result.freeze_layout_with_stride_order(stride_order)
     return result
+
+
+@register_spyre_lowering(
+    torch.ops.prims.convert_element_type.default,
+    type_promotion_kind=None,
+)
+def lower_convert_element_type(x, dst_dtype):
+    op = torch.ops.prims.convert_element_type.default
+
+    src_dtype = x.get_dtype()
+    supported_conversions = {
+        (torch.float16, torch.bool),
+        (torch.bool, torch.float16),
+    }
+    if src_dtype == dst_dtype or (src_dtype, dst_dtype) in supported_conversions:
+        # Use the original lowering
+        return lowering.to_dtype(x, dst_dtype, copy=True)
+
+    # Fallback to the CPU
+    warn_fallback(f"conversion from {src_dtype} to {dst_dtype}")
+
+    tmp = to_device(x, torch.device("cpu"))
+    out = cpu_fallback(op, tmp, dst_dtype)
+    return to_device(out, x.get_device())

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -27,6 +27,7 @@ from torch._inductor.ir import (
     Reduction,
     StorageBox,
     TensorBox,
+    DeviceCopy,
 )
 from torch._inductor.scheduler import (
     BaseSchedulerNode,
@@ -42,7 +43,7 @@ from torch_spyre._C import (
     get_elem_in_stick,
 )
 from .errors import Unsupported
-from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
+from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP, DEVICE_NAME
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
@@ -411,8 +412,13 @@ def propagate_spyre_tensor_layouts(
                 ):
                     raise RuntimeError("FallbackKernel must be followed by MultiOutput")
 
-                output_layout = generic_layout(n)
-                n.node.layout = output_layout
+                if n.node.layout.get_device().type == DEVICE_NAME:
+                    output_layout = generic_layout(n)
+                    n.node.layout = output_layout
+            elif isinstance(n.node, DeviceCopy):
+                if n.node.layout.get_device().type == DEVICE_NAME:
+                    output_layout = generic_layout(n)
+                    n.node.layout = output_layout
             else:
                 logger.warning(f"unhandled node type {type(n.node)}")
         elif isinstance(n, NopKernelSchedulerNode):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR implements dtype conversion operations that use native Spyre lowering for supported dtype pairs and automatically fall back to CPU execution for unsupported pairs.

**Key implementation details:**
- Explicit CPU fallback is generated during the lowering phase (not via implicit eager fallback)
- Native support: `float16 ↔ bool` and same-dtype conversions
- CPU fallback: all other dtype pairs with warning messages
- Provides infrastructure for implementing conditional fallback operations

This approach enables fine-grained control over which operations use native execution versus CPU fallback, making it suitable for operations that require conditional fallback behavior.

#### Which issue(s) this PR is related to:

- #937
- #1098


#### Special notes for your reviewer:

**Scope of this PR**

This PR only enables compilation of dtype conversions that originate from
explicit `.to(dtype=...)` calls.

**Out of scope: type promotion**

Automatic type promotion is not addressed in this PR. It will be handled
separately in:
- Issue: #1154
- PR: #1123

**Out of scope: eager path**

This PR only affects the compiled path.

In eager mode, `.to(dtype=...)` is handled through `spyre_copy_from` and
does not go through the `torch.ops.prims.convert_element_type` path:

https://github.com/torch-spyre/torch-spyre/blob/09a619ee22b6cbfda696a9de06883f57002cdb70/torch_spyre/csrc/spyre_mem.cpp#L672-L675

#### Does this PR introduce a user-facing change?

Yes. Users can use `.to(dtype=...)` operations in their models. Unsupported conversions will trigger a fallback warning but will execute correctly.

#### Additional note:

When new dtype conversion pairs are supported by the backend compiler, they can be easily enabled by updating the supported dtype pairs table in the lowering implementation.
- #1153


<details>
<summary>pytest result</summary>

```
(dt-inductor) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
================================================================= test session starts ==================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9, xdist-3.8.0
collected 596 items

tests/inductor/test_building_blocks.py ....                                                                                                      [  0%]
tests/inductor/test_inductor_decomp.py ...                                                                                                       [  1%]
tests/inductor/test_inductor_fx_passes.py .......                                                                                                [  2%]
tests/inductor/test_inductor_ops.py ...s........................................................................................................ [ 20%]
................................................................................................................................................ [ 44%]
................................................................................................................................................ [ 68%]
................................                                                                                                                 [ 74%]
tests/inductor/test_logging.py ....                                                                                                              [ 74%]
tests/tensor/test_coordinates.py ..                                                                                                              [ 75%]
tests/tensor/test_tensor_layout.py ..............                                                                                                [ 77%]
tests/test_fallbacks.py ........                                                                                                                 [ 78%]
tests/test_modules.py .sssss.                                                                                                                    [ 80%]
tests/test_ops.py ...s...s...s..................................s...sss.ss.....................                                                  [ 92%]
tests/test_regex.py .                                                                                                                            [ 93%]
tests/test_spyre.py ..s..ss............                                                                                                          [ 96%]
tests/test_spyre_lazy_silent.py .                                                                                                                [ 96%]
tests/test_stream.py .....................                                                                                                       [100%]

=================================================================== warnings summary ===================================================================
tests/test_ops.py::TestOps::test_isin_scalar_tensor_out
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/ops/fallbacks.py:262: UserWarning: An output with one or more elements was resized since it had shape [], which does not match the required output shape [0]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (Triggered internally at /home/yohei/dt-inductor/pytorch/aten/src/ATen/native/Resize.cpp:31.)
    return torch.isin(

tests/test_spyre.py::TestSpyre::test_ones_factory
tests/test_spyre.py::TestSpyre::test_printing
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:239: FallbackWarning: torch.ops.spyre.ones_scalar is falling back to cpu
    warn_fallback("torch.ops.spyre.ones_scalar")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 578 passed, 18 skipped, 3 warnings in 510.87s (0:08:30) ================================================
```
</details>
