### PR TITLE
Add CODEOWNERS for torch_spyre/profiler/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,9 @@
 /torch_spyre/memory/     @JRosenkranz @thoangtrvn
 /torch_spyre/csrc/       @JRosenkranz @thoangtrvn
 
+# Profiler
+/torch_spyre/profiler/   @ppnaik1890 @kaoutar55 @flop1971
+
 # Operations (eager ops and fallbacks)
 /torch_spyre/ops/        @ani300 @moriohara @pradghos
 /codegen/                @ani300 @moriohara @pradghos


### PR DESCRIPTION
## Summary
- Adds @ppnaik1890, @kaoutar55, and @flop1971 as code owners for `torch_spyre/profiler/`

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm the three users are tagged for review on profiler changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)