### PR TITLE
Creates a config for codegen options using torch's ConfigModule

### DIFF
--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -1,0 +1,47 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch as mock_patch
+import torch
+from torch_spyre._inductor import config
+from torch_spyre._inductor.dsc import SuperDSCScheduling
+from utils_inductor import cached_randn
+
+
+def test_config_change_invalidates_cache():
+    fn = torch.abs
+    x = cached_randn((256,))
+    call_count = 0
+    original_define_kernel = SuperDSCScheduling.define_kernel
+
+    def counting_define_kernel(self_sched, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_define_kernel(self_sched, *args, **kwargs)
+
+    with mock_patch.object(SuperDSCScheduling, "define_kernel", counting_define_kernel):
+        torch._dynamo.reset_code_caches()
+        torch.compile(fn)(x.to("spyre"))
+        first_count = call_count
+
+        # Same config — should hit cache (no new codegen)
+        # torch._dynamo.reset_code_caches()
+        torch.compile(fn)(x.to("spyre"))
+        assert call_count == first_count, "Expected cache hit"
+
+        # Different config — should miss cache (new codegen)
+        with config.patch("sencores", 1):
+            torch._dynamo.reset_code_caches()
+            torch.compile(fn)(x.to("spyre"))
+            assert call_count > first_count, "Expected recompilation"

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -14,7 +14,6 @@
 
 import torch
 from torch_spyre._inductor import config
-from utils_inductor import cached_randn
 from torch.testing import FileCheck
 from torch._inductor.exc import InductorError
 from torch._inductor.test_case import TestCase as InductorTestCase
@@ -26,16 +25,20 @@ from torch._inductor.utils import (
 class TestSpyreConfig(InductorTestCase):
     def test_config_default(self):
         fn = torch.abs
-        x = cached_randn((256,)).to("spyre")
+        x = torch.randn((256, 128, 512)).to("spyre")
 
         comp_fn = torch.compile(fn)
         out, source_codes = run_and_get_code(comp_fn, x)
-        FileCheck().check("sdsc_fused_abs_0").run(source_codes[0])
+        # print("test_config_default")
+        # print(source_codes[0])
+        FileCheck().check("sdsc_fused_abs").check(
+            f"sympify('c0'): (sympify('256'), {config.sencores})"
+        ).run(source_codes[0])
 
     @config.patch({"sencores": 64})
     def test_config_too_many_sencores(self):
         fn = torch.abs
-        x = cached_randn((256,)).to("spyre")
+        x = torch.randn((256, 128, 512)).to("spyre")
 
         with self.assertRaisesRegex(
             InductorError,
@@ -44,13 +47,36 @@ class TestSpyreConfig(InductorTestCase):
             comp_fn = torch.compile(fn)
             comp_fn(x)
 
-    # Need a test where getting lx_planning to True generates a different kernel
-    # @config.patch({'lx_planning': True})
-    # def test_config_lx_planning(self):
+    @config.patch({"sencores": 16})
+    def test_sencores_16(self):
+        fn = torch.abs
+        x = torch.randn((256, 128, 512)).to("spyre")
+        cfn = torch.compile(fn, dynamic=False)
+        out, source_codes = run_and_get_code(cfn, x)
+        # print("test_sencores 16")
+        # print(source_codes[0])
+        FileCheck().check("sdsc_fused_abs").check(
+            f"sympify('c0'): (sympify('256'), {config.sencores})"
+        ).run(source_codes[0])
+
+    # Need a test where changing dxp_lx_frac_avail changes the generated OpSpec
+    # @config.patch({"dxp_lx_frac_avail": 0.01, "lx_planning": True})
+    # def test_config_dxp_lx_frac_avail(self):
     #    fn = torch.abs
-    #    x = cached_randn((256,)).to("spyre")
+    #    x = torch.randn((256, 128, 512)).to("spyre")
     #
     #    comp_fn = torch.compile(fn)
     #    out, source_codes = run_and_get_code(comp_fn, x)
-    #    print(f"lx_planning {config.lx_planning}")
-    #    print(source_codes[0])
+    #    #print("test_conf_dxp_lx_frac_avail")
+    #    #print(source_codes[0])
+
+    # Need a test where setting lx_planning to True generates a different OpSpec
+    # @config.patch({'lx_planning': True})
+    # def test_config_lx_planning(self):
+    #    fn = torch.abs
+    #    x = torch.randn((256, 128, 512)).to("spyre")
+    #
+    #    comp_fn = torch.compile(fn)
+    #    out, source_codes = run_and_get_code(comp_fn, x)
+    #    #print(f"lx_planning {config.lx_planning}")
+    #    #print(source_codes[0])

--- a/tests/inductor/test_codegen.py
+++ b/tests/inductor/test_codegen.py
@@ -12,36 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch as mock_patch
 import torch
 from torch_spyre._inductor import config
-from torch_spyre._inductor.dsc import SuperDSCScheduling
 from utils_inductor import cached_randn
+from torch.testing import FileCheck
+from torch._inductor.exc import InductorError
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import (
+    run_and_get_code,
+)
 
 
-def test_config_change_invalidates_cache():
-    fn = torch.abs
-    x = cached_randn((256,))
-    call_count = 0
-    original_define_kernel = SuperDSCScheduling.define_kernel
+class TestSpyreConfig(InductorTestCase):
+    def test_config_default(self):
+        fn = torch.abs
+        x = cached_randn((256,)).to("spyre")
 
-    def counting_define_kernel(self_sched, *args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        return original_define_kernel(self_sched, *args, **kwargs)
+        comp_fn = torch.compile(fn)
+        out, source_codes = run_and_get_code(comp_fn, x)
+        FileCheck().check("sdsc_fused_abs_0").run(source_codes[0])
 
-    with mock_patch.object(SuperDSCScheduling, "define_kernel", counting_define_kernel):
-        torch._dynamo.reset_code_caches()
-        torch.compile(fn)(x.to("spyre"))
-        first_count = call_count
+    @config.patch({"sencores": 64})
+    def test_config_too_many_sencores(self):
+        fn = torch.abs
+        x = cached_randn((256,)).to("spyre")
 
-        # Same config — should hit cache (no new codegen)
-        # torch._dynamo.reset_code_caches()
-        torch.compile(fn)(x.to("spyre"))
-        assert call_count == first_count, "Expected cache hit"
+        with self.assertRaisesRegex(
+            InductorError,
+            "Unsupported: Spyre backend does not support: invalid SENCORES value 64",
+        ):
+            comp_fn = torch.compile(fn)
+            comp_fn(x)
 
-        # Different config — should miss cache (new codegen)
-        with config.patch("sencores", 1):
-            torch._dynamo.reset_code_caches()
-            torch.compile(fn)(x.to("spyre"))
-            assert call_count > first_count, "Expected recompilation"
+    # Need a test where getting lx_planning to True generates a different kernel
+    # @config.patch({'lx_planning': True})
+    # def test_config_lx_planning(self):
+    #    fn = torch.abs
+    #    x = cached_randn((256,)).to("spyre")
+    #
+    #    comp_fn = torch.compile(fn)
+    #    out, source_codes = run_and_get_code(comp_fn, x)
+    #    print(f"lx_planning {config.lx_planning}")
+    #    print(source_codes[0])

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -159,8 +159,10 @@ def _autoload():
         from .wrapper import SpyrePythonWrapperCodegen
 
         register_backend_for_device(
-            DEVICE_NAME, SuperDSCScheduling, SpyrePythonWrapperCodegen,
-            device_custom_config=config
+            DEVICE_NAME,
+            SuperDSCScheduling,
+            SpyrePythonWrapperCodegen,
+            device_custom_config=config,
         )
 
         _autoload._ran = True

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -14,6 +14,7 @@
 
 from .constants import DEVICE_NAME
 from .patches import enable_spyre_context
+from . import config
 
 import threading
 from functools import wraps
@@ -158,7 +159,8 @@ def _autoload():
         from .wrapper import SpyrePythonWrapperCodegen
 
         register_backend_for_device(
-            DEVICE_NAME, SuperDSCScheduling, SpyrePythonWrapperCodegen
+            DEVICE_NAME, SuperDSCScheduling, SpyrePythonWrapperCodegen,
+            device_custom_config=config
         )
 
         _autoload._ran = True

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -17,14 +17,10 @@ import sys
 
 from torch.utils._config_module import install_config_module
 
-from .errors import Unsupported
-
 lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
 
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
-if sencores > 32 or sencores < 1:
-    raise Unsupported(f"invalid SENCORES value {sencores}")
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -1,7 +1,23 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
-from .errors import Unsupported
+
 from torch.utils._config_module import install_config_module
+
+from .errors import Unsupported
 
 lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
 
@@ -9,6 +25,6 @@ dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
 if sencores > 32 or sencores < 1:
-        raise Unsupported(f"invalid SENCORES value {sencores}")
+    raise Unsupported(f"invalid SENCORES value {sencores}")
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from .errors import Unsupported
+from torch.utils._config_module import install_config_module
+
+lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
+
+dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
+
+sencores: int = int(os.getenv("SENCORES", "32"))
+if sencores > 32 or sencores < 1:
+        raise Unsupported(f"invalid SENCORES value {sencores}")
+
+install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -40,6 +40,7 @@ from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .pass_utils import SchedNodeArg, get_mem_deps, device_coordinates, iteration_space
 from .logging_utils import get_inductor_logger
+from . import config
 import logging
 
 logger = get_inductor_logger("core_division")
@@ -351,9 +352,7 @@ def core_division_planning(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
     # Nodes are in topological order (guaranteed by caller).
-    max_cores = int(os.getenv("SENCORES", "32"))
-    if max_cores > 32 or max_cores < 1:
-        raise Unsupported(f"invalid SENCORES value {max_cores}")
+    max_cores = config.sencores
 
     it = iter(nodes)
     for n in it:

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -34,6 +34,7 @@ from torch._inductor.scheduler import (
 
 from torch._inductor.dependencies import MemoryDep
 
+from .errors import Unsupported
 from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .pass_utils import SchedNodeArg, get_mem_deps, device_coordinates, iteration_space
@@ -351,6 +352,8 @@ def core_division_planning(
 ) -> list[BaseSchedulerNode]:
     # Nodes are in topological order (guaranteed by caller).
     max_cores = config.sencores
+    if max_cores > 32 or max_cores < 1:
+        raise Unsupported(f"invalid SENCORES value {max_cores}")
 
     it = iter(nodes)
     for n in it:

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -15,7 +15,6 @@
 
 import dataclasses
 import math
-import os
 from sympy import Expr, Symbol
 
 import torch
@@ -35,7 +34,6 @@ from torch._inductor.scheduler import (
 
 from torch._inductor.dependencies import MemoryDep
 
-from .errors import Unsupported
 from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .pass_utils import SchedNodeArg, get_mem_deps, device_coordinates, iteration_space

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -35,6 +35,7 @@ from .core_division import core_division_planning
 from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
+from . import config
 
 
 def _maybe_run_graph_pass(pass_fn, graph: torch.fx.graph.Graph) -> None:
@@ -121,7 +122,7 @@ def scheduler_pre_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNo
 
     nodes = propagate_spyre_tensor_layouts(nodes)
     nodes = core_division_planning(nodes)
-    if os.environ.get("LX_PLANNING", "0") == "1":
+    if config.lx_planning:
         nodes = scratchpad_planning(nodes)
     return nodes
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import inspect
-import os
 from typing import Optional, Any, Callable, List
 
 import torch

--- a/torch_spyre/_inductor/scratchpad.py
+++ b/torch_spyre/_inductor/scratchpad.py
@@ -35,9 +35,7 @@ class ScratchPadAllocator:
         # scratch pad is 2MB = 2<<20 bytes in total. preserve total * DXP_LX_FRAC_AVAIL
         # for backend usage unless specified otherwise
         if size == -1:
-            size = int(
-                (2 << 20) * (1.0 - config.dxp_lx_frac_avail)
-            )
+            size = int((2 << 20) * (1.0 - config.dxp_lx_frac_avail))
         self.limit = size
         self.usage: dict = {}  # each record will be tensor_name:{"addr": yy, "size": zz}
         self.lx_usage_hist: list = []

--- a/torch_spyre/_inductor/scratchpad.py
+++ b/torch_spyre/_inductor/scratchpad.py
@@ -22,6 +22,7 @@ from torch._inductor.scheduler import (
     SchedulerNode,
 )
 from torch._inductor.virtualized import V
+from . import config
 
 
 OPS_GOOD_FOR_LX_REUSE = {"input": {"sub", "div"}, "output": {"max", "sum"}}
@@ -35,7 +36,7 @@ class ScratchPadAllocator:
         # for backend usage unless specified otherwise
         if size == -1:
             size = int(
-                (2 << 20) * (1.0 - float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2")))
+                (2 << 20) * (1.0 - config.dxp_lx_frac_avail)
             )
         self.limit = size
         self.usage: dict = {}  # each record will be tensor_name:{"addr": yy, "size": zz}

--- a/torch_spyre/_inductor/scratchpad.py
+++ b/torch_spyre/_inductor/scratchpad.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-import os
+
 from torch._inductor.ir import (
     ComputedBuffer,
 )


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- [x] Adds a config module to _inductor similar to torch._dynamo.config and torch._inductor.config
- [x] Registered with torch.inductor
- [x] Adds test for code cache

#### Which issue(s) this PR is related to:

Closes #1178

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
