### PR TITLE
Fix shallow_copy_from

### DIFF
--- a/torch_spyre/csrc/spyre_tensor_impl.cpp
+++ b/torch_spyre/csrc/spyre_tensor_impl.cpp
@@ -260,7 +260,6 @@ SpyreTensorImpl::shallow_copy_and_detach_core(
   }
   auto impl = c10::make_intrusive<SpyreTensorImpl>(storage_, key_set_,
                                                    data_type_, spyre_layout);
-
   impl->dma_sizes = this->dma_sizes;
   impl->dma_strides = this->dma_strides;
   copy_tensor_metadata(
@@ -290,8 +289,11 @@ at::intrusive_ptr<c10::TensorImpl> SpyreTensorImpl::shallow_copy_and_detach(
 // storage basic operation (view) to work
 void SpyreTensorImpl::shallow_copy_from(
     const at::intrusive_ptr<at::TensorImpl>& impl) {
-  DEBUGINFO("Parent's implementation");
+  auto spyre_impl = static_cast<SpyreTensorImpl*>(impl.get());
   at::TensorImpl::shallow_copy_from(impl);
+  this->dma_sizes = spyre_impl->dma_sizes;
+  this->dma_strides = spyre_impl->dma_strides;
+  this->spyre_layout = spyre_impl->spyre_layout;
 }
 
 uint64_t get_device_size_in_bytes(SpyreTensorLayout stl) {


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR properly implements `SpyreTensorImpl::shallow_copy_from` to copy all metadata properly.

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/1076

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
