### PR TITLE
Refactor to graph-free DMA with FlexAllocator, CompositeAddress, and dynamic supernode resolution

### DIFF
--- a/codegen/inputs/spyre_torch_ops.cpp
+++ b/codegen/inputs/spyre_torch_ops.cpp
@@ -24,6 +24,7 @@
 #include <c10/util/ArrayRef.h>
 #include <logging.h>
 #include <module.h>
+#include <spyre_allocator.h>
 #include <spyre_mem.h>
 #include <spyre_sendnn_utils.h>
 #include <spyre_storage_impl.h>
@@ -206,7 +207,7 @@ void matmul_input_assignment(
   }
   eager_inputs[eager_idx] = (static_cast<SharedOwnerCtx *>(
                                  tmp_tensor.storage().data_ptr().get_context()))
-                                ->owner;
+                                ->interim_alloc_ptr;
 }
 // TODO(filhan): Even though codegen generated version should work,
 // this manually implemented version handles more failure cases.
@@ -280,7 +281,7 @@ at::Tensor spyre__bmm_default(const at::Tensor &self, const at::Tensor &mat2) {
       createOutputTensor(gl, result.storage().data_ptr().get(), 0, 2);
   output_sendnn_tensor.SetSpyreData(
       static_cast<SharedOwnerCtx *>(result.storage().data_ptr().get_context())
-          ->owner);
+          ->interim_alloc_ptr);
 
   auto copy_status =
       gl.Compute({output_sendnn_tensor},
@@ -467,18 +468,18 @@ at::Tensor spyre__clone_default(
     input_sendnn_tensor.SetSpyreData(
         (static_cast<SharedOwnerCtx *>(
              tmp_0.storage().data_ptr().get_context()))
-            ->owner);
+            ->interim_alloc_ptr);
   } else {
     input_sendnn_tensor.SetSpyreData(
         (static_cast<SharedOwnerCtx *>(self.storage().data_ptr().get_context()))
-            ->owner);
+            ->interim_alloc_ptr);
   }
 
   auto output_sendnn_tensor =
       createOutputTensor(gl, result.storage().data_ptr().get());
   output_sendnn_tensor.SetSpyreData(
       (static_cast<SharedOwnerCtx *>(result.storage().data_ptr().get_context()))
-          ->owner);
+          ->interim_alloc_ptr);
 
   auto copy_status =
       gl.Compute({output_sendnn_tensor}, {input_sendnn_tensor}, 1);

--- a/codegen/inputs/spyre_torch_ops.cpp
+++ b/codegen/inputs/spyre_torch_ops.cpp
@@ -207,7 +207,7 @@ void matmul_input_assignment(
   }
   eager_inputs[eager_idx] = (static_cast<SharedOwnerCtx *>(
                                  tmp_tensor.storage().data_ptr().get_context()))
-                                ->interim_alloc_ptr;
+                                ->owner;
 }
 // TODO(filhan): Even though codegen generated version should work,
 // this manually implemented version handles more failure cases.
@@ -281,7 +281,7 @@ at::Tensor spyre__bmm_default(const at::Tensor &self, const at::Tensor &mat2) {
       createOutputTensor(gl, result.storage().data_ptr().get(), 0, 2);
   output_sendnn_tensor.SetSpyreData(
       static_cast<SharedOwnerCtx *>(result.storage().data_ptr().get_context())
-          ->interim_alloc_ptr);
+          ->owner);
 
   auto copy_status =
       gl.Compute({output_sendnn_tensor},
@@ -468,18 +468,18 @@ at::Tensor spyre__clone_default(
     input_sendnn_tensor.SetSpyreData(
         (static_cast<SharedOwnerCtx *>(
              tmp_0.storage().data_ptr().get_context()))
-            ->interim_alloc_ptr);
+            ->owner);
   } else {
     input_sendnn_tensor.SetSpyreData(
         (static_cast<SharedOwnerCtx *>(self.storage().data_ptr().get_context()))
-            ->interim_alloc_ptr);
+            ->owner);
   }
 
   auto output_sendnn_tensor =
       createOutputTensor(gl, result.storage().data_ptr().get());
   output_sendnn_tensor.SetSpyreData(
       (static_cast<SharedOwnerCtx *>(result.storage().data_ptr().get_context()))
-          ->interim_alloc_ptr);
+          ->owner);
 
   auto copy_status =
       gl.Compute({output_sendnn_tensor}, {input_sendnn_tensor}, 1);

--- a/codegen/templates/list_inp.jinja2
+++ b/codegen/templates/list_inp.jinja2
@@ -100,12 +100,12 @@
   unsigned int input_index = 0;
   for (const auto& tensor : {{ arguments[0].name }}) {
     auto& input_sendnn_tensor = input_sendnn_tensor_vector.emplace_back(createInputTensor(gl, tensor.storage().data_ptr().get(), input_index, sn_index));
-    input_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context()))->owner);
+    input_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context()))->interim_alloc_ptr);
     input_index++;
   }
 
   auto output_sendnn_tensor = createOutputTensor(gl, {{ output_variable_name }}.storage().data_ptr().get(), 0, sn_index);
-  output_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>({{ output_variable_name }}.storage().data_ptr().get_context()))->owner);
+  output_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>({{ output_variable_name }}.storage().data_ptr().get_context()))->interim_alloc_ptr);
 
   auto copy_status = gl.Compute({output_sendnn_tensor}, input_sendnn_tensor_vector, sn_index);
 

--- a/codegen/templates/list_inp.jinja2
+++ b/codegen/templates/list_inp.jinja2
@@ -100,12 +100,12 @@
   unsigned int input_index = 0;
   for (const auto& tensor : {{ arguments[0].name }}) {
     auto& input_sendnn_tensor = input_sendnn_tensor_vector.emplace_back(createInputTensor(gl, tensor.storage().data_ptr().get(), input_index, sn_index));
-    input_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context()))->interim_alloc_ptr);
+    input_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context()))->owner);
     input_index++;
   }
 
   auto output_sendnn_tensor = createOutputTensor(gl, {{ output_variable_name }}.storage().data_ptr().get(), 0, sn_index);
-  output_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>({{ output_variable_name }}.storage().data_ptr().get_context()))->interim_alloc_ptr);
+  output_sendnn_tensor.SetSpyreData((static_cast<SharedOwnerCtx*>({{ output_variable_name }}.storage().data_ptr().get_context()))->owner);
 
   auto copy_status = gl.Compute({output_sendnn_tensor}, input_sendnn_tensor_vector, sn_index);
 

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -293,6 +293,26 @@ class TestSpyre(TestCase):
                 x = torch.empty(64, dtype=dtype)
                 x.to("spyre")
 
+    def test_device_to_device_copy(self):
+        # Test device-to-device copy using copy_() method
+        x = torch.ones(3, dtype=torch.float16, device="spyre")
+        y = torch.empty(3, dtype=torch.float16, device="spyre")
+        y.copy_(x)
+
+        # Check that values are the same by comparing on CPU
+        self.assertTrue(torch.all(x.cpu() == y.cpu()))
+        self.assertTrue(torch.all(y.cpu() == 1.0))
+
+        # Test with different values
+        z = torch.tensor([1.5, 2.5, 3.5], dtype=torch.float16, device="spyre")
+        y.copy_(z)
+
+        # Check that values are the same by comparing on CPU
+        self.assertTrue(torch.all(y.cpu() == z.cpu()))
+        self.assertTrue(
+            torch.all(y.cpu() == torch.tensor([1.5, 2.5, 3.5], dtype=torch.float16))
+        )
+
     def test_detach(self):
         # exercises the shallow copy code path
         for dtype in [torch.float16, torch.float32, torch.bool, torch.int8]:

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -191,13 +191,13 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
           createInputTensor(gl, tmp_0.storage().data_ptr().get(), i, 1);
       tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                               tmp_0.storage().data_ptr().get_context())
-                              ->interim_alloc_ptr);
+                              ->owner);
       sen_inputs.push_back(tensor);
     } else {
       auto tensor = createInputTensor(gl, arg.storage().data_ptr().get(), i, 1);
       tensor.SetSpyreData(
           static_cast<SharedOwnerCtx *>(arg.storage().data_ptr().get_context())
-              ->interim_alloc_ptr);
+              ->owner);
       sen_inputs.push_back(tensor);
     }
   }
@@ -205,7 +205,7 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
       createOutputTensor(gl, args.back().storage().data_ptr().get(), 0, 1);
   tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                           args.back().storage().data_ptr().get_context())
-                          ->interim_alloc_ptr);
+                          ->owner);
   sen_outputs.push_back(tensor);
 
   // Execute device init

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -191,13 +191,13 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
           createInputTensor(gl, tmp_0.storage().data_ptr().get(), i, 1);
       tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                               tmp_0.storage().data_ptr().get_context())
-                              ->owner);
+                              ->interim_alloc_ptr);
       sen_inputs.push_back(tensor);
     } else {
       auto tensor = createInputTensor(gl, arg.storage().data_ptr().get(), i, 1);
       tensor.SetSpyreData(
           static_cast<SharedOwnerCtx *>(arg.storage().data_ptr().get_context())
-              ->owner);
+              ->interim_alloc_ptr);
       sen_inputs.push_back(tensor);
     }
   }
@@ -205,7 +205,7 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
       createOutputTensor(gl, args.back().storage().data_ptr().get(), 0, 1);
   tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                           args.back().storage().data_ptr().get_context())
-                          ->owner);
+                          ->interim_alloc_ptr);
   sen_outputs.push_back(tensor);
 
   // Execute device init

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -179,6 +179,22 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
   status = gl.ParseGraph();
   if (!status.IsOk()) throw std::runtime_error(status.Message());
 
+  // Determine supernode indices dynamically.
+  // Graph may have: [DeviceInit, PrepareModel, Compute] or [DeviceInit, Compute]
+  int prepare_model_idx = -1;
+  int compute_sn_idx = -1;
+  for (size_t i = 0; i < g2.compute_ops_.size(); ++i) {
+    auto &sn = g2.compute_ops_[i];
+    if (sn->Name() == "PrepareModel") {
+      prepare_model_idx = static_cast<int>(i);
+    } else if (sn->Name() != "DeviceInit") {
+      compute_sn_idx = static_cast<int>(i);
+    }
+  }
+  TORCH_CHECK(compute_sn_idx >= 0,
+              "launchKernel: no compute supernode found in G2 graph");
+  uint64_t sn_idx = static_cast<uint64_t>(compute_sn_idx);
+
   // Create sendnn tensors
   std::vector<sendnn::ConstTensor> sen_inputs;
   std::vector<sendnn::Tensor> sen_outputs;
@@ -187,32 +203,46 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
     at::Tensor tmp_0;
     if (arg.dim() == 0) {
       tmp_0 = (at::ones({1}, arg.dtype()) * arg).to(arg.device());
-      auto tensor =
-          createInputTensor(gl, tmp_0.storage().data_ptr().get(), i, 1);
+      auto tensor = createInputTensor(gl, tmp_0.storage().data_ptr().get(), i,
+                                      sn_idx);
       tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                               tmp_0.storage().data_ptr().get_context())
                               ->owner);
       sen_inputs.push_back(tensor);
     } else {
-      auto tensor = createInputTensor(gl, arg.storage().data_ptr().get(), i, 1);
+      auto tensor = createInputTensor(gl, arg.storage().data_ptr().get(), i,
+                                      sn_idx);
       tensor.SetSpyreData(
           static_cast<SharedOwnerCtx *>(arg.storage().data_ptr().get_context())
               ->owner);
       sen_inputs.push_back(tensor);
     }
   }
-  auto tensor =
-      createOutputTensor(gl, args.back().storage().data_ptr().get(), 0, 1);
+  auto tensor = createOutputTensor(gl, args.back().storage().data_ptr().get(),
+                                   0, sn_idx);
   tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                           args.back().storage().data_ptr().get_context())
                           ->owner);
   sen_outputs.push_back(tensor);
 
-  // Execute device init
-  status = gl.Predict(sendnn::Outputs(), sendnn::Inputs(), 0);
-  if (!status.IsOk()) throw std::runtime_error(status.Message());
+  // Execute device init + compute
+  if (prepare_model_idx >= 0) {
+    uint64_t pm_idx = static_cast<uint64_t>(prepare_model_idx);
+    if (args.size() == 6) {
+      status = gl.Predict(sendnn::Outputs(),
+                          {sen_inputs[1], sen_outputs.front()}, pm_idx);
+    } else if (args.size() >= 3) {
+      status = gl.Predict(sendnn::Outputs(), {sen_inputs[1]}, pm_idx);
+    } else {
+      status = gl.Predict(sendnn::Outputs(), sendnn::Inputs(), pm_idx);
+    }
+    if (!status.IsOk()) throw std::runtime_error(status.Message());
+  } else {
+    status = gl.Predict(sendnn::Outputs(), sendnn::Inputs(), 0);
+    if (!status.IsOk()) throw std::runtime_error(status.Message());
+  }
 
-  status = gl.Compute(sen_outputs, sen_inputs, 1);
+  status = gl.Compute(sen_outputs, sen_inputs, sn_idx);
   if (!status.IsOk()) throw std::runtime_error(status.Message());
 
   return;

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -35,22 +35,13 @@ c10::CachingDeviceAllocator::DeviceStats SpyreAllocator::stats_;
 c10::CachingDeviceAllocator::StatTypes SpyreAllocator::stat_types = {
     true, false, false};  // {AGGREGATE, SMALL_POOL, LARGE_POOL}
 
