### PR TITLE
Subclass wrapper for spyre tensors

### DIFF
--- a/codegen/templates/base.jinja2
+++ b/codegen/templates/base.jinja2
@@ -22,12 +22,13 @@ def spyre__{{ template_data.op_name }}({{ signature_in }}){% if returns|length >
     {{ scalar_name }}_scaTensor = torch.tensor([{{ scalar_name }}], device="spyre")
     {% endfor %}
     {% endif %}
+    args, kwargs = torch_spyre.tensor.wrap_spyre_tensor_args({{ arg_names }})
     {% if "out" in overload_name %}
     # Out variant
     compiled_{{ operator_name }} = torch.compile({{ template_data.torch_prefix }}.{{ template_data.torch_func_name }}, dynamic=False)
-    return compiled_{{ operator_name }}({{ arg_names }}, out=out)
+    return compiled_{{ operator_name }}(*args, out=out, **kwargs)
     {% else %}
     # Standard variant
     compiled_{{ operator_name }} = torch.compile({{ template_data.torch_prefix }}.{{ template_data.torch_func_name }}, dynamic=False)
-    return compiled_{{ operator_name }}({{ arg_names }})
+    return compiled_{{ operator_name }}(*args, **kwargs)
     {% endif %}

--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -19,6 +19,8 @@ __all__: list[str] = [
     "as_strided_with_layout",
     "convert_artifacts",
     "empty_with_layout",
+    "spyre_empty",
+    "spyre_empty_strided",
     "encode_constant",
     "free_runtime",
     "get_device_dtype",
@@ -251,6 +253,22 @@ def empty_with_layout(
     arg3: torch.device | None,
     arg4: bool | None,
     arg5: torch.memory_format | None,
+) -> torch.Tensor: ...
+def spyre_empty(
+    arg0: tuple[int, ...],
+    arg1: torch.dtype | None,
+    arg2: torch.layout | None,
+    arg3: torch.device | None,
+    arg4: bool | None,
+    arg5: torch.memory_format | None,
+) -> torch.Tensor: ...
+def spyre_empty_strided(
+    arg0: tuple[int, ...],
+    arg1: tuple[int, ...],
+    arg2: torch.dtype | None,
+    arg3: torch.layout | None,
+    arg4: torch.device | None,
+    arg5: bool | None,
 ) -> torch.Tensor: ...
 def encode_constant(arg0: typing.SupportsFloat, arg1: DataFormats) -> int: ...
 def free_runtime() -> None: ...

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -159,6 +159,7 @@ def make_spyre_module() -> types.ModuleType:
             "current_stream",
             "default_stream",
             "synchronize",
+            "SpyreTensor",
         }:
             impl._lazy_init()
             from torch_spyre.streams import (
@@ -168,6 +169,7 @@ def make_spyre_module() -> types.ModuleType:
                 default_stream,
                 synchronize,
             )
+            from torch_spyre.tensor import SpyreTensor
 
             streams_map = {
                 "Stream": Stream,
@@ -175,6 +177,7 @@ def make_spyre_module() -> types.ModuleType:
                 "current_stream": current_stream,
                 "default_stream": default_stream,
                 "synchronize": synchronize,
+                "SpyreTensor": SpyreTensor,
             }
             return streams_map[name]
         if hasattr(impl._C, name):

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -210,6 +210,7 @@ def _autoload():
     # Set all the appropriate state on PyTorch
     torch.utils.rename_privateuse1_backend(DEVICE_NAME)
     torch._register_device_module(DEVICE_NAME, make_spyre_module())
+    import torch_spyre.tensor  # noqa: F401
     import torch_spyre.codegen_ops  # noqa: F401
     from torch_spyre._inductor import _light_autoload
 

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -17,6 +17,7 @@ import torch
 from torch_spyre.ops.fallbacks import warn_fallback
 
 from .errors import Unsupported
+import torch_spyre.tensor
 
 
 @torch.library.custom_op("spyre::softplus", mutates_args=(), device_types="spyre")
@@ -110,7 +111,8 @@ def rms_norm(
         raise Unsupported(
             f"spyre.layernorm: unsupported reduction shape {normalized_shape}"
         )
-    return torch.compile(torch.ops.spyre.rms_norm)(x, normalized_shape, weight, eps)
+    args = torch_spyre.tensor.wrap_spyre_tensor_args(x, normalized_shape, weight, eps)
+    return torch.compile(torch.ops.spyre.rms_norm)(*args)
 
 
 @rms_norm.register_fake

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -24,6 +24,7 @@ import torch._decomp as decomp
 from .constants import DEVICE_NAME
 from .errors import Unsupported
 from . import customops  # noqa: F401
+import torch_spyre.tensor
 
 import threading
 
@@ -294,6 +295,9 @@ def register_spyre_decompositions_via_dispatchkey(
                     return self.spyre_fn(*args, **kwargs)
                 else:
                     # Eager mode: use the pre-compiled wrapper.
+                    args, kwargs = torch_spyre.tensor.wrap_spyre_tensor_args(
+                        *args, **kwargs
+                    )
                     return self._compiled_fn(*args, **kwargs)
 
         def register(op):

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -312,6 +312,8 @@ PYBIND11_MODULE(_C, m) {
                                             t[4].cast<DataFormats>());
           }));
 
