### PR TITLE
Register aten::copy_ for PrivateUse1 backend

### DIFF
--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -698,10 +698,18 @@ at::Tensor py_empty_with_layout(
                            pin_memory_opt, memory_format_opt);
 }
 
+at::Tensor& spyre_copy_(at::Tensor& self, const at::Tensor& src,
+                        bool non_blocking) {
+  TORCH_CHECK(self.is_privateuseone());
+  spyre_copy_from(src, self, non_blocking);
+  return self;
+}
+
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("empty.memory_format", TORCH_FN(spyre_empty));
   m.impl("empty_strided", TORCH_FN(spyre_empty_strided));
   m.impl("set_.source_Storage_storage_offset", TORCH_FN(spyre_set_storage));
+  m.impl("copy_", TORCH_FN(spyre_copy_));
   m.impl("_copy_from", TORCH_FN(spyre_copy_from));
 }
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This PR adds a PrivateUse1 registration for aten::copy_ in the Spyre backend.

Previously, the backend only registered `aten::_copy_from`, which is the low-level copy primitive used for device copy flows. While many copy cases already worked through `_copy_from`, `copy_` is still the public in-place API and the natural destination-side entry point for tensor copy semantics.
This change makes the Spyre backend explicitly handle `aten::copy_` for PrivateUse1, while forwarding the actual transfer logic to the existing backend copy implementation.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
