### PR TITLE
Rework frontend compiler node fusion logic

### DIFF
--- a/torch_spyre/_inductor/choices.py
+++ b/torch_spyre/_inductor/choices.py
@@ -18,10 +18,6 @@ import torch
 from torch._inductor.choices import InductorChoices
 from torch._inductor.scheduler import BaseSchedulerNode, Scheduler
 
-from torch_spyre._inductor.logging_utils import _get_env_bool
-
-_FUSION_ENABLED = _get_env_bool("SPYRE_INDUCTOR_ENABLE_FUSION")
-
 
 class SpyreHeuristics(InductorChoices):
     @staticmethod
@@ -43,7 +39,7 @@ class SpyreHeuristics(InductorChoices):
         node2: BaseSchedulerNode,
         shared_data_score: int,
     ) -> bool:
-        return _FUSION_ENABLED
+        return False
 
     @staticmethod
     def can_fuse_vertical(
@@ -52,7 +48,7 @@ class SpyreHeuristics(InductorChoices):
         node2: BaseSchedulerNode,
         shared_data_score: int,
     ) -> bool:
-        return _FUSION_ENABLED
+        return False
 
     @staticmethod
     def can_fuse_horizontal(
@@ -61,4 +57,4 @@ class SpyreHeuristics(InductorChoices):
         node2: BaseSchedulerNode,
         shared_data_score: int,
     ) -> bool:
-        return _FUSION_ENABLED
+        return False

--- a/torch_spyre/_inductor/fusion.py
+++ b/torch_spyre/_inductor/fusion.py
@@ -1,0 +1,29 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torch._inductor.scheduler import BaseSchedulerNode, FusedSchedulerNode
+
+from torch_spyre._inductor.logging_utils import _get_env_bool
+
+_FUSION_ENABLED = _get_env_bool("SPYRE_INDUCTOR_ENABLE_FUSION")
+
+
+def spyre_fuse_nodes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
+    """
+    If fusion is enabled, put all nodes into a single SpyreKernel
+    """
+    if not _FUSION_ENABLED or len(nodes) == 0:
+        return nodes
+
+    return [FusedSchedulerNode(nodes[0].scheduler, nodes)]

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -33,6 +33,7 @@ from .temp_passes import (
 from .stickify import propagate_spyre_tensor_layouts
 from .core_division import core_division_planning
 from .scratchpad import scratchpad_planning
+from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
 
 
@@ -107,10 +108,10 @@ def _maybe_run_scheduler_pass(
     return nodes
 
 
-def scheduler_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
+def scheduler_pre_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     """
     This inductor extension point enables Spyre-specific passes to run over
-    the graph of LoopLevelIR nodes immediately before fusion is applied.
+    the graph of LoopLevelIR nodes immediately before Inductor's fusion pass runs.
 
     The list of nodes is guarenteed by the caller to be in topological order.
     The returned list of nodes must also be in topological order.
@@ -121,3 +122,15 @@ def scheduler_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     if os.environ.get("LX_PLANNING", "0") == "1":
         nodes = scratchpad_planning(nodes)
     return nodes
+
+
+def scheduler_post_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
+    """
+    This inductor extension point enables Spyre-specific passes to run over
+    the graph of LoopLevelIR nodes immediately after Inductor's fusion pass runs.
+
+    The list of nodes is guarenteed by the caller to be in topological order.
+    The returned list of nodes must also be in topological order.
+    """
+
+    return spyre_fuse_nodes(nodes)

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -74,7 +74,8 @@ def enable_spyre_context(
     from torch_spyre._inductor.passes import (
         CustomPrePasses,
         CustomPostPasses,
-        scheduler_passes,
+        scheduler_pre_passes,
+        scheduler_post_passes,
         _maybe_run_scheduler_pass,
     )
 
@@ -95,7 +96,10 @@ def enable_spyre_context(
     inductor_config.post_grad_custom_pre_pass = CustomPrePasses()
     inductor_config.post_grad_custom_post_pass = CustomPostPasses()
     inductor_config._pre_fusion_custom_pass = lambda nodes: _maybe_run_scheduler_pass(
-        scheduler_passes, nodes
+        scheduler_pre_passes, nodes
+    )
+    inductor_config._post_fusion_custom_pass = lambda nodes: _maybe_run_scheduler_pass(
+        scheduler_post_passes, nodes
     )
     # Adding this configuration in so as to avoid the optimization of turning small matmuls into non-matmuls
     # found here: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/ir.py#L1580


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Straightforward implementation of fusion for SpyreKernel.

We want all the nodes in the graph to be put into a single SuperDSCBundle. 
We don't have the same loop nest compatibility constraints as Inductor, so rather than trying
to fight the heuristics to get them to do something reasonable, we can simply disable inductor's
fusion and then put every node in the graph into a single FusedSchedulerNode in a post-fusion pass.

#### Which issue(s) this PR is related to:

This implements the front-end compiler piece of #826 

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
