### PR TITLE
patch stream support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,10 +204,14 @@ if __name__ == "__main__":
         if OUTPUT_CODEGEN_DIR:
             sources += list(OUTPUT_CODEGEN_DIR.glob("*.cpp"))
 
-        # Filenames that belong to the tiny hooks module
-        hook_files = {"spyre_hooks.cpp"}
-        hooks_src_paths = [p for p in sources if p.name in hook_files]
-        core_src_paths = [p for p in sources if p.name not in hook_files]
+        # Filenames that belong to the tiny hooks module.
+        # "shared" files are compiled into both _hooks.so and _C.so.
+        hooks_only_files = {"spyre_hooks.cpp"}
+        shared_files = {"spyre_device_enum.cpp", "logging.cpp"}
+        hooks_src_paths = [
+            p for p in sources if p.name in hooks_only_files | shared_files
+        ]
+        core_src_paths = [p for p in sources if p.name not in hooks_only_files]
         hooks_src_paths = [
             p.relative_to(ROOT_DIR).as_posix() for p in sorted(hooks_src_paths)
         ]

--- a/tests/test_device_enum.py
+++ b/tests/test_device_enum.py
@@ -1,0 +1,154 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Owner(s): ["module: cpp"]
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+
+# Spyre PCI vendor/device IDs (must match spyre_device_enum.cpp)
+SPYRE_VENDOR_ID = 0x1014  # IBM
+SPYRE_DEVICE_ID = 0x06A7  # Spyre Accelerator
+
+
+def discover_spyre_pci_bus_ids() -> list[str]:
+    """
+    Discover Spyre PCI bus IDs by scanning /sys/bus/pci/devices/.
+
+    Returns list of PCI bus IDs (e.g., ['0000:29:00.0', '0000:3c:00.0'])
+    """
+    sysfs_path = Path("/sys/bus/pci/devices")
+    if not sysfs_path.exists():
+        return []
+
+    bus_ids = []
+    for device_dir in sysfs_path.iterdir():
+        try:
+            vendor_file = device_dir / "vendor"
+            device_file = device_dir / "device"
+
+            if vendor_file.exists() and device_file.exists():
+                vendor = int(vendor_file.read_text().strip(), 16)
+                device = int(device_file.read_text().strip(), 16)
+
+                if vendor == SPYRE_VENDOR_ID and device == SPYRE_DEVICE_ID:
+                    bus_ids.append(device_dir.name)
+        except (OSError, ValueError):
+            continue
+
+    return bus_ids
+
+
+def get_device_count_in_subprocess(env_vars: Optional[dict] = None) -> int:
+    """
+    Run device_count() in an isolated subprocess with specific env vars.
+
+    This bypasses the std::call_once caching in getVisibleDevices()
+    by running each test in a fresh process.
+    """
+    code = """
+import torch # noqa: F401
+print(torch.spyre.device_count())
+"""
+    env = os.environ.copy()
+    if env_vars is not None:
+        env.update(env_vars)
+        # Remove env vars that might interfere if not specified
+        for key in ["SPYRE_VISIBLE_DEVICES", "PCIDEVICE_IBM_COM_AIU_PF"]:
+            if key not in env_vars:
+                env.pop(key, None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Subprocess failed with code {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    return int(result.stdout.strip())
+
+
+class TestDeviceEnumEnvVars:
+    """Test environment variable handling for device enumeration."""
+
+    def test_default_pci_scan(self):
+        """Test default PCI bus scan - verifies hardware is detected."""
+        count = get_device_count_in_subprocess({})
+        assert count > 0, "No Spyre devices found via PCI scan"
+
+    def test_spyre_visible_devices_single(self):
+        """Test SPYRE_VISIBLE_DEVICES with single index."""
+        count = get_device_count_in_subprocess({"SPYRE_VISIBLE_DEVICES": "0"})
+        assert count == 1
+
+    def test_spyre_visible_devices_multiple(self):
+        """Test SPYRE_VISIBLE_DEVICES with multiple indices."""
+        # Check total count first
+        total = get_device_count_in_subprocess({})
+        if total < 2:
+            pytest.skip("Need at least 2 devices")
+
+        count = get_device_count_in_subprocess({"SPYRE_VISIBLE_DEVICES": "0,1"})
+        assert count == 2
+
+    def test_k8s_pci_device_env(self):
+        """Test PCIDEVICE_IBM_COM_AIU_PF (K8s device plugin)."""
+        bus_ids = discover_spyre_pci_bus_ids()
+        if not bus_ids:
+            pytest.skip("No Spyre devices found via sysfs scan")
+
+        # Test with single PCI bus ID
+        count = get_device_count_in_subprocess({"PCIDEVICE_IBM_COM_AIU_PF": bus_ids[0]})
+        assert count == 1
+
+    def test_env_var_priority(self):
+        """SPYRE_VISIBLE_DEVICES takes priority over PCIDEVICE_IBM_COM_AIU_PF."""
+        count = get_device_count_in_subprocess(
+            {
+                "SPYRE_VISIBLE_DEVICES": "0",
+                "PCIDEVICE_IBM_COM_AIU_PF": "invalid_bus_id",
+            }
+        )
+        assert count == 1, "SPYRE_VISIBLE_DEVICES should take priority"
+
+    def test_k8s_invalid_pci_bus_id_filtered(self):
+        """Invalid PCI bus IDs are filtered out, count equals valid IDs only."""
+        bus_ids = discover_spyre_pci_bus_ids()
+        if not bus_ids:
+            pytest.skip("No Spyre devices found via sysfs scan")
+
+        # Use first valid PCI bus ID + append an invalid one
+        valid_id = bus_ids[0]
+        env_val = f"{valid_id},0000:ff:ff.ff"
+        count = get_device_count_in_subprocess({"PCIDEVICE_IBM_COM_AIU_PF": env_val})
+
+        # Count should be 1 (invalid ID filtered out)
+        assert count == 1, f"Expected 1 (invalid ID filtered), got {count}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -338,12 +338,7 @@ class TestSpyre(TestCase):
         count = torch.spyre.device_count()
 
         assert isinstance(count, int)
-        assert count >= 0
-
-        if count == 0:
-            with pytest.raises(Exception):
-                torch.spyre.set_device(0)
-            return
+        assert count > 0
 
         orig = torch.spyre.current_device()
 

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -19,6 +19,7 @@ import unittest
 import psutil
 import warnings
 from contextlib import contextmanager
+import pytest
 
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -332,6 +333,32 @@ class TestSpyre(TestCase):
         self.assertEqual(
             torch.spyre.memory.max_memory_allocated(), prev_max_allocated + mem_size
         )
+
+    def test_spyre_device_count_and_set_device(self):
+        count = torch.spyre.device_count()
+
+        assert isinstance(count, int)
+        assert count >= 0
+
+        if count == 0:
+            with pytest.raises(Exception):
+                torch.spyre.set_device(0)
+            return
+
+        orig = torch.spyre.current_device()
+
+        try:
+            for i in range(min(2, count)):
+                torch.spyre.set_device(i)
+                assert torch.spyre.current_device() == i
+
+            with pytest.raises(Exception):
+                torch.spyre.set_device(count)
+
+            with pytest.raises(Exception):
+                torch.spyre.set_device(-1)
+        finally:
+            torch.spyre.set_device(orig)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -29,6 +29,7 @@ class _SpyreImpl:
     def __init__(self):
         self._initialized = False
         self._in_bad_fork = False
+        self._pending_device_idx = None
 
         # When spawning a supprocess from inductor, ensure that IS_INDUCTOR_SPAWNED_SUBPROCESS=1
         # This will avoid additional initialization when processes are spawned from torch inductor (This happens in Triton pathway)
@@ -58,6 +59,10 @@ class _SpyreImpl:
             # Load the C++ Module
             # put any light, once-per-process setup here
             self._C = importlib.import_module("torch_spyre._C")
+            # Apply pending device index before runtime init
+            pending = self._pending_device_idx
+            if pending is not None:
+                self._C.set_device(pending)
             # this will create the allocator
             self._C.start_runtime()
             self._initialized = True
@@ -112,16 +117,20 @@ class _SpyreImpl:
         return self._initialized and not self._is_in_bad_fork()
 
     def device_count(self) -> int:
-        # TODO(tmhoangt) - invoke the right API to return
-        return 1
+        from . import _hooks
+
+        return _hooks.device_count()
 
     def current_device(self) -> int:
         return getattr(self._C, "current_device", lambda: 0)()
 
     def set_device(self, idx: int) -> None:
-        fn = getattr(self._C, "set_device", None)
-        if fn:
-            fn(int(idx))
+        self._pending_device_idx = int(idx)
+        # If runtime is already initialized, also set it on the C++ side.
+        if self._initialized:
+            fn = getattr(self._C, "set_device", None)
+            if fn:
+                fn(int(idx))
 
     def _mark_after_fork(self):
         self._initialized = True

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -409,9 +409,17 @@ PYBIND11_MODULE(_C, m) {
                " id=" + std::to_string(stream.id()) + ">";
       });
   m.def("set_device", [](int idx) {
+    int count = spyre::device_count();
+    TORCH_CHECK(idx >= 0 && idx < count, "Device index ", idx,
+                " out of range [0, ", count, ")");
     c10::impl::getDeviceGuardImpl(c10::DeviceType::PrivateUse1)
         ->setDevice(c10::Device(c10::DeviceType::PrivateUse1,
                                 static_cast<c10::DeviceIndex>(idx)));
+  });
+  m.def("current_device", []() {
+    return c10::impl::getDeviceGuardImpl(c10::DeviceType::PrivateUse1)
+        ->getDevice()
+        .index();
   });
   m.def("device_count", &spyre::device_count);
 }

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -40,6 +40,8 @@
 
 #include "logging.h"
 #include "spyre_allocator.h"
