### PR TITLE
Extends test_inductor_ops to test_inductor_ops_lx_planning

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -22,7 +22,7 @@ from utils_inductor import (
     make_param_dict,
     unique_randn_along_dim,
 )
-from utils_inductor import compare, compare_with_cpu
+import utils_inductor
 
 POINTWISE_UNARY_OPS_DICT = {
     "abs": torch.abs,
@@ -1589,6 +1589,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def compare_with_cpu(self, *args, **kwargs):
+        return utils_inductor.compare_with_cpu(*args, **kwargs)
+
+    def compare(self, *args, **kwargs):
+        return utils_inductor.compare(*args, **kwargs)
+
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_unary_op(self, op, x):
         if op == torch.reciprocal:
@@ -1602,11 +1608,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             torch.sin,  # CPU fallback
         }
         if op in cpu_ops:
-            compare_with_cpu(op, x)
+            self.compare_with_cpu(op, x)
         elif op == torch.neg:
-            compare_with_cpu(op, x)
+            self.compare_with_cpu(op, x)
         else:
-            compare(op, x)
+            self.compare(op, x)
 
     def test_bool(self):
         dtype = torch.bool
@@ -1630,14 +1636,14 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         tensor_args = [arg for arg in args if isinstance(arg, torch.Tensor)]
 
-        compare_with_cpu(fn, *tensor_args)
+        self.compare_with_cpu(fn, *tensor_args)
 
     def test_unary_op_cpu(self, op, x):
-        compare_with_cpu(op, x)
+        self.compare_with_cpu(op, x)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_fallback_unary_op_cpu(self, op, x):
-        compare_with_cpu(op, x)
+        self.compare_with_cpu(op, x)
 
     def test_binary_op(self, op, a, b):
         if op == torch.div:
@@ -1646,17 +1652,17 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             b[tiny_value_mask] = FP16_EPS
 
         if a.dtype == torch.float32:
-            compare_with_cpu(op, a, b)
+            self.compare_with_cpu(op, a, b)
         else:
-            compare(op, a, b)
+            self.compare(op, a, b)
 
     # Increased mm test tolerance for splitk
     def test_mm_relaxed(self, op, a, b):
         K = b.shape[-2]
         if K >= (128 // b.element_size()):  # multiple sticks
-            compare(op, a, b, atol=0.1, rtol=0.1)
+            self.compare(op, a, b, atol=0.1, rtol=0.1)
         else:  # single stick, no need to relax
-            compare(op, a, b)
+            self.compare(op, a, b)
 
     def test_binary_op_cpu(self, op, x, y):
         # Eager mode support varies by op:
@@ -1664,71 +1670,71 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         # - torch.ne, torch.le: aten::ne.Tensor_out / aten::le.Tensor_out not registered
         # - torch.matmul: numerical divergence (close=False) in eager 2d case
         eager_supported = op in (torch.eq, torch.ge, torch.gt, torch.lt)
-        compare_with_cpu(op, x, y, run_eager=eager_supported)
+        self.compare_with_cpu(op, x, y, run_eager=eager_supported)
 
     def test_linear_fn(self, x, weight, bias):
         # NOTE: relaxing atol from 2e-1 to 3e-1 for multi-dim work division, single element fails without
-        compare_with_cpu(
+        self.compare_with_cpu(
             torch.nn.functional.linear, x, weight, bias, atol=3e-1, rtol=2e-1
         )
 
     @unittest.skip("deeptools: error")
     def test_add_broadcast(self, x, y):
-        compare(lambda x, y: torch.add(x[None, :], y), x, y)
+        self.compare(lambda x, y: torch.add(x[None, :], y), x, y)
 
     # Example where base function is not parameterized
     def test_add_broadcast_cpu(self, x, y):
-        compare_with_cpu(lambda x, y: torch.add(x[None, :], y), x, y)
+        self.compare_with_cpu(lambda x, y: torch.add(x[None, :], y), x, y)
 
     def test_addmm_cpu(self, input, mat1, mat2):
         # NOTE: relaxing atol from 2e-1 to 3e-1 for multi-dim work division
-        compare_with_cpu(torch.addmm, input, mat1, mat2, atol=3e-1, rtol=2e-1)
+        self.compare_with_cpu(torch.addmm, input, mat1, mat2, atol=3e-1, rtol=2e-1)
 
     def test_reduce_keepdim0_cpu(self, op, dim: int, x):
         # torch.max returns a tuple; torch.amax is not registered for Spyre eager dispatch
         if op == torch.max:
-            compare_with_cpu(
+            self.compare_with_cpu(
                 lambda x: op(x, dim=dim, keepdim=False)[0], x, run_eager=False
             )
         elif op == torch.amax:
             # aten::amax.out is not registered for the Spyre backend
-            compare_with_cpu(
+            self.compare_with_cpu(
                 lambda x: op(x, dim=dim, keepdim=False), x, run_eager=False
             )
         else:
-            compare_with_cpu(lambda x: op(x, dim=dim, keepdim=False), x)
+            self.compare_with_cpu(lambda x: op(x, dim=dim, keepdim=False), x)
 
     def test_reduce_keepdim0_cpu_no_eager(self, op, dim: int, x):
         # aten::max.dim and aten::amin are not registered for Spyre eager dispatch
         if op == torch.max:
-            compare_with_cpu(
+            self.compare_with_cpu(
                 lambda x: op(x, dim=dim, keepdim=False)[0], x, run_eager=False
             )
         else:
-            compare_with_cpu(
+            self.compare_with_cpu(
                 lambda x: op(x, dim=dim, keepdim=False), x, run_eager=False
             )
 
     def test_reduce_keepdim1_cpu(self, op, dim: int, x):
         # torch.max returns a tuple; torch.amax is not registered for Spyre eager dispatch
         if op == torch.max:
-            compare_with_cpu(
+            self.compare_with_cpu(
                 lambda x: op(x, dim=dim, keepdim=True)[0], x, run_eager=False
             )
         elif op == torch.amax:
             # aten::amax.out is not registered for the Spyre backend
-            compare_with_cpu(lambda x: op(x, dim=dim, keepdim=True), x, run_eager=False)
+            self.compare_with_cpu(lambda x: op(x, dim=dim, keepdim=True), x, run_eager=False)
         else:
-            compare_with_cpu(lambda x: op(x, dim=dim, keepdim=True), x)
+            self.compare_with_cpu(lambda x: op(x, dim=dim, keepdim=True), x)
 
     def test_reduce_keepdim1_cpu_no_eager(self, op, dim: int, x):
         # aten::max.dim and aten::amin are not registered for Spyre eager dispatch
         if op == torch.max:
-            compare_with_cpu(
+            self.compare_with_cpu(
                 lambda x: op(x, dim=dim, keepdim=True)[0], x, run_eager=False
             )
         else:
-            compare_with_cpu(lambda x: op(x, dim=dim, keepdim=True), x, run_eager=False)
+            self.compare_with_cpu(lambda x: op(x, dim=dim, keepdim=True), x, run_eager=False)
 
     def test_max_sub_broadcast(self, dim: int, x):
         def fn(x):
@@ -1736,59 +1742,59 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             z = x - torch.unsqueeze(x_max, dim=dim)
             return z
 
-        compare(fn, x)
+        self.compare(fn, x)
 
     def test_t_1d_cpu(self, x):
-        compare_with_cpu(lambda x: x.t(), x)
+        self.compare_with_cpu(lambda x: x.t(), x)
 
     def test_t_1d_contiguous_cpu(self, x):
         # Note: .contiguous() causes issues with eager mode, see https://github.com/torch-spyre/torch-spyre/issues/1149
-        compare_with_cpu(lambda x: x.t().contiguous(), x, run_eager=False)
+        self.compare_with_cpu(lambda x: x.t().contiguous(), x, run_eager=False)
 
     def test_t_2d_cpu(self, x):
-        compare_with_cpu(lambda x: x.t(), x)
+        self.compare_with_cpu(lambda x: x.t(), x)
 
     def test_t_2d_contiguous_cpu(self, x):
         # Note: .contiguous() causes issues with eager mode, see https://github.com/torch-spyre/torch-spyre/issues/1149
-        compare_with_cpu(lambda x: x.t().contiguous(), x, run_eager=False)
+        self.compare_with_cpu(lambda x: x.t().contiguous(), x, run_eager=False)
 
     def test_transpose_2d_cpu(self, dim0: int, dim1: int, x):
-        compare_with_cpu(lambda x: torch.transpose(x, dim0, dim1), x)
+        self.compare_with_cpu(lambda x: torch.transpose(x, dim0, dim1), x)
 
     def test_transpose_2d_contiguous_cpu(self, dim0: int, dim1: int, x):
         # Note: .contiguous() causes issues with eager mode, see https://github.com/torch-spyre/torch-spyre/issues/1149
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda x: torch.transpose(x, dim0, dim1).contiguous(), x, run_eager=False
         )
 
     def test_transpose_3d_cpu(self, dim0: int, dim1: int, x):
-        compare_with_cpu(lambda x: torch.transpose(x, dim0, dim1), x)
+        self.compare_with_cpu(lambda x: torch.transpose(x, dim0, dim1), x)
 
     def test_transpose_3d_contiguous_cpu(self, dim0: int, dim1: int, x):
         # Note: .contiguous() causes issues with eager mode, see https://github.com/torch-spyre/torch-spyre/issues/1149
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda x: torch.transpose(x, dim0, dim1).contiguous(), x, run_eager=False
         )
 
     def test_transpose_4d_cpu(self, dim0: int, dim1: int, x):
-        compare_with_cpu(lambda x: torch.transpose(x, dim0, dim1), x)
+        self.compare_with_cpu(lambda x: torch.transpose(x, dim0, dim1), x)
 
     def test_transpose_4d_contiguous_cpu(self, dim0: int, dim1: int, x):
         # Note: .contiguous() causes issues with eager mode, see https://github.com/torch-spyre/torch-spyre/issues/1149
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda x: torch.transpose(x, dim0, dim1).contiguous(), x, run_eager=False
         )
 
     def test_where_cpu(self, cond_op, x, y):
         # aten::where.self is not registered for the Spyre backend
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda x, y: torch.where(cond_op(x, y), x, y), x, y, run_eager=False
         )
 
     def test_range_op(self, op, input, min, max, err):
         # aten::clamp is not registered for Spyre eager dispatch; it uses the
         # spyre::clamp custom op which only works inside torch.compile
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda x: op(x, min, max), input, atol=err, rtol=err, run_eager=False
         )
 
@@ -1796,12 +1802,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         # Spyre activation custom ops (e.g. spyre::gelu) have a pass-through
         # implementation that returns None in eager mode; they only work inside
         # torch.compile where the inductor lowering handles them
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda x: op(**kwargs)(x), input, atol=err, rtol=err, run_eager=False
         )
 
     def test_activation_fn(self, op, input, err):
-        compare_with_cpu(lambda x: op(x), input, atol=err, rtol=err)
+        self.compare_with_cpu(lambda x: op(x), input, atol=err, rtol=err)
 
     @pytest.mark.filterwarnings(
         "ignore:Backend Spyre does not support int64:UserWarning"
@@ -1810,16 +1816,16 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         # Eager clone + .cpu() causes heap corruption (invalid fastbin / corrupted
         # double-linked list) in libsenlib for fp16/fp32 small tensors, and SIGBUS
         # for bool tensors.  Disable eager mode for all dtypes.
-        compare_with_cpu(lambda a: torch.clone(a).contiguous(), x, run_eager=False)
+        self.compare_with_cpu(lambda a: torch.clone(a).contiguous(), x, run_eager=False)
 
     def test_permute(self, input_dims, dims):
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda input: torch.permute(input, dims),
             cached_randn(input_dims, dtype=torch.float16),
         )
 
     def test_dropout_functional(self, input, kwargs):
-        compare_with_cpu(lambda a: torch.nn.functional.dropout(a, **kwargs), input)
+        self.compare_with_cpu(lambda a: torch.nn.functional.dropout(a, **kwargs), input)
 
     def test_inplace_op_cpu(self, op, dst, src):
         def fn(dst, src):
@@ -1829,7 +1835,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return result
 
         # Eager mode hangs/crashes when executing inplace operations on Spyre tensors
-        compare_with_cpu(fn, dst, src, run_eager=False)
+        self.compare_with_cpu(fn, dst, src, run_eager=False)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_fallback_cpu(self, x):
@@ -1840,7 +1846,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return t
 
         with pytest.warns(UserWarning) as record:
-            compare_with_cpu(fn, x, cpu_compile=True)
+            self.compare_with_cpu(fn, x, cpu_compile=True)
 
         print(f"Warn {len(record)}")
 
@@ -1849,11 +1855,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         def fn(device=None):
             return torch.arange(*args, dtype=torch.float16, device=device)
 
-        compare_with_cpu(fn, needs_device=True)
+        self.compare_with_cpu(fn, needs_device=True)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_new_ones_cpu(self, x, y):
-        compare_with_cpu(lambda x: x.new_ones((x.size())), x)
+        self.compare_with_cpu(lambda x: x.new_ones((x.size())), x)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_ones_cpu(self, size):
@@ -1862,16 +1868,16 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         def fn(device=None):
             return torch.ones(size, dtype=torch.float16, device=device)
 
-        compare_with_cpu(fn, needs_device=True, cpu_compile=False)
+        self.compare_with_cpu(fn, needs_device=True, cpu_compile=False)
 
     def test_numel_cpu(self, x):
-        compare_with_cpu(lambda x: torch.numel(x), x)
+        self.compare_with_cpu(lambda x: torch.numel(x), x)
 
     def test_cat_cpu(self, dim, *tensors):
         def fn(*tensors):
             return torch.cat(tensors, dim=dim)
 
-        compare_with_cpu(fn, *tensors)
+        self.compare_with_cpu(fn, *tensors)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_pad_cpu(self, x, pad):
@@ -1902,7 +1908,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         def fn(device=None):
             return torch.full(*args, dtype=torch.float16, device=device)
 
-        compare_with_cpu(fn, needs_device=True, cpu_compile=False)
+        self.compare_with_cpu(fn, needs_device=True, cpu_compile=False)
 
     def test_dim_op_cpu(self, op, dim, *args):
         def fn(*args):
@@ -1911,14 +1917,14 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         # Combined ops (exp+squeeze, exp+unsqueeze, add+unsqueeze) fail in eager
         # because the eager exp/add dispatch internally triggers torch.compile on
         # shapes that the Spyre backend compiler cannot handle
-        compare_with_cpu(fn, *args, run_eager=False)
+        self.compare_with_cpu(fn, *args, run_eager=False)
 
     def test_dim_op_cpu_eager(self, op, dim, *args):
         def fn(*args):
             return op(dim, *args)
 
         # Simple dim ops (softmax, squeeze, unsqueeze, sum+squeeze) work in eager
-        compare_with_cpu(fn, *args)
+        self.compare_with_cpu(fn, *args)
 
     def test_attention_cpu(self, *args):
         def fn(q, k, v, sm_scale):
@@ -1928,7 +1934,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         # mm/bmm on Spyre tensors segfaults in libsenlib without the torch.compile
         # execution context that normally initialises the hardware session
-        compare_with_cpu(fn, *args, run_eager=False)
+        self.compare_with_cpu(fn, *args, run_eager=False)
 
     def test_layernorm_cpu(self, input, weight, bias):
         def fn(input, weight, bias):
@@ -1936,14 +1942,14 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 input, input.shape[1:], weight=weight, bias=bias
             )
 
-        compare_with_cpu(fn, input, weight, bias)
+        self.compare_with_cpu(fn, input, weight, bias)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_rmsnorm_cpu(self, x):
         def fn(input):
             return torch.nn.functional.rms_norm(input, [input.shape[-1]], eps=1e-6)
 
-        compare_with_cpu(fn, x)
+        self.compare_with_cpu(fn, x)
 
     def test_softplus_cpu(self, x):
         beta = 1.0
@@ -1952,21 +1958,21 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         def fn(input):
             return torch.nn.functional.softplus(input, beta, threshold)
 
-        compare_with_cpu(fn, x)
+        self.compare_with_cpu(fn, x)
 
     # --- Migrated from test_ops.py ---
 
     def test_copy_roundtrip(self, x):
-        compare_with_cpu(lambda x: x, x)
+        self.compare_with_cpu(lambda x: x, x)
 
     def test_mean_cpu(self, dim, keepdim, x):
-        compare_with_cpu(lambda x: torch.mean(x, dim=dim, keepdim=keepdim), x)
+        self.compare_with_cpu(lambda x: torch.mean(x, dim=dim, keepdim=keepdim), x)
 
     def test_zeros_cpu(self, size):
         def fn(device=None):
             return torch.zeros(*size, dtype=torch.float16, device=device)
 
-        compare_with_cpu(fn, needs_device=True, cpu_compile=False)
+        self.compare_with_cpu(fn, needs_device=True, cpu_compile=False)
 
     def test_fill_scalar_cpu(self, value, x):
         def fn(x):
@@ -1975,11 +1981,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return x
 
         # spyre__fill_scalar crashes with SIGBUS in eager mode
-        compare_with_cpu(fn, x, run_eager=False)
+        self.compare_with_cpu(fn, x, run_eager=False)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_addmm_scaled_cpu(self, alpha, input, mat1, mat2):
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda input, mat1, mat2: torch.addmm(input, mat1, mat2, alpha=alpha),
             input,
             mat1,
@@ -1996,11 +2002,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             torch.addmm(input, mat1, mat2, out=out)
             return out
 
-        compare_with_cpu(fn, input, mat1, mat2, atol=2e-1, rtol=2e-1)
+        self.compare_with_cpu(fn, input, mat1, mat2, atol=2e-1, rtol=2e-1)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_embedding_cpu(self, indices, weight, padding_idx):
-        compare_with_cpu(
+        self.compare_with_cpu(
             lambda indices, weight: torch.nn.functional.embedding(
                 indices, weight, padding_idx=padding_idx
             ),
@@ -2010,7 +2016,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_isin_cpu(self, elements, test_elements):
-        compare_with_cpu(torch.isin, elements, test_elements)
+        self.compare_with_cpu(torch.isin, elements, test_elements)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_isin_out_cpu(self, elements, test_elements):
@@ -2019,7 +2025,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             torch.isin(elements, test_elements, out=out)
             return out
 
-        compare_with_cpu(fn, elements, test_elements)
+        self.compare_with_cpu(fn, elements, test_elements)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_isin_tensor_scalar_cpu(self):
@@ -2106,14 +2112,14 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         def fn(input):
             return torch.tril(input)
 
-        compare_with_cpu(fn, x)
+        self.compare_with_cpu(fn, x)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_triu_cpu(self, x, diagonal):
         def fn(input, diagonal):
             return torch.triu(input, diagonal)
 
-        compare_with_cpu(fn, x, diagonal)
+        self.compare_with_cpu(fn, x, diagonal)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_sdpa_cpu(self, q, k, v, attn_mask, is_causal, enable_gqa):
@@ -2122,7 +2128,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 q, k, v, attn_mask, is_causal=is_causal, enable_gqa=enable_gqa
             )
 
-        compare_with_cpu(fn, q, k, v, attn_mask, is_causal, enable_gqa)
+        self.compare_with_cpu(fn, q, k, v, attn_mask, is_causal, enable_gqa)
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_implicit_loading(self):
@@ -2143,7 +2149,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             def fn(t):
                 return t.item()
 
-            compare_with_cpu(fn, x, cpu_compile=False)
+            self.compare_with_cpu(fn, x, cpu_compile=False)
 
         elif len(args) == 2:
             x, y = args
@@ -2152,7 +2158,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 result = a * b
                 return result.item()
 
-            compare_with_cpu(fn, x, y, cpu_compile=False)
+            self.compare_with_cpu(fn, x, y, cpu_compile=False)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -1,15 +1,20 @@
-import torch
 import functools
 import copy
 import torch_spyre
+import os
+import sys
 
 from torch._dynamo.testing import make_test_cls_with_patches
 
-from .test_inductor_ops import TestOps
-
 import unittest
 
-def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):  # noqa: B902
+_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(_test_dir)
+
+from inductor.test_inductor_ops import TestOps  # noqa: E402
+
+
+def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):
     for name, value in my_cls.__dict__.items():
         if name.startswith("test_"):
             # You cannot copy functions in Python, so we use closures here to
@@ -49,13 +54,15 @@ def make_lx_planning_class(cls):
         cls,
         "LxPlanning",
         "_lx_planning",
-        (torch_spyre._inductor.config, "lx_planning", True)
+        (torch_spyre._inductor.config, "lx_planning", True),
     )
 
 
 LxPlanningTemplate = make_lx_planning_class(TestOps)
 
+
 class LxPlanningTest(unittest.TestCase):
     pass
+
 
 copy_tests(LxPlanningTemplate, LxPlanningTest, "lx_planning")

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -1,5 +1,6 @@
 import functools
 import copy
+import dataclasses
 import torch_spyre
 import os
 import sys
@@ -11,12 +12,20 @@ import unittest
 _test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(_test_dir)
 
-from inductor.test_inductor_ops import TestOps  # noqa: E402
+import inductor.test_inductor_ops  # noqa: E402
+
+
+@dataclasses.dataclass
+class TestFailure:
+    suffixes: tuple[str, ...]
+    is_skip: bool = False
+    __test__: bool = False
 
 
 def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):
     for name, value in my_cls.__dict__.items():
         if name.startswith("test_"):
+            print(name)
             # You cannot copy functions in Python, so we use closures here to
             # create objects with different ids. Otherwise, unittest.skip
             # would modify all methods sharing the same object id. Also, by
