### PR TITLE
Enable reduction dimension as work division candidate

### DIFF
--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -327,6 +327,7 @@ def divide_reduction_op(n: SchedulerNode, args: list[SchedNodeArg], max_cores):
 
     # FIXME: For non-matmul reduction, excluting reduction dimensions from work
     #        division candidates temporarily till known backend issue is fixed
+    #        https://github.com/torch-spyre/torch-spyre/issues/1304
     priorities, min_splits = prioritize_dimensions(
         output_td, it_space, input_tds, exclude_reduction=not is_matmul
     )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The changes enable:

1.  Considering reduction dimensions as work division candidates. Previously, we turned this off to prevent a backend bug when reduction dimension slices are not assigned to neighboring cores. 
2. ~~Removing the guard for preventing work division of regular (non-matmul) reductions~~ Enabling multi-dimension work division for regular attention op but excluding reduction dimension split for now due to known issue #1304 

NOTE: The PR will remain in draft till the deeptool fix is merged.

#### Which issue(s) this PR is related to:

Partially fix #820 
Depends on #1279 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