+#include "spyre_device_enum.h"
+#include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_sendnn_utils.h"
 #include "spyre_stream.h"
@@ -73,13 +75,36 @@ static void init_from_env() {
 
 void _startRuntime() {
   DEBUGINFO("starting runtime");
+  // Determine logical device index with priority:
+  //   1. tls_idx (non-zero) — set via explicit set_device() call
+  //   2. LOCAL_RANK env var — set by torchrun per process
+  //   3. 0 — single-device / non-torchrun default
+  int logical_device_id = 0;
+  int tls_idx = static_cast<int>(SpyreGuardImpl::tls_idx);
+  if (tls_idx != 0) {
+    logical_device_id = tls_idx;
+  } else if (const char *lr = std::getenv("LOCAL_RANK")) {
+    logical_device_id = std::atoi(lr);
+  }
+  ensureSpyreDevicesEnv();
+
+  const auto &devices = getVisibleDevices();
+  if (logical_device_id >= 0 &&
+      logical_device_id < static_cast<int>(devices.size())) {
+    DEBUGINFO("logical_device_id =", logical_device_id,
+              "-> PCI bus ID =", devices[logical_device_id].pci_bus_id);
+  }
+
   std::shared_ptr<Runtime> runtime;
-  auto s = flex::initializeRuntime(&runtime);
+  auto s = flex::initializeRuntime(&runtime, logical_device_id);
   init_from_env();
   if (runtime) {
     GlobalRuntime::set(runtime);
     DEBUGINFO(s);
-    DEBUGINFO("runtime started");
+    std::string env_key = "AIU_WORLD_RANK_" + std::to_string(logical_device_id);
+    const char *pci = std::getenv(env_key.c_str());
+    DEBUGINFO("runtime started, device PCI bus ID:",
+              pci ? pci : "(default/senlib)");
   } else {
     DEBUGINFO("runtime FAILED TO START.");
     throw std::runtime_error("Failed to initialize Spyre runtime. ");
@@ -243,9 +268,8 @@ bool is_supported_dtype(c10::ScalarType dtype) {
   return sen_dtype_dev != DataFormats::INVALID &&
          elems_per_stick(sen_dtype_dev) > 0;
 }
-// TODO(tmhoangt): add real code
 int device_count() {
-  return 1;
+  return getVisibleDeviceCount();
 }
 
 }  // namespace spyre
@@ -384,4 +408,10 @@ PYBIND11_MODULE(_C, m) {
                std::to_string(stream.device().index()) +
                " id=" + std::to_string(stream.id()) + ">";
       });
+  m.def("set_device", [](int idx) {
+    c10::impl::getDeviceGuardImpl(c10::DeviceType::PrivateUse1)
+        ->setDevice(c10::Device(c10::DeviceType::PrivateUse1,
+                                static_cast<c10::DeviceIndex>(idx)));
+  });
+  m.def("device_count", &spyre::device_count);
 }

