### PR TITLE
fix for dma_sizes and dma_stride update

### DIFF
--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -266,8 +266,8 @@ SpyreTensorImpl::shallow_copy_and_detach_core(
       /*dest_impl=*/impl.get(),
       /*version_counter=*/version_counter,
       /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
-      impl->dma_sizes = this->dma_sizes;
-      impl->dma_strides = this->dma_strides;
+  impl->dma_sizes = this->dma_sizes;
+  impl->dma_strides = this->dma_strides;
 
   return impl;
 }


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This pr solves the sigbart issue present in the issue #1076 
After updating the dim size , dim stride sigbart issue seems to be gone

```
[ spyre_copy_from ]  After host->device copy:
[ spyre_copy_from ]    dst dma_sizes size:  2
[ spyre_copy_from ]    dst dma_strides size:  2
[ spyre_copy_from ]    dst spyre_layout:  SpyreTensorLayout(device_size=[1, 100, 32], dim_map =[1, 0, 1], stride_map =[32, 32, 1], device_dtype=DataFormats.IEEE_FP32)
[ SpyreTensorImpl ]  SpyreTensorImpl Ctor 3 with layout:  SpyreTensorLayout(device_size=[1, 100, 32], dim_map =[1, 0, 1], stride_map =[32, 32, 1], device_dtype=DataFormats.IEEE_FP32)
[ shallow_copy_and_detach_core ]  SpyreTensorImpl::shallow_copy_and_detach_core copied layout:  SpyreTensorLayout(device_size=[1, 100, 32], dim_map =[1, 0, 1], stride_map =[32, 32, 1], device_dtype=DataFormats.IEEE_FP32)
[ spyre_copy_from ]  self ( Float ) is on: spyre:0
[ spyre_copy_from ]  dst ( Float ) on: cpu
[ spyre_copy_from ]  Before device->host copy:
[ spyre_copy_from ]    src dma_sizes size:  2
[ spyre_copy_from ]    src dma_strides size:  2
[ spyre_copy_from ]    src spyre_layout:  SpyreTensorLayout(device_size=[1, 100, 32], dim_map =[1, 0, 1], stride_map =[32, 32, 1], device_dtype=DataFormats.IEEE_FP32)
[ generate_dci ]  DataConversionInfo:  {
```
<img width="1552" height="582" alt="image" src="https://github.com/user-attachments/assets/db23e9f4-0d49-4311-90a0-2495849c5fc4" />

#### Which issue(s) this PR is related to:
Fixes #1076 
cc:
@pradghos @ani300 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
