### PR TITLE
Remove default tiling for overwrite operation 

### DIFF
--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -83,12 +83,6 @@ def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
                 return FixedTiledLayout(
                     output.device, output.dtype, output.size, output.stride, stl
                 )
-
-            case spyreop.overwrite.default:
-                stl = SpyreTensorLayout(output.size, output.dtype)
-                return FixedTiledLayout(
-                    output.device, output.dtype, output.size, output.stride, stl
-                )
             case _:
                 x_stl = x.layout.device_layout
                 in_coords = host_coordinates(x.layout, x.dep)
@@ -97,6 +91,7 @@ def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
                     in_coords == out_coords
                     and x.dep.index == output_dep.index
                     and same_device_size(x.layout.dtype, output.dtype)
+                    and x.layout.size == output.size
                 ):
                     # Input and output tensors are being accessed identically and elem size is the same.
                     # We can simply propagate the device_layout.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
This PR removes the default to generic stick tiling for the `spyreop.overwrite.default` when generating the SpyreTensorLayout for the output.
For this operation, the input and output coordinates are the same, but the sizes differ. A check is added to the default handling to ensure the output of this operation does not inherit it's size from the input. 
 
#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
