### PR TITLE
Make SpyreTensorLayout pickleable and copyable

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -101,11 +101,11 @@ class TestSpyreTensorLayout(TestCase):
         self.assertNotEqual(y, z)
 
     def test_stl_pickleable(self):
-        stl = SpyreTensorLayout([512, 256], torch.float16, [1, 0])
+        stl = SpyreTensorLayout([512, 256], [256, 1], torch.float16, [1, 0])
         self.assertEqual(stl, pickle.loads(pickle.dumps(stl)))
 
     def test_stl_copyable(self):
-        stl = SpyreTensorLayout([512, 256], torch.float16, [1, 0])
+        stl = SpyreTensorLayout([512, 256], [256, 1], torch.float16, [1, 0])
         self.assertEqual(stl, copy.deepcopy(stl))
 
     def test_to_spyre_layout(self):

--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -14,6 +14,9 @@
 
 # Owner(s): ["module: cpp"]
 
+import copy
+import pickle
+
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch_spyre._C import (
@@ -96,6 +99,14 @@ class TestSpyreTensorLayout(TestCase):
         z = SpyreTensorLayout([512, 256], [256, 1], torch.float16, [1, 0])
         self.assertEqual(x, y)
         self.assertNotEqual(y, z)
+
+    def test_stl_pickleable(self):
+        stl = SpyreTensorLayout([512, 256], torch.float16, [1, 0])
+        self.assertEqual(stl, pickle.loads(pickle.dumps(stl)))
+
+    def test_stl_copyable(self):
+        stl = SpyreTensorLayout([512, 256], torch.float16, [1, 0])
+        self.assertEqual(stl, copy.deepcopy(stl))
 
     def test_to_spyre_layout(self):
         x = torch.rand([512, 256], dtype=torch.float16)

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -48,6 +48,8 @@
 
 namespace spyre {
 
+static constexpr int32_t kSpyreTensorLayoutPickleVersion = 1;
+
 std::atomic<bool> g_downcast_warn_enabled{true};
 
 bool get_downcast_warn_enabled() {
@@ -284,15 +286,26 @@ PYBIND11_MODULE(_C, m) {
           [](const spyre::SpyreTensorLayout &p) {  // __getstate__
             // Return a tuple that fully encodes the state of the object
             // If the pickle format changes, then update
-            // stl_pickle_layout_version but keep the tuple as the returned
-            // object and the first element to be the stl_pickle_layout_version
-            int32_t stl_pickle_layout_version = 1;
-            return py::make_tuple(stl_pickle_layout_version, p.device_size,
-                                  p.dim_map, p.stride_map, p.device_dtype);
+            // kSpyreTensorLayoutPickleVersion but keep the tuple as the
+            // returned object and the first element to be the
+            // kSpyreTensorLayoutPickleVersion
+            return py::make_tuple(kSpyreTensorLayoutPickleVersion,
+                                  p.device_size, p.dim_map, p.stride_map,
+                                  p.device_dtype);
           },
           [](py::tuple t) {  // __setstate__
-            if (t.size() != 5 || t[0].cast<int32_t>() != 1)
-              throw std::runtime_error("Invalid state!");
+            if (t.size() != 5) {
+              throw py::value_error(
+                  "Invalid SpyreTensorLayout pickle: wrong tuple size");
+            }
+
+            int32_t version = t[0].cast<int32_t>();
+            if (version != kSpyreTensorLayoutPickleVersion) {
+              throw py::value_error(
+                  "Unsupported SpyreTensorLayout pickle version: " +
+                  std::to_string(version));
+            }
+
             return spyre::SpyreTensorLayout(t[1].cast<std::vector<int64_t>>(),
                                             t[2].cast<std::vector<int32_t>>(),
                                             t[3].cast<std::vector<int64_t>>(),

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -279,7 +279,26 @@ PYBIND11_MODULE(_C, m) {
       .def(py::init<std::vector<int64_t>, std::vector<int32_t>,
                     std::vector<int64_t>, DataFormats>(),
            py::arg("device_size"), py::arg("dim_map"), py::arg("stride_map"),
-           py::arg("device_dtype"));
+           py::arg("device_dtype"))
+      .def(py::pickle(
+           [](const spyre::SpyreTensorLayout &p) { // __getstate__
+               /* Return a tuple that fully encodes the state of the object */
+               return py::make_tuple(
+	           p.device_size,
+		   p.dim_map,
+		   p.stride_map,
+		   p.device_dtype);
+           },
+           [](py::tuple t) { // __setstate__
+               if (t.size() != 4)
+                   throw std::runtime_error("Invalid state!");
+               return spyre::SpyreTensorLayout(
+	           t[0].cast<std::vector<int64_t>>(),
+	           t[1].cast<std::vector<int32_t>>(),
+	           t[2].cast<std::vector<int64_t>>(),
+		   t[3].cast<DataFormats>()
+	       );
+           }));
 
   m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);
   m.def("to_with_layout", &spyre::to_with_layout);

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -282,16 +282,21 @@ PYBIND11_MODULE(_C, m) {
            py::arg("device_dtype"))
       .def(py::pickle(
           [](const spyre::SpyreTensorLayout &p) {  // __getstate__
-            /* Return a tuple that fully encodes the state of the object */
-            return py::make_tuple(p.device_size, p.dim_map, p.stride_map,
-                                  p.device_dtype);
+            // Return a tuple that fully encodes the state of the object
+            // If the pickle format changes, then update
+            // stl_pickle_layout_version but keep the tuple as the returned
+            // object and the first element to be the stl_pickle_layout_version
+            int32_t stl_pickle_layout_version = 1;
+            return py::make_tuple(stl_pickle_layout_version, p.device_size,
+                                  p.dim_map, p.stride_map, p.device_dtype);
           },
           [](py::tuple t) {  // __setstate__
-            if (t.size() != 4) throw std::runtime_error("Invalid state!");
-            return spyre::SpyreTensorLayout(t[0].cast<std::vector<int64_t>>(),
-                                            t[1].cast<std::vector<int32_t>>(),
-                                            t[2].cast<std::vector<int64_t>>(),
-                                            t[3].cast<DataFormats>());
+            if (t.size() != 5 || t[0].cast<std::vector<int32_t>>() != 1)
+              throw std::runtime_error("Invalid state!");
+            return spyre::SpyreTensorLayout(t[1].cast<std::vector<int64_t>>(),
+                                            t[2].cast<std::vector<int32_t>>(),
+                                            t[3].cast<std::vector<int64_t>>(),
+                                            t[4].cast<DataFormats>());
           }));
 
   m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -289,7 +289,7 @@ PYBIND11_MODULE(_C, m) {
             // kSpyreTensorLayoutPickleVersion but keep the tuple as the
             // returned object and the first element to be the
             // kSpyreTensorLayoutPickleVersion
-            return py::make_tuple(kSpyreTensorLayoutPickleVersion,
+            return py::make_tuple(spyre::kSpyreTensorLayoutPickleVersion,
                                   p.device_size, p.dim_map, p.stride_map,
                                   p.device_dtype);
           },
@@ -300,7 +300,7 @@ PYBIND11_MODULE(_C, m) {
             }
 
             int32_t version = t[0].cast<int32_t>();
-            if (version != kSpyreTensorLayoutPickleVersion) {
+            if (version != spyre::kSpyreTensorLayoutPickleVersion) {
               throw py::value_error(
                   "Unsupported SpyreTensorLayout pickle version: " +
                   std::to_string(version));

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -281,24 +281,18 @@ PYBIND11_MODULE(_C, m) {
            py::arg("device_size"), py::arg("dim_map"), py::arg("stride_map"),
            py::arg("device_dtype"))
       .def(py::pickle(
-           [](const spyre::SpyreTensorLayout &p) { // __getstate__
-               /* Return a tuple that fully encodes the state of the object */
-               return py::make_tuple(
-	           p.device_size,
-		   p.dim_map,
-		   p.stride_map,
-		   p.device_dtype);
-           },
-           [](py::tuple t) { // __setstate__
-               if (t.size() != 4)
-                   throw std::runtime_error("Invalid state!");
-               return spyre::SpyreTensorLayout(
-	           t[0].cast<std::vector<int64_t>>(),
-	           t[1].cast<std::vector<int32_t>>(),
-	           t[2].cast<std::vector<int64_t>>(),
-		   t[3].cast<DataFormats>()
-	       );
-           }));
+          [](const spyre::SpyreTensorLayout &p) {  // __getstate__
+            /* Return a tuple that fully encodes the state of the object */
+            return py::make_tuple(p.device_size, p.dim_map, p.stride_map,
+                                  p.device_dtype);
+          },
+          [](py::tuple t) {  // __setstate__
+            if (t.size() != 4) throw std::runtime_error("Invalid state!");
+            return spyre::SpyreTensorLayout(t[0].cast<std::vector<int64_t>>(),
+                                            t[1].cast<std::vector<int32_t>>(),
+                                            t[2].cast<std::vector<int64_t>>(),
+                                            t[3].cast<DataFormats>());
+          }));
 
   m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);
   m.def("to_with_layout", &spyre::to_with_layout);

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -291,7 +291,7 @@ PYBIND11_MODULE(_C, m) {
                                   p.dim_map, p.stride_map, p.device_dtype);
           },
           [](py::tuple t) {  // __setstate__
-            if (t.size() != 5 || t[0].cast<std::vector<int32_t>>() != 1)
+            if (t.size() != 5 || t[0].cast<int32_t>() != 1)
               throw std::runtime_error("Invalid state!");
             return spyre::SpyreTensorLayout(t[1].cast<std::vector<int64_t>>(),
                                             t[2].cast<std::vector<int32_t>>(),


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This makes the SpyreTensorLayout class be serialized using pickle and copied using `copy.deepcopy`.
I needed this for a demo I was doing.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Users can now serialize SpyreTensorLayout.

#### Additional note:
