### PR TITLE
Enable FX Graph caching

### DIFF
--- a/tests/inductor/test_cache.py
+++ b/tests/inductor/test_cache.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import torch
+from torch._inductor.utils import fresh_cache, clear_caches
+from torch._dynamo.utils import counters
+
+
+class TestCache(unittest.TestCase):
+    def test_cache(self):
+        with fresh_cache():
+            x = torch.randn((64, 64)).to("spyre")
+            cfn = torch.compile(torch.abs, dynamic=False)
+
+            cfn(x)
+            artifacts = torch.compiler.save_cache_artifacts()
+            self.assertIsNotNone(artifacts)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+
+            artifact_bytes, cache_info = artifacts
+            torch._dynamo.reset()
+            clear_caches()
+
+            cfn(x)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)

--- a/tests/inductor/test_cache.py
+++ b/tests/inductor/test_cache.py
@@ -20,6 +20,7 @@ from torch._dynamo.utils import counters
 
 class TestCache(unittest.TestCase):
     def test_cache(self):
+        counters.clear()
         a = torch.randn((64, 64)).to("spyre")
         fn = torch.compile(torch.abs, dynamic=False)
         with fresh_cache():

--- a/tests/inductor/test_cache.py
+++ b/tests/inductor/test_cache.py
@@ -24,7 +24,7 @@ class TestCache(unittest.TestCase):
         a = torch.randn((64, 64)).to("spyre")
         fn = torch.compile(torch.abs, dynamic=False)
         with fresh_cache():
-            result = fn(a)
+            fn(a)
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
 
@@ -39,7 +39,7 @@ class TestCache(unittest.TestCase):
 
         with fresh_cache():
             torch.compiler.load_cache_artifacts(artifact_bytes)
-            result = fn(a)
+            fn(a)
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 

--- a/tests/inductor/test_cache.py
+++ b/tests/inductor/test_cache.py
@@ -14,24 +14,32 @@
 
 import unittest
 import torch
-from torch._inductor.utils import fresh_cache, clear_caches
+from torch._inductor.utils import fresh_cache
 from torch._dynamo.utils import counters
 
 
 class TestCache(unittest.TestCase):
     def test_cache(self):
+        a = torch.randn((64, 64)).to("spyre")
+        fn = torch.compile(torch.abs, dynamic=False)
         with fresh_cache():
-            x = torch.randn((64, 64)).to("spyre")
-            cfn = torch.compile(torch.abs, dynamic=False)
-
-            cfn(x)
-            artifacts = torch.compiler.save_cache_artifacts()
-            self.assertIsNotNone(artifacts)
+            result = fn(a)
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
 
-            artifact_bytes, cache_info = artifacts
-            torch._dynamo.reset()
-            clear_caches()
+        artifacts = torch.compiler.save_cache_artifacts()
 
-            cfn(x)
+        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
+        self.assertIsNotNone(artifacts)
+
+        artifact_bytes, cache_info = artifacts
+
+        torch._dynamo.reset()
+
+        with fresh_cache():
+            torch.compiler.load_cache_artifacts(artifact_bytes)
+            result = fn(a)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+        self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -14,6 +14,7 @@
 
 import inspect
 from typing import Optional, Any, Callable, List
+from abc import abstractmethod
 
 import torch
 import torch.fx.graph
@@ -110,7 +111,24 @@ def _maybe_run_scheduler_pass(
     return nodes
 
 
-def scheduler_pre_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
+class CustomNodePassBase(CustomGraphPass):
+    def __call__(self, nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
+        for _pass in self.get_passes():
+            nodes = _maybe_run_scheduler_pass(_pass, nodes)
+        return nodes
+
+    @abstractmethod
+    def get_passes(
+        self,
+    ) -> list[Callable[[list[BaseSchedulerNode]], list[BaseSchedulerNode]]]:
+        pass
+
+    def uuid(self) -> Optional[Any]:
+        files = [inspect.getfile(c) for c in self.get_passes()]
+        return get_hash_for_files(tuple(dict.fromkeys(files + [__file__])))
+
+
+class CustomPreFusionPasses(CustomNodePassBase):
     """
     This inductor extension point enables Spyre-specific passes to run over
     the graph of LoopLevelIR nodes immediately before Inductor's fusion pass runs.
@@ -119,14 +137,14 @@ def scheduler_pre_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNo
     The returned list of nodes must also be in topological order.
     """
 
-    nodes = propagate_spyre_tensor_layouts(nodes)
-    nodes = core_division_planning(nodes)
-    if config.lx_planning:
-        nodes = scratchpad_planning(nodes)
-    return nodes
+    def get_passes(self):
+        passes = [propagate_spyre_tensor_layouts, core_division_planning]
+        if config.lx_planning:
+            passes.append(scratchpad_planning)
+        return passes
 
 
-def scheduler_post_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
+class CustomPostFusionPasses(CustomNodePassBase):
     """
     This inductor extension point enables Spyre-specific passes to run over
     the graph of LoopLevelIR nodes immediately after Inductor's fusion pass runs.
@@ -135,4 +153,5 @@ def scheduler_post_passes(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerN
     The returned list of nodes must also be in topological order.
     """
 
-    return spyre_fuse_nodes(nodes)
+    def get_passes(self):
+        return [spyre_fuse_nodes]

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -74,9 +74,8 @@ def enable_spyre_context(
     from torch_spyre._inductor.passes import (
         CustomPrePasses,
         CustomPostPasses,
-        scheduler_pre_passes,
-        scheduler_post_passes,
-        _maybe_run_scheduler_pass,
+        CustomPreFusionPasses,
+        CustomPostFusionPasses,
     )
 
     # *) Inductor config tweaks (saved/restored)
@@ -96,12 +95,8 @@ def enable_spyre_context(
     inductor_config.benchmark_harness = False
     inductor_config.post_grad_custom_pre_pass = CustomPrePasses()
     inductor_config.post_grad_custom_post_pass = CustomPostPasses()
-    inductor_config._pre_fusion_custom_pass = lambda nodes: _maybe_run_scheduler_pass(
-        scheduler_pre_passes, nodes
-    )
-    inductor_config._post_fusion_custom_pass = lambda nodes: _maybe_run_scheduler_pass(
-        scheduler_post_passes, nodes
-    )
+    inductor_config._pre_fusion_custom_pass = CustomPreFusionPasses()
+    inductor_config._post_fusion_custom_pass = CustomPostFusionPasses()
     # Adding this configuration in so as to avoid the optimization of turning small matmuls into non-matmuls
     # found here: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/ir.py#L1580
     inductor_config.unroll_reductions_threshold = 1


### PR DESCRIPTION
Making _{pre/post}_fusion_custom_pass derive from CustomGraphPass makes things cacheable.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Changes _pre_fusion_custom_pass to a CustomGraphPass object instead of a callable to enable FX Graph caching.
<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
