### PR TITLE
Add torch.pad via identity broadcast and overwrite

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1834,6 +1834,24 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         compare_with_cpu(fn, x)
 
+    def test_pad_unsupported(self):
+        """Padding cases that raise Unsupported and cannot compile on Spyre."""
+        from torch_spyre._inductor.errors import Unsupported
+
+        unsupported_cases = [
+            # Negative padding (cropping).
+            (cached_randn((3, 64), dtype=torch.float16), (0, -32)),
+            (cached_randn((4, 64), dtype=torch.float16), (0, 0, 0, -2)),
+            # Sub-stick last dim: gap not a multiple of inner repeats.
+            (cached_randn((3, 1), dtype=torch.float16), (0, 63)),
+            (cached_randn((3, 2), dtype=torch.float16), (0, 126)),
+        ]
+        from torch_spyre._inductor.decompositions import pad_decomp
+
+        for x, pad in unsupported_cases:
+            with pytest.raises(Unsupported):
+                pad_decomp(x, list(pad))
+
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_full_cpu(self, *args):
         def fn(device=None):

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -820,6 +820,29 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             },
         },
         (
+            "test_pad",
+            "test_pad_cpu",
+        ): {
+            "param_sets": {
+                "2d_last_dim_right": (
+                    cached_randn((3, 64), dtype=torch.float16),
+                    (0, 64),
+                ),
+                "2d_both_dims": (
+                    cached_randn((3, 64), dtype=torch.float16),
+                    (0, 64, 0, 2),
+                ),
+                "3d_last_dim_right": (
+                    cached_randn((2, 3, 64), dtype=torch.float16),
+                    (0, 64),
+                ),
+                "3d_dim1_right": (
+                    cached_randn((2, 3, 64), dtype=torch.float16),
+                    (0, 0, 0, 2),
+                ),
+            },
+        },
+        (
             "test_fallback",
             "test_fallback_cpu",
         ): {
@@ -1801,6 +1824,15 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return torch.cat(tensors, dim=dim)
 
         compare_with_cpu(fn, *tensors)
+
+    @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+    def test_pad_cpu(self, x, pad):
+        """Compiled torch.nn.functional.pad (constant zero) on Spyre matches CPU."""
+
+        def fn(x):
+            return torch.nn.functional.pad(x, pad)
+
+        compare_with_cpu(fn, x)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_full_cpu(self, *args):

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1835,16 +1835,13 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         compare_with_cpu(fn, x)
 
     def test_pad_unsupported(self):
-        """Padding cases that raise Unsupported and cannot compile on Spyre."""
+        """Padding cases that raise Unsupported due to logical decomposition constraints."""
         from torch_spyre._inductor.errors import Unsupported
 
         unsupported_cases = [
             # Negative padding (cropping).
             (cached_randn((3, 64), dtype=torch.float16), (0, -32)),
             (cached_randn((4, 64), dtype=torch.float16), (0, 0, 0, -2)),
-            # Sub-stick last dim: gap not a multiple of inner repeats.
-            (cached_randn((3, 1), dtype=torch.float16), (0, 63)),
-            (cached_randn((3, 2), dtype=torch.float16), (0, 126)),
         ]
         from torch_spyre._inductor.decompositions import pad_decomp
 

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -21,8 +21,8 @@ def core_idx_to_slice_offset(
     arg,
     wk_slice: dict,
     work_slices: dict,
-    offset: int,
 ) -> int:
+    offset = sum(arg.offsets.values())
     for dim, stride in arg.strides.items():
         if str(dim) in wk_slice and arg.scales[dim] > 0:
             offset += wk_slice[str(dim)] * stride // work_slices[dim]
@@ -322,7 +322,6 @@ def generate_sdsc(sdsc_spec):
                                                 tensor,
                                                 core_id_to_wk_slice[str(c)],
                                                 sdsc_spec.work_slices,
-                                                offset=tensor.offset,
                                             )
                                             * num_bytes(tensor.data_format)
                                         )

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -48,7 +48,6 @@ class SDSCArgs:
     allocation: dict[str, Any]
     start_address: int | Symbol
     backGap: dict[Symbol, int]
