### PR TITLE
Suppress buffer allocation for LX allocated tensors

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -318,7 +318,8 @@ class SpyreKernel(Kernel[CSEVariable]):
             device_coords,
             tensor.layout.allocation,
         )
-        self.spyre_kernel_args.append((name, tensor_arg))
+        if not tensor.layout.allocation:
+            self.spyre_kernel_args.append((name, tensor_arg))
         return tensor_arg
 
     def create_op_spec(
@@ -355,17 +356,24 @@ class SpyreKernel(Kernel[CSEVariable]):
         )
 
     def remove_kernel_local_buffers(self) -> None:
-        """Do not remove kernel local buffers becasue we need the allocate in hbm/lx"""
-        pass
+        """Remove buffers that have a scratchpad allocation from the kernel's arg list."""
+        for name in list(self.store_buffer_names):
+            buf = V.graph.get_buffer(name)
+            if buf is None:
+                continue
+            layout = buf.get_layout()
+            if isinstance(layout, FixedTiledLayout) and layout.allocation:
+                self.remove_buffer(name)
 
     def load(self, name: str, index: sympy.Expr):
         """Codegen a load from an InputBuffer"""
-        _ = self.args.input(name)
         buf = V.graph.get_buffer(name)
         layout = buf.get_layout()
         if not isinstance(layout, FixedTiledLayout):
             raise Unsupported(f"{name} does not have FixedTiledLayout")
         index = sympy_subs(index, V.graph.sizevars.precomputed_replacements)
+        if not layout.allocation:
+            _ = self.args.input(name)
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

If a tensor is LX allocated, we should not also be allocating a HBM buffer for it or passing it as a kernel argument.

After this fix, we correctly adjust the host code.  For the softmax example compiled with `LX_PLANNING=1`, the first 2 kernels now correspond to the host code: 
```
    def call(self, args):
        arg0_1, = args
        args.clear()
        assert_size_stride(arg0_1, (512, 1024), (1024, 1))
        sdsc_fused__softmax_0.run(arg0_1)
        buf1 = spyre_empty_with_layout((512, 1024), (1024, 1), torch.float16, SpyreTensorLayout(device_size=[16, 512, 64], dim_map =[1, 0, 1], stride_map =[64, 1024, 1], device_dtype=DataFormats.SEN169_FP16))
        sdsc_fused__softmax_1.run(arg0_1, buf1)
        del arg0_1
```
and the `OpSpecs`
```
# Topologically Sorted Source Nodes: [softmax], Original ATen: [aten._softmax]
# Source node to ATen node mapping:
#   softmax => amax
# Graph fragment:
#   %arg0_1 : Tensor "f16[512, 1024][1024, 1]spyre:0" = PlaceHolder[target=arg0_1]
#   %amax : Tensor "f16[1, 1024][1024, 1]spyre:0"[num_users=1] = call_function[target=torch.ops.aten.amax.default](args = (%arg0_1, [0], True), kwargs = {})
#   return %amax
sdsc_fused__softmax_0 = async_compile.sdsc('sdsc_fused__softmax_0',
    [
        OpSpec(
            op='max',
            is_reduction=True,
            iteration_space={sympify('c0'): (sympify('1024'), 1), sympify('c1'): (sympify('512'), 1)},
            op_info={},
            args=[
                TensorArg(
                    is_input=True, arg_index=0, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[16, 512, 64],
                    device_coordinates=[sympify('floor(c0/64)'), sympify('c1'), sympify('Mod(c0, 64)')],
                    allocation={},
                ),
                TensorArg(
                    is_input=False, arg_index=-1, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[1, 16, 64],
                    device_coordinates=[sympify('0'), sympify('floor(c0/64)'), sympify('Mod(c0, 64)')],
                    allocation={'lx:0': 1048576, 'lx:1': 1048576},
                ),
            ]
        ),
    ]
)


# Topologically Sorted Source Nodes: [softmax], Original ATen: [aten._softmax]
# Source node to ATen node mapping:
#   softmax => sub
# Graph fragment:
#   %arg0_1 : Tensor "f16[512, 1024][1024, 1]spyre:0" = PlaceHolder[target=arg0_1]
#   %amax : Tensor "f16[1, 1024][1024, 1]spyre:0" = PlaceHolder[target=amax]
#   %sub : Tensor "f16[512, 1024][1024, 1]spyre:0"[num_users=1] = call_function[target=torch.ops.aten.sub.Tensor](args = (%arg0_1, %amax), kwargs = {})
#   return %sub
sdsc_fused__softmax_1 = async_compile.sdsc('sdsc_fused__softmax_1',
    [
        OpSpec(
            op='sub',
            is_reduction=False,
            iteration_space={sympify('d0'): (sympify('512'), 1), sympify('d1'): (sympify('1024'), 1)},
            op_info={},
            args=[
                TensorArg(
                    is_input=True, arg_index=0, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[16, 512, 64],
                    device_coordinates=[sympify('floor(d1/64)'), sympify('d0'), sympify('Mod(d1, 64)')],
                    allocation={},
                ),
                TensorArg(
                    is_input=True, arg_index=-1, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[1, 16, 64],
                    device_coordinates=[sympify('0'), sympify('floor(d1/64)'), sympify('Mod(d1, 64)')],
                    allocation={'lx:0': 1048576, 'lx:1': 1048576},
                ),
                TensorArg(
                    is_input=False, arg_index=1, device_dtype=DataFormats.SEN169_FP16,
                    device_size=[16, 512, 64],
                    device_coordinates=[sympify('floor(d1/64)'), sympify('d0'), sympify('Mod(d1, 64)')],
                    allocation={},
                ),
            ]
        ),
    ]
)
```

#### Which issue(s) this PR is related to:

This is part of #223 and is related to #1257 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
