### PR TITLE
test: add work division regression coverage for splitting (#1253)

### DIFF
--- a/tests/inductor/test_core_division.py
+++ b/tests/inductor/test_core_division.py
@@ -1,0 +1,95 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import sympy
+
+from torch_spyre._inductor.work_division_utils import (
+    multi_dim_iteration_space_split,
+    multi_dim_core_split,
+    extend_iteration_space_with_core_division,
+)
+
+
+def test_extend_iteration_space_uses_symbol_keys_for_core_division() -> None:
+    """Regression test for #1244: lookup must use Symbol key, not size value."""
+    k = sympy.Symbol("k")
+    it_space = {k: 1152}
+    core_division = {k: 8}
+
+    it_space_extended = extend_iteration_space_with_core_division(
+        it_space, core_division
+    )
+
+    assert it_space_extended[k] == (1152, 8)
+
+
+def test_extend_iteration_space_defaults_to_single_core() -> None:
+    m = sympy.Symbol("m")
+    it_space = {m: 256}
+
+    it_space_extended = extend_iteration_space_with_core_division(it_space, {})
+
+    assert it_space_extended[m] == (256, 1)
+
+
+def test_multi_dim_iteration_space_split_creates_real_split() -> None:
+    """Guard against accidental control-flow changes that disable splitting."""
+    mb, k, n = sympy.symbols("mb k n")
+    it_space = {mb: 256, k: 1152, n: 256}
+
+    splits = multi_dim_iteration_space_split(
+        it_space,
+        max_cores=32,
+        priorities=[mb, n, k],
+    )
+
+    assert math.prod(splits.values()) > 1
+    assert splits[mb] == 32
+
+
+def test_multi_dim_iteration_space_split_respects_core_budget() -> None:
+    """Split product must never exceed max_cores."""
+    a, b, c = sympy.symbols("a b c")
+    it_space = {a: 4096, b: 2048, c: 1024}
+
+    splits = multi_dim_iteration_space_split(
+        it_space,
+        max_cores=16,
+        priorities=[a, b, c],
+    )
+
+    assert math.prod(splits.values()) <= 16
+    assert math.prod(splits.values()) > 1
+
+
+def test_multi_dim_core_split_uses_all_divisible_cores() -> None:
+    sizes = [256, 256, 64]
+
+    splits = multi_dim_core_split(sizes, max_cores=32, priorities=[3, 2, 1])
+
+    assert math.prod(splits) == 32
+    assert splits[0] > 1
+
+
+def test_multi_dim_core_split_respects_disabled_dimension_priority() -> None:
+    """Negative priority excludes a dimension from splitting."""
+    sizes = [256, 1152, 256]
+    priorities = [3, -1, 2]
+
+    splits = multi_dim_core_split(sizes, max_cores=32, priorities=priorities)
+
+    assert splits[1] == 1
+    assert math.prod(splits) > 1

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -37,6 +37,7 @@ from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .pass_utils import SchedNodeArg, get_mem_deps, device_coordinates, iteration_space
 from .logging_utils import get_inductor_logger
+from .work_division_utils import multi_dim_core_split, multi_dim_iteration_space_split
 import logging
 
 logger = get_inductor_logger("core_division")
@@ -83,133 +84,6 @@ def get_host_dim_size(layout: FixedTiledLayout, host_dim_idx: int) -> int:
         )
 
     return dl.device_size[device_dim_idx]
