### PR TITLE
cicd: use the new runner set that exposes the node name as an env var…

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,5 @@ self-hosted-runner:
   labels:
     - self-hosted
     - official-aiu-x86-64-arc-runner-set-v1
+    - official-aiu-x86-64-arc-runner-set-v2
+    - official-aiu-x86-64-arc-runner-set-v3

--- a/.github/workflows/runtests.yaml
+++ b/.github/workflows/runtests.yaml
@@ -22,7 +22,9 @@ permissions:
 jobs:
   test:
     name: Run Spyre unit tests
-    runs-on: official-aiu-x86-64-arc-runner-set-v1
+    # runs-on: official-aiu-x86-64-arc-runner-set-v1
+    # runs-on: official-aiu-x86-64-arc-runner-set-v2
+    runs-on: official-aiu-x86-64-arc-runner-set-v3
     # increase timeout to 12 hours
     timeout-minutes: 720
     # env: {}
@@ -36,6 +38,7 @@ jobs:
           ls -la
           whoami
           id
+          echo "GHA_RUNNER_POD_NODE_NAME $GHA_RUNNER_POD_NODE_NAME"
           echo "PATH $PATH"
           echo "HOME $HOME"
           python3 --version


### PR DESCRIPTION
… MY_NODE_NAME

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Switch to a new runner set that exposes the node name as the env var `MY_NODE_NAME`

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