@@ -34,6 +43,7 @@ def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):
                 new_test = unittest.expectedFailure(new_test)
 
             tf = test_failures and test_failures.get(name)
+            print("name", name, tf)
             if tf and suffix in tf.suffixes:
                 skip_func = (
                     unittest.skip("Skipped!")
@@ -49,20 +59,57 @@ def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):
         other_cls.is_dtype_supported = my_cls.is_dtype_supported
 
 
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_1d_dim0_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_1d_dim0_three_tensors_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_2d_dim0_diff_size_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_2d_dim0_three_tensors_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_2d_dim1_diff_size_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim0_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim1_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim1_size1_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim2_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim0_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim1_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim2_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim3_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
+
+# xfail by default, set is_skip=True to skip
+test_failures = {
+    "test_cat_1d_dim0": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_1d_dim0_three_tensors": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_2d_dim0_diff_size": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_2d_dim0_three_tensors": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_2d_dim1_diff_size": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_3d_dim0": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_3d_dim1": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_3d_dim1_size1": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_3d_dim2": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_4d_dim0": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_4d_dim1": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_4d_dim2": TestFailure(("lx_planning"), is_skip=True),
+    "test_cat_4d_dim3": TestFailure(("lx_planning"), is_skip=True),
+    "test_activation_fn_mish_fp16": TestFailure(("lx_planning"), is_skip=True),
+    "test_activation_fn_silu_fp16": TestFailure(("lx_planning"), is_skip=True),
+    "test_addmm_out_basic": TestFailure(("lx_planning"), is_skip=True),
+}
+
+
 def make_lx_planning_class(cls):
     return make_test_cls_with_patches(
         cls,
         "LxPlanning",
-        "_lx_planning",
+        "",
         (torch_spyre._inductor.config, "lx_planning", True),
     )