-
-
-def core_split(size: int, max_cores: int) -> int:
-    """
-    Find the largest divisor of size that doesn't exceed max_cores.
-
-    Args:
-        size: The dimension size to split
-        max_cores: Maximum number of cores to use for this dimension
-
-    Returns:
-        Number of cores to use (always divides size evenly)
-    """
-    for i in range(max_cores, 0, -1):
-        if size % i == 0:
-            return i
-    return 1
-
-
-def multi_dim_core_split(
-    sizes: list[int], max_cores: int, priorities: list[int] | None = None
-) -> list[int]:
-    """
-    Distribute max_cores across multiple dimensions optimally.
-
-    This function tries to split cores across multiple dimensions to maximize
-    parallelism while ensuring even division. It uses a greedy approach that
-    prioritizes dimensions based on:
-    1. User-specified priorities (if provided)
-    2. Dimension size (larger dimensions get priority)
-    3. Divisibility (dimensions that divide evenly get priority)
-
-    Dimensions with negative priorities are excluded from splitting and will
-    always have a split value of 1.
-
-    Args:
-        sizes: List of dimension sizes that can be parallelized
-        max_cores: Total number of cores available
-        priorities: Optional list of priority values (higher = more important)
-                   If None, uses dimension sizes as priorities.
-                   Use negative values to exclude dimensions from splitting.
-
-    Returns:
-        List of core splits for each dimension (same length as sizes)
-        The product of all splits will be <= max_cores
-
-    Example:
-        >>> multi_dim_core_split([128, 64, 32], max_cores=8)
-        [4, 2, 1]  # 4*2*1 = 8 cores total
-
-        >>> multi_dim_core_split([100, 50], max_cores=10)
-        [5, 2]  # 5*2 = 10 cores total
-
-        >>> multi_dim_core_split([128, 64, 32], max_cores=8, priorities=[3, -1, 2])
-        [4, 1, 2]  # Middle dimension excluded from splitting (priority=-1)
-    """
-    if not sizes:
-        return []
-
-    n_dims = len(sizes)
-    splits = [1] * n_dims
-
-    # Use provided priorities or default to the sizes of dimensions
-    if priorities is None:
-        priorities = sizes.copy()
-
-    # Create list of (dimension_index, size, priority) tuples
-    # Filter out dimensions with negative priorities (they should not be split)
-    dim_info = [
-        (i, sizes[i], priorities[i]) for i in range(n_dims) if priorities[i] >= 0
-    ]
-
-    # Sort by priority (descending), then by size (descending)
-    dim_info.sort(key=lambda x: (x[2], x[1]), reverse=True)
-
-    n_cores_to_split = max_cores
-
-    # Greedy allocation: try to split highest priority dimensions first
-    for dim_idx, size, _ in dim_info:
-        if n_cores_to_split <= 1:
-            break
-
-        # Find the best split for this dimension given n_cores_to_split
-        best_split = core_split(size, n_cores_to_split)
-
-        if best_split > 1:
-            splits[dim_idx] = best_split
-            n_cores_to_split = n_cores_to_split // best_split
-
-    return splits
-
-
-def multi_dim_iteration_space_split(
-    iteration_space: dict[Symbol, Expr],
-    max_cores: int,
-    priorities: list[Symbol],
-) -> dict[Symbol, int]:
-    """
-    Distribute max_cores across multiple dimensions of an iteration space.
-
-    This function tries to split cores across multiple dimensions to maximize
-    parallelism while ensuring even division. It uses a greedy approach that
-    prioritizes dimensions of the iteration space based on:
-    1. User-specified priorities
-    2. Divisibility (dimensions that divide evenly get priority)
-
-    Args:
-        iteration_space: The iteration space to be parallelized
-        max_cores: Total number of cores available
-        priorities: Order in which to consider the dimensions
-
-    Returns:
-        The core splits for the iteration_space
-        The product of all splits will be <= max_cores
-    """
-    n_cores_to_split = max_cores
-    splits = {v: 1 for v in iteration_space.keys()}
-
-    for v in priorities:
-        if n_cores_to_split <= 1:
-            break
-        best_split = core_split(iteration_space[v], n_cores_to_split)
-        if best_split > 1:
-            splits[v] = best_split
-            n_cores_to_split = n_cores_to_split // best_split
-
-    return splits
 
 
 def prioritize_dimensions(

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -42,6 +42,7 @@ from .pass_utils import iteration_space
 from .views import compute_coordinates, align_tensors
 from .logging_utils import get_inductor_logger
 from .op_spec import OpSpec, TensorArg
+from .work_division_utils import extend_iteration_space_with_core_division
 import logging
 
 logger = get_inductor_logger("spyre_kernel")
@@ -347,9 +348,9 @@ class SpyreKernel(Kernel[CSEVariable]):
             core_division = self.current_node.op_it_space_splits  # type: ignore[union-attr]
 
         it_space = iteration_space(self.current_node)
-        it_space_extended = {
-            k: (v, core_division.get(k, 1)) for k, v in it_space.items()
-        }
+        it_space_extended = extend_iteration_space_with_core_division(
+            it_space, core_division
+        )
 
         return OpSpec(
             op,

--- a/torch_spyre/_inductor/work_division_utils.py
+++ b/torch_spyre/_inductor/work_division_utils.py
@@ -1,0 +1,134 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sympy import Expr, Symbol
+
+
+"""Pure work-division helpers shared by scheduler and codegen paths.
+
+This module intentionally avoids importing heavy backend/runtime components,
+so unit tests can validate work-division behavior without requiring the native
+`torch_spyre._C` extension to be present.
+"""
+
+
+def extend_iteration_space_with_core_division(
+    it_space: dict[Symbol, Expr],
+    core_division: dict[Symbol, int],
+) -> dict[Symbol, tuple[Expr, int]]:
+    """Attach per-dimension core split factors to an iteration space."""
+    return {k: (v, core_division.get(k, 1)) for k, v in it_space.items()}
+
+
+def core_split(size: int, max_cores: int) -> int:
+    """Find the largest divisor of size that doesn't exceed max_cores.
+
+    Args:
+        size: The dimension size to split.
+        max_cores: Maximum number of cores to use for this dimension.
+
+    Returns:
+        Number of cores to use (always divides size evenly).
+    """
+    for i in range(max_cores, 0, -1):
+        if size % i == 0:
+            return i
+    return 1
+
+
+def multi_dim_core_split(
+    sizes: list[int], max_cores: int, priorities: list[int] | None = None
+) -> list[int]:
+    """Distribute max_cores across multiple dimensions optimally.
+
+    This function tries to split cores across multiple dimensions to maximize
+    parallelism while ensuring even division. It uses a greedy approach that
+    prioritizes dimensions based on:
+    1. User-specified priorities (if provided)
+    2. Dimension size (larger dimensions get priority)
+
+    Dimensions with negative priorities are excluded from splitting and will
+    always have a split value of 1.
+
+    Args:
+        sizes: List of dimension sizes that can be parallelized.
+        max_cores: Total number of cores available.
+        priorities: Optional list of priority values (higher = more important).
+            If None, uses dimension sizes as priorities.
+            Use negative values to exclude dimensions from splitting.
+
+    Returns:
+        List of core splits for each dimension (same length as sizes).
+        The product of all splits will be <= max_cores.
+    """
+    if not sizes:
+        return []
+
+    n_dims = len(sizes)
+    splits = [1] * n_dims
+
+    if priorities is None:
+        priorities = sizes.copy()
+
+    dim_info = [
+        (i, sizes[i], priorities[i]) for i in range(n_dims) if priorities[i] >= 0
+    ]
+    dim_info.sort(key=lambda x: (x[2], x[1]), reverse=True)
+
+    n_cores_to_split = max_cores
+    for dim_idx, size, _ in dim_info:
+        if n_cores_to_split <= 1:
+            break
+
+        best_split = core_split(size, n_cores_to_split)
+        if best_split > 1:
+            splits[dim_idx] = best_split
+            n_cores_to_split = n_cores_to_split // best_split
+
+    return splits
+
+
+def multi_dim_iteration_space_split(
+    iteration_space: dict[Symbol, Expr],
+    max_cores: int,
+    priorities: list[Symbol],
+) -> dict[Symbol, int]:
+    """Distribute max_cores across multiple dimensions of an iteration space.
+
+    This function tries to split cores across multiple dimensions to maximize
+    parallelism while ensuring even division. It uses a greedy approach that
+    prioritizes dimensions of the iteration space based on caller-provided
+    priority order.
+
+    Args:
+        iteration_space: The iteration space to be parallelized.
+        max_cores: Total number of cores available.
+        priorities: Order in which to consider the dimensions.
+
+    Returns:
+        Core splits for iteration_space dimensions.
+        The product of all splits will be <= max_cores.
+    """
+    n_cores_to_split = max_cores
+    splits = {v: 1 for v in iteration_space.keys()}
+
+    for v in priorities:
+        if n_cores_to_split <= 1:
+            break
+        best_split = core_split(iteration_space[v], n_cores_to_split)
+        if best_split > 1:
+            splits[v] = best_split
+            n_cores_to_split = n_cores_to_split // best_split
+
+    return splits


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

- Adds dedicated work-division regression tests to ensure splitting is happening.
- Verifies Symbol-key based split lookup in iteration-space extension (regression guard for #1244 behavior).
- Adds deterministic checks for:
  - split product > 1 when splitting should occur,
  - split product never exceeding `max_cores`,
  - negative-priority dimensions staying unsplit.
- Refactors shared split helpers into a lightweight utility module so tests can run without native extension dependencies.
- Keeps runtime behavior unchanged while improving testability and regression safety.

#### Which issue(s) this PR is related to:

Fixes #1253  
Related: #1244

#### Special notes for your reviewer:

- Focus is regression prevention for work-division control flow and split assignment.
- Added/updated files:
  - `tests/inductor/test_core_division.py`
  - `torch_spyre/_inductor/work_division_utils.py`
  - `torch_spyre/_inductor/spyre_kernel.py`
  - `torch_spyre/_inductor/core_division.py`
- Local validation:
  - `python -m pytest -q tests/inductor/test_core_division.py` (6 passed)
  - `pre-commit run --all-files` passed

#### Does this PR introduce a user-facing change?

No. This change is internal (compiler/runtime regression tests and helper refactor) and does not alter the public API.

#### Additional note:

This PR hardens CI coverage against accidental control-flow regressions that could silently disable work splitting.