-flex::FlexAllocator* SpyreAllocator::getFlexAllocator() {
+std::shared_ptr<flex::FlexAllocator> SpyreAllocator::getFlexAllocator() {
   // FlexAllocator is owned by RuntimeContext (one per device per process).
   // RuntimeContext::getAllocator() returns shared_ptr<const FlexAllocator>;
-  // we const_cast because allocate()/deallocate() are non-const
-  // (internally mutex-protected and thread-safe).
-  // Returns nullptr on PF devices where FlexAllocator is not available
-  // (see flex#796 for the Scheduler integration needed to enable it).
-  auto runtime_ctx = flex::getFlexRuntimeContext();
-  TORCH_CHECK(runtime_ctx != nullptr,
-              "RuntimeContext is null. Ensure the Spyre runtime has been "
-              "started before allocating device memory.");
-  auto const_alloc = runtime_ctx->getAllocator();
-  if (!const_alloc) {
-    return nullptr;
-  }
-  return const_cast<flex::FlexAllocator*>(const_alloc.get());
+  // we const_cast to shared_ptr<FlexAllocator> because allocate()/deallocate()
+  // are non-const (internally mutex-protected and thread-safe).
+  auto const_alloc = flex::getFlexRuntimeContext()->getAllocator();
+  return std::const_pointer_cast<flex::FlexAllocator>(const_alloc);
 }
 
 SpyreAllocator& SpyreAllocator::instance() {
@@ -145,47 +136,27 @@ c10::DataPtr SpyreAllocator::allocate(size_t nbytes) {
     return {nullptr, nullptr, &ReportAndDelete, curr_device};
   }
 
-  auto* flex_alloc = getFlexAllocator();
+  // Get shared_ptr to keep FlexAllocator alive during operations
+  auto flex_alloc = getFlexAllocator();
 
-  if (flex_alloc) {
-    // VF path: allocate via FlexAllocator -> CompositeAddress
-    auto allocateViaFlex = [&]()
-        -> std::pair<flex::CompositeAddress, flex::DeviceMemoryAllocationPtr> {
-      try {
-        auto addr = flex_alloc->allocate(nbytes);
-        auto ptr = flex_alloc->makeInterimAllocationPtr(addr);
-        return {std::move(addr), std::move(ptr)};
-      }
-      catch (const std::exception& e) {
-        TORCH_CHECK(false, "Failed to allocate ", nbytes,
-                    " bytes on Spyre device: ", e.what());
-      }
-    };
-    auto [composite_addr, interim_ptr] = allocateViaFlex();
-    auto* ctx = new SharedOwnerCtx(std::move(composite_addr), device_id, nbytes,
-                                   std::move(interim_ptr));
-    void* data_void = static_cast<void*>(ctx->interim_alloc_ptr.get());
-    recordAlloc(nbytes, data_void, device_id);
-    return at::DataPtr(data_void, static_cast<void*>(ctx), &ReportAndDelete,
-                       curr_device);
-  }
+  // Allocate first-class raw storage via CompositeAddress.
+  flex::CompositeAddress composite_addr = flex_alloc->allocate(nbytes);
 
-  // PF fallback: allocate directly via legacy DeviceMemoryAllocator.
-  // FlexAllocator is not available on PF because its region-based allocation
-  // conflicts with the Scheduler's direct DeviceMemoryAllocator usage
-  // (see flex#796).
-  auto allocator =
-      GlobalRuntime::get()->GetDeviceHandle(0)->GetDeviceMemoryAllocator();
-  flex::DeviceMemoryAllocationPtr data;
-  allocator->TryAllocate(&data, nbytes, 0);
+  // Bridge to the legacy DeviceMemoryAllocationPtr view for existing PF-mode
+  // users that still expect a pointer-like object referring to the same
+  // storage.
+  flex::DeviceMemoryAllocationPtr data =
+      flex_alloc->makeInterimAllocationPtr(composite_addr);
   TORCH_CHECK(data, "Failed to allocate ", nbytes, " bytes on Spyre device.");
-  auto* ctx =
-      new SharedOwnerCtx(flex::CompositeAddress(std::vector<flex::Chunk>{}),
-                         device_id, nbytes, std::move(data));
-  void* data_void = static_cast<void*>(ctx->interim_alloc_ptr.get());
+
+  // Create context with both owner and CompositeAddress
+  auto* ctx = new SharedOwnerCtx(std::move(data), std::move(composite_addr),
+                                 device_id, nbytes);
+  void* ctx_void = static_cast<void*>(ctx);
+
+  void* data_void = static_cast<void*>(ctx->owner.get());
   recordAlloc(nbytes, data_void, device_id);
-  return at::DataPtr(data_void, static_cast<void*>(ctx), &ReportAndDelete,
-                     curr_device);
+  return at::DataPtr(data_void, ctx_void, &ReportAndDelete, curr_device);
 }
 
 void SpyreAllocator::ReportAndDelete(void* ctx_void) {
@@ -200,17 +171,11 @@ void SpyreAllocator::ReportAndDelete(void* ctx_void) {
   if (alive_) {
     size_t nbytes = ctx->nbytes;
 
-    auto* flex_alloc = getFlexAllocator();
-    if (flex_alloc) {
-      // VF path: deallocate via FlexAllocator using CompositeAddress.
-      flex_alloc->deallocate(ctx->owner);
-    }
-    // PF path: interim_alloc_ptr is an owning DeviceMemoryAllocationPtr
-    // whose destructor calls DeviceMemoryAllocator::Free().
-
     SpyreAllocator::instance().recordRelease(
-        nbytes, static_cast<void*>(ctx->interim_alloc_ptr.get()),
-        ctx->device_id);
+        nbytes, static_cast<void*>(ctx->owner.get()), ctx->device_id);
+
+    auto flex_alloc = getFlexAllocator();
+    flex_alloc->deallocate(ctx->composite_addr);
   }
 
   delete ctx;

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -15,6 +15,8 @@
  */
 #include "spyre_allocator.h"
 
+#include <flex/runtime_stream/runtime_context.hpp>
+#include <memory>
 #include <utility>
 
 #include "logging.h"
@@ -25,16 +27,30 @@
 namespace spyre {
 
 SpyreAllocator::SpyreAllocator() = default;
+SpyreAllocator::~SpyreAllocator() {
+  alive_ = false;
+}
+bool SpyreAllocator::alive_ = true;
 c10::CachingDeviceAllocator::DeviceStats SpyreAllocator::stats_;
 c10::CachingDeviceAllocator::StatTypes SpyreAllocator::stat_types = {
     true, false, false};  // {AGGREGATE, SMALL_POOL, LARGE_POOL}
 
-flex::DeviceMemoryAllocatorPtr SpyreAllocator::getAllocator(
-    unsigned int /*dev_id*/) {
-  // Each process has exactly one runtime with one device handle (index 0).
-  // The PyTorch device index (dev_id) is the logical index across processes,
-  // not an index into the runtime's device handle vector.
-  return GlobalRuntime::get()->GetDeviceHandle(0)->GetDeviceMemoryAllocator();
+flex::FlexAllocator* SpyreAllocator::getFlexAllocator() {
+  // FlexAllocator is owned by RuntimeContext (one per device per process).
+  // RuntimeContext::getAllocator() returns shared_ptr<const FlexAllocator>;
+  // we const_cast because allocate()/deallocate() are non-const
+  // (internally mutex-protected and thread-safe).
+  // Returns nullptr on PF devices where FlexAllocator is not available
+  // (see flex#796 for the Scheduler integration needed to enable it).
+  auto runtime_ctx = flex::getFlexRuntimeContext();
+  TORCH_CHECK(runtime_ctx != nullptr,
+              "RuntimeContext is null. Ensure the Spyre runtime has been "
+              "started before allocating device memory.");
+  auto const_alloc = runtime_ctx->getAllocator();
+  if (!const_alloc) {
+    return nullptr;
+  }
+  return const_cast<flex::FlexAllocator*>(const_alloc.get());
 }
 
 SpyreAllocator& SpyreAllocator::instance() {
@@ -128,21 +144,48 @@ c10::DataPtr SpyreAllocator::allocate(size_t nbytes) {
   if (nbytes == 0) {
     return {nullptr, nullptr, &ReportAndDelete, curr_device};
   }
-  auto allocator = getAllocator(device_id);
-  flex::DeviceMemoryAllocationPtr data;  // a smart-pointer object
-  // NOTE: last argument should be set to 0
+
+  auto* flex_alloc = getFlexAllocator();
+
+  if (flex_alloc) {
+    // VF path: allocate via FlexAllocator -> CompositeAddress
+    auto allocateViaFlex = [&]()
+        -> std::pair<flex::CompositeAddress, flex::DeviceMemoryAllocationPtr> {
+      try {
+        auto addr = flex_alloc->allocate(nbytes);
+        auto ptr = flex_alloc->makeInterimAllocationPtr(addr);
+        return {std::move(addr), std::move(ptr)};
+      }
+      catch (const std::exception& e) {
+        TORCH_CHECK(false, "Failed to allocate ", nbytes,
+                    " bytes on Spyre device: ", e.what());
+      }
+    };
+    auto [composite_addr, interim_ptr] = allocateViaFlex();
+    auto* ctx = new SharedOwnerCtx(std::move(composite_addr), device_id, nbytes,
+                                   std::move(interim_ptr));
+    void* data_void = static_cast<void*>(ctx->interim_alloc_ptr.get());
+    recordAlloc(nbytes, data_void, device_id);
+    return at::DataPtr(data_void, static_cast<void*>(ctx), &ReportAndDelete,
+                       curr_device);
+  }
+
+  // PF fallback: allocate directly via legacy DeviceMemoryAllocator.
+  // FlexAllocator is not available on PF because its region-based allocation
+  // conflicts with the Scheduler's direct DeviceMemoryAllocator usage
+  // (see flex#796).
+  auto allocator =
+      GlobalRuntime::get()->GetDeviceHandle(0)->GetDeviceMemoryAllocator();
+  flex::DeviceMemoryAllocationPtr data;
   allocator->TryAllocate(&data, nbytes, 0);
   TORCH_CHECK(data, "Failed to allocate ", nbytes, " bytes on Spyre device.");
-  auto* ctx = new SharedOwnerCtx{std::move(data), device_id, nbytes};
-  void* ctx_void = static_cast<void*>(ctx);
-
-  void* data_void = static_cast<void*>(ctx->owner.get());
+  auto* ctx =
+      new SharedOwnerCtx(flex::CompositeAddress(std::vector<flex::Chunk>{}),
+                         device_id, nbytes, std::move(data));
+  void* data_void = static_cast<void*>(ctx->interim_alloc_ptr.get());
   recordAlloc(nbytes, data_void, device_id);
-
-  auto data_ptr_result =
-      at::DataPtr(data_void, ctx_void, &ReportAndDelete, curr_device);
-
-  return data_ptr_result;
+  return at::DataPtr(data_void, static_cast<void*>(ctx), &ReportAndDelete,
+                     curr_device);
 }
 
 void SpyreAllocator::ReportAndDelete(void* ctx_void) {
@@ -150,10 +193,26 @@ void SpyreAllocator::ReportAndDelete(void* ctx_void) {
     return;
   }
   auto* ctx = static_cast<SharedOwnerCtx*>(ctx_void);
-  size_t nbytes = ctx->nbytes;
 
-  SpyreAllocator::instance().recordRelease(
-      nbytes, static_cast<void*>(ctx->owner.get()), ctx->device_id);
+  // Guard against static destruction order: if the SpyreAllocator singleton
+  // has already been destroyed (process shutdown), skip deallocation.
+  // The device memory will be reclaimed by the OS when the process exits.
+  if (alive_) {
+    size_t nbytes = ctx->nbytes;
+
+    auto* flex_alloc = getFlexAllocator();
+    if (flex_alloc) {
+      // VF path: deallocate via FlexAllocator using CompositeAddress.
+      flex_alloc->deallocate(ctx->owner);
+    }
+    // PF path: interim_alloc_ptr is an owning DeviceMemoryAllocationPtr
+    // whose destructor calls DeviceMemoryAllocator::Free().
+
+    SpyreAllocator::instance().recordRelease(
+        nbytes, static_cast<void*>(ctx->interim_alloc_ptr.get()),
+        ctx->device_id);
+  }
+
   delete ctx;
 }
 
@@ -171,8 +230,6 @@ void SpyreAllocator::copy_data(void* dest, const void* src,
   py::gil_scoped_acquire acquire;
   DEBUGINFO("entering allocator->copy_data method");
   // do nothing -- look into when this is called
-  // spyre_copy_from(reinterpret_cast<spyre_ptr_t>(dest),
-  // reinterpret_cast<spyre_ptr_t>(src));
 }
 
 // Register our custom allocator

--- a/torch_spyre/csrc/spyre_allocator.h
+++ b/torch_spyre/csrc/spyre_allocator.h
@@ -19,29 +19,58 @@
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
 
+#include <flex/allocator/alloc_address.hpp>
+#include <flex/allocator/flex_allocator.hpp>
 #include <flex/device_types/device_memory_allocator.hpp>
+#include <memory>
+#include <utility>
 
 namespace spyre {
 
 struct SharedOwnerCtx {
-  flex::DeviceMemoryAllocationPtr owner;
+  // Canonical allocation address from FlexAllocator (the "owner" per RFC).
+  // On PF fallback path this is an empty CompositeAddress.
+  flex::CompositeAddress owner;
   signed char device_id;
   size_t nbytes;
+  // INTERIM: cached non-owning DeviceMemoryAllocationPtr for SetSpyreData().
+  // Constructed once via makeInterimAllocationPtr() and reused for all
+  // SetSpyreData() calls on this tensor.
+  // Remove when SetSpyreData accepts CompositeAddress directly.
+  // On PF fallback path this is an owning allocation (allocator_ != nullptr).
+  flex::DeviceMemoryAllocationPtr interim_alloc_ptr;
+
+  SharedOwnerCtx(flex::CompositeAddress addr, signed char dev_id, size_t nbytes,
+                 flex::DeviceMemoryAllocationPtr interim)
+      : owner(std::move(addr)),
+        device_id(dev_id),
+        nbytes(nbytes),
+        interim_alloc_ptr(std::move(interim)) {}
 };
 
-// A custom allocator for our custom device, which returns a handle to the
-// allocated memory, not the actual pointer.
+// A custom allocator for our custom device, using FlexAllocator to manage
+// device memory. Returns a handle (not a dereferenceable pointer) to the
+// allocated memory via CompositeAddress stored in SharedOwnerCtx.
 struct SpyreAllocator final : public c10::DeviceAllocator {
  private:
   SpyreAllocator();
+  ~SpyreAllocator();
   static c10::CachingDeviceAllocator::DeviceStats stats_;
   static c10::CachingDeviceAllocator::StatTypes
       stat_types;  // {AGGREGATE, SMALL_POOL, LARGE_POOL}
-
-  flex::DeviceMemoryAllocatorPtr getAllocator(unsigned int dev_id);
+  // Guard against use-after-destroy during static destruction.
+  // Set to false in destructor; checked by ReportAndDelete.
+  static bool alive_;
 
  public:
   static SpyreAllocator& instance();
+
+  // Returns a mutable FlexAllocator from RuntimeContext.
+  // Uses const_pointer_cast because RuntimeContext::getAllocator() returns
+  // shared_ptr<const FlexAllocator>, but allocate()/deallocate() are
+  // non-const (internally mutex-protected).
+  static flex::FlexAllocator* getFlexAllocator();
+
   bool initialized() override;
 
   void emptyCache(c10::MempoolId_t mempool_id) override;

--- a/torch_spyre/csrc/spyre_allocator.h
+++ b/torch_spyre/csrc/spyre_allocator.h
@@ -28,24 +28,17 @@
 namespace spyre {
 
 struct SharedOwnerCtx {
-  // Canonical allocation address from FlexAllocator (the "owner" per RFC).
-  // On PF fallback path this is an empty CompositeAddress.
-  flex::CompositeAddress owner;
+  flex::DeviceMemoryAllocationPtr owner;
+  flex::CompositeAddress composite_addr;
   signed char device_id;
   size_t nbytes;
-  // INTERIM: cached non-owning DeviceMemoryAllocationPtr for SetSpyreData().
-  // Constructed once via makeInterimAllocationPtr() and reused for all
-  // SetSpyreData() calls on this tensor.
-  // Remove when SetSpyreData accepts CompositeAddress directly.
-  // On PF fallback path this is an owning allocation (allocator_ != nullptr).
-  flex::DeviceMemoryAllocationPtr interim_alloc_ptr;
 
-  SharedOwnerCtx(flex::CompositeAddress addr, signed char dev_id, size_t nbytes,
-                 flex::DeviceMemoryAllocationPtr interim)
-      : owner(std::move(addr)),
+  SharedOwnerCtx(flex::DeviceMemoryAllocationPtr own,
+                 flex::CompositeAddress addr, signed char dev_id, size_t nb)
+      : owner(std::move(own)),
+        composite_addr(std::move(addr)),
         device_id(dev_id),
-        nbytes(nbytes),
-        interim_alloc_ptr(std::move(interim)) {}
+        nbytes(nb) {}
 };
 
 // A custom allocator for our custom device, using FlexAllocator to manage
@@ -65,11 +58,7 @@ struct SpyreAllocator final : public c10::DeviceAllocator {
  public:
   static SpyreAllocator& instance();
 
-  // Returns a mutable FlexAllocator from RuntimeContext.
-  // Uses const_pointer_cast because RuntimeContext::getAllocator() returns
-  // shared_ptr<const FlexAllocator>, but allocate()/deallocate() are
-  // non-const (internally mutex-protected).
-  static flex::FlexAllocator* getFlexAllocator();
+  static std::shared_ptr<flex::FlexAllocator> getFlexAllocator();
 
   bool initialized() override;
 

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -541,8 +541,7 @@ auto copy_host_to_device(const at::Tensor& self, const at::Tensor& dst) {
                                       tensor_idx, sn_idx);
   auto* ctx =
       static_cast<SharedOwnerCtx*>(dst.storage().data_ptr().get_context());
-  flex::DeviceMemoryAllocationPtr& dev_data = ctx->owner;
-  inp_tensor.SetSpyreData(dev_data);  // ctx->owner;
+  inp_tensor.SetSpyreData(ctx->interim_alloc_ptr);
 
   SEN_THROW_NOK(gl->Copy(sendnn::Outputs(), {inp_tensor}, sn_idx));
 }
@@ -556,7 +555,7 @@ auto copy_device_to_host(const at::Tensor& self, const at::Tensor& dst) {
                                        tensor_idx, sn_idx);
   auto* ctx =
       static_cast<SharedOwnerCtx*>(self.storage().data_ptr().get_context());
-  out_tensor.SetSpyreData(ctx->owner);
+  out_tensor.SetSpyreData(ctx->interim_alloc_ptr);
   SEN_THROW_NOK(gl->Copy({out_tensor}, sendnn::Inputs(), sn_idx));
 }
 

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -27,14 +27,8 @@
 #include <util/sen_data_convert.h>
 
 #include <algorithm>
-#include <flex/runtime_graph/graph/graph_builder/flex_graph_builder.hpp>
 #include <map>
 #include <memory>
-#include <sendnn/graph/graph_builder.hpp>
-#include <sendnn/interface/graph_loader.hpp>
-#include <sendnn/runtime/runtime_interface.hpp>
-#include <sendnn/tensor/sentensor_info.hpp>
-#include <sendnn/util/status.hpp>
 #include <string>
 #include <utility>
 #include <vector>
@@ -44,6 +38,7 @@
 #include "spyre_allocator.h"
 #include "spyre_sendnn_utils.h"
 #include "spyre_storage_impl.h"
+#include "spyre_stream.h"
 #include "spyre_tensor_impl.h"
 #include "types_mapping.h"
 
@@ -51,17 +46,6 @@ namespace spyre {
 
 using DataConversionStrideInfo = data_conversion_stride_info;
 using DataConversionInfo = data_conversion_info;
-
-/* struct holding the parameters for DMA-based copy
-   size_bytes: number of bytes to transfer
-   src_offset: offset from src base pointer
-   dst_offset: offset from destination base pointer
- */
-struct DMAParameters {
-  const int64_t size_bytes;
-  const off64_t src_offset;
-  const off64_t dst_offset;
-};
 
 /* Generates the dimension mapping between `strides` and `stride_map`.
  *
@@ -350,16 +334,15 @@ auto get_device_stride_infos(c10::IntArrayRef sizes, c10::IntArrayRef strides,
  * Generate description of data conversion for a tensor.
  *
  * @param tensor: tensor to convert
- * @return data conversion information in string
+ * @return data conversion information
  */
 auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
-                  int64_t cpu_offset, bool host2device) -> std::string {
+                  int64_t cpu_offset, bool host2device) -> DataConversionInfo {
   /*   host2device = true : then 'tensor' is CPU-tensor
    *   host2device = false: then 'tensor' is Spyre-tensor
    */
   auto str_type = torchScalarToString[tensor->scalar_type()];
   const auto [dtype_cpu, dtype_dev] = stringToDTDataFormatPair(str_type);
-  std::stringstream s;
 
   DataConversionInfo dci{};
   dci.dci_dsName_ = "DCI-Tensor-0";
@@ -392,171 +375,7 @@ auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
 
   dci.input_shape_ = host2device ? cpu_shape : dev_shape;
   dci.output_shape_ = host2device ? dev_shape : cpu_shape;
-  dci.exportJson(s);
-  DEBUGINFO("DataConversionInfo: ", s.str());
-  return s.str();
-}
-
-auto create_dma_graph(const at::Tensor& self, const at::Tensor& dst,
-                      bool host2device)
-    -> std::shared_ptr<sendnn::GraphLoader> {
-  /* self = source
-   * dst  = destination
-   */
-  const at::Tensor* dev_tensor;
-  const at::Tensor* cpu_tensor;
-  if (host2device) {
-    cpu_tensor = &self;
-    dev_tensor = &dst;
-  } else {
-    cpu_tensor = &dst;
-    dev_tensor = &self;
-  }
-
-  auto str_type = torchScalarToString[cpu_tensor->scalar_type()];
-  const auto [sen_dtype_cpu, sen_dtype_dev] = stringToSenDatatypePair(str_type);
-  auto layout = sendnn::TensorLayout::NHWC;
-  SpyreTensorLayout stl = get_spyre_tensor_layout(host2device ? dst : self);
-  sendnn::TensorShape dev_tensor_shape(stl.device_size);
-
-  // ti = transfer info
-  // dci = data conversion info
-  sendnn::TensorInfo cpu_ti(sen_dtype_cpu,
-                            sendnn::TensorShape(cpu_tensor->sizes().vec()),
-                            layout, sendnn::TensorLocation::HOST());
-  sendnn::TensorInfo dev_ti(sen_dtype_dev, dev_tensor_shape, layout,
-                            sendnn::TensorLocation::DEVICE());
-  sendnn::TensorInfo dci_ti(sen_dtype_dev, dev_tensor_shape, layout,
-                            sendnn::TensorLocation::HOST());
-  //  STAGE 1: execution graph
-  sendnn::SubGraph sub_graph;
-  const auto [elem_bytes_cpu, elem_bytes_spyre] =
-      spyre::elementSize(cpu_tensor->scalar_type());
-  int64_t xfer_size = dev_tensor_shape.Volume() * elem_bytes_spyre;
-  {
-    flex::FlexGraphBuilder gb;
-    DMAParameters dma_param{xfer_size, 0, 0};
-    if (host2device) {
-      auto inp_node = gb.PrimaryInput("Input", dci_ti);
-      auto xfer_node = gb.SenDataTransfer(
-          "Host2Sen-Transfer",
-          dev_ti,    // output (holding shape, type, and location DEVICE)
-          inp_node,  // input (node created using PrimaryInput and on HOST)
-          dev_ti.DataSize(), dma_param.src_offset, dma_param.dst_offset);
-      auto out_node = gb.PrimaryOutput("Output", xfer_node);
-    } else {
-      auto inp_node = gb.PrimaryInput("Input", dev_ti);
-      auto xfer_node = gb.SenDataTransfer(
-          "Sen2Host-Transfer",
-          dci_ti,    // output (holding shape, type and location HOST)
-          inp_node,  // input (node created as a result of SenDataTransfer)
-          dev_ti.DataSize(), dma_param.src_offset, dma_param.dst_offset);
-      auto out_node = gb.PrimaryOutput("Output", xfer_node);
-    }
-
-    SEN_THROW_NOK(gb.Finalize(&sub_graph));
-  }
-  sendnn::SubGraph exec_graph;
-  {  // add above subgraph as part of SenFusedDeviceCompute node
-    flex::FlexGraphBuilder gb;
-    auto dci = generate_dci(dev_tensor, stl, cpu_tensor->storage_offset(),
-                            host2device);
-    if (host2device) {
-      auto inp_node = gb.PrimaryInput("Input", cpu_ti);
-      auto dci_node = gb.SenHostCompute("Host2Sen-HostPrep", {dci_ti},
-                                        {inp_node}, "SenDataConvert", dci);
-
-      auto dev_node = gb.SenFusedDeviceCompute("SenFusedDeviceNode_0", {dci_ti},
-                                               {dci_node}, sub_graph);
-      gb.PrimaryOutput("Output", dev_node->OutputPort(0));
-    } else {
-      sendnn::Node* inp_node = gb.PrimaryInput("Input", dci_ti);
-      auto dev_node = gb.SenFusedDeviceCompute("SenFusedDeviceNode_0", {dci_ti},
-                                               {inp_node}, sub_graph);
-      auto dci_node = gb.SenHostCompute("Sen2Host-HostPrep", cpu_ti, dev_node,
-                                        "SenDataConvert", dci);
-
-      gb.PrimaryOutput("Output", dci_node->OutputPort(0));
-    }
-
-    SEN_THROW_NOK(gb.Finalize(&exec_graph));
-  }
-
-  sendnn::SegmentTable segment_table = {
-      sendnn::Segment::PRIMARY_OUT(xfer_size),
-      sendnn::Segment::PRIMARY_IN(xfer_size),
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::PROGRAM(128),
-  };
-  // STAGE 2: SenSuperNodeV2 graph
-  sendnn::Graph sn_graph;  // sn = supernode
-  {                        // SenSuperNodeV2 graph
-    flex::FlexGraphBuilder gb;
-
-    sendnn::TensorInfo inp_ti =
-        sendnn::TensorInfo(exec_graph.input_ops_.front()->OutputAt(0));
-    sendnn::TensorInfo out_ti =
-        sendnn::TensorInfo(exec_graph.output_ops_.front()->InputAt(0));
-    sendnn::NodeOrIndexedNode inp_node = gb.PrimaryInput("Input", inp_ti);
-
-    std::string k_uuid = "dma-network";
-    sendnn::attributes::SenPartitionInit part_init;
-    part_init.network_uuid_ = k_uuid;
-    part_init.partition_idx_ = 0;
-    part_init.segment_table_ = segment_table;
-
-    auto sn =
-        gb.SenSuperNodeV2("SenSuperNodeV2_0", {out_ti}, {inp_node}, k_uuid, 0,
-                          1, part_init, exec_graph, {}, false, true, true);
-    gb.PrimaryOutput("Output", {0, sn});
-
-    SEN_THROW_NOK(gb.Finalize(&sn_graph));
-  }
-
-  // STAGE 3:
-  std::shared_ptr<sendnn::GraphLoader> gl;
-  gl = std::make_shared<sendnn::GraphLoader>(GlobalRuntime::get());
-  {
-    SEN_THROW_NOK(gl->LoadGraph(sn_graph));
-    SEN_THROW_NOK(gl->CompileGraph());
-    SEN_THROW_NOK(gl->ParseGraph());
-  }
-  return gl;
-}
-
-auto copy_host_to_device(const at::Tensor& self, const at::Tensor& dst) {
-  std::shared_ptr<sendnn::GraphLoader> gl = create_dma_graph(self, dst, true);
-  if (!gl) {
-    DEBUGINFO("GraphLoader is null!");
-    return;
-  }
-  // execute
-  constexpr int sn_idx = 0;
-  constexpr int tensor_idx = 0;
-  auto inp_tensor = createInputTensor(*gl, self.storage().data_ptr().get(),
-                                      tensor_idx, sn_idx);
-  auto* ctx =
-      static_cast<SharedOwnerCtx*>(dst.storage().data_ptr().get_context());
-  inp_tensor.SetSpyreData(ctx->interim_alloc_ptr);
-
-  SEN_THROW_NOK(gl->Copy(sendnn::Outputs(), {inp_tensor}, sn_idx));
-}
-
-auto copy_device_to_host(const at::Tensor& self, const at::Tensor& dst) {
-  std::shared_ptr<sendnn::GraphLoader> gl = create_dma_graph(self, dst, false);
-  // execute
-  constexpr int sn_idx = 0;
-  constexpr int tensor_idx = 0;
-  auto out_tensor = createOutputTensor(*gl, dst.storage().data_ptr().get(),
-                                       tensor_idx, sn_idx);
-  auto* ctx =
-      static_cast<SharedOwnerCtx*>(self.storage().data_ptr().get_context());
-  out_tensor.SetSpyreData(ctx->interim_alloc_ptr);
-  SEN_THROW_NOK(gl->Copy({out_tensor}, sendnn::Inputs(), sn_idx));
+  return dci;
 }
 
 // Empty op needs C++ code and cannot be handled by python side fallback
@@ -694,56 +513,26 @@ at::Tensor& spyre_set_storage(at::Tensor& result, at::Storage storage,
   return at::cpu::set_(result, storage, storage_offset, size, stride);
 }
 
-/**
- * This method handles copy between devices. When copying to Spyre, this method
- * marks the tensor to compute on Spyre, but continue to use CPU tensor for now
- * such that when we run an op on the tensor on the Spyre, it will have the
- * proper handle to the Spyre allocation
- */
 at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
                            bool non_blocking) {
   DEBUGINFO("self (", self.scalar_type(), ") is on:", self.device());
   DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
-  at::Storage source_storage;
-  at::Storage dest_storage;
 
-  // TODO(tmhoangt): add type conversion node
   TORCH_CHECK(
       self.scalar_type() == dst.scalar_type(),
       "Spyre backend does not support type conversion yet during copy.");
 
-  if (self.is_cpu() && dst.is_privateuseone()) {
-    if (self.dim() == 0) {
-      at::Tensor tmp_tensor = self.reshape({1});
-      copy_host_to_device(tmp_tensor, dst);
-    } else {
-      copy_host_to_device(self, dst);
-    }
-    return dst;
-
-  } else if (self.is_privateuseone() && dst.is_cpu()) {
-    copy_device_to_host(self, dst);
-    return dst;
-
-  } else if (self.is_privateuseone() && dst.is_privateuseone()) {
-    // Copy from Spyre to Spyre
-    TORCH_CHECK(false, "Error: In-device copy not implemented.");
-    // FIXME: This will need to be addressed for proper spyre to spyre copy
-    // source_storage =
-    //     (static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl()))->storage();
-    // dest_storage =
-    //     (static_cast<SpyreTensorImpl*>(dst.unsafeGetTensorImpl()))->storage();
-    // DEBUGINFO("Copying", source_storage.nbytes(), "bytes from",
-    //           source_storage.device(), "to", dest_storage.device());
-    // std::memcpy(dest_storage.data_ptr().get(),
-    // source_storage.data_ptr().get(),
-    //             source_storage.nbytes());
-    // DEBUGINFO("Finished Copying ");
-    return dst;
+  SpyreStream stream;
+  if (dst.is_privateuseone()) {
+    stream = getCurrentStream(dst.device());
   } else {
-    // For all other cases fallback to the upstream implementation
-    return at::_copy_from(self, dst, non_blocking);
+    stream = getCurrentStream(self.device());
   }
+  stream.copyAsync(self, dst);
+  if (!non_blocking) {
+    stream.synchronize();
+  }
+  return dst;
 }
 
 at::Tensor to_with_layout(const at::Tensor& self,

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -19,6 +19,8 @@
 #include <ATen/ATen.h>
 #include <c10/util/intrusive_ptr.h>
 
+#include "module.h"
+
 namespace spyre {
 
 at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
@@ -52,4 +54,6 @@ at::Tensor py_empty_with_layout(
     std::optional<c10::Device> device_opt, std::optional<bool> pin_memory_opt,
     std::optional<c10::MemoryFormat> memory_format_opt);
 
+auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
+                  int64_t cpu_offset, bool host2device) -> DataConversionInfo;
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -19,12 +19,15 @@
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
 
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
 
+#include "flex/runtime_stream/runtime_operation.hpp"
 #include "logging.h"
 #include "module.h"
+#include "spyre_allocator.h"
 #include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_tensor_impl.h"
@@ -126,9 +129,52 @@ c10::Stream SpyreStream::unwrap() const {
   return stream_;
 }
 
-void SpyreStream::copy_async(const at::Tensor& src,
-                             const at::Tensor& dst) const {
-  // TODO(tmhoangt): place-holder to be implemented in the next PR
+void SpyreStream::copyAsync(const at::Tensor& src,
+                            const at::Tensor& dst) const {
+  DEBUGINFO("src (", src.scalar_type(), ") is on:", src.device());
+  DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
+
+  // TODO(tmhoangt): add type conversion node
+  TORCH_CHECK(
+      src.scalar_type() == dst.scalar_type(),
+      "Spyre backend does not support type conversion yet during copy.");
+
+  bool host2device = src.is_cpu() && dst.is_privateuseone();
+  bool device2host = src.is_privateuseone() && dst.is_cpu();
+  bool device2device = src.is_privateuseone() && dst.is_privateuseone();
+
+  const at::Tensor* dev_tensor = host2device ? &dst : &src;
+  const at::Tensor* cpu_tensor = host2device ? &src : &dst;
+
+  at::Tensor tmp_tensor;
+  if (cpu_tensor->dim() == 0 && (host2device || device2host)) {
+    tmp_tensor = cpu_tensor->unsqueeze(0);
+    cpu_tensor = &tmp_tensor;
+  }
+
+  if (host2device || device2host) {
+    void* cpu_ptr = cpu_tensor->storage().data_ptr().get();
+
+    SpyreTensorLayout stl = get_spyre_tensor_layout(*dev_tensor);
+
+    auto* spyre_impl =
+        static_cast<SpyreTensorImpl*>(dev_tensor->unsafeGetTensorImpl());
+    auto& storage = spyre_impl->storage();
+    auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
+
+    DataConversionInfo dci =
+        generate_dci(dev_tensor, stl, cpu_tensor->storage_offset(), host2device);
+
+    copyAsyncImpl(cpu_ptr, &ctx->composite_addr, dci, host2device);
+
+  } else if (device2device) {
+    const at::Tensor intermediate = src.cpu();
+    copyAsync(intermediate, dst);
+
+  } else {
+    TORCH_CHECK(false, "Unsupported copy types: src on ", src.device(),
+                " dst on ", dst.device());
+  }
 }
 
 flex::RuntimeStream* SpyreStream::getRuntimeHandle() const {
@@ -142,10 +188,21 @@ flex::RuntimeStream* SpyreStream::getRuntimeHandle() const {
   return it->second;
 }
 
-void SpyreStream::copy_async_impl(
-    void* cpu_ptr, flex::DeviceMemoryAllocationPtr& device_allocation,
-    int device_id, const DataConversionInfo& dci, bool host2device) const {
-  // TODO(tmhoangt): place-holder to be implemented in the next PR
+void SpyreStream::copyAsyncImpl(void* cpu_ptr,
+                                const flex::CompositeAddress* device_address,
+                                const DataConversionInfo& dci,
+                                bool host2device) const {
+  auto dci_ptr = std::make_shared<data_conversion_info>(dci);
+
+  flex::RuntimeStream* flex_stream = getRuntimeHandle();
+
+  if (host2device) {
+    flex::RuntimeOperationH2D op(cpu_ptr, device_address, dci_ptr);
+    flex_stream->launchOperation(op);
+  } else {
+    flex::RuntimeOperationD2H op(device_address, cpu_ptr, dci_ptr);
+    flex_stream->launchOperation(op);
+  }
 }
 
 void initializeStreamPoolImpl(c10::DeviceIndex device_index) {

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -19,6 +19,8 @@
 #include <ATen/ATen.h>
 #include <c10/core/Stream.h>
 
+#include <flex/allocator/alloc_address.hpp>
+
 #include "module.h"
 
 namespace spyre {
@@ -39,17 +41,16 @@ class SpyreStream {
   bool query() const;        // Check if work completed
   void synchronize() const;  // Block until work done
 
-  void copy_async(const at::Tensor& src, const at::Tensor& dst) const;
+  void copyAsync(const at::Tensor& src, const at::Tensor& dst) const;
 
   // Conversions
   c10::Stream unwrap() const;
 
  private:
   flex::RuntimeStream* getRuntimeHandle() const;
-  void copy_async_impl(void* cpu_ptr,
-                       flex::DeviceMemoryAllocationPtr& device_allocation,
-                       int device_id, const DataConversionInfo& dci,
-                       bool host2device) const;
+  void copyAsyncImpl(void* cpu_ptr,
+                     const flex::CompositeAddress* device_address,
+                     const DataConversionInfo& dci, bool host2device) const;
 };
 
 /**


### PR DESCRIPTION
## Summary

Aligns torch-spyre with flex PR #832 (`tmhoangt/pr_dma-runtimestream-interim`) to use graph-free, stream-based DMA and the FlexAllocator-based allocation model.

### Changes

- **SpyreAllocator**: Route `allocate()` through `FlexAllocator::allocate()` → `CompositeAddress`, bridge to legacy `DeviceMemoryAllocationPtr` via `makeInterimAllocationPtr()`. Deallocate via `FlexAllocator::deallocate(composite_addr)`.
- **SharedOwnerCtx**: Now holds both `DeviceMemoryAllocationPtr owner` (for `SetSpyreData` bridge) and `CompositeAddress composite_addr` (canonical address for DMA and deallocation).
- **spyre_mem.cpp**: Remove graph-based DMA (`create_dma_graph`, `copy_host_to_device`, `copy_device_to_host`, `DMAParameters`, all sendnn graph imports). `spyre_copy_from` now delegates to `SpyreStream::copyAsync()`.
- **SpyreStream**: Implement `copyAsync()` for H2D, D2H, and D2D (via intermediate CPU buffer) using `RuntimeOperationH2D`/`RuntimeOperationD2H` with `launchOperation()`.
- **module.cpp**: Fix `launchKernel` to dynamically resolve supernode indices. The new flex no longer emits a `PrepareModel` supernode, changing the graph layout from `[DeviceInit(0), PrepareModel(1), Compute(2)]` to `[DeviceInit(0), Compute(1)]`. The old hardcoded index 2 caused an out-of-bounds crash. Now scans `g2.compute_ops_` at runtime.
- **SetSpyreData call sites**: Updated from `->interim_alloc_ptr` to `->owner` in `module.cpp`, `spyre_torch_ops.cpp`, and `list_inp.jinja2`.
- **New test**: `test_device_to_device_copy` for D2D copy path.

### Dependencies

- **flex PR #832** (`tmhoangt/pr_dma-runtimestream-interim`): Provides `RuntimeOperationH2D`/`RuntimeOperationD2H`, `launchOperation()`, `FlexAllocator` in `RuntimeContext`.
- **flex PR #849** (`chenw615/fix-flex-allocator-always-create`): Fixes FlexAllocator not being created when the device singleton already exists (targets PR #832's branch).

### Test results (on hardware, PF mode)

```
21 passed, 3 skipped in 11.79s
```

All tests pass including `test_cross_device_copy` (which was failing before the supernode index fix).

## Test plan
- [x] Build: `python3 setup.py build_ext --inplace`
- [x] `python3 -m pytest tests/test_spyre.py -v` — 21 passed, 3 skipped
- [x] Allocation, copy, D2D, round-trip, memory stats all verified on device
- [ ] CI (requires flex PR #832 + #849 merged)

Closes #978
Closes #961