+  m.def("spyre_empty", &spyre::spyre_empty);
+  m.def("spyre_empty_strided", &spyre::spyre_empty_strided);
   m.def("spyre_empty_with_layout", &spyre::spyre_empty_with_layout);
   m.def("to_with_layout", &spyre::to_with_layout);
   m.def("empty_with_layout", &spyre::py_empty_with_layout);

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -699,8 +699,8 @@ at::Tensor py_empty_with_layout(
 }
 
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
-  m.impl("empty.memory_format", TORCH_FN(spyre_empty));
-  m.impl("empty_strided", TORCH_FN(spyre_empty_strided));
+  // m.impl("empty.memory_format", TORCH_FN(spyre_empty));
+  // m.impl("empty_strided", TORCH_FN(spyre_empty_strided));
   m.impl("set_.source_Storage_storage_offset", TORCH_FN(spyre_set_storage));
   m.impl("_copy_from", TORCH_FN(spyre_copy_from));
 }

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -52,4 +52,11 @@ at::Tensor py_empty_with_layout(
     std::optional<c10::Device> device_opt, std::optional<bool> pin_memory_opt,
     std::optional<c10::MemoryFormat> memory_format_opt);
 
+at::Tensor spyre_empty(c10::IntArrayRef size,
+                       std::optional<c10::ScalarType> dtype_opt,
+                       std::optional<c10::Layout> layout_opt,
+                       std::optional<c10::Device> device_opt,
+                       std::optional<bool> pin_memory_opt,
+                       std::optional<c10::MemoryFormat> memory_format_opt);
+
 }  // namespace spyre

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -15,8 +15,13 @@
 import os
 from torch_spyre._C import launch_kernel
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre.tensor import SpyreTensor
 
 logger = get_inductor_logger("kernel_runner")
+
+
+def _unwrap_spyre_tensor(arg):
+    return arg._t if isinstance(arg, SpyreTensor) else arg
 
 
 class SpyreUnimplementedRunner:
@@ -40,5 +45,5 @@ class SpyreSDSCKernelRunner:
         for i in range(len(self.code_dirs)):
             g2 = os.path.join(self.code_dirs[i], "g2.graph.cbor")
             logger.info(f"RUN: {self.kernel_name}_{i} {g2}")
-            actuals = [args[i] for i in self.arg_mappings[i]]
+            actuals = [_unwrap_spyre_tensor(args[i]) for i in self.arg_mappings[i]]
             launch_kernel(g2, actuals)

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -14,6 +14,8 @@
 
 import torch
 import torch_spyre.ops.fallbacks  # noqa: F401
+from torch_spyre._C import spyre_empty, spyre_empty_strided
+import torch_spyre.tensor
 
 
 def maybe_wrap_dim(dim: int, ndims: int) -> int:
@@ -22,10 +24,35 @@ def maybe_wrap_dim(dim: int, ndims: int) -> int:
     return dim
 
 
