### PR TITLE
Bugfix: use symbol key (k) not value (v) in core_division lookup

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -348,7 +348,7 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         it_space = iteration_space(self.current_node)
         it_space_extended = {
-            k: (v, core_division.get(v, 1)) for k, v in it_space.items()
+            k: (v, core_division.get(k, 1)) for k, v in it_space.items()
         }
 
         return OpSpec(


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixing a typo bug introduced in PR #1238 

Details:
In create_op_spec, it_space_extended was built with core_division.get(v, 1) where v is the size expression (e.g. 1152), not the symbol key. This meant the lookup always missed, returning 1 and discarding the core division splits computed by core_division_planning.

#### Which issue(s) this PR is related to:

#1238 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