-    offset: int
 
     def __str__(self) -> str:
         scales = ", ".join(f"{k}={v}" for k, v in self.scales.items())
@@ -67,7 +66,6 @@ class SDSCArgs:
             f"  allocation=[{allocation}],\n"
             f"  start_address={self.start_address}\n"
             f"  backGap={self.backGap}\n"
-            f"  offset={self.offset}\n"
             f")"
         )
 
@@ -258,29 +256,25 @@ def _create_sdsc_tensors(
     layouts: dict = {}
     use_op_dims = not _is_matmul(op_spec.op)
 
-    output_offset = 0
-    gap = 0
-    device_stride = None
     missing_dim = None
-    backGap = {}
-    op_info = dict(op_spec.op_info.get("overwrite_info", {})) if op_spec.op_info else {}
+    backGap: dict[Symbol, int] = {}
+    overwrite_infos: dict = (
+        dict(op_spec.op_info.get("overwrite_infos", {})) if op_spec.op_info else {}
+    )
     adjusted_output_size = op_spec.args[-1].device_size.copy()
-    if op_info and (
-        "gap" in op_info and "device_offset" in op_info and "device_stride" in op_info
-    ):
-        device_stride = op_info["device_stride"]
-        gap = op_info["gap"]
-        output_offset = op_info["device_offset"] * device_stride
+    if overwrite_infos:
         output = op_spec.args[-1]
         dim_order, stick_dim = _get_device_dim_order(output, symbol_mapping)
         for dim_idx, dim in enumerate(reversed(dim_order)):
-            if device_stride == math.prod(output.device_size[dim_idx + 1 :]):
-                dim_size = iteration_space.get(dim, 1)
-                adjusted_output_size[dim_idx] = (
-                    dim_size // output.device_dtype.elems_per_stick()
-                    if dim == stick_dim
-                    else dim_size
-                )
+            for info in overwrite_infos.values():
+                if info["device_stride"] == math.prod(output.device_size[dim_idx + 1 :]):
+                    dim_size = iteration_space.get(dim, 1)
+                    adjusted_output_size[dim_idx] = (
+                        dim_size // output.device_dtype.elems_per_stick()
+                        if dim == stick_dim
+                        else dim_size
+                    )
+                    break
     sdsc_args: list[SDSCArgs] = []
     for arg in op_spec.args:
         addr = None if arg.arg_index < 0 else SEGMENT_OFFSETS[arg.arg_index]
@@ -311,13 +305,15 @@ def _create_sdsc_tensors(
                 dim_idx,
                 arg.device_size if not use_adjusted_size else adjusted_output_size,
             )
-            if (
-                device_stride == math.prod(arg.device_size[-dim_idx - 1 :])
-                and not arg.is_input
-            ):
-                backGap[dim] = gap
-                use_adjusted_size = False
             offsets[dim] = 0
+            dim_device_stride = math.prod(arg.device_size[-dim_idx - 1 :])
+            for key in list(overwrite_infos.keys()):
+                info = overwrite_infos[key]
+                if info["device_stride"] == dim_device_stride and not arg.is_input:
+                    backGap[dim] = info["gap"]
+                    offsets[dim] = info["device_offset"] * info["device_stride"]
+                    overwrite_infos.pop(key)
+                    break
             max_dim_sizes[dim] = -1
 
         effective_stick = op_stick_dim if stick_dim is None else stick_dim
@@ -339,25 +335,26 @@ def _create_sdsc_tensors(
                 allocation=arg.allocation,
                 start_address=addr,
                 backGap=backGap if not arg.is_input else {},
-                offset=output_offset if not arg.is_input else 0,
             )
         )
 
-    if not backGap and "gap" in op_info:
-        # Size of the dim with gap is 1 and was absent from the iteration space - add it
+    # For each overwrite entry with a device dimension of size 1 (absent from
+    # the iteration space), inject a synthetic dimension.
+    for info in overwrite_infos.values():
         missing_dim = Symbol(INPUT_DIM_LABELS[len(op_dim_order)])
         iteration_space[missing_dim] = 1