+@torch.library.register_kernel("aten::empty.memory_format", ["spyre"])
+def _spyre_empty_memory_format(
+    size, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
+) -> torch.Tensor:
+    # layout is omitted; c10::Layout has no pybind11 type caster,
+    # so we drop that parameter and always uses the default (Strided).
+    assert layout in (None, torch.strided)
+    return torch_spyre.tensor.wrap_spyre_tensor(
+        spyre_empty(size, dtype, None, device, pin_memory, memory_format)
+    )
+
+
+@torch.library.register_kernel("aten::empty_strided", ["spyre"])
+def _spyre_empty_strided(
+    size, stride, *, dtype=None, layout=None, device=None, pin_memory=None
+) -> torch.Tensor:
+    # layout is omitted; c10::Layout has no pybind11 type caster,
+    # so we drop that parameter and always uses the default (Strided).
+    assert layout in (None, torch.strided)
+    return torch_spyre.tensor.wrap_spyre_tensor(
+        spyre_empty_strided(size, stride, dtype, None, device, pin_memory)
+    )
+
+
 @torch.library.register_kernel("aten::mm", ["spyre"])  # type:ignore
 def spyre__mm(self: torch.Tensor, mat2: torch.Tensor) -> torch.Tensor:
     compiled_mm = torch.compile(torch.mm, dynamic=False)
-    return compiled_mm(self, mat2)
+    args, _ = torch_spyre.tensor.wrap_spyre_tensor_args(self, mat2)
+    return compiled_mm(*args)
 
 
 @torch.library.register_kernel("aten::mm.out", ["spyre"])  # type:ignore
@@ -33,7 +60,8 @@ def spyre__mm_out(
     self: torch.Tensor, mat2: torch.Tensor, out: torch.Tensor
 ) -> torch.Tensor:
     compiled_mm = torch.compile(torch.mm, dynamic=False)
-    return compiled_mm(self, mat2, out=out)
+    args, _ = torch_spyre.tensor.wrap_spyre_tensor_args(self, mat2)
+    return compiled_mm(*args, out=out)
 
 
 @torch.library.register_kernel("aten::fill_.Scalar", ["spyre"])  # type:ignore
@@ -73,6 +101,7 @@ def spyre__zero_(self: torch.Tensor) -> torch.Tensor:
 def spyre__silu_out(self: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
     # Out variant
     compiled_silu = torch.compile(torch.ops.aten.silu.out, dynamic=False)
+    (self,), _ = torch_spyre.tensor.wrap_spyre_tensor_args(self)
     return compiled_silu(self, out=out)
 
 
@@ -80,6 +109,7 @@ def spyre__silu_out(self: torch.Tensor, out: torch.Tensor = None) -> torch.Tenso
 def spyre__mish_out(self: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
     # Out variant
     compiled_mish = torch.compile(torch.ops.aten.mish.out, dynamic=False)
+    (self,), _ = torch_spyre.tensor.wrap_spyre_tensor_args(self)
     return compiled_mish(self, out=out)
 
 

--- a/torch_spyre/tensor.py
+++ b/torch_spyre/tensor.py
@@ -1,0 +1,173 @@
+import torch
+import torch.utils._pytree as pytree
+import os
+
+from ._C import (
+    get_spyre_tensor_layout,
+    empty_with_layout,
+    to_with_layout,
+)
+
+aten = torch.ops.aten
+
+_initialized = False
+
+
+class SpyreTensor(torch.Tensor):
+    def __init__(self, t, device_tensor_layout=None):
+        orig_layout = None
+        while isinstance(t, SpyreTensor):
+            orig_layout = orig_layout or t.device_tensor_layout()
+            t = t._t
+
+        try:
+            orig_layout = get_spyre_tensor_layout(t)
+        except RuntimeError:
+            pass
+
+        if t.device.type == "spyre":
+            if (
+                device_tensor_layout is not None
+                and orig_layout is not None
+                and device_tensor_layout != orig_layout
+            ):
+                t = to_with_layout(t, device_tensor_layout)._t
+        else:
+            if device_tensor_layout is None:
+                device_tensor = t.to("spyre")
+                device_tensor_layout = device_tensor.device_tensor_layout()
+                t = device_tensor._t
+            else:
+                t = to_with_layout(t, device_tensor_layout)._t
+        assert not isinstance(t, SpyreTensor)
+        self._t = t
+        self._stl = device_tensor_layout or orig_layout
+
+    @staticmethod
+    def __new__(cls, t, device_tensor_layout=None):
+        shape = t.shape
+        kwargs = {}
+        kwargs["strides"] = t.stride()
+        kwargs["storage_offset"] = t.storage_offset()
+        kwargs["device"] = "spyre"
+        kwargs["layout"] = t.layout
+        kwargs["requires_grad"] = t.requires_grad
+        kwargs["dtype"] = t.dtype
+        out = torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)
+        return out
+
+    def __repr__(self):
+        t_repr = repr(self._t)
+        if t_repr.startswith("tensor("):
+            t_repr = t_repr[len("tensor(") : -1]
+        return (
+            f"SpyreTensor({t_repr}, device_tensor_layout={self.device_tensor_layout()})"
+        )
+
+    def device_tensor_layout(self):
+        return self._stl
+
+    def to(self, *args, device_layout=None, **kwargs):
+        if (
+            device_layout is None
+        ):  # use original implementation if no layout is provided
+            return SpyreTensor(self._t.to(*args, **kwargs))
+        else:
+            return to_with_layout(self, device_layout)
+
+    @classmethod
+    def empty(
+        cls,
+        *args,
+        device_layout=None,
+        out=None,
+        dtype=None,
+        layout=torch.strided,
+        device=None,
+        requires_grad=False,
+        pin_memory=False,
+        memory_format=torch.contiguous_format,
+    ):
+        assert device is None or torch.device(device).type == "spyre", (
+            f"Device should be None or spyre. Got: {device}"
+        )
+        if (
+            device_layout is None
+        ):  # use original implementation if no layout is provided
+            return cls(
+                torch.empty(
+                    *args,
+                    out=out,
+                    dtype=dtype,
+                    layout=layout,
+                    device=device,
+                    requires_grad=requires_grad,
+                    pin_memory=pin_memory,
+                    memory_format=memory_format,
+                )
+            )
+        else:
+            global _initialized
+            if not _initialized:
+                # TODO: figure out why we need a call here
+                _ = torch.randn(2).to("spyre")
+                _initialized = True
+            # layout_opt is omitted; c10::Layout has no pybind11 type caster,
+            # so py_empty_with_layout drops that parameter and always uses
+            # the default (Strided).
+            return cls(
+                empty_with_layout(
+                    *args, device_layout, dtype, device, pin_memory, memory_format
+                )
+            )
+
+    def __tensor_flatten__(self):
+        layout = self.device_tensor_layout()
+        return ["_t"], {"device_tensor_layout": layout}
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, _, __):
+        t = inner_tensors["_t"]
+        return SpyreTensor(t, meta["device_tensor_layout"])
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs):
+        if kwargs is None:
+            kwargs = {}
+        args_a = pytree.tree_map(
+            lambda x: x._t if isinstance(x, SpyreTensor) else x, args
+        )
+        kwargs_a = pytree.tree_map(
+            lambda x: x._t if isinstance(x, SpyreTensor) else x, kwargs
+        )
+        out_a = func(*args_a, **kwargs_a)
+        out = pytree.tree_map(
+            lambda x: (
+                SpyreTensor(x)
+                if isinstance(x, torch.Tensor) and x.device.type == "spyre"
+                else x
+            ),
+            out_a,
+        )
+        return out
+
+
+def wrap_spyre_tensor(x):
+    if os.environ.get("TORCH_SPYRE_WRAPPER_SUBCLASS", "0") == "0":
+        return x
+    else:
+        return SpyreTensor(x)
+
+
+def wrap_spyre_tensor_args(*args, **kwargs):
+    if os.environ.get("TORCH_SPYRE_WRAPPER_SUBCLASS", "0") == "0":
+        return args, kwargs
+
+    def wrap(x):
+        return (
+            SpyreTensor(x)
+            if isinstance(x, torch.Tensor) and not isinstance(x, SpyreTensor)
+            else x
+        )
+
+    return pytree.tree_map_(wrap, args), pytree.tree_map_(wrap, kwargs)

--- a/torch_spyre/tensor.py
+++ b/torch_spyre/tensor.py
@@ -153,14 +153,14 @@ class SpyreTensor(torch.Tensor):
 
 
 def wrap_spyre_tensor(x):
