### PR TITLE
Remove inheritance of SIMDKernel/SIMDScheduling

### DIFF
--- a/torch_spyre/_inductor/choices.py
+++ b/torch_spyre/_inductor/choices.py
@@ -16,7 +16,6 @@
 import torch
 
 from torch._inductor.choices import InductorChoices
-from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.scheduler import BaseSchedulerNode, Scheduler
 
 from torch_spyre._inductor.logging_utils import _get_env_bool
@@ -25,29 +24,6 @@ _FUSION_ENABLED = _get_env_bool("SPYRE_INDUCTOR_ENABLE_FUSION")
 
 
 class SpyreHeuristics(InductorChoices):
-    @staticmethod
-    def should_use_cooperative_reduction(features: SIMDKernelFeatures) -> bool:
-        """Heuristic to decide if a cooperative reduction should be used."""
-        return False
-
-    @staticmethod
-    def should_use_persistent_reduction(
-        features: SIMDKernelFeatures, cooperative_reduction: bool
-    ) -> bool:
-        """
-        Heuristic to decide if a persistent reduction should be used.
-        """
-        return True
-
-    @staticmethod
-    def want_no_x_dim(features: SIMDKernelFeatures) -> bool:
-        """
-        Heuristic to decide if we should drop the X dimension from a persistent reduction kernel.
-        So the [XBLOCK, RBLOCK] block becomes a [RBLOCK] block and XBLOCK is forced to be always 1.
-        Strangely this is faster than a [1, RBLOCK] block in some cases.
-        """
-        return False
-
     @staticmethod
     def reduction_split_factor(
         device: torch.device,

--- a/torch_spyre/_inductor/dsc.py
+++ b/torch_spyre/_inductor/dsc.py
@@ -12,29 +12,120 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import Any, Sequence, Union
 
 from torch._inductor.utils import IndentedBuffer
-from torch._inductor.codegen.simd import SIMDScheduling
 from torch._inductor.utils import (
     get_kernel_metadata,
     get_fused_kernel_name,
+    sympy_product,
+)
+from torch._inductor.scheduler import (
+    BaseScheduling,
+    BaseSchedulerNode,
+    FusedSchedulerNode,
+    SchedulerNode,
 )
 from torch._inductor.virtualized import V
+from torch._inductor.codecache import code_hash
 from torch.utils._ordered_set import OrderedSet
 
 from .spyre_kernel import SpyreKernel
+from .pass_utils import iteration_space
 
 
-class SuperDSCScheduling(SIMDScheduling):
+class SuperDSCScheduling(BaseScheduling):
     kernel_type: type[Any] = SpyreKernel
     dsc_type: str = "sdsc"
+
+    def group_fn(self, sizes):
+        return tuple(V.graph.sizevars.simplify(sympy_product(s)) for s in sizes)
+
+    def flush(self):
+        pass
+
+    def ready_to_flush(self) -> bool:
+        return False
 
     def can_buffer_be_removed_through_fusion(
         self, name: str, fused_node_names: OrderedSet[str]
     ) -> bool:
         """We need intermediate buffers to be allocated even if only used within a single Kernel"""
         return False
+
+    def can_fuse_vertical(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        """
+        Check whether node1 and node2 can be vertically fused or not.
+        """
+        return False
+
+    def can_fuse_horizontal(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        """
+        Check whether node1 and node2 can be horizontally fused or not.
+        """
+        return False
+
+    def codegen_node_schedule_with_kernel(
+        self, node_schedule: Sequence[BaseSchedulerNode], kernel: SpyreKernel
+    ):
+        with kernel:
+            for node in node_schedule:
+                if isinstance(node, SchedulerNode):
+                    var_ranges = iteration_space(node)
+                    vars = list(var_ranges.keys())
+                    index_vars = [
+                        vars[: len(node._body.iter_vars)],
+                        vars[len(node._body.iter_vars) :],
+                    ]
+                    node.codegen(index_vars)
+                else:
+                    raise RuntimeError(f"TODO: implement for {node}")
+
+    def generate_node_schedule(self, nodes: Sequence[BaseSchedulerNode]):
+        node_schedule: list[BaseSchedulerNode] = []
+        done = OrderedSet[BaseSchedulerNode]()
+        for node in nodes:
+            if node in done:
+                continue
+            done.add(node)
+            node_schedule.append(node)
+        return node_schedule
+
+    def codegen_node(self, node: Union[FusedSchedulerNode, SchedulerNode]) -> None:
+        assert self.scheduler
+        nodes = [
+            node
+            for node in node.get_nodes()
+            if node.get_name() not in self.scheduler.removed_ops
+        ]
+        if len(nodes) == 0:
+            return
+
+        node_schedule = self.generate_node_schedule(nodes)
+        kernel = SpyreKernel()
+        self.codegen_node_schedule_with_kernel(node_schedule, kernel)
+
+        with V.set_kernel_handler(kernel):
+            src_code = kernel.codegen_kernel()
+        kernel_name = self.define_kernel(src_code, node_schedule, kernel)
+        kernel.kernel_name = kernel_name
+        kernel.code_hash = code_hash(src_code)
+
+        with V.set_kernel_handler(kernel):
+            for node in node_schedule:
+                node.mark_run()
+
+        self.codegen_comment(node_schedule, kernel_name)
+        kernel.call_kernel(kernel.kernel_name)
+
+        V.graph.removed_buffers |= kernel.removed_buffers
+        V.graph.inplaced_to_remove |= kernel.inplaced_to_remove
+
+        self.free_buffers_in_scheduler()
 
     def define_kernel(self, src_code, node_schedule, kernel):
         """Codegen kernel definition to go in output wrapper code"""

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -17,11 +17,12 @@ from typing import NamedTuple
 from sympy import Expr, Symbol
 
 import sympy
-from torch._inductor.ir import FixedLayout
+from torch._inductor.ir import FixedLayout, Pointwise, Reduction
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.utils import sympy_subs
 from torch._inductor.virtualized import V
+from torch_spyre._inductor.errors import Unsupported
 
 from .ir import FixedTiledLayout
 from .views import compute_coordinates
@@ -87,3 +88,18 @@ def device_coordinates(layout: FixedTiledLayout, dep: MemoryDep) -> list[sympy.E
         dep.ranges,
         dep.index,
     )
+
+
+def iteration_space(n: SchedulerNode) -> dict[sympy.Symbol, sympy.Expr]:
+    if isinstance(n.node.data, Pointwise):
+        # The iteration space of a Pointwise is that of its output range
+        return next(iter(n.read_writes.writes)).ranges.copy()
+    elif isinstance(n.node.data, Reduction):
+        # The iteration space of a Reduction is the union of its input ranges.
+        iteration_space = {}
+        for arg in n.read_writes.reads:
+            if isinstance(arg, MemoryDep):
+                iteration_space.update(arg.ranges)
+        return iteration_space
+    else:
+        raise Unsupported("Unexpected node type")

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -27,7 +27,6 @@ from torch._inductor.codegen.common import (
     Kernel,
 )
 from torch._inductor.ops_handler import DefaultHandler, StoreMode
-from torch._inductor.codegen.simd import SIMDKernel
 from torch._inductor.utils import IndentedBuffer, sympy_subs
 from torch._inductor.virtualized import V
 
@@ -40,11 +39,7 @@ from .constants import (
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .pass_utils import (
-    is_wildcard,
-    map_dims_to_vars,
-    wildcard_symbol,
-)
+from .pass_utils import is_wildcard, map_dims_to_vars, wildcard_symbol, iteration_space
 from .views import compute_coordinates
 from .stickify import is_sparse
 from .logging_utils import get_inductor_logger
@@ -263,7 +258,7 @@ class SpyreOpFuncs:
 
 class SpyreKernelOpsHandler(DefaultHandler):
     """
-    This class plays the same role for SpyreKernel as common.CSEProxy does for SIMDKernel and Kernel.
+    This class plays the same role for SpyreKernel as common.CSEProxy does for Kernel.
     """
 
     name = "SpyreKernelOpsHandler"
@@ -378,15 +373,11 @@ def create_op_spec(
     )
 
 
-class SpyreKernel(SIMDKernel[CSEVariable]):
+class SpyreKernel(Kernel[CSEVariable]):
     overrides = SpyreOpFuncs  # type: ignore[assignment]
 
-    def __init__(
-        self,
-        tiling: dict[str, sympy.Expr],
-        **kwargs,
-    ) -> None:
-        super().__init__(tiling, **kwargs)
+    def __init__(self) -> None:
+        super().__init__()
         self.op_specs: list[OpSpec | UnimplementedOp] = []
         self.spyre_kernel_args: list[Tuple[str, TensorArg]] = []
 
@@ -404,7 +395,7 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
         device_coords = compute_coordinates(
             tensor.layout.device_layout.device_size,
             tensor.layout.device_layout.stride_map,
-            self.var_ranges(),
+            iteration_space(self.current_node),
             tensor.index,
         )
         tensor_arg = TensorArg(
@@ -695,7 +686,7 @@ class SpyreKernel(SIMDKernel[CSEVariable]):
         """
         Return the iteration space implied by the tensor access
         """
-        var_ranges = self.var_ranges()
+        var_ranges = iteration_space(self.current_node)
         if var_ranges:
             dim_map = map_dims_to_vars(access.layout, access.index)
             return [


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR reworks SDSC code generation in inductor to remove our inheritance of the Triton/Halide SIMDKernel and SIMDScheduling classes. This significantly simplifies the mapping between LoopLevelIR and OpSpec as it removes the complex SIMDKernel scaffolding for loop tiling and the string-oriented codegen that OpSpec will never utilize.

#### Which issue(s) this PR is related to:

This is part of the work for #911. 

#### Special notes for your reviewer:
```
=============================================================================================================================== test session starts ================================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/dgrove/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 557 items                                                                                                                                                                                                                                                                

tests/inductor/test_building_blocks.py ....                                                                                                                                                                                                                                  [  0%]
tests/inductor/test_inductor_decomp.py ...                                                                                                                                                                                                                                   [  1%]
tests/inductor/test_inductor_fx_passes.py .......                                                                                                                                                                                                                            [  2%]
tests/inductor/test_inductor_ops.py ...s.................................................................................................................................................................................................................................... [ 44%]
.............................................................................................................................................................                                                                                                                [ 72%]
tests/inductor/test_logging.py ....                                                                                                                                                                                                                                          [ 73%]
tests/tensor/test_coordinates.py ..                                                                                                                                                                                                                                          [ 73%]
tests/tensor/test_tensor_layout.py ..............                                                                                                                                                                                                                            [ 75%]
tests/test_fallbacks.py ........                                                                                                                                                                                                                                             [ 77%]
tests/test_modules.py .sssss.                                                                                                                                                                                                                                                [ 78%]
tests/test_ops.py ...s...s...s..................................s...sss.ss.....................                                                                                                                                                                              [ 92%]
tests/test_regex.py .                                                                                                                                                                                                                                                        [ 92%]
tests/test_spyre.py ..s..ss............                                                                                                                                                                                                                                      [ 96%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                                                                                                            [ 96%]
tests/test_stream.py .....................                                                                                                                                                                                                                                   [100%]

================================================================================================================================= warnings summary =================================================================================================================================
tests/test_ops.py::TestOps::test_isin_scalar_tensor_out
  /home/dgrove/dt-inductor/torch-spyre/torch_spyre/ops/fallbacks.py:262: UserWarning: An output with one or more elements was resized since it had shape [], which does not match the required output shape [0]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (Triggered internally at /home/dgrove/dt-inductor/pytorch/aten/src/ATen/native/Resize.cpp:31.)
    return torch.isin(

tests/test_spyre.py::TestSpyre::test_ones_factory
tests/test_spyre.py::TestSpyre::test_printing
  /home/dgrove/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:239: FallbackWarning: torch.ops.spyre.ones_scalar is falling back to cpu
    warn_fallback("torch.ops.spyre.ones_scalar")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================= 539 passed, 18 skipped, 3 warnings in 434.56s (0:07:14) ==============================================================================================================

```
#### Does this PR introduce a user-facing change?

#### Additional note:
