### PR TITLE
Add missing _post_fusion_custom_pass in saved_config

### DIFF
--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -88,6 +88,7 @@ def enable_spyre_context(
         "post_grad_custom_pre_pass": inductor_config.post_grad_custom_pre_pass,
         "post_grad_custom_post_pass": inductor_config.post_grad_custom_post_pass,
         "_pre_fusion_custom_pass": inductor_config._pre_fusion_custom_pass,
+        "_post_fusion_custom_pass": inductor_config._post_fusion_custom_pass,
         "unroll_reductions_threshold": inductor_config.unroll_reductions_threshold,
         "permute_fusion": inductor_config.permute_fusion,
     }


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug

#### What this PR does:

This PR fixes a regression introduced in #1286.

The newly added `_post_fusion_custom_pass` needs to be included in `saved_config` to avoid pickling issue.