-    if os.environ.get("TORCH_SPYRE_WRAPPER_SUBCLASS", "0") == "0":
+    if os.environ.get("TORCH_SPYRE_WRAPPER_SUBCLASS", "1") == "0":
         return x
     else:
         return SpyreTensor(x)
 
 
 def wrap_spyre_tensor_args(*args, **kwargs):
-    if os.environ.get("TORCH_SPYRE_WRAPPER_SUBCLASS", "0") == "0":
+    if os.environ.get("TORCH_SPYRE_WRAPPER_SUBCLASS", "1") == "0":
         return args, kwargs
 
     def wrap(x):

--- a/torch_spyre/tensor.py
+++ b/torch_spyre/tensor.py
@@ -31,14 +31,14 @@ class SpyreTensor(torch.Tensor):
                 and orig_layout is not None
                 and device_tensor_layout != orig_layout
             ):
-                t = to_with_layout(t, device_tensor_layout)._t
+                t = to_with_layout(t, device_tensor_layout)
         else:
             if device_tensor_layout is None:
                 device_tensor = t.to("spyre")
                 device_tensor_layout = device_tensor.device_tensor_layout()
                 t = device_tensor._t
             else:
-                t = to_with_layout(t, device_tensor_layout)._t
+                t = to_with_layout(t, device_tensor_layout)
         assert not isinstance(t, SpyreTensor)
         self._t = t
         self._stl = device_tensor_layout or orig_layout
@@ -71,9 +71,13 @@ class SpyreTensor(torch.Tensor):
         if (
             device_layout is None
         ):  # use original implementation if no layout is provided
-            return SpyreTensor(self._t.to(*args, **kwargs))
+            result = self._t.to(*args, **kwargs)
+            if result.device.type == "spyre":
+                return SpyreTensor(result)
+            else:
+                return result
         else:
-            return to_with_layout(self, device_layout)
+            return SpyreTensor(to_with_layout(self, device_layout))
 
     @classmethod
     def empty(
@@ -100,7 +104,7 @@ class SpyreTensor(torch.Tensor):
                     out=out,
                     dtype=dtype,
                     layout=layout,
-                    device=device,
+                    device=device or "spyre",
                     requires_grad=requires_grad,
                     pin_memory=pin_memory,
                     memory_format=memory_format,
@@ -134,21 +138,28 @@ class SpyreTensor(torch.Tensor):
     def __torch_dispatch__(cls, func, types, args, kwargs):
         if kwargs is None:
             kwargs = {}
-        args_a = pytree.tree_map(
-            lambda x: x._t if isinstance(x, SpyreTensor) else x, args
-        )
-        kwargs_a = pytree.tree_map(
-            lambda x: x._t if isinstance(x, SpyreTensor) else x, kwargs
-        )
+        spyre_tensors = {}
+
+        def unwrap(x):
+            if isinstance(x, SpyreTensor):
+                spyre_tensors[id(x._t)] = x
+                return x._t
+            else:
+                return x
+
+        def wrap(x):
+            if isinstance(x, torch.Tensor) and x.device.type == "spyre":
+                found = spyre_tensors.get(id(x))
+                if found is not None:
+                    return found
+                else:
+                    return SpyreTensor(x)
+            return x
+
+        args_a = pytree.tree_map(unwrap, args)
+        kwargs_a = pytree.tree_map(unwrap, kwargs)
         out_a = func(*args_a, **kwargs_a)
-        out = pytree.tree_map(
-            lambda x: (
-                SpyreTensor(x)
-                if isinstance(x, torch.Tensor) and x.device.type == "spyre"
-                else x
-            ),
-            out_a,
-        )
+        out = pytree.tree_map(wrap, out_a)
         return out
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
This makes all torch operations returning a SpyreTensor which is
wrapper subclass of torch.Tensor when the env variable
TORCH_SPYRE_WRAPPER_SUBCLASS=1. Some advantages over keeping the
class torch.Tensor is that,

1. We can add new methods without monkeypatching
2. Central place for factory methods to live
3. Inductor codecache works correctly for tensors with different SpyreTensorLayouts

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