-        backGap[missing_dim] = gap
         for sdsc_arg, src_arg in zip(sdsc_args, op_spec.args):
             dim_idx = len(sdsc_arg.scales)
             sdsc_arg.scales[missing_dim] = 1
-            sdsc_arg.offsets[missing_dim] = 0
             sdsc_arg.max_dim_sizes[missing_dim] = -1
             sdsc_arg.strides[missing_dim] = _calculate_device_stride(
                 dim_idx, src_arg.device_size
             )
             if not src_arg.is_input:
-                sdsc_arg.backGap[missing_dim] = gap
+                sdsc_arg.backGap[missing_dim] = info["gap"]
+                sdsc_arg.offsets[missing_dim] = (
+                    info["device_offset"] * info["device_stride"]
+                )
             if missing_dim not in layouts[sdsc_arg.layout]["dim_order"]:
                 layouts[sdsc_arg.layout]["dim_order"] = layouts[sdsc_arg.layout][
                     "dim_order"

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -265,18 +265,18 @@ def _create_sdsc_tensors(
     if overwrite_infos:
         output = op_spec.args[-1]
         dim_order, stick_dim = _get_device_dim_order(output, symbol_mapping)
-        for dim_idx, dim in enumerate(reversed(dim_order)):
+        for dim_idx, dim in enumerate(dim_order):
             for info in overwrite_infos.values():
                 if info["device_stride"] == math.prod(
-                    output.device_size[dim_idx + 1 :]
+                    output.device_size[-dim_idx - 1 :]
                 ):
-                    dim_size = iteration_space.get(dim, 1)
-                    adjusted_output_size[dim_idx] = (
+                    dim_size = iteration_space[dim]
+                    dev_dim_idx = len(output.device_size) - 2 - dim_idx
+                    adjusted_output_size[dev_dim_idx] = (
                         dim_size // output.device_dtype.elems_per_stick()
                         if dim == stick_dim
                         else dim_size
                     )
-                    break
     sdsc_args: list[SDSCArgs] = []
     for arg in op_spec.args:
         addr = None if arg.arg_index < 0 else SEGMENT_OFFSETS[arg.arg_index]
@@ -315,7 +315,9 @@ def _create_sdsc_tensors(
                     backGap[dim] = info["gap"]
                     offsets[dim] = info["device_offset"] * info["device_stride"]
                     overwrite_infos.pop(key)
+                    use_adjusted_size = False
                     break
+
             max_dim_sizes[dim] = -1
 
         effective_stick = op_stick_dim if stick_dim is None else stick_dim

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -267,7 +267,9 @@ def _create_sdsc_tensors(
         dim_order, stick_dim = _get_device_dim_order(output, symbol_mapping)
         for dim_idx, dim in enumerate(reversed(dim_order)):
             for info in overwrite_infos.values():
-                if info["device_stride"] == math.prod(output.device_size[dim_idx + 1 :]):
+                if info["device_stride"] == math.prod(
+                    output.device_size[dim_idx + 1 :]
+                ):
                     dim_size = iteration_space.get(dim, 1)
                     adjusted_output_size[dim_idx] = (
                         dim_size // output.device_dtype.elems_per_stick()

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -207,15 +207,23 @@ def _ones_scalar_fake(
     return torch.empty(1, dtype=dtype, device="spyre")
 
 
-# Copy input into output starting at offset along dimension dim and
+# Copy input into output starting at offsets along dimensions dims and
 # return the updated output.
 @torch.library.custom_op("spyre::overwrite", mutates_args=(), device_types="spyre")
 def overwrite(
-    input: torch.Tensor, output: torch.Tensor, dim: int, offset: int
+    input: torch.Tensor,
+    output: torch.Tensor,
+    dims: Sequence[int],
+    offsets: Sequence[int],
 ) -> torch.Tensor:
     pass
 
 
 @overwrite.register_fake
-def _(input: torch.Tensor, output: torch.Tensor, dim: int, offset: int) -> torch.Tensor:
+def _(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    dims: Sequence[int],
+    offsets: Sequence[int],
+) -> torch.Tensor:
     return output

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -603,6 +603,44 @@ def decompose_cat(
         return orig_decomp
 
 
+@register_spyre_decomposition([torch.ops.aten.constant_pad_nd.default])
+def pad_decomp(
+    input: torch.Tensor,
+    pad: list[int],
+    value: float = 0,
+) -> torch.Tensor:
+    # pad is in reverse dim order: (left_last, right_last, left_2nd_last, right_2nd_last, ...)
+    n_dims_padded = len(pad) // 2
+
+    # Left-padding on any dimension requires updating the output start address,
+    # which the SFP overwrite op does not support.
+    if any(pad[2 * i] > 0 for i in range(n_dims_padded)):
+        raise Unsupported(
+            f"constant_pad_nd: left-padding is not supported on Spyre (pad={pad})"
+        )
+
+    # Apply padding one dimension at a time, from outermost to innermost.
+    # Each step fills an intermediate tensor with the pad value and overwrites
+    # it with the current tensor.  Processing outermost-first ensures that each
+    # overwrite call sees matching sizes on all non-overwrite dimensions.
+    scalar = torch.ops.spyre.full([1], value, input.device, dtype=input.dtype)
+    current = input
+    for i in range(n_dims_padded - 1, -1, -1):
+        left = pad[2 * i]
+        right = pad[2 * i + 1]
+        if left + right == 0:
+            continue
+        dim = input.dim() - 1 - i
+        intermediate_size = list(current.size())
+        intermediate_size[dim] += left + right
+        intermediate = scalar.expand(intermediate_size).clone()
+        current = torch.ops.spyre.overwrite(
+            input=current, output=intermediate, dim=dim, offset=left
+        )
+
+    return current
+
+
 ###############################################################################################
 ##                           Register custom kernels for Spyre.                              ##
 ###############################################################################################

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -595,7 +595,7 @@ def decompose_cat(
         offset = 0
         for input in tensors:
             output = torch.ops.spyre.overwrite(
-                input=input, output=output, dim=dim, offset=offset
+                input=input, output=output, dims=[dim], offsets=[offset]
             )
             offset += input.size(dim)
         return output
@@ -619,26 +619,28 @@ def pad_decomp(
             f"constant_pad_nd: left-padding is not supported on Spyre (pad={pad})"
         )
 
-    # Apply padding one dimension at a time, from outermost to innermost.
-    # Each step fills an intermediate tensor with the pad value and overwrites
-    # it with the current tensor.  Processing outermost-first ensures that each
-    # overwrite call sees matching sizes on all non-overwrite dimensions.
+    # Build the padded output shape and collect which dimensions need padding.
     scalar = torch.ops.spyre.full([1], value, input.device, dtype=input.dtype)
-    current = input
+    output_size = list(input.size())
+    dims: list[int] = []
+    offsets: list[int] = []
     for i in range(n_dims_padded - 1, -1, -1):
         left = pad[2 * i]
         right = pad[2 * i + 1]
         if left + right == 0:
             continue
         dim = input.dim() - 1 - i
-        intermediate_size = list(current.size())
-        intermediate_size[dim] += left + right
-        intermediate = scalar.expand(intermediate_size).clone()
-        current = torch.ops.spyre.overwrite(
-            input=current, output=intermediate, dim=dim, offset=left
-        )
+        output_size[dim] += left + right
+        dims.append(dim)
+        offsets.append(left)
 
-    return current
+    if not dims:
+        return input
+
+    output = scalar.expand(output_size).clone()
+    return torch.ops.spyre.overwrite(
+        input=input, output=output, dims=dims, offsets=offsets
+    )
 
 
 ###############################################################################################

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -612,12 +612,39 @@ def pad_decomp(
     # pad is in reverse dim order: (left_last, right_last, left_2nd_last, right_2nd_last, ...)
     n_dims_padded = len(pad) // 2
 
+    # Negative pad values (cropping) require reading from a non-zero storage
+    # offset or a sub-stick position, neither of which the SFP supports.
+    if any(p < 0 for p in pad):
+        raise Unsupported(
+            f"constant_pad_nd: negative padding (cropping) is not supported on "
+            f"Spyre (pad={pad})"
+        )
+
     # Left-padding on any dimension requires updating the output start address,
     # which the SFP overwrite op does not support.
     if any(pad[2 * i] > 0 for i in range(n_dims_padded)):
         raise Unsupported(
             f"constant_pad_nd: left-padding is not supported on Spyre (pad={pad})"
         )
+
+    # When the input's last dimension is smaller than one stick (64 fp16 elements),
+    # the data is repeated within each stick (inner_repeats = 64 // last_dim).
+    # The DSC requires the gap (right-pad on last dim) to be a multiple of
+    # inner_repeats; otherwise the hardware aborts with "Gap must be a multiple
+    # of inner repeats in expanded layout".
+    if n_dims_padded >= 1:
+        last_dim_size = input.size(-1)
+        right_pad_last = pad[1]
+        _FP16_ELEMS_PER_STICK = 64
+        if last_dim_size < _FP16_ELEMS_PER_STICK and right_pad_last > 0:
+            inner_repeats = _FP16_ELEMS_PER_STICK // last_dim_size
+            if right_pad_last % inner_repeats != 0:
+                raise Unsupported(
+                    f"constant_pad_nd: right-pad on last dimension ({right_pad_last}) "
+                    f"must be a multiple of inner repeats ({inner_repeats}) when "
+                    f"last dimension size ({last_dim_size}) is smaller than a stick "
+                    f"(pad={pad})"
+                )
 
     # Build the padded output shape and collect which dimensions need padding.
     scalar = torch.ops.spyre.full([1], value, input.device, dtype=input.dtype)

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -620,31 +620,13 @@ def pad_decomp(
             f"Spyre (pad={pad})"
         )
 
-    # Left-padding on any dimension requires updating the output start address,
-    # which the SFP overwrite op does not support.
+    # Left-padding requires shifting the output start address by the left amount,
+    # which is not yet supported. Tracked in:
+    # https://github.com/torch-spyre/torch-spyre/issues/1480
     if any(pad[2 * i] > 0 for i in range(n_dims_padded)):
         raise Unsupported(
             f"constant_pad_nd: left-padding is not supported on Spyre (pad={pad})"
         )
-
-    # When the input's last dimension is smaller than one stick (64 fp16 elements),
-    # the data is repeated within each stick (inner_repeats = 64 // last_dim).
-    # The DSC requires the gap (right-pad on last dim) to be a multiple of
-    # inner_repeats; otherwise the hardware aborts with "Gap must be a multiple
-    # of inner repeats in expanded layout".
-    if n_dims_padded >= 1:
-        last_dim_size = input.size(-1)
-        right_pad_last = pad[1]
-        _FP16_ELEMS_PER_STICK = 64
-        if last_dim_size < _FP16_ELEMS_PER_STICK and right_pad_last > 0:
-            inner_repeats = _FP16_ELEMS_PER_STICK // last_dim_size
-            if right_pad_last % inner_repeats != 0:
-                raise Unsupported(
-                    f"constant_pad_nd: right-pad on last dimension ({right_pad_last}) "
-                    f"must be a multiple of inner repeats ({inner_repeats}) when "
-                    f"last dimension size ({last_dim_size}) is smaller than a stick "
-                    f"(pad={pad})"
-                )
 
     # Build the padded output shape and collect which dimensions need padding.
     scalar = torch.ops.spyre.full([1], value, input.device, dtype=input.dtype)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -504,15 +504,18 @@ def clone(x, *, memory_format=None):
 
 
 @register_spyre_lowering(torch.ops.spyre.overwrite)
-def lower_overwrite(input, output, dim, offset):
+def lower_overwrite(input, output, dims, offsets):
     fn = lowering.ops_wrapper(torch.ops.spyre.overwrite.__name__)
+
+    strides = [int(output.get_layout().stride[d]) for d in dims]
+    gaps = [int(output.get_layout().size[d] - input.get_layout().size[d]) for d in dims]
 
     def inner_fn(index):
         return fn(
             input.make_loader()(index),
-            int(output.get_layout().stride[dim]),
-            offset,
-            int(output.get_layout().size[dim] - input.get_layout().size[dim]),
+            strides,
+            offsets,
+            gaps,
         )
 
     inp = Pointwise(

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -169,12 +169,11 @@ class SpyreOpFuncs:
         return PointwiseOp("neg", [a])
 
     @staticmethod
-    def overwrite(input, stride, offset, gap):
+    def overwrite(input, strides, offsets, gaps):
         op_info = {
-            "overwrite_info": {
-                "stride": stride,
-                "offset": offset,
-                "gap": gap,
+            "overwrite_infos": {
+                i: {"stride": s, "offset": o, "gap": g}
+                for i, (s, o, g) in enumerate(zip(strides, offsets, gaps))
             }
         }
         return PointwiseOp("overwrite", [input], op_info)
@@ -443,7 +442,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             op_info.update(value.op_info)
             if value.op == "overwrite":
                 convert_overwrite(
-                    value.op_info["overwrite_info"], dst.layout.device_layout
+                    value.op_info["overwrite_infos"], dst.layout.device_layout
                 )
             self.op_specs.append(self.create_op_spec(value.op, False, args, op_info))
         elif isinstance(value, TensorAccess):
@@ -626,16 +625,17 @@ def simplify_op_spec(op_spec):
         arg.device_coordinates = t["coordinates"]
 
 
-def convert_overwrite(overwrite_info, stl):
-    stride = overwrite_info["stride"]
-    gap = overwrite_info["gap"]
-    offset = overwrite_info["offset"]
-    span = gap * stride
-    device_dim = None
-    max_stride = 0
-    for i, st in enumerate(stl.stride_map):
-        if st > max_stride and span >= st and stl.device_size[i] > 1:
-            max_stride = st
-            device_dim = i
-    overwrite_info["device_stride"] = math.prod(stl.device_size[device_dim + 1 :])
-    overwrite_info["device_offset"] = offset * stride // max_stride
+def convert_overwrite(overwrite_infos, stl):
+    for info in overwrite_infos.values():
+        stride = info["stride"]
+        gap = info["gap"]
+        offset = info["offset"]
+        span = gap * stride
+        device_dim = None
+        max_stride = 0
+        for i, st in enumerate(stl.stride_map):
+            if st > max_stride and span >= st and stl.device_size[i] > 1:
+                max_stride = st
+                device_dim = i
+        info["device_stride"] = math.prod(stl.device_size[device_dim + 1 :])
+        info["device_offset"] = offset * stride // max_stride


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Implements `torch.nn.functional.pad` (constant padding) for the Spyre backend
using the identity broadcast + overwrite pattern introduced by `torch.cat`.

The decomposition of `aten.constant_pad_nd` proceeds in two steps:
1. **Fill**: create a 1-element scalar via `spyre::full`, broadcast-expand to
   the output shape, and materialize via `.clone()` (SFP identity broadcast).
   This zero-fills (or value-fills) the entire padded output.
2. **Copy**: call `spyre::overwrite` on the innermost padded dimension with the
   appropriate left offset. The `gap` between input and output size on that
   dimension maps to `backGap` in the SFP SDSC, causing the accelerator to
   skip the padded region automatically. Outer-dimension padding is already
   handled by the fill in step 1.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

The approach mirrors `decompose_cat` in `decompositions.py`. The critical
insight is that `overwrite` only needs to be called for the innermost padded
dimension; outer-dimension padding rows are naturally left at the fill value
since `inner_fn` iterates over the input's shape only.

Test cases cover:
- 2D right-only padding on the last dim
- 2D padding on both last and outer dim simultaneously
- 3D right-only padding on the last dim
- 3D right-only padding on a non-last dim (outer dim only)

#### Does this PR introduce a user-facing change?

Yes 

#### Additional note: