### PR TITLE
extend matching_dim for some key split dim patterns

### DIFF
--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -123,17 +123,41 @@ def compute_device_coordinates(
     return coordinates
 
 
+def _is_range_subset(expr: sympy.Expr, coord: sympy.Expr, v: sympy.Symbol) -> bool:
+    """
+    Return True if the set of values expr can produce (as v varies) is a subset
+    of the values coord can produce.
+
+    Handles two cases:
+    - coord == v: coord is unbounded, so any expr in v is a subset.
+    - coord == Mod(v, b) and expr == Mod(v, a) with a <= b: [0,a-1] ⊆ [0,b-1].
+    """
+    if coord == v:
+        return True
+    if (
+        isinstance(coord, sympy.Mod)
+        and isinstance(expr, sympy.Mod)
+        and coord.args[0] == v
+        and expr.args[0] == v
+    ):
+        coord_mod = coord.args[1]
+        expr_mod = expr.args[1]
+        return bool(sympy.Le(expr_mod, coord_mod))
+    return False
+
+
 def matching_dim(coords: list[sympy.Expr], expr: sympy.Expr) -> Optional[int]:
     """
     Given a coordinate array and an expression, determine if there is a unique
-    dimension in coords whose coordinate expression is exactly the one free variable
-    in the expression.  Return None if expr does not have exactly one free variable
-    or if there is not exactly one matching dimension in coords.
+    dimension in coords whose possible values are a superset of expr's possible
+    values (both expressed in the single free variable of expr).  Return None if
+    expr does not have exactly one free variable or if there is not exactly one
+    matching dimension in coords.
     """
     if len(expr.free_symbols) != 1:
         return None
     v = next(iter(expr.free_symbols))
-    dims = [d for d, e in enumerate(coords) if e == v]
+    dims = [d for d, e in enumerate(coords) if _is_range_subset(expr, e, v)]
     if len(dims) != 1:
         return None
     else:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR is part of #911.  It extends the`matching_dim` helper function to support a key pattern of a split dimension.

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
