### PR TITLE
Improve readability of printed sympy Exprs

### DIFF
--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -46,11 +46,11 @@ def get_mem_deps(n: SchedulerNode) -> list[SchedNodeArg]:
 
 
 def wildcard_symbol(dim) -> Symbol:
-    return sympy.Symbol(f"wc_{dim}")
+    return sympy.Symbol(f"*_{dim}")
 
 
 def is_wildcard(s: Symbol) -> bool:
-    return s.name.startswith("wc_")
+    return s.name.startswith("*_")
 
 
 # @deprecated("switch to _coordinates")

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -413,7 +413,11 @@ class SpyreKernel(Kernel[CSEVariable]):
         if hasattr(self.current_node, "op_it_space_splits"):
             core_division = self.current_node.op_it_space_splits  # type: ignore[union-attr]
 
-        it_space = {d.var: (d.numel, core_division.get(d.var, 1)) for d in dims}
+        it_space = {
+            d.var: (d.numel, core_division.get(d.var, 1))
+            for d in dims
+            if not is_wildcard(d.var)
+        }
 
         return OpSpec(
             op,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This cleanup is part of the work for #911.

It makes the generated OpSpec more readable by using `sympify` to evaluate string literals as sympy expressions.

A sample OpSpec is:
```
        OpSpec(
            op='add',
            is_reduction=False,
            iteration_space=[512, 1024],
            iteration_space_dict={sympify('c0'): (sympify('512'), 32), sympify('c1'): (sympify('1024'), 1)},
            op_info={'n_cores_used': 1},
            args=[
                TensorArg(
                    is_input=True, arg_index=0, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[16, 512, 64],
                    device_coordinates=[sympify('floor(c1/64)'), sympify('c0'), sympify('Mod(c1, 64)')],
                    allocation={}, dtype=torch.float16, it_dim_map=[0, 1], 
                    device_layout=SpyreTensorLayout(device_size=[16, 512, 64], dim_map =[1, 0, 1], stride_map =[64, 1024, 1], device_dtype=DataFormats.SEN169_FP16)
                ),
                TensorArg(
                    is_input=True, arg_index=1, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[16, 64],
                    device_coordinates=[sympify('floor(c1/64)'), sympify('Mod(c1, 64)')],
                    allocation={}, dtype=torch.float16, it_dim_map=[-1, 0], 
                    device_layout=SpyreTensorLayout(device_size=[16, 64], dim_map =[0, 0], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16)
                ),
                TensorArg(
                    is_input=False, arg_index=2, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[16, 512, 64],
                    device_coordinates=[sympify('floor(c1/64)'), sympify('c0'), sympify('Mod(c1, 64)')],
                    allocation={}, dtype=torch.float16, it_dim_map=[0, 1], 
                    device_layout=SpyreTensorLayout(device_size=[16, 512, 64], dim_map =[1, 0, 1], stride_map =[64, 1024, 1], device_dtype=DataFormats.SEN169_FP16)
                ),
            ]
        ),
```

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