-
-
-LxPlanningTemplate = make_lx_planning_class(TestOps)
 
 
 class LxPlanningTest(unittest.TestCase):
     pass
 
 
-copy_tests(LxPlanningTemplate, LxPlanningTest, "lx_planning")
+copy_tests(
+    make_lx_planning_class(inductor.test_inductor_ops.TestOps),
+    LxPlanningTest,
+    "lx_planning",
+    test_failures,
+)

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -7,6 +7,7 @@ import sys
 import inspect
 import torch
 from torch.utils import _pytree as pytree
+import utils_inductor
 
 from torch._dynamo.testing import make_test_cls_with_patches
 
@@ -17,7 +18,6 @@ sys.path.append(_test_dir)
 
 import inductor.test_inductor_ops  # noqa: E402
 
-import utils_inductor
 
 @dataclasses.dataclass
 class TestFailure:
@@ -49,7 +49,7 @@ def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):
                 new_test = unittest.expectedFailure(new_test)
 
             tf = test_failures and test_failures.get(name)
-            print("name", name, tf)
+            # print("name", name, tf)
             if tf and suffix in tf.suffixes:
                 skip_func = (
                     unittest.skip("Skipped!")
@@ -99,19 +99,43 @@ def make_lx_planning_class(cls):
 class LxPlanningTest(unittest.TestCase):
     def compare_with_cpu(self, fn, *args, **kwargs):
         kwargs["cpu_compile"] = False
+
         @functools.wraps(fn)
         def make_seq_of_ops(*fn_args, **fn_kwargs):
             result = fn(*fn_args, **fn_kwargs)
-            return pytree.tree_map(lambda x: x + x if isinstance(x, torch.Tensor) else x, result)
+            return pytree.tree_map(
+                lambda x: x + x if isinstance(x, torch.Tensor) else x, result
+            )
+
         return utils_inductor.compare_with_cpu(make_seq_of_ops, *args, **kwargs)
 
-    def compare(self, fn, *args, atol=0.0, rtol=0.0, cpu_atol=0.1, cpu_rtol=0.1, needs_device=False):
+    def compare(
+        self,
+        fn,
+        *args,
+        atol=0.0,
+        rtol=0.0,
+        cpu_atol=0.1,
+        cpu_rtol=0.1,
+        needs_device=False,
+    ):
         # utils_inductor.compare spyre with cpu and sendnn, here we skip sendnn
         @functools.wraps(fn)
         def make_seq_of_ops(*fn_args, **fn_kwargs):
             result = fn(*fn_args, **fn_kwargs)
-            return pytree.tree_map(lambda x: x + x if isinstance(x, torch.Tensor) else x, result)
-        return utils_inductor.compare_with_cpu(make_seq_of_ops, *args, atol=cpu_atol, rtol=cpu_rtol, needs_device=needs_device, cpu_compile=False)
+            return pytree.tree_map(
+                lambda x: x + x if isinstance(x, torch.Tensor) else x, result
+            )
+
+        return utils_inductor.compare_with_cpu(
+            make_seq_of_ops,
+            *args,
+            atol=cpu_atol,
+            rtol=cpu_rtol,
+            needs_device=needs_device,
+            cpu_compile=False,
+        )
+
 
 copy_tests(
     make_lx_planning_class(inductor.test_inductor_ops.TestOps),

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -59,20 +59,6 @@ def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):
         other_cls.is_dtype_supported = my_cls.is_dtype_supported
 
 
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_1d_dim0_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_1d_dim0_three_tensors_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_2d_dim0_diff_size_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_2d_dim0_three_tensors_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_2d_dim1_diff_size_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim0_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim1_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim1_size1_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_3d_dim2_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim0_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim1_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim2_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-# FAILED tests/inductor/test_inductor_ops_lx_planning.py::LxPlanningTest::test_cat_4d_dim3_lx_planning - torch._inductor.exc.InductorError: AttributeError: 'NoneType' object has no attribute 'name'
-
 # xfail by default, set is_skip=True to skip
 test_failures = {
     "test_cat_1d_dim0": TestFailure(("lx_planning"), is_skip=True),

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -1,0 +1,61 @@
+import torch
+import functools
+import copy
+import torch_spyre
+
+from torch._dynamo.testing import make_test_cls_with_patches
+
+from .test_inductor_ops import TestOps
+
+import unittest
+
+def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):  # noqa: B902
+    for name, value in my_cls.__dict__.items():
+        if name.startswith("test_"):
+            # You cannot copy functions in Python, so we use closures here to
+            # create objects with different ids. Otherwise, unittest.skip
+            # would modify all methods sharing the same object id. Also, by
+            # using a default argument, we create a copy instead of a
+            # reference. Otherwise, we would lose access to the value.
+
+            @functools.wraps(value)
+            def new_test(self, value=value):
+                return value(self)
+
+            # Copy __dict__ which may contain test metadata
+            new_test.__dict__ = copy.deepcopy(value.__dict__)
+
+            if xfail_prop is not None and hasattr(value, xfail_prop):
+                new_test = unittest.expectedFailure(new_test)
+
+            tf = test_failures and test_failures.get(name)
+            if tf and suffix in tf.suffixes:
+                skip_func = (
+                    unittest.skip("Skipped!")
+                    if tf.is_skip
+                    else unittest.expectedFailure
+                )
+                new_test = skip_func(new_test)
+
+            setattr(other_cls, f"{name}_{suffix}", new_test)
+
+    # Special case convenience routine
+    if hasattr(my_cls, "is_dtype_supported"):
+        other_cls.is_dtype_supported = my_cls.is_dtype_supported
+
+
+def make_lx_planning_class(cls):
+    return make_test_cls_with_patches(
+        cls,
+        "LxPlanning",
+        "_lx_planning",
+        (torch_spyre._inductor.config, "lx_planning", True)
+    )
+
+
+LxPlanningTemplate = make_lx_planning_class(TestOps)
+
+class LxPlanningTest(unittest.TestCase):
+    pass
+
+copy_tests(LxPlanningTemplate, LxPlanningTest, "lx_planning")

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -4,6 +4,9 @@ import dataclasses
 import torch_spyre
 import os
 import sys
+import inspect
+import torch
+from torch.utils import _pytree as pytree
 
 from torch._dynamo.testing import make_test_cls_with_patches
 
@@ -14,6 +17,7 @@ sys.path.append(_test_dir)
 
 import inductor.test_inductor_ops  # noqa: E402
 
+import utils_inductor
 
 @dataclasses.dataclass
 class TestFailure:
@@ -25,7 +29,9 @@ class TestFailure:
 def copy_tests(my_cls, other_cls, suffix, test_failures=None, xfail_prop=None):
     for name, value in my_cls.__dict__.items():
         if name.startswith("test_"):
-            print(name)
+            if "compare" not in inspect.getsource(value):
+                continue
+
             # You cannot copy functions in Python, so we use closures here to
             # create objects with different ids. Otherwise, unittest.skip
             # would modify all methods sharing the same object id. Also, by
@@ -90,8 +96,21 @@ def make_lx_planning_class(cls):
 
 
 class LxPlanningTest(unittest.TestCase):
-    pass
+    def compare_with_cpu(self, fn, *args, **kwargs):
+        kwargs["cpu_compile"] = False
+        @functools.wraps(fn)
+        def make_seq_of_ops(*fn_args, **fn_kwargs):
+            result = fn(*fn_args, **fn_kwargs)
+            return pytree.tree_map(lambda x: x + x if isinstance(x, torch.Tensor) else x, result)
+        return utils_inductor.compare_with_cpu(make_seq_of_ops, *args, **kwargs)
 
+    def compare(self, fn, *args, atol=0.0, rtol=0.0, cpu_atol=0.1, cpu_rtol=0.1, needs_device=False):
+        # utils_inductor.compare spyre with cpu and sendnn, here we skip sendnn
+        @functools.wraps(fn)
+        def make_seq_of_ops(*fn_args, **fn_kwargs):
+            result = fn(*fn_args, **fn_kwargs)
+            return pytree.tree_map(lambda x: x + x if isinstance(x, torch.Tensor) else x, result)
+        return utils_inductor.compare_with_cpu(make_seq_of_ops, *args, atol=cpu_atol, rtol=cpu_rtol, needs_device=needs_device, cpu_compile=False)
 
 copy_tests(
     make_lx_planning_class(inductor.test_inductor_ops.TestOps),

--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -92,6 +92,7 @@ def make_lx_planning_class(cls):
         "LxPlanning",
         "",
         (torch_spyre._inductor.config, "lx_planning", True),
+        (torch_spyre._inductor.config, "allow_all_ops_in_lx_planning", True),
     )
 
 

--- a/tests/inductor/test_torchinductor_opinfo.py
+++ b/tests/inductor/test_torchinductor_opinfo.py
@@ -1,0 +1,57 @@
+import torch
+from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_device_type import (
+    ops,
+    instantiate_device_type_tests,
+    DeviceTypeTestBase,
+    device_type_test_bases,
+)
+from torch.testing._internal.common_methods_invocations import op_db
+
+aten = torch.ops.aten
+
+SPYRE_WHITELIST = {"sum"}
+SPYRE_OPS = [op for op in op_db if op.name in SPYRE_WHITELIST]
+
+SPYRE_DTYPES = {torch.float16}
+
+
+class SpyreTestBase(DeviceTypeTestBase):
+    device_type = "spyre"
+
+
+device_type_test_bases.append(SpyreTestBase)
+
+
+class TestSpyreInductorOpInfo(TestCase):
+    def _get_sample_inputs(self, op, dtype, device="spyre"):
+        """Get sample imputs from OpInfo using reference_inputs for comprehensive coverage."""
+        # Use reference_inputs for more comprehensive test coverage
+        # Falls back to sample_inputs if reference_inputs_func is not defined
+        try:
+            samples = list(op.reference_inputs(device, dtype, requires_grad=False))
+        except Exception:
+            samples = list(op.sample_inputs(device, dtype, requires_grad=False))
+        return samples
+
+    @ops(SPYRE_OPS, allowed_dtypes=SPYRE_DTYPES)
+    def test_single_op(self, dtype, op):
+        aten_op = getattr(aten, op.aten_name)
+        for sample in self._get_sample_inputs(op, dtype):
+            try:
+                # eager
+                # first_op = aten_op(sample.input, *sample.args, **sample.kwargs)
+                continue
+            except Exception:
+                # if eager failed skip this sample
+                continue
+
+            # spyre
+            # second_op = torch.compile(aten_op)(
+            #     sample.input, *sample.args, **sample.kwargs
+            # )
+
+            # self.assertTrue(torch.allclose(first_op, second_op))
+
+
+instantiate_device_type_tests(TestSpyreInductorOpInfo, globals(), only_for=("spyre"))

--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -403,6 +403,7 @@ def _compile_and_run(fn, args, device, backend=None, needs_device=False, compile
     device_kwargs = {"device": device} if needs_device else {}
 
     if compile:
+        print(f"backend {backend}")
         if backend:
             result = torch.compile(fn, backend=backend)(*device_args, **device_kwargs)
         else:

--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -403,7 +403,7 @@ def _compile_and_run(fn, args, device, backend=None, needs_device=False, compile
     device_kwargs = {"device": device} if needs_device else {}
 
     if compile:
-        print(f"backend {backend}")
+        # print(f"backend {backend}")
         if backend:
             result = torch.compile(fn, backend=backend)(*device_args, **device_kwargs)
         else:

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -19,6 +19,8 @@ from torch.utils._config_module import install_config_module
 
 lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
 
+allow_all_ops_in_lx_planning: bool = False
+
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))

--- a/torch_spyre/_inductor/scratchpad.py
+++ b/torch_spyre/_inductor/scratchpad.py
@@ -113,7 +113,7 @@ class ScratchPadAllocator:
             # Decide whether to reuse. For now, only allow ops we've tested successfully.
             # TODO may be able to generalize this decision in buf end-of-life analysis
             in_or_out = "input" if needed["is_input"] else "output"
-            can_reuse = any(
+            can_reuse = config.allow_all_ops_in_lx_planning or any(
                 op in org_op_name for op in OPS_GOOD_FOR_LX_REUSE[in_or_out]
             )
             # Special cases check:


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Copies the tests found in `tests/inductor/test_inductor_ops.TestOps` to `tests/inductor/test_inductor_ops_lx_planning.LxPlanningTest` where the first one uses the default setting for `lx_planning` (`False`) in `torch_spyre._inductor.config` and the later changes it to `True`.

#### Which issue(s) this PR is related to:

Related to https://github.com/torch-spyre/torch-spyre/issues/1207

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