--- a/torch_spyre/csrc/module.h
+++ b/torch_spyre/csrc/module.h
@@ -20,7 +20,7 @@
 #include <torch/csrc/utils/pybind.h>
 #include <util/sen_host_ops.h>
 
-#include <flex/stream/stream_runtime.hpp>
+#include <flex/runtime_stream/runtime_entry.hpp>
 #include <memory>
 
 using DataConversionStrideInfo = data_conversion_stride_info;
@@ -28,7 +28,7 @@ using DataConversionInfo = data_conversion_info;
 
 namespace spyre {
 
-using Runtime = flex::StreamRuntime;
+using Runtime = flex::RuntimeEntry;
 
 class GlobalRuntime {
  public:

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -30,10 +30,11 @@ c10::CachingDeviceAllocator::StatTypes SpyreAllocator::stat_types = {
     true, false, false};  // {AGGREGATE, SMALL_POOL, LARGE_POOL}
 
 flex::DeviceMemoryAllocatorPtr SpyreAllocator::getAllocator(
-    unsigned int dev_id) {
-  return GlobalRuntime::get()
-      ->GetDeviceHandle(dev_id)
-      ->GetDeviceMemoryAllocator();
+    unsigned int /*dev_id*/) {
+  // Each process has exactly one runtime with one device handle (index 0).
+  // The PyTorch device index (dev_id) is the logical index across processes,
+  // not an index into the runtime's device handle vector.
+  return GlobalRuntime::get()->GetDeviceHandle(0)->GetDeviceMemoryAllocator();
 }
 
 SpyreAllocator& SpyreAllocator::instance() {

--- a/torch_spyre/csrc/spyre_device_enum.cpp
+++ b/torch_spyre/csrc/spyre_device_enum.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "spyre_device_enum.h"
+
+#include <dirent.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "logging.h"
+
+namespace spyre {
+
+namespace detail {
+
+// Read a hex value from a sysfs file, e.g. /sys/bus/pci/devices/XXX/vendor
+// Returns -1 on failure.
+int readSysfsHex(const std::string& path) {
+  std::ifstream f(path);
+  if (!f.is_open()) return -1;
+  int val = -1;
+  f >> std::hex >> val;
+  return val;
+}
+
+// Scan /sys/bus/pci/devices/ for all Spyre accelerators.
+// Returns PCI bus IDs sorted lexicographically.
+std::vector<std::string> scanPciBus() {
+  std::vector<std::string> bus_ids;
+  const std::string sysfs_path = "/sys/bus/pci/devices";
+  DIR* dir = opendir(sysfs_path.c_str());
+  if (!dir) {
+    DEBUGINFO("spyre_device_enum: cannot open", sysfs_path);
+    return bus_ids;
+  }
+
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    std::string name(entry->d_name);
+    if (name == "." || name == "..") continue;
+
+    std::string dev_dir = sysfs_path + "/" + name;
+    int vendor = readSysfsHex(dev_dir + "/vendor");
+    int device = readSysfsHex(dev_dir + "/device");
+
+    if (vendor == kSpyreVendorId && device == kSpyreDeviceId) {
+      bus_ids.push_back(name);
+    }
+  }
+  closedir(dir);
+
+  std::sort(bus_ids.begin(), bus_ids.end());
+  return bus_ids;
+}
+
+// Parse SPYRE_VISIBLE_DEVICES env var.
+// Accepts comma-separated PCI bus IDs or 0-based integer indices.
+// Returns resolved PCI bus IDs.
+std::vector<std::string> parseVisibleDevices(
+    const std::string& env_val, const std::vector<std::string>& all_bus_ids) {
+  std::vector<std::string> result;
+  std::istringstream ss(env_val);
+  std::string token;
+
+  while (std::getline(ss, token, ',')) {
+    // Trim whitespace
+    while (!token.empty() && token.front() == ' ') token.erase(0, 1);
+    while (!token.empty() && token.back() == ' ') token.pop_back();
+    if (token.empty()) continue;
+
+    // Check if token is a plain integer (index) or a PCI bus ID
+    bool is_index =
+        !token.empty() && std::all_of(token.begin(), token.end(), ::isdigit);
+
+    if (is_index) {
+      int idx = std::stoi(token);
+      if (idx >= 0 && idx < static_cast<int>(all_bus_ids.size())) {
+        result.push_back(all_bus_ids[idx]);
+      } else {
+        DEBUGINFO("spyre_device_enum: SPYRE_VISIBLE_DEVICES index", idx,
+                  "out of range (", all_bus_ids.size(), "devices found)");
+      }
+    } else {
+      // Assume it's a PCI bus ID — validate it exists
+      if (std::find(all_bus_ids.begin(), all_bus_ids.end(), token) !=
+          all_bus_ids.end()) {
+        result.push_back(token);
+      } else {
+        DEBUGINFO("spyre_device_enum: SPYRE_VISIBLE_DEVICES bus ID", token,
+                  "not found among Spyre devices");
+      }
+    }
+  }
+  return result;
+}
+
+std::vector<SpyreDeviceInfo> buildDeviceList() {
+  std::vector<std::string> all_bus_ids = scanPciBus();
+  std::vector<std::string> visible_bus_ids;
+
+  // Priority:
+  //   1. SPYRE_VISIBLE_DEVICES — explicit user/admin override
+  //   2. PCIDEVICE_IBM_COM_AIU_PF — set by K8s device plugin
+  //   3. Full PCI bus scan
+  const char* env = std::getenv("SPYRE_VISIBLE_DEVICES");
+  const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
+
+  if (env && env[0] != '\0') {
+    visible_bus_ids = parseVisibleDevices(env, all_bus_ids);
+    DEBUGINFO("spyre_device_enum: SPYRE_VISIBLE_DEVICES =", env, "->",
+              visible_bus_ids.size(), "devices");
+  } else if (k8s_env && k8s_env[0] != '\0') {
+    visible_bus_ids = parseVisibleDevices(k8s_env, all_bus_ids);
+    DEBUGINFO("spyre_device_enum: PCIDEVICE_IBM_COM_AIU_PF =", k8s_env, "->",
+              visible_bus_ids.size(), "devices");
+  } else {
+    visible_bus_ids = all_bus_ids;
+    DEBUGINFO("spyre_device_enum: found", visible_bus_ids.size(),
+              "Spyre devices via PCI scan");
+  }
+
+  std::vector<SpyreDeviceInfo> devices;
+  devices.reserve(visible_bus_ids.size());
+  for (int i = 0; i < static_cast<int>(visible_bus_ids.size()); ++i) {
+    devices.push_back({visible_bus_ids[i], i});
+  }
+  return devices;
+}
+
+}  // namespace detail
+
+const std::vector<SpyreDeviceInfo>& getVisibleDevices() {
+  static std::once_flag flag;
+  static std::vector<SpyreDeviceInfo> devices;
+  std::call_once(flag, [&]() { devices = detail::buildDeviceList(); });
+  return devices;
+}
+
+int getVisibleDeviceCount() {
+  return static_cast<int>(getVisibleDevices().size());
+}
+
+void ensureSpyreDevicesEnv() {
+  // If SPYRE_DEVICES is already set, flex will use it directly — nothing to do.
+  const char* existing = std::getenv("SPYRE_DEVICES");
+  if (existing && existing[0] != '\0') {
+    DEBUGINFO("spyre_device_enum: SPYRE_DEVICES already set =", existing);
+    return;
+  }
+
+  // If no K8s or user override is active, let flex use its default scan.
+  const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
+  const char* user_env = std::getenv("SPYRE_VISIBLE_DEVICES");
+  if ((!k8s_env || k8s_env[0] == '\0') && (!user_env || user_env[0] == '\0')) {
+    return;
+  }
+
+  // Set AIU_WORLD_RANK_<i> env vars with the PCI bus IDs of visible devices.
+  // flex's CreatePciId reads RANK (set by torchrun), then calls
+  // RdmaGetPCIeAddress(rank) which checks AIU_WORLD_RANK_<id> and passes
+  // the PCI bus ID directly to senlib::SenPci::pf(pci_address).
+  //
+  // This avoids senlib index mapping entirely — we pass the exact PCI bus ID.
+  const auto& visible = getVisibleDevices();
+
+  for (const auto& dev : visible) {
+    std::string env_name = "AIU_WORLD_RANK_" + std::to_string(dev.index);
+    setenv(env_name.c_str(), dev.pci_bus_id.c_str(), /*overwrite=*/0);
+    DEBUGINFO("spyre_device_enum: set", env_name, "=", dev.pci_bus_id);
+  }
+
+  // Also set SPYRE_DEVICES as sequential indices so flex's
+  // RdmaGetPCIeAddress uses the correct rank-to-index mapping.
+  std::string spyre_devices;
+  for (int i = 0; i < static_cast<int>(visible.size()); ++i) {
+    if (!spyre_devices.empty()) spyre_devices += ',';
+    spyre_devices += std::to_string(i);
+  }
+  if (!spyre_devices.empty()) {
+    setenv("SPYRE_DEVICES", spyre_devices.c_str(), /*overwrite=*/0);
+    DEBUGINFO("spyre_device_enum: synthesized SPYRE_DEVICES =", spyre_devices);
+  }
+}
+
+}  // namespace spyre

--- a/torch_spyre/csrc/spyre_device_enum.h
+++ b/torch_spyre/csrc/spyre_device_enum.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace spyre {
+
+// PCI vendor/device IDs for IBM Spyre Accelerator
+constexpr uint16_t kSpyreVendorId = 0x1014;  // IBM
+constexpr uint16_t kSpyreDeviceId = 0x06a7;  // Spyre Accelerator
+
+// PCI bus ID, e.g. "0000:29:00.0"
+struct SpyreDeviceInfo {
+  std::string pci_bus_id;
+  int index;  // logical index (0-based)
+};
+
+// Returns the list of Spyre devices visible to this process.
+//
+// Priority:
+//   1. SPYRE_VISIBLE_DEVICES env var — comma-separated PCI bus IDs or
+//      0-based indices (e.g. "0,1,2" or "0000:29:00.0,0000:2a:00.0")
+//   2. PCIDEVICE_IBM_COM_AIU_PF env var — set by K8s device plugin,
+//      comma-separated PCI bus IDs
+//   3. Full PCI bus scan via /sys/bus/pci/devices/
+//
+// The result is cached after the first call.
+const std::vector<SpyreDeviceInfo>& getVisibleDevices();
+
+// Convenience: returns the number of visible Spyre devices.
+int getVisibleDeviceCount();
+
+// If SPYRE_DEVICES is not already set, and PCIDEVICE_IBM_COM_AIU_PF is
+// available, synthesize SPYRE_DEVICES from the K8s-assigned PCI bus IDs
+// so that flex picks the correct physical cards.
+//
+// Must be called before flex::initializeRuntime().
+void ensureSpyreDevicesEnv();
+
+}  // namespace spyre

--- a/torch_spyre/csrc/spyre_guard.cpp
+++ b/torch_spyre/csrc/spyre_guard.cpp
@@ -19,6 +19,7 @@
 #include <ATen/core/op_registration/adaption.h>
 
 #include "module.h"
+#include "spyre_device_enum.h"
 #include "spyre_stream.h"
 
 namespace spyre {
@@ -46,8 +47,7 @@ void SpyreGuardImpl::setDevice(c10::Device d) const {
 void SpyreGuardImpl::uncheckedSetDevice(c10::Device) const noexcept {}
 
 c10::DeviceIndex SpyreGuardImpl::deviceCount() const noexcept {
-  //  FIXME (tmhoangt) - return actual device count
-  return 1;
+  return c10::DeviceIndex(getVisibleDeviceCount());
 }
 
 c10::Stream SpyreGuardImpl::getStream(c10::Device device) const {

--- a/torch_spyre/csrc/spyre_hooks.cpp
+++ b/torch_spyre/csrc/spyre_hooks.cpp
@@ -19,6 +19,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "spyre_device_enum.h"
+
 namespace py = pybind11;
 
 namespace spyre {
@@ -55,6 +57,7 @@ PYBIND11_MODULE(_hooks, m) {
   at::RegisterPrivateUse1HooksInterface(hooks);
   m.doc() =
       "Spyre bootstrap: registers PrivateUse1 hooks only (no heavy init).";
+  m.def("device_count", &spyre::getVisibleDeviceCount);
 }
 
 c10::Device current_device = c10::Device(c10::DeviceType::PrivateUse1, 0);
@@ -212,8 +215,7 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * you should report that there are zero available devices.
    */
   c10::DeviceIndex deviceCount() const noexcept override {
-    py::gil_scoped_acquire acquire;
-    return c10::DeviceIndex(1);
+    return c10::DeviceIndex(spyre::getVisibleDeviceCount());
   }
   /**
    * Return true if all the work previously enqueued on the stream for

--- a/torch_spyre/csrc/spyre_hooks.cpp
+++ b/torch_spyre/csrc/spyre_hooks.cpp
@@ -83,7 +83,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   c10::Device exchangeDevice(c10::Device d) const override {
     TORCH_INTERNAL_ASSERT(d.is_privateuseone());
-    py::gil_scoped_acquire acquire;
     auto old_device_index = current_device.index();
     return c10::Device(static_type, old_device_index);
   }
@@ -92,8 +91,7 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * Get the current device.
    */
   c10::Device getDevice() const override {
-    py::gil_scoped_acquire acquire;
-    return c10::Device(static_type, 0);
+    return current_device;
   }
 
   /**
@@ -101,7 +99,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   void setDevice(c10::Device d) const override {
     TORCH_INTERNAL_ASSERT(d.is_privateuseone());
-    py::gil_scoped_acquire acquire;
     current_device = c10::Device(static_type, d.index());
   }
 
@@ -110,7 +107,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * (so, e.g., this can be called from a destructor).
    */
   void uncheckedSetDevice(c10::Device d) const noexcept override {
-    py::gil_scoped_acquire acquire;
     current_device = c10::Device(static_type, d.index());
   }
 
@@ -118,7 +114,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * Get the current stream for a given device.
    */
   c10::Stream getStream(c10::Device d) const noexcept override {
-    py::gil_scoped_acquire acquire;
     // FIXME: This is just assuming 0 - ControlBlockStream
     return c10::Stream(c10::Stream::UNSAFE, current_device, 0);
   }
@@ -127,7 +122,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * Get the default stream for a given device.
    */
   c10::Stream getDefaultStream(c10::Device d) const override {
-    py::gil_scoped_acquire acquire;
     // FIXME: This is just assuming 0 - ControlBlockStream
     return c10::Stream(c10::Stream::UNSAFE, current_device, 0);
   }
@@ -137,7 +131,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   c10::Stream getStreamFromGlobalPool(
       c10::Device d, bool isHighPriority = false) const override {
-    py::gil_scoped_acquire acquire;
     // FIXME: This is just assuming 0 - ControlBlockStream
     return c10::Stream(c10::Stream::UNSAFE, current_device, 0);
   }
@@ -148,7 +141,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * the lifetime of the stream.
    */
   c10::Stream getNewStream(c10::Device d, int priority = 0) const override {
-    py::gil_scoped_acquire acquire;
     return c10::Stream(c10::Stream::UNSAFE, current_device, 0);
   }
 
@@ -158,7 +150,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * to set the current device to match the device of this stream.
    */
   c10::Stream exchangeStream(c10::Stream s) const noexcept override {
-    py::gil_scoped_acquire acquire;
     return c10::Stream(c10::Stream::UNSAFE, current_device, 0);
   }
 
@@ -167,7 +158,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   void destroyEvent(void* event, const c10::DeviceIndex device_index)
       const noexcept override {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
   }
 
@@ -180,7 +170,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   void record(void** event, const c10::Stream& stream,
               const c10::DeviceIndex device_index,
               const c10::EventFlag flag) const override {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
   }
 
@@ -193,7 +182,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * additional commands until that version of the event is marked as recorded.
    */
   void block(void* event, const c10::Stream& stream) const override {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
   }
 
@@ -204,7 +192,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * Returns false otherwise.
    */
   bool queryEvent(void* event) const override {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
     return false;
   }
@@ -222,7 +209,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * asynchronous execution has completed running on the device.
    */
   bool queryStream(const c10::Stream& stream) const override {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
     return true;
   }
@@ -232,7 +218,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * enqueued on the stream has completed running on the device.
    */
   virtual void synchronizeStream(const c10::Stream& stream) const {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
   }
 
@@ -241,7 +226,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * recorded on the event has completed running on the device.
    */
   void synchronizeEvent(void* event) const override {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
   }
 
@@ -252,7 +236,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   void recordDataPtrOnStream(const c10::DataPtr& data_ptr,
                              const c10::Stream& stream) const override {
-    py::gil_scoped_acquire acquire;
     // not implemented on spyre - do nothing
   }
 
@@ -261,7 +244,6 @@ struct SpyreGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   double elapsedTime(void* event1, void* event2,
                      const c10::DeviceIndex device_index) const override {
-    py::gil_scoped_acquire acquire;
     return 0.0;
   }
 };

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -49,8 +49,8 @@ struct StreamPool {
   std::unordered_map<c10::DeviceIndex, size_t> next_low_priority_idx;
   std::unordered_map<c10::DeviceIndex, size_t> next_high_priority_idx;
 
-  // Mapping from c10::StreamId to flex::StreamHandle
-  std::unordered_map<c10::StreamId, flex::StreamHandle> stream_handle_map;
+  // Mapping from c10::StreamId to flex::RuntimeStream*
+  std::unordered_map<c10::StreamId, flex::RuntimeStream*> stream_handle_map;
 
   // Per-device initialization flags
   std::unordered_map<c10::DeviceIndex, std::once_flag> device_init_flags;
@@ -108,7 +108,7 @@ bool SpyreStream::query() const {
   DEBUGINFO("SpyreStream::query() - stream ", id(), " on device ",
             device().index());
 
-  flex::StreamHandle handle = getRuntimeHandle();
+  flex::RuntimeStream* handle = getRuntimeHandle();
   return handle->query();
 }
 
@@ -118,7 +118,7 @@ void SpyreStream::synchronize() const {
   DEBUGINFO("SpyreStream::synchronize() - stream ", id(), " on device ",
             device().index());
 
-  flex::StreamHandle handle = getRuntimeHandle();
+  flex::RuntimeStream* handle = getRuntimeHandle();
   handle->synchronize();
 }
 
@@ -131,7 +131,7 @@ void SpyreStream::copy_async(const at::Tensor& src,
   // TODO(tmhoangt): place-holder to be implemented in the next PR
 }
 
-flex::StreamHandle SpyreStream::getRuntimeHandle() const {
+flex::RuntimeStream* SpyreStream::getRuntimeHandle() const {
   auto& pool = getStreamPool();
   std::lock_guard<std::mutex> lock(pool.mutex);
 
@@ -243,7 +243,7 @@ SpyreStream getStreamFromPool(c10::Device device, int priority) {
   // Create corresponding flex stream handle (if not exists)
   if (pool.stream_handle_map.find(stream_id) == pool.stream_handle_map.end()) {
     auto runtime = GlobalRuntime::get();
-    flex::StreamHandle flex_handle =
+    flex::RuntimeStream* flex_handle =
         runtime->createStream(device.index(), runtime->toPriority(priority));
     pool.stream_handle_map[stream_id] = flex_handle;
   }
@@ -258,7 +258,7 @@ void synchronizeDevice(c10::optional<c10::Device> device) {
     }
     const auto device_index = dev.index();
 
-    std::vector<flex::StreamHandle> handles_to_sync;
+    std::vector<flex::RuntimeStream*> handles_to_sync;
     {
       auto& pool = getStreamPool();
       std::lock_guard<std::mutex> lock(pool.mutex);

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -25,6 +25,7 @@
 
 #include "logging.h"
 #include "module.h"
+#include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_tensor_impl.h"
 
@@ -75,7 +76,8 @@ constexpr int kHighPriorityStreamsPerDevice = 32;
 
 // Constructor
 SpyreStream::SpyreStream()
-    : stream_(getCurrentStream(c10::Device(c10::DeviceType::PrivateUse1, 0))
+    : stream_(getCurrentStream(c10::Device(c10::DeviceType::PrivateUse1,
+                                           SpyreGuardImpl::tls_idx))
                   .unwrap()) {}
 SpyreStream::SpyreStream(c10::Stream stream) : stream_(stream) {
   TORCH_CHECK(stream_.device_type() == c10::DeviceType::PrivateUse1,
@@ -106,9 +108,8 @@ bool SpyreStream::query() const {
   DEBUGINFO("SpyreStream::query() - stream ", id(), " on device ",
             device().index());
 
-  auto runtime = GlobalRuntime::get();
-  flex::StreamHandle handle = get_flex_handle();
-  return runtime->queryStream(handle);
+  flex::StreamHandle handle = getRuntimeHandle();
+  return handle->query();
 }
 
 void SpyreStream::synchronize() const {
@@ -117,9 +118,8 @@ void SpyreStream::synchronize() const {
   DEBUGINFO("SpyreStream::synchronize() - stream ", id(), " on device ",
             device().index());
 
-  auto runtime = GlobalRuntime::get();
-  flex::StreamHandle handle = get_flex_handle();
-  runtime->synchronizeStream(handle);
+  flex::StreamHandle handle = getRuntimeHandle();
+  handle->synchronize();
 }
 
 c10::Stream SpyreStream::unwrap() const {
@@ -131,19 +131,15 @@ void SpyreStream::copy_async(const at::Tensor& src,
   // TODO(tmhoangt): place-holder to be implemented in the next PR
 }
 
-flex::StreamHandle SpyreStream::get_flex_handle() const {
+flex::StreamHandle SpyreStream::getRuntimeHandle() const {
   auto& pool = getStreamPool();
   std::lock_guard<std::mutex> lock(pool.mutex);
 
-  // Look up the flex handle using this stream's ID
   auto it = pool.stream_handle_map.find(id());
-
-  if (it != pool.stream_handle_map.end()) {
-    return it->second;
-  }
-
-  // Default stream (ID 0) returns nullptr
-  return flex::DEFAULT_STREAM;
+  TORCH_CHECK(it != pool.stream_handle_map.end(),
+              "SpyreStream: no flex handle for stream id ", id(),
+              " — was the stream pool initialized for this device?");
+  return it->second;
 }
 
 void SpyreStream::copy_async_impl(
@@ -155,6 +151,12 @@ void SpyreStream::copy_async_impl(
 void initializeStreamPoolImpl(c10::DeviceIndex device_index) {
   auto& pool = getStreamPool();
   std::lock_guard<std::mutex> lock(pool.mutex);
+
+  // Register the default stream (ID 0) using the concrete flex handle.
+  // This ensures getRuntimeHandle() resolves stream 0 to the real RuntimeStream
+  // instance owned by RuntimeContext.
+  auto runtime = GlobalRuntime::get();
+  pool.stream_handle_map[0] = runtime->getDefaultStream(device_index);
 
   // Initialize low priority streams (IDs 1 to kStreamsPerDevice)
   pool.low_priority_streams[device_index].reserve(kStreamsPerDevice);
@@ -180,14 +182,15 @@ void initializeStreamPool(c10::DeviceIndex device_index) {
 
 SpyreStream getDefaultStream(c10::Device device) {
   if (device.index() == -1) {
-    device = c10::Device(c10::DeviceType::PrivateUse1, 0);
+    device = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
   }
+  initializeStreamPool(device.index());
   return SpyreStream(c10::Stream(c10::Stream::DEFAULT, device));
 }
 
 SpyreStream getCurrentStream(c10::Device device) {
   if (device.index() == -1) {
-    device = c10::Device(c10::DeviceType::PrivateUse1, 0);
+    device = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
   }
 
   auto it = current_streams.find(device.index());
@@ -207,7 +210,7 @@ SpyreStream setCurrentStream(SpyreStream stream) {
 
 SpyreStream getStreamFromPool(c10::Device device, int priority) {
   if (device.index() == -1) {
-    device = c10::Device(c10::DeviceType::PrivateUse1, 0);
+    device = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
   }
 
   // Ensure runtime is initialized before creating streams
@@ -241,7 +244,7 @@ SpyreStream getStreamFromPool(c10::Device device, int priority) {
   if (pool.stream_handle_map.find(stream_id) == pool.stream_handle_map.end()) {
     auto runtime = GlobalRuntime::get();
     flex::StreamHandle flex_handle =
-        runtime->createStream(device.index(), priority);
+        runtime->createStream(device.index(), runtime->toPriority(priority));
     pool.stream_handle_map[stream_id] = flex_handle;
   }
 
@@ -251,7 +254,7 @@ SpyreStream getStreamFromPool(c10::Device device, int priority) {
 void synchronizeDevice(c10::optional<c10::Device> device) {
   auto sync_one_device = [](c10::Device dev) {
     if (dev.index() == -1) {
-      dev = c10::Device(c10::DeviceType::PrivateUse1, 0);
+      dev = c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx);
     }
     const auto device_index = dev.index();
 
@@ -260,8 +263,11 @@ void synchronizeDevice(c10::optional<c10::Device> device) {
       auto& pool = getStreamPool();
       std::lock_guard<std::mutex> lock(pool.mutex);
 
-      // Default stream is always present
-      handles_to_sync.push_back(flex::DEFAULT_STREAM);
+      // Default stream (ID 0) is always present when the pool is initialized
+      auto default_it = pool.stream_handle_map.find(0);
+      if (default_it != pool.stream_handle_map.end()) {
+        handles_to_sync.push_back(default_it->second);
+      }
 
       auto collect = [&](auto& stream_map) {
         auto it = stream_map.find(device_index);
@@ -280,16 +286,14 @@ void synchronizeDevice(c10::optional<c10::Device> device) {
     auto runtime = GlobalRuntime::get();
     c10::DeviceGuard guard(dev);
     for (auto handle : handles_to_sync) {
-      runtime->synchronizeStream(handle);
+      handle->synchronize();
     }
   };
   if (device.has_value()) {
     sync_one_device(device.value());
   } else {
-    // Synchronize all devices
-    for (int i = 0; i < device_count(); ++i) {
-      sync_one_device(c10::Device(c10::DeviceType::PrivateUse1, i));
-    }
+    sync_one_device(
+        c10::Device(c10::DeviceType::PrivateUse1, SpyreGuardImpl::tls_idx));
   }
 }
 

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -19,8 +19,6 @@
 #include <ATen/ATen.h>
 #include <c10/core/Stream.h>
 
-#include <flex/stream/stream_handle.hpp>
-
 #include "module.h"
 
 namespace spyre {
@@ -47,7 +45,7 @@ class SpyreStream {
   c10::Stream unwrap() const;
 
  private:
-  flex::StreamHandle get_flex_handle() const;
+  flex::StreamHandle getRuntimeHandle() const;
   void copy_async_impl(void* cpu_ptr,
                        flex::DeviceMemoryAllocationPtr& device_allocation,
                        int device_id, const DataConversionInfo& dci,

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -45,7 +45,7 @@ class SpyreStream {
   c10::Stream unwrap() const;
 
  private:
-  flex::StreamHandle getRuntimeHandle() const;
+  flex::RuntimeStream* getRuntimeHandle() const;
   void copy_async_impl(void* cpu_ptr,
                        flex::DeviceMemoryAllocationPtr& device_allocation,
                        int device_id, const DataConversionInfo& dci,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR 
* makes use of Flex's RuntimeStream's API directly for handling Pytorch-level streams.
* correctly use the device-index (allows running a device with non-zero index in a process)
* pick up the available devices and update `AIU_WORLD_RANK_<idx>` to be used for loading the right device. It K8s pod, it relies on the variable `PCIDEVICE_IBM_COM_AIU_PF`. We can further limit what devices a Python process can see via `SPYRE_VISIBLE_DEVICES`.

This PR depends on PR 718 in Flex (merged).  

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

The test won't be successful until the CI image pickup the latest change in flex. 

Local test result:
```sh
((.venv) )  (git:stream-patch)pod:~/dt-inductor/_worktrees/stream-patch-after-616/torch-spyre$ pytest tests -x 
===================================================================================== test session starts ======================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/tmhoangt/dt-inductor/_worktrees/stream-patch-after-616/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 573 items                                                                                                                                                                            

tests/inductor/test_building_blocks.py ....                                                                                                                                              [  0%]
tests/inductor/test_cache.py .                                                                                                                                                           [  0%]
tests/inductor/test_codegen.py ...                                                                                                                                                       [  1%]
tests/inductor/test_inductor_decomp.py ...                                                                                                                                               [  1%]
tests/inductor/test_inductor_fx_passes.py .......                                                                                                                                        [  3%]
tests/inductor/test_inductor_ops.py ....s............................................................................................................................................... [ 28%]
........................................................................................................................................................................................ [ 61%]
...............................................................................................................................................                                          [ 86%]
tests/inductor/test_logging.py ....                                                                                                                                                      [ 86%]
tests/tensor/test_coordinates.py ..                                                                                                                                                      [ 87%]
tests/tensor/test_tensor_layout.py ................                                                                                                                                      [ 89%]
tests/test_fallbacks.py ........                                                                                                                                                         [ 91%]
tests/test_modules.py .sssss.                                                                                                                                                            [ 92%]
tests/test_regex.py .                                                                                                                                                                    [ 92%]
tests/test_spyre.py ..s..ss.............                                                                                                                                                 [ 96%]
tests/test_spyre_lazy_silent.py .                                                                                                                                                        [ 96%]
tests/test_stream.py .....................                                                                                                                                               [100%]

======================================================================================= warnings summary =======================================================================================
tests/inductor/test_inductor_ops.py::TestOps::test_fill_scalar_1d
tests/inductor/test_inductor_ops.py::TestOps::test_zeros_aligned
tests/inductor/test_inductor_ops.py::TestOps::test_zeros_padded
  /home/tmhoangt/dt-inductor/_worktrees/stream-patch-after-616/torch-spyre/torch_spyre/_inductor/customops.py:165: FallbackWarning: torch.ops.spyre.full is falling back to cpu
    warn_fallback("torch.ops.spyre.full")

tests/inductor/test_inductor_ops.py::TestOps::test_isin_scalar_tensor_out_cpu
  /home/tmhoangt/dt-inductor/_worktrees/stream-patch-after-616/torch-spyre/torch_spyre/ops/fallbacks.py:262: UserWarning: An output with one or more elements was resized since it had shape [], which does not match the required output shape [0]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (Triggered internally at /pytorch/aten/src/ATen/native/Resize.cpp:31.)
    return torch.isin(

tests/test_spyre.py::TestSpyre::test_ones_factory
tests/test_spyre.py::TestSpyre::test_printing
  /home/tmhoangt/dt-inductor/_worktrees/stream-patch-after-616/torch-spyre/torch_spyre/_inductor/customops.py:196: FallbackWarning: torch.ops.spyre.ones_scalar is falling back to cpu
    warn_fallback("torch.ops.spyre.ones_scalar")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== 564 passed, 9 skipped, 6 warnings in 608.97s (0:10:08) ====================================================================
```