### PR TITLE
Resolve stick conflicts with automatic restickification

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -59,22 +59,27 @@ SIZES_2D_FULL = [
     (128, 64),
 ]
 
+
 @pytest.fixture(params=SIZES_2D_FULL, ids=lambda p: f"{p[0]}x{p[1]}")
 def tensors_2arg(request):
     s1, s2 = request.param
     return _make_2d_tensors(s1, s2)
 
+
 def test_2arg_at_plus_x(tensors_2arg):
     A, _, X, _ = tensors_2arg
     _compare(lambda a, x: a.t() + x, A, X)
+
 
 def test_2arg_x_plus_at(tensors_2arg):
     A, _, X, _ = tensors_2arg
     _compare(lambda a, x: x + a.t(), A, X)
 
+
 def test_2arg_xt_plus_a(tensors_2arg):
     A, _, X, _ = tensors_2arg
     _compare(lambda a, x: x.t() + a, A, X)
+
 
 def test_2arg_a_plus_xt(tensors_2arg):
     A, _, X, _ = tensors_2arg
@@ -86,38 +91,47 @@ SIZES_2D_SMALL = [
     (256, 128),
 ]
 
+
 @pytest.fixture(params=SIZES_2D_SMALL, ids=lambda p: f"{p[0]}x{p[1]}")
 def tensors_multiarg(request):
     s1, s2 = request.param
     return _make_2d_tensors(s1, s2)
 
+
 def test_3arg_at_bt_x(tensors_multiarg):
     A, B, X, _ = tensors_multiarg
     _compare(lambda a, b, x: a.t() + b.t() + x, A, B, X)
+
 
 def test_3arg_at_x_bt(tensors_multiarg):
     A, B, X, _ = tensors_multiarg
     _compare(lambda a, b, x: a.t() + x + b.t(), A, B, X)
 
+
 def test_3arg_x_at_bt(tensors_multiarg):
     A, B, X, _ = tensors_multiarg
     _compare(lambda a, b, x: x + a.t() + b.t(), A, B, X)
+
 
 def test_3arg_at_x_y(tensors_multiarg):
     A, _, X, Y = tensors_multiarg
     _compare(lambda a, x, y: a.t() + x + y, A, X, Y)
 
+
 def test_4arg_at_bt_x_y(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
     _compare(lambda a, b, x, y: a.t() + b.t() + x + y, A, B, X, Y)
+
 
 def test_4arg_at_x_bt_y(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
     _compare(lambda a, b, x, y: a.t() + x + b.t() + y, A, B, X, Y)
 
+
 def test_4arg_x_at_y_bt(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
     _compare(lambda a, b, x, y: x + a.t() + y + b.t(), A, B, X, Y)
+
 
 def test_4arg_at_x_y_bt(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
@@ -125,10 +139,8 @@ def test_4arg_at_x_y_bt(tensors_multiarg):
 
 
 # 3D tests
-SIZES_3D = [
-    (2, 256, 128), 
-    (4, 128, 64)
-]
+SIZES_3D = [(2, 256, 128), (4, 128, 64)]
+
 
 @pytest.fixture(params=SIZES_3D, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}")
 def tensors_3d(request):
@@ -137,20 +149,20 @@ def tensors_3d(request):
     x = torch.randn((s0, s2, s1), dtype=torch.float16)
     return a, x
 
+
 def test_3d_transpose12_plus_x(tensors_3d):
     a, x = tensors_3d
     _compare(lambda a, x: a.transpose(1, 2) + x, a, x)
+
 
 def test_3d_x_plus_transpose12(tensors_3d):
     a, x = tensors_3d
     _compare(lambda a, x: x + a.transpose(1, 2), a, x)
 
 
-# 4D tests: 
-SIZES_4D = [
-    (2, 256, 3, 128),
-    (2, 128, 4, 64)
-]
+# 4D tests:
+SIZES_4D = [(2, 256, 3, 128), (2, 128, 4, 64)]
+
 
 @pytest.fixture(params=SIZES_4D, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}x{p[3]}")
 def tensors_4d(request):
@@ -159,9 +171,11 @@ def tensors_4d(request):
     x = torch.randn((s0, s3, s2, s1), dtype=torch.float16)
     return a, x
 
+
 def test_4d_transpose13_plus_x(tensors_4d):
     a, x = tensors_4d
     _compare(lambda a, x: a.transpose(1, 3) + x, a, x)
+
 
 def test_4d_x_plus_transpose13(tensors_4d):
     a, x = tensors_4d
@@ -171,6 +185,7 @@ def test_4d_x_plus_transpose13(tensors_4d):
 # Expand tests
 SIZES_EXPAND = [(128, 256)]
 
+
 @pytest.fixture(params=SIZES_EXPAND, ids=lambda p: f"{p[0]}x{p[1]}")
 def tensors_expand(request):
     s0, s1 = request.param
@@ -178,22 +193,25 @@ def tensors_expand(request):
     y = torch.randn((s1, s0), dtype=torch.float16)
     return x, y
 
+
 def test_expand_x_plus_yt_expand(tensors_expand):
     x, y = tensors_expand
     _compare(lambda x, y: x + y.transpose(0, 1).unsqueeze(1).expand(x.shape), x, y)
 
+
 def test_expand_yt_expand_plus_x(tensors_expand):
     x, y = tensors_expand
-    _compare(lambda x, y: y.transpose(0, 1).unsqueeze(1).expand(x.shape) + x, x, y, 
-        check_strides=False     # Stride differes from CPU even before restickify, skipping stride check
-
+    _compare(
+        lambda x, y: y.transpose(0, 1).unsqueeze(1).expand(x.shape) + x,
+        x,
+        y,
+        check_strides=False,  # Stride differes from CPU even before restickify, skipping stride check
     )
 
 
 # 2-arg tests with size-1
-SIZES_4D_SIZE1 = [
-    (128, 256)
-]
+SIZES_4D_SIZE1 = [(128, 256)]
+
 
 @pytest.fixture(params=SIZES_4D_SIZE1, ids=lambda p: f"1x{p[0]}x1x{p[1]}")
 def tensors_size1(request):
@@ -202,9 +220,11 @@ def tensors_size1(request):
     Y = torch.randn((1, s1, 1, s2), dtype=torch.float16)
     return X, Y
 
+
 def test_2arg_size1_x_plus_yt13(tensors_size1):
     X, Y = tensors_size1
     _compare(lambda x, y: x + y.transpose(1, 3), X, Y)
+
 
 def test_2arg_size1_yt13_plus_x(tensors_size1):
     X, Y = tensors_size1
@@ -213,10 +233,8 @@ def test_2arg_size1_yt13_plus_x(tensors_size1):
 
 # ------- Matmul Tests ---------
 
-MATMUL_SIZES = [
-    (128, 256), 
-    (64, 128)
-]
+MATMUL_SIZES = [(128, 256), (64, 128)]
+
 
 @pytest.fixture(params=MATMUL_SIZES, ids=[f"{a}x{b}" for a, b in MATMUL_SIZES])
 def matmul_tensors_ab(request):
@@ -225,6 +243,7 @@ def matmul_tensors_ab(request):
     y = torch.randn((a, b), dtype=torch.float16) * 0.1
     return x, y
 
+
 @pytest.fixture(params=MATMUL_SIZES, ids=[f"{a}x{b}" for a, b in MATMUL_SIZES])
 def matmul_tensors_ab_ba(request):
     a, b = request.param
@@ -232,13 +251,16 @@ def matmul_tensors_ab_ba(request):
     y = torch.randn((b, a), dtype=torch.float16) * 0.1
     return x, y
 
+
 def test_matmul_xt_y(matmul_tensors_ab):
     x, y = matmul_tensors_ab
     _compare(lambda x, y: torch.matmul(x.t(), y), x, y)
 
+
 def test_matmul_x_yt(matmul_tensors_ab):
     x, y = matmul_tensors_ab
     _compare(lambda x, y: torch.matmul(x, y.t()), x, y)
+
 
 def test_matmul_xt_yt(matmul_tensors_ab_ba):
     x, y = matmul_tensors_ab_ba
@@ -249,12 +271,14 @@ def test_matmul_xt_yt(matmul_tensors_ab_ba):
 
 BMM_SIZES = [(3, 128, 64)]
 
+
 @pytest.fixture(params=BMM_SIZES, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}")
 def bmm_tensors_ab(request):
     batch, a, b = request.param
     x = torch.randn((batch, a, b), dtype=torch.float16) * 0.1
     y = torch.randn((batch, a, b), dtype=torch.float16) * 0.1
     return x, y
+
 
 @pytest.fixture(params=BMM_SIZES, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}")
 def bmm_tensors_ab_ba(request):
@@ -263,13 +287,16 @@ def bmm_tensors_ab_ba(request):
     y = torch.randn((batch, b, a), dtype=torch.float16) * 0.1
     return x, y
 
+
 def test_bmm_xt_y(bmm_tensors_ab):
     x, y = bmm_tensors_ab
     _compare(lambda x, y: torch.matmul(x.transpose(1, 2), y), x, y)
 
+
 def test_bmm_x_yt(bmm_tensors_ab):
     x, y = bmm_tensors_ab
     _compare(lambda x, y: torch.matmul(x, y.transpose(1, 2)), x, y)
+
 
 def test_bmm_xt_yt(bmm_tensors_ab_ba):
     x, y = bmm_tensors_ab_ba

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -301,3 +301,24 @@ def test_bmm_x_yt(bmm_tensors_ab):
 def test_bmm_xt_yt(bmm_tensors_ab_ba):
     x, y = bmm_tensors_ab_ba
     _compare(lambda x, y: torch.matmul(x.transpose(1, 2), y.transpose(1, 2)), x, y)
+
+
+# ------- Mutation + restickify regression test ---------
+
+
+def test_bmm_with_inplace_mutation():
+    # Regression test: copy_() creates a mutation_renames chain in the Inductor
+    # scheduler. Combined with a bmm whose weight needs restickifying, this
+    # previously caused a topo-sort cycle when compute_dependencies() was called
+    # a second time inside insert_restickify.
+    B, M, K, N = 1, 8, 64, 64
+    x = torch.randn((B, M, K), dtype=torch.float16)
+    weight = torch.randn((N, K), dtype=torch.float16)
+    cache = torch.zeros((B, M, K), dtype=torch.float16)
+
+    def func(x, weight, cache):
+        cache.copy_(x)
+        return torch.bmm(cache, weight.t().unsqueeze(0).expand(B, -1, -1))
+
+    spyre_result = _compile_and_run(func, (x, weight, cache), DEVICE)
+    compare_with_cpu(func, x, weight, cache, target=spyre_result, run_eager=False)

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -1,0 +1,276 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for restickify insertion in pointwise operations.
+#
+# Restickify is triggered when a transposed (non-contiguous) tensor is used
+# in a pointwise op alongside a contiguous tensor, and the layouts are
+# stick-incompatible. The compiler inserts a restickify kernel to convert
+# the layout before the pointwise op proceeds.
+#
+# Shapes use multiples of 64 (stick size = 64 fp16 elements) to ensure
+# stick-aligned inputs that exercise the restickify path rather than fallback.
+
+import pytest
+import torch
+
+from utils_inductor import _compile_and_run, compare_with_cpu
+
+DEVICE = torch.device("spyre")
+
+
+def _compare(fn, *args, check_strides=True):
+    spyre_result = _compile_and_run(fn, args, DEVICE)
+    compare_with_cpu(fn, *args, target=spyre_result, run_eager=False)
+    if check_strides:
+        cpu_result = fn(*args)
+        assert cpu_result.stride() == spyre_result.stride(), (
+            f"Stride mismatch: CPU {cpu_result.stride()} vs Spyre {spyre_result.stride()}"
+        )
+
+
+def _make_2d_tensors(s1, s2):
+    # A, B: shape [s1, s2]; X, Y: shape [s2, s1]
+    A = torch.randn((s1, s2), dtype=torch.float16)
+    B = torch.randn((s1, s2), dtype=torch.float16)
+    X = torch.randn((s2, s1), dtype=torch.float16)
+    Y = torch.randn((s2, s1), dtype=torch.float16)
+    return A, B, X, Y
+
+
+# -------- Pointwise tests ----------
+
+# 2-arg tests — run on a full set of size pairs
+SIZES_2D_FULL = [
+    (256, 128),
+    (128, 256),
+    (64, 128),
+    (128, 64),
+]
+
+@pytest.fixture(params=SIZES_2D_FULL, ids=lambda p: f"{p[0]}x{p[1]}")
+def tensors_2arg(request):
+    s1, s2 = request.param
+    return _make_2d_tensors(s1, s2)
+
+def test_2arg_at_plus_x(tensors_2arg):
+    A, _, X, _ = tensors_2arg
+    _compare(lambda a, x: a.t() + x, A, X)
+
+def test_2arg_x_plus_at(tensors_2arg):
+    A, _, X, _ = tensors_2arg
+    _compare(lambda a, x: x + a.t(), A, X)
+
+def test_2arg_xt_plus_a(tensors_2arg):
+    A, _, X, _ = tensors_2arg
+    _compare(lambda a, x: x.t() + a, A, X)
+
+def test_2arg_a_plus_xt(tensors_2arg):
+    A, _, X, _ = tensors_2arg
+    _compare(lambda a, x: a + x.t(), A, X)
+
+
+# 3-arg and 4-arg tests — run on a smaller set of size pairs
+SIZES_2D_SMALL = [
+    (256, 128),
+]
+
+@pytest.fixture(params=SIZES_2D_SMALL, ids=lambda p: f"{p[0]}x{p[1]}")
+def tensors_multiarg(request):
+    s1, s2 = request.param
+    return _make_2d_tensors(s1, s2)
+
+def test_3arg_at_bt_x(tensors_multiarg):
+    A, B, X, _ = tensors_multiarg
+    _compare(lambda a, b, x: a.t() + b.t() + x, A, B, X)
+
+def test_3arg_at_x_bt(tensors_multiarg):
+    A, B, X, _ = tensors_multiarg
+    _compare(lambda a, b, x: a.t() + x + b.t(), A, B, X)
+
+def test_3arg_x_at_bt(tensors_multiarg):
+    A, B, X, _ = tensors_multiarg
+    _compare(lambda a, b, x: x + a.t() + b.t(), A, B, X)
+
+def test_3arg_at_x_y(tensors_multiarg):
+    A, _, X, Y = tensors_multiarg
+    _compare(lambda a, x, y: a.t() + x + y, A, X, Y)
+
+def test_4arg_at_bt_x_y(tensors_multiarg):
+    A, B, X, Y = tensors_multiarg
+    _compare(lambda a, b, x, y: a.t() + b.t() + x + y, A, B, X, Y)
+
+def test_4arg_at_x_bt_y(tensors_multiarg):
+    A, B, X, Y = tensors_multiarg
+    _compare(lambda a, b, x, y: a.t() + x + b.t() + y, A, B, X, Y)
+
+def test_4arg_x_at_y_bt(tensors_multiarg):
+    A, B, X, Y = tensors_multiarg
+    _compare(lambda a, b, x, y: x + a.t() + y + b.t(), A, B, X, Y)
+
+def test_4arg_at_x_y_bt(tensors_multiarg):
+    A, B, X, Y = tensors_multiarg
+    _compare(lambda a, b, x, y: a.t() + x + y + b.t(), A, B, X, Y)
+
+
+# 3D tests
+SIZES_3D = [
+    (2, 256, 128), 
+    (4, 128, 64)
+]
+
+@pytest.fixture(params=SIZES_3D, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}")
+def tensors_3d(request):
+    s0, s1, s2 = request.param
+    a = torch.randn((s0, s1, s2), dtype=torch.float16)
+    x = torch.randn((s0, s2, s1), dtype=torch.float16)
+    return a, x
+
+def test_3d_transpose12_plus_x(tensors_3d):
+    a, x = tensors_3d
+    _compare(lambda a, x: a.transpose(1, 2) + x, a, x)
+
+def test_3d_x_plus_transpose12(tensors_3d):
+    a, x = tensors_3d
+    _compare(lambda a, x: x + a.transpose(1, 2), a, x)
+
+
+# 4D tests: 
+SIZES_4D = [
+    (2, 256, 3, 128),
+    (2, 128, 4, 64)
+]
+
+@pytest.fixture(params=SIZES_4D, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}x{p[3]}")
+def tensors_4d(request):
+    s0, s1, s2, s3 = request.param
+    a = torch.randn((s0, s1, s2, s3), dtype=torch.float16)
+    x = torch.randn((s0, s3, s2, s1), dtype=torch.float16)
+    return a, x
+
+def test_4d_transpose13_plus_x(tensors_4d):
+    a, x = tensors_4d
+    _compare(lambda a, x: a.transpose(1, 3) + x, a, x)
+
+def test_4d_x_plus_transpose13(tensors_4d):
+    a, x = tensors_4d
+    _compare(lambda a, x: x + a.transpose(1, 3), a, x)
+
+
+# Expand tests
+SIZES_EXPAND = [(128, 256)]
+
+@pytest.fixture(params=SIZES_EXPAND, ids=lambda p: f"{p[0]}x{p[1]}")
+def tensors_expand(request):
+    s0, s1 = request.param
+    x = torch.randn((s0, s1, s1), dtype=torch.float16)
+    y = torch.randn((s1, s0), dtype=torch.float16)
+    return x, y
+
+def test_expand_x_plus_yt_expand(tensors_expand):
+    x, y = tensors_expand
+    _compare(lambda x, y: x + y.transpose(0, 1).unsqueeze(1).expand(x.shape), x, y)
+
+def test_expand_yt_expand_plus_x(tensors_expand):
+    x, y = tensors_expand
+    _compare(lambda x, y: y.transpose(0, 1).unsqueeze(1).expand(x.shape) + x, x, y, 
+        check_strides=False     # Stride differes from CPU even before restickify, skipping stride check
+
+    )
+
+
+# 2-arg tests with size-1
+SIZES_4D_SIZE1 = [
+    (128, 256)
+]
+
+@pytest.fixture(params=SIZES_4D_SIZE1, ids=lambda p: f"1x{p[0]}x1x{p[1]}")
+def tensors_size1(request):
+    s1, s2 = request.param
+    X = torch.randn((1, s2, 1, s1), dtype=torch.float16)
+    Y = torch.randn((1, s1, 1, s2), dtype=torch.float16)
+    return X, Y
+
+def test_2arg_size1_x_plus_yt13(tensors_size1):
+    X, Y = tensors_size1
+    _compare(lambda x, y: x + y.transpose(1, 3), X, Y)
+
+def test_2arg_size1_yt13_plus_x(tensors_size1):
+    X, Y = tensors_size1
+    _compare(lambda x, y: y.transpose(1, 3) + x, X, Y)
+
+
+# ------- Matmul Tests ---------
+
+MATMUL_SIZES = [
+    (128, 256), 
+    (64, 128)
+]
+
+@pytest.fixture(params=MATMUL_SIZES, ids=[f"{a}x{b}" for a, b in MATMUL_SIZES])
+def matmul_tensors_ab(request):
+    a, b = request.param
+    x = torch.randn((a, b), dtype=torch.float16) * 0.1
+    y = torch.randn((a, b), dtype=torch.float16) * 0.1
+    return x, y
+
+@pytest.fixture(params=MATMUL_SIZES, ids=[f"{a}x{b}" for a, b in MATMUL_SIZES])
+def matmul_tensors_ab_ba(request):
+    a, b = request.param
+    x = torch.randn((a, b), dtype=torch.float16) * 0.1
+    y = torch.randn((b, a), dtype=torch.float16) * 0.1
+    return x, y
+
+def test_matmul_xt_y(matmul_tensors_ab):
+    x, y = matmul_tensors_ab
+    _compare(lambda x, y: torch.matmul(x.t(), y), x, y)
+
+def test_matmul_x_yt(matmul_tensors_ab):
+    x, y = matmul_tensors_ab
+    _compare(lambda x, y: torch.matmul(x, y.t()), x, y)
+
+def test_matmul_xt_yt(matmul_tensors_ab_ba):
+    x, y = matmul_tensors_ab_ba
+    _compare(lambda x, y: torch.matmul(x.t(), y.t()), x, y)
+
+
+# ------- Batched Matmul Tests ---------
+
+BMM_SIZES = [(3, 128, 64)]
+
+@pytest.fixture(params=BMM_SIZES, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}")
+def bmm_tensors_ab(request):
+    batch, a, b = request.param
+    x = torch.randn((batch, a, b), dtype=torch.float16) * 0.1
+    y = torch.randn((batch, a, b), dtype=torch.float16) * 0.1
+    return x, y
+
+@pytest.fixture(params=BMM_SIZES, ids=lambda p: f"{p[0]}x{p[1]}x{p[2]}")
+def bmm_tensors_ab_ba(request):
+    batch, a, b = request.param
+    x = torch.randn((batch, a, b), dtype=torch.float16) * 0.1
+    y = torch.randn((batch, b, a), dtype=torch.float16) * 0.1
+    return x, y
+
+def test_bmm_xt_y(bmm_tensors_ab):
+    x, y = bmm_tensors_ab
+    _compare(lambda x, y: torch.matmul(x.transpose(1, 2), y), x, y)
+
+def test_bmm_x_yt(bmm_tensors_ab):
+    x, y = bmm_tensors_ab
+    _compare(lambda x, y: torch.matmul(x, y.transpose(1, 2)), x, y)
+
+def test_bmm_xt_yt(bmm_tensors_ab_ba):
+    x, y = bmm_tensors_ab_ba
+    _compare(lambda x, y: torch.matmul(x.transpose(1, 2), y.transpose(1, 2)), x, y)

--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -171,28 +171,6 @@ class TestSpyreTensorLayout(TestCase):
             cpu_result, compiled_result, rtol=0.001, atol=0.00001
         )
 
-    def test_add_with_incompatible_mixed_layout_dim_orders(self):
-        """
-        Compiled add where x and y have incompatible device layouts.
-
-        When we implement https://github.com/torch-spyre/torch-spyre/issues/738,
-        this test will be updated to expect cpu_result and compiled_result to be equal.
-        """
-        x = torch.rand(3, 2, 2048, dtype=torch.float16)
-        y = torch.rand(3, 2, 2048, dtype=torch.float16)
-        x_stl = SpyreTensorLayout(x.size(), x.stride(), torch.float16, [1, 0, 2])
-        y_stl = SpyreTensorLayout(x.size(), x.stride(), torch.float16, [2, 1, 0])
-        _ = x.to("spyre")  # required for lazy device initialization
-        x_dev = x.to(device_layout=x_stl)
-        y_dev = y.to(device_layout=y_stl)
-        compiled = torch.compile(torch.add)
-        with self.assertRaises(RuntimeError) as context:
-            _ = compiled(x_dev, y_dev).cpu()
-        self.assertIn(
-            "pointwise op with nonuniform stick indexing",
-            str(context.exception),
-        )
-
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -21,7 +21,6 @@ import torch
 from torch._inductor.ir import (
     ComputedBuffer,
     FallbackKernel,
-    MultiOutput,
     Pointwise,
     Reduction,
 )

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -367,13 +367,12 @@ def core_division_planning(
                 pass
         elif isinstance(n, ExternKernelSchedulerNode):
             if isinstance(n.node, FallbackKernel):
-                n = next(it, None)
-                if not (
-                    isinstance(n, ExternKernelSchedulerNode)
-                    and isinstance(n.node, MultiOutput)
-                ):
-                    raise RuntimeError("FallbackKernel must be followed by MultiOutput")
-
+                # n = next(it, None)
+                # if not (
+                #     isinstance(n, ExternKernelSchedulerNode)
+                #     and isinstance(n.node, MultiOutput)
+                # ):
+                #     raise RuntimeError("FallbackKernel must be followed by MultiOutput")
                 # Core division not supported on fallback kernels
                 pass
             else:

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -219,3 +219,10 @@ def overwrite(
 @overwrite.register_fake
 def _(input: torch.Tensor, output: torch.Tensor, dim: int, offset: int) -> torch.Tensor:
     return output
+
+
+@torch.library.custom_op("spyre::restickify", mutates_args=(), device_types="spyre")
+def restickify(  # type: ignore[empty-body]
+    x: torch.Tensor,
+) -> torch.Tensor:
+    pass

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -479,7 +479,7 @@ def spyre_softplus(
 def spyre_linear(
     input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
 ) -> torch.Tensor:
-    weight = weight.transpose(-1, -2).contiguous()
+    weight = weight.transpose(-1, -2)
     while weight.dim() < input.dim():
         weight = torch.unsqueeze(weight, 0)
     out = input @ weight

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -19,6 +19,7 @@ from torch._inductor.ir import ComputedBuffer, TensorBox
 from torch._inductor.ops_handler import WrapperHandler
 from torch._inductor.scheduler import (
     BaseSchedulerNode,
+    NodeUser,
 )
 from torch._inductor.virtualized import V
 
@@ -119,6 +120,24 @@ def insert_restickify_on_node_inputs(
             scheduler.name_to_buf[buf.get_name()] = buf
         scheduler.nodes.append(restick_sn)
         global_name_map[old_name] = restick_sn.node.name
+
+        # Keep buf.users consistent so downstream passes (fusion, memory planning)
+        # see the correct graph structure without needing to re-run
+        # compute_dependencies().
+        #
+        # Before restickify:  input_buf -> n
+        # After restickify:   input_buf -> restick_sn -> n
+        #
+        # 1. input_buf: replace n as user with restick_sn
+        if old_name in scheduler.name_to_buf:
+            input_buf = scheduler.name_to_buf[old_name]
+            input_buf.users = [
+                u for u in input_buf.users if u.node is not n
+            ]
+            input_buf.users.append(NodeUser(restick_sn, can_inplace=False))
+        # 2. restick output buf: n is its sole user
+        for restick_out_buf in restick_sn.get_outputs():
+            restick_out_buf.users = [NodeUser(n, can_inplace=False)]
 
     # Patch inner_fn once with the full name_map covering all restickified args
     orig_inner = n.node.data.inner_fn

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -1,0 +1,167 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from .logging_utils import get_inductor_logger
+from torch._inductor.ir import ComputedBuffer, TensorBox
+from torch._inductor.ops_handler import WrapperHandler
+from torch._inductor.scheduler import (
+    BaseSchedulerNode,
+)
+from torch._inductor.virtualized import V
+
+from torch.utils._ordered_set import OrderedSet
+
+logger = get_inductor_logger("insert_restickify")
+
+
+class NameSwapHandler(WrapperHandler):
+    def __init__(self, inner, name_map: dict[str, str]):
+        super().__init__(inner)
+        self._name_map = name_map
+
+    def load(self, name, index):
+        return super().load(self._name_map.get(name, name), index)
+
+
+def _create_restickify_node(
+    restick_arg_info: dict, n: BaseSchedulerNode, scheduler
+) -> tuple[str, object]:
+    """
+    Insert one restickify scheduler node for a given incompatible arg specified in restick_arg_info.
+    Restickify nodes will comply with the layout specified in restick_arg_infos.
+
+    Returns (old_buffer_name, new_scheduler_node).
+    """
+    mem_dep = list(n.read_writes.reads)[restick_arg_info["arg_index"]]
+    arg_name = mem_dep.name
+
+    graph_lowering = V.graph
+    fx_graph = graph_lowering.graph
+
+    # View ops (e.g. permute) lower to ReinterpretView with no buffer name, so
+    # they are absent from name_to_users and missing from env. Rebuild from
+    # name_to_users so fetch_args_kwargs_from_env can resolve fx_arg_node.
+    env = {}
+    for tbs in graph_lowering.name_to_users.values():
+        for tb in tbs:
+            tb_fx_node = list(tb.data.origins)[0]
+            env[tb_fx_node] = tb
+    graph_lowering.env.update(env)
+
+    # Find the FX node whose buffer name matches arg_name.
+    # Using arg_index to index origin_node.args is fragile since FX args include
+    # scalars/constants that don't appear in read_writes.reads.
+    fx_arg_node = next(
+        fx_node
+        for fx_node, tb in graph_lowering.env.items()
+        if isinstance(fx_node, torch.fx.Node)
+        and isinstance(tb, TensorBox)
+        and tb.get_name() == arg_name
+    )
+    # Insert before the first computation node so the restickify node
+    # precedes all potential consumers in the graph node list.
+    first_compute_node = next(n2 for n2 in fx_graph.nodes if n2.op != "placeholder")
+    with fx_graph.inserting_before(first_compute_node):
+        restick_fx_node = fx_graph.create_node(
+            "call_function", torch.ops.spyre.restickify, (fx_arg_node,)
+        )
+    # Lower via run_node — handles buffer registration automatically
+    restick_tb = graph_lowering.run_node(restick_fx_node)
+    restick_buff = restick_tb.data.data  # TensorBox -> StorageBox -> ComputedBuffer
+    assert isinstance(restick_buff, ComputedBuffer), (
+        f"Expected ComputedBuffer, got {type(restick_buff).__name__}"
+    )
+    # restick_fx_node is synthetically created post-lowering and has no ATen metadata.
+    # Restickify runs before any view op on the arg, so there is no ATen op to
+    # attribute it to. Leave origins as just restick_fx_node — the comment will show [].
+    restick_buff.origins = OrderedSet([restick_fx_node])
+    graph_lowering.env[restick_fx_node] = restick_tb
+
+    restick_sn = scheduler.create_scheduler_node(restick_buff)
+    restick_sn.node.layout = restick_arg_info["target_layout"]
+    ComputedBuffer.get_default_sizes_body.clear_cache(restick_sn.node)
+    restick_sn._compute_attrs()
+
+    return arg_name, restick_sn
+
+
+def insert_restickify_on_node_inputs(
+    n: BaseSchedulerNode, restick_infos: list[dict], scheduler
+) -> None:
+    """Create a restickify node for each incompatible input arg of node n.
+    Use NameSwapHandler to patch n's inner_fn to use the new buffer names instead of
+    original input buffers.
+    """
+    name_map = {}
+
+    for restick_arg_info in restick_infos:
+        old_name, restick_sn = _create_restickify_node(restick_arg_info, n, scheduler)
+        name_map[old_name] = restick_sn.node.name
+
+        for buf in restick_sn.get_outputs():
+            scheduler.name_to_buf[buf.get_name()] = buf
+        scheduler.nodes.append(restick_sn)
+
+    # Patch inner_fn once with the full name_map covering all restickified args
+    orig_inner = n.node.data.inner_fn
+
+    def new_inner_fn(*args, _map=name_map, _orig_inner=orig_inner):
+        with V.set_ops_handler(NameSwapHandler(V.ops, _map)):
+            return _orig_inner(*args)
+
+    object.__setattr__(n.node.data, "inner_fn", new_inner_fn)
+
+    # Rebuilding ComputedBuffer around patched inner_fn to reduce
+    # number of internal datastructures that need to be hacked
+    new_consumer_buffer = ComputedBuffer(
+        name=n.node.name,
+        layout=n.node.layout,
+        data=n.node.data,
+        _split_size=n.node._split_size,
+        _original_inner_fn=n.node._original_inner_fn,
+        _original_ranges=n.node._original_ranges,
+        _original_reduction_ranges=n.node._original_reduction_ranges,
+    )
+    new_consumer_buffer.operation_name = n.node.operation_name
+    new_consumer_buffer.origins = n.node.origins
+    n.node = new_consumer_buffer
+
+    # Recompute internal metadata including read/write dependencies based on new inner_fn
+    ComputedBuffer.get_default_sizes_body.clear_cache(n.node)
+    n._compute_attrs()
+
+
+def insert_restickify(
+    nodes: list[BaseSchedulerNode], restick_needed: dict
+) -> list[BaseSchedulerNode]:
+    """
+    Insert restickify(ies) before all nodes in restick_needed.
+    """
+    scheduler = V.graph.scheduler
+    for n in list(nodes):  # copy because loop updates scheduler.nodes
+        if n in restick_needed:
+            insert_restickify_on_node_inputs(n, restick_needed[n], scheduler)
+
+    scheduler.compute_dependencies()
+    scheduler.name_to_fused_node = {n.get_name(): n for n in scheduler.nodes}
+
+    # Can maybe skip sorting if new_sn was inserted in the correct spot to
+    # maintain topological order, but safer to just re-sort
+    sorted_order = scheduler._topological_sort_nodes()
+    scheduler.nodes = [node for group in sorted_order for node in group]
+    scheduler.compute_ancestors()
+
+    return scheduler.nodes

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -99,7 +99,7 @@ def _create_restickify_node(
     restick_sn.node.layout = restick_arg_info["target_layout"]
     ComputedBuffer.get_default_sizes_body.clear_cache(restick_sn.node)
     restick_sn._compute_attrs()
-    
+
     return arg_name, restick_sn
 
 
@@ -131,9 +131,7 @@ def insert_restickify_on_node_inputs(
         # 1. input_buf: replace n as user with restick_sn
         if old_name in scheduler.name_to_buf:
             input_buf = scheduler.name_to_buf[old_name]
-            input_buf.users = [
-                u for u in input_buf.users if u.node is not n
-            ]
+            input_buf.users = [u for u in input_buf.users if u.node is not n]
             input_buf.users.append(NodeUser(restick_sn, can_inplace=False))
         # 2. restick output buf: n is its sole user
         for restick_out_buf in restick_sn.get_outputs():
@@ -182,14 +180,16 @@ def insert_restickify(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     global_name_map: dict[str, str] = {}
     for n in list(nodes):  # copy because loop updates scheduler.nodes
         if n in restickify_plan:
-            insert_restickify_on_node_inputs(n, restickify_plan[n], scheduler, global_name_map)
+            insert_restickify_on_node_inputs(
+                n, restickify_plan[n], scheduler, global_name_map
+            )
 
     # Do NOT call scheduler.compute_dependencies() again. It already ran in
     # Scheduler.__init__ and left unmet_dependencies with mutation-renamed buffer
-    # names (e.g. buf18 already renamed to buf20 happens for Granite). Re-running it 
-    # applies those renames again, making nodes appear to read their own 
-    # output → topo-sort cycle. Instead, update unmet_dependencies incrementally 
-    # via prune_deps() (for new restickify nodes) and manual dep-swapping (for 
+    # names (e.g. buf18 already renamed to buf20 happens for Granite). Re-running it
+    # applies those renames again, making nodes appear to read their own
+    # output → topo-sort cycle. Instead, update unmet_dependencies incrementally
+    # via prune_deps() (for new restickify nodes) and manual dep-swapping (for
     # patched consumer nodes).
     for node in scheduler.nodes:
         node.prune_deps()
@@ -198,13 +198,18 @@ def insert_restickify(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     for n in list(nodes):
         if n in restickify_plan:
             from torch._inductor.dependencies import MemoryDep, StarDep
+
             new_unmet = OrderedSet()
             for dep in n.unmet_dependencies:
                 if dep.name in global_name_map:
                     # Replace with a dep on the restickify buffer
                     new_name = global_name_map[dep.name]
                     if isinstance(dep, MemoryDep):
-                        new_unmet.add(MemoryDep(new_name, dep.index, dep.var_names, dep.size, dep.mode))
+                        new_unmet.add(
+                            MemoryDep(
+                                new_name, dep.index, dep.var_names, dep.size, dep.mode
+                            )
+                        )
                     else:
                         new_unmet.add(StarDep(new_name))
                 else:
@@ -214,9 +219,7 @@ def insert_restickify(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     # Update name_to_fused_node to include the newly inserted restickify nodes.
     # The scheduler set this during __init__ before our pass ran, so the new nodes
     # are absent and _get_unmet_dep_nodes will KeyError without this update.
-    scheduler.name_to_fused_node.update(
-        {n.get_name(): n for n in scheduler.nodes}
-    )
+    scheduler.name_to_fused_node.update({n.get_name(): n for n in scheduler.nodes})
 
     sorted_order = scheduler._topological_sort_nodes()
     scheduler.nodes = [node for group in sorted_order for node in group]

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -27,10 +27,9 @@ from torch.utils._ordered_set import OrderedSet
 logger = get_inductor_logger("insert_restickify")
 
 
-
 class NameSwapHandler(WrapperHandler):
     """
-    Wrapper to patch a node's inner_fn to use new buffer names after inserting 
+    Wrapper to patch a node's inner_fn to use new buffer names after inserting
     nodes upstream that change the input buffers.
     """
 
@@ -106,8 +105,7 @@ def _create_restickify_node(
 def insert_restickify_on_node_inputs(
     n: BaseSchedulerNode, resticks_needed: list[dict], scheduler
 ) -> None:
-    """Create a restickify node for each incompatible input arg of node n.
-    """
+    """Create a restickify node for each incompatible input arg of node n."""
     name_map = {}
 
     for restick_arg_info in resticks_needed:

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -27,7 +27,13 @@ from torch.utils._ordered_set import OrderedSet
 logger = get_inductor_logger("insert_restickify")
 
 
+
 class NameSwapHandler(WrapperHandler):
+    """
+    Wrapper to patch a node's inner_fn to use new buffer names after inserting 
+    nodes upstream that change the input buffers.
+    """
+
     def __init__(self, inner, name_map: dict[str, str]):
         super().__init__(inner)
         self._name_map = name_map
@@ -51,9 +57,9 @@ def _create_restickify_node(
     graph_lowering = V.graph
     fx_graph = graph_lowering.graph
 
-    # View ops (e.g. permute) lower to ReinterpretView with no buffer name, so
-    # they are absent from name_to_users and missing from env. Rebuild from
-    # name_to_users so fetch_args_kwargs_from_env can resolve fx_arg_node.
+    # View ops (e.g. permute) lower to ReinterpretView with no buffer name and
+    # are absent from env. Patch env from name_to_users so the search below can
+    # resolve them.
     env = {}
     for tbs in graph_lowering.name_to_users.values():
         for tb in tbs:
@@ -61,9 +67,9 @@ def _create_restickify_node(
             env[tb_fx_node] = tb
     graph_lowering.env.update(env)
 
-    # Find the FX node whose buffer name matches arg_name.
-    # Using arg_index to index origin_node.args is fragile since FX args include
-    # scalars/constants that don't appear in read_writes.reads.
+    # Search by buffer name rather than arg_index: FX args include scalars and
+    # constants that don't appear in read_writes.reads, making index-based lookup
+    # unreliable.
     fx_arg_node = next(
         fx_node
         for fx_node, tb in graph_lowering.env.items()
@@ -71,22 +77,21 @@ def _create_restickify_node(
         and isinstance(tb, TensorBox)
         and tb.get_name() == arg_name
     )
-    # Insert before the first computation node so the restickify node
-    # precedes all potential consumers in the graph node list.
+    # Insert at a valid position in the FX graph; scheduling order is determined
+    # by the topological sort in insert_restickify, not by position here.
     first_compute_node = next(n2 for n2 in fx_graph.nodes if n2.op != "placeholder")
     with fx_graph.inserting_before(first_compute_node):
         restick_fx_node = fx_graph.create_node(
             "call_function", torch.ops.spyre.restickify, (fx_arg_node,)
         )
-    # Lower via run_node — handles buffer registration automatically
+    # Lower the FX node; run_node lowers and registers the output buffer in graph.buffers.
     restick_tb = graph_lowering.run_node(restick_fx_node)
     restick_buff = restick_tb.data.data  # TensorBox -> StorageBox -> ComputedBuffer
     assert isinstance(restick_buff, ComputedBuffer), (
         f"Expected ComputedBuffer, got {type(restick_buff).__name__}"
     )
-    # restick_fx_node is synthetically created post-lowering and has no ATen metadata.
-    # Restickify runs before any view op on the arg, so there is no ATen op to
-    # attribute it to. Leave origins as just restick_fx_node — the comment will show [].
+    # Synthetic node with no corresponding ATen op; set origins to the synthetic
+    # FX node so code that expects non-empty origins doesn't crash.
     restick_buff.origins = OrderedSet([restick_fx_node])
     graph_lowering.env[restick_fx_node] = restick_tb
 
@@ -102,8 +107,6 @@ def insert_restickify_on_node_inputs(
     n: BaseSchedulerNode, resticks_needed: list[dict], scheduler
 ) -> None:
     """Create a restickify node for each incompatible input arg of node n.
-    Use NameSwapHandler to patch n's inner_fn to use the new buffer names instead of
-    original input buffers.
     """
     name_map = {}
 
@@ -124,8 +127,7 @@ def insert_restickify_on_node_inputs(
 
     object.__setattr__(n.node.data, "inner_fn", new_inner_fn)
 
-    # Rebuilding ComputedBuffer around patched inner_fn to reduce
-    # number of internal datastructures that need to be hacked
+    # Reconstruct ComputedBuffer so internal caches see the patched inner_fn.
     new_consumer_buffer = ComputedBuffer(
         name=n.node.name,
         layout=n.node.layout,
@@ -161,8 +163,6 @@ def insert_restickify(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
     scheduler.compute_dependencies()
     scheduler.name_to_fused_node = {n.get_name(): n for n in scheduler.nodes}
 
-    # Can maybe skip sorting if new_sn was inserted in the correct spot to
-    # maintain topological order, but safer to just re-sort
     sorted_order = scheduler._topological_sort_nodes()
     scheduler.nodes = [node for group in sorted_order for node in group]
     scheduler.compute_ancestors()

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -98,12 +98,15 @@ def _create_restickify_node(
     restick_sn.node.layout = restick_arg_info["target_layout"]
     ComputedBuffer.get_default_sizes_body.clear_cache(restick_sn.node)
     restick_sn._compute_attrs()
-
+    
     return arg_name, restick_sn
 
 
 def insert_restickify_on_node_inputs(
-    n: BaseSchedulerNode, resticks_needed: list[dict], scheduler
+    n: BaseSchedulerNode,
+    resticks_needed: list[dict],
+    scheduler,
+    global_name_map: dict[str, str],
 ) -> None:
     """Create a restickify node for each incompatible input arg of node n."""
     name_map = {}
@@ -115,6 +118,7 @@ def insert_restickify_on_node_inputs(
         for buf in restick_sn.get_outputs():
             scheduler.name_to_buf[buf.get_name()] = buf
         scheduler.nodes.append(restick_sn)
+        global_name_map[old_name] = restick_sn.node.name
 
     # Patch inner_fn once with the full name_map covering all restickified args
     orig_inner = n.node.data.inner_fn
@@ -154,12 +158,46 @@ def insert_restickify(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]
         return nodes
 
     scheduler = V.graph.scheduler
+
+    # name_map accumulated across all restickify insertions: old_buf -> restick_buf
+    global_name_map: dict[str, str] = {}
     for n in list(nodes):  # copy because loop updates scheduler.nodes
         if n in restickify_plan:
-            insert_restickify_on_node_inputs(n, restickify_plan[n], scheduler)
+            insert_restickify_on_node_inputs(n, restickify_plan[n], scheduler, global_name_map)
 
-    scheduler.compute_dependencies()
-    scheduler.name_to_fused_node = {n.get_name(): n for n in scheduler.nodes}
+    # Do NOT call scheduler.compute_dependencies() again. It already ran in
+    # Scheduler.__init__ and left unmet_dependencies with mutation-renamed buffer
+    # names (e.g. buf18 already renamed to buf20 happens for Granite). Re-running it 
+    # applies those renames again, making nodes appear to read their own 
+    # output → topo-sort cycle. Instead, update unmet_dependencies incrementally 
+    # via prune_deps() (for new restickify nodes) and manual dep-swapping (for 
+    # patched consumer nodes).
+    for node in scheduler.nodes:
+        node.prune_deps()
+
+    # Patch unmet_dependencies on consumer nodes: swap old read deps for restickify deps.
+    for n in list(nodes):
+        if n in restickify_plan:
+            from torch._inductor.dependencies import MemoryDep, StarDep
+            new_unmet = OrderedSet()
+            for dep in n.unmet_dependencies:
+                if dep.name in global_name_map:
+                    # Replace with a dep on the restickify buffer
+                    new_name = global_name_map[dep.name]
+                    if isinstance(dep, MemoryDep):
+                        new_unmet.add(MemoryDep(new_name, dep.index, dep.var_names, dep.size, dep.mode))
+                    else:
+                        new_unmet.add(StarDep(new_name))
+                else:
+                    new_unmet.add(dep)
+            n.unmet_dependencies = new_unmet
+
+    # Update name_to_fused_node to include the newly inserted restickify nodes.
+    # The scheduler set this during __init__ before our pass ran, so the new nodes
+    # are absent and _get_unmet_dep_nodes will KeyError without this update.
+    scheduler.name_to_fused_node.update(
+        {n.get_name(): n for n in scheduler.nodes}
+    )
 
     sorted_order = scheduler._topological_sort_nodes()
     scheduler.nodes = [node for group in sorted_order for node in group]

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -99,7 +99,7 @@ def _create_restickify_node(
 
 
 def insert_restickify_on_node_inputs(
-    n: BaseSchedulerNode, restick_infos: list[dict], scheduler
+    n: BaseSchedulerNode, resticks_needed: list[dict], scheduler
 ) -> None:
     """Create a restickify node for each incompatible input arg of node n.
     Use NameSwapHandler to patch n's inner_fn to use the new buffer names instead of
@@ -107,7 +107,7 @@ def insert_restickify_on_node_inputs(
     """
     name_map = {}
 
-    for restick_arg_info in restick_infos:
+    for restick_arg_info in resticks_needed:
         old_name, restick_sn = _create_restickify_node(restick_arg_info, n, scheduler)
         name_map[old_name] = restick_sn.node.name
 
@@ -144,16 +144,19 @@ def insert_restickify_on_node_inputs(
     n._compute_attrs()
 
 
-def insert_restickify(
-    nodes: list[BaseSchedulerNode], restick_needed: dict
-) -> list[BaseSchedulerNode]:
+def insert_restickify(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     """
-    Insert restickify(ies) before all nodes in restick_needed.
+    Insert restickify(ies) before all nodes in restickify_plan
     """
+
+    restickify_plan = getattr(V.graph, "restickify_plan", {})
+    if not restickify_plan:
+        return nodes
+
     scheduler = V.graph.scheduler
     for n in list(nodes):  # copy because loop updates scheduler.nodes
-        if n in restick_needed:
-            insert_restickify_on_node_inputs(n, restick_needed[n], scheduler)
+        if n in restickify_plan:
+            insert_restickify_on_node_inputs(n, restickify_plan[n], scheduler)
 
     scheduler.compute_dependencies()
     scheduler.name_to_fused_node = {n.get_name(): n for n in scheduler.nodes}

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 
 import torch
 
-from torch._inductor.ir import ComputedBuffer, Reduction, Pointwise
+from torch._inductor.ir import ComputedBuffer, Reduction, Pointwise, StorageBox
 import torch._inductor.lowering as lowering
 
 from typing import Any, Callable, Union
@@ -31,6 +31,7 @@ from .errors import Unsupported
 import threading
 from .logging_utils import get_inductor_logger
 import logging
+
 
 logger = get_inductor_logger("lowering")
 
@@ -541,3 +542,29 @@ def lower_overwrite(input, output, dim, offset):
     V.graph.register_operation(buffer)
 
     return output
+
+
+@register_spyre_lowering(torch.ops.spyre.restickify)
+def lower_restickify(x):
+    # Restickify must operate on base tenors, so we need
+    # to unwrap any views.
+    base = x
+    while not isinstance(base, StorageBox):
+        base = base.data
+
+    loader = base.make_loader()
+
+    def inner_fn(index):
+        return loader(index)
+
+    pw = Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=base.get_size(),
+        origin_node=V.get_current_node(),
+        traceback=x.get_traceback(),
+    )
+
+    pw.realize()
+    return pw

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -136,21 +136,15 @@ class CustomPreFusionPasses(CustomNodePassBase):
     The returned list of nodes must also be in topological order.
     """
 
-<<<<<<< HEAD
     def get_passes(self):
-        passes = [propagate_spyre_tensor_layouts, core_division_planning]
+        passes = [
+            propagate_spyre_tensor_layouts,
+            insert_restickify,
+            core_division_planning,
+        ]
         if config.lx_planning:
             passes.append(scratchpad_planning)
         return passes
-=======
-    nodes, restickify_plan = propagate_spyre_tensor_layouts(nodes)
-    if restickify_plan:
-        nodes = insert_restickify(nodes, restickify_plan)
-    nodes = core_division_planning(nodes)
-    if os.environ.get("LX_PLANNING", "0") == "1":
-        nodes = scratchpad_planning(nodes)
-    return nodes
->>>>>>> c885068 (Implement restickify feature)
 
 
 class CustomPostFusionPasses(CustomNodePassBase):

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -27,7 +27,6 @@ from torch._inductor.scheduler import BaseSchedulerNode
 from .temp_passes import (
     bmm_unflatten_pass,
     mm_to_bmm_pass,
-    relayout_linear_weights,
     replace_scalar_with_tensor,
 )
 from .stickify import propagate_spyre_tensor_layouts
@@ -36,6 +35,7 @@ from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
 from . import config
+from .insert_restickify import insert_restickify
 
 
 def _maybe_run_graph_pass(pass_fn, graph: torch.fx.graph.Graph) -> None:
@@ -82,7 +82,6 @@ class CustomPostPasses(CustomGraphPass):
     """
     passes: List[Callable[[torch.fx.graph.Graph], None]] = [
         replace_scalar_with_tensor,
-        relayout_linear_weights,
         mm_to_bmm_pass.apply,
         bmm_unflatten_pass.apply,
     ]
@@ -137,11 +136,21 @@ class CustomPreFusionPasses(CustomNodePassBase):
     The returned list of nodes must also be in topological order.
     """
 
+<<<<<<< HEAD
     def get_passes(self):
         passes = [propagate_spyre_tensor_layouts, core_division_planning]
         if config.lx_planning:
             passes.append(scratchpad_planning)
         return passes
+=======
+    nodes, restickify_plan = propagate_spyre_tensor_layouts(nodes)
+    if restickify_plan:
+        nodes = insert_restickify(nodes, restickify_plan)
+    nodes = core_division_planning(nodes)
+    if os.environ.get("LX_PLANNING", "0") == "1":
+        nodes = scratchpad_planning(nodes)
+    return nodes
+>>>>>>> c885068 (Implement restickify feature)
 
 
 class CustomPostFusionPasses(CustomNodePassBase):

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import logging
+from typing import Any
 
-
+import sympy
 import torch
 from .logging_utils import get_inductor_logger
 from torch._inductor.ir import (
@@ -52,6 +53,7 @@ from .pass_utils import (
 )
 from .views import matching_dim
 
+
 logger = get_inductor_logger("stickify")
 
 aten = torch.ops.aten
@@ -62,7 +64,166 @@ def same_device_size(t1: torch.dtype, t2: torch.dtype) -> bool:
     return get_elem_in_stick(t1) == get_elem_in_stick(t2)
 
 
-def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLayout:
+def restickify_device_size(
+    old_device_size: list,
+    idc: list,
+    old_stick_expr,
+    target_stick_expr,
+    host_size: list,
+    old_sd: int,
+    new_sd: int,
+    stick_size: int = 64,
+) -> list:
+    """Compute device_size for a restickify by swapping old_stick_expr with target_stick_expr.
+
+    Uses idc coordinate expressions to identify which device dims cover old_sd vs new_sd:
+    - Last device dim (stick): size is always stick_size
+    - Dims involving old_var (outer stick): size becomes host_size[new_sd] // stick_size
+    - Dims involving new_var (non-stick for new_sd): size becomes host_size[old_sd]
+    - Constant zero (degenerate outer stick when host_size[old_sd] == stick_size): host_size[new_sd] // stick_size
+    All other dims are unchanged.
+    """
+    old_var = next(iter(old_stick_expr.free_symbols))
+    new_var = next(iter(target_stick_expr.free_symbols))
+    # Detect whether there is an explicit outer-stick dim for old_var in idc (any non-last dim
+    # containing old_var). If not, old_sd fits in one stick (host_size[old_sd] <= stick_size)
+    # and any size-1 placeholder adjacent to the new_var dim should absorb the new outer stick.
+    has_old_outer_stick = any(
+        old_var in idc[j].free_symbols for j in range(len(idc) - 1)
+    )
+    result = []
+    for j, coord in enumerate(idc):
+        if j == len(idc) - 1:
+            # Last device dim is always the stick, size is always stick_size.
+            result.append(stick_size)
+            print(f"  device_size[{j}]: last(stick) -> {stick_size}")
+        elif old_var in coord.free_symbols:
+            result.append(host_size[new_sd] // stick_size)
+        elif new_var in coord.free_symbols:
+            result.append(host_size[old_sd])
+        elif coord == sympy.S.Zero and old_device_size[j] != 1:
+            # Degenerate outer stick: host_size[old_sd] == stick_size so floor(var/stick_size) == 0.
+            # Distinguished from size-1 host dims (which also produce coord==0) by device_size[j] != 1.
+            result.append(host_size[new_sd] // stick_size)
+        elif coord == sympy.S.Zero and old_device_size[j] == 1 and not has_old_outer_stick and host_size[new_sd] > stick_size:
+            # Size-1 placeholder that should absorb the new outer stick when old_sd fits in one
+            # stick (no explicit floor(old_var/stick) dim) but new_sd requires tiling.
+            result.append(host_size[new_sd] // stick_size)
+        else:
+            result.append(old_device_size[j])
+    return result
+
+
+def restickify_stride_map(
+    old_stride_map: list,
+    old_device_size: list,
+    idc: list,
+    old_stick_expr,
+    target_stick_expr,
+    host_size: list,
+    host_stride: list,
+    old_sd: int,
+    new_sd: int,
+    stick_size: int = 64,
+) -> list:
+    """Compute stride_map for a restickify by swapping old_stick_expr with target_stick_expr.
+
+    Uses idc coordinate expressions to identify which device dims cover old_sd vs new_sd,
+    then rescales their stride_map values by host_stride[new_sd] / host_stride[old_sd]
+    and vice versa. All other dims are unchanged.
+    """
+    old_var = next(iter(old_stick_expr.free_symbols))
+    new_var = next(iter(target_stick_expr.free_symbols))
+    has_old_outer_stick = any(
+        old_var in idc[j].free_symbols for j in range(len(idc) - 1)
+    )
+    result = []
+    for j, coord in enumerate(idc):
+        if j == len(idc) - 1:
+            # Last device dim is always the stick; stride_map is the host stride of new_sd.
+            result.append(host_stride[new_sd])
+        elif old_var in coord.free_symbols:
+            result.append(old_stride_map[j] * host_stride[new_sd] // host_stride[old_sd])
+        elif new_var in coord.free_symbols:
+            result.append(old_stride_map[j] * host_stride[old_sd] // host_stride[new_sd])
+        elif coord == sympy.S.Zero and old_device_size[j] != 1:
+            # Degenerate outer stick: host_size[old_sd] == stick_size so floor(var/stick_size) == 0.
+            result.append(old_stride_map[j] * host_stride[new_sd] // host_stride[old_sd])
+        elif coord == sympy.S.Zero and old_device_size[j] == 1 and not has_old_outer_stick and host_size[new_sd] > stick_size:
+            # Size-1 placeholder absorbing the new outer stick.
+            result.append(host_stride[new_sd] * stick_size)
+        else:
+            result.append(old_stride_map[j])
+    return result
+
+
+def schedule_restickify(
+    n: SchedulerNode,
+    arg: SchedNodeArg,
+    arg_i: int,
+    target_stick_expr,
+    ic: list,
+    idc: list,
+    restickify_plan: dict,
+) -> None:
+    """Record a restickify needed for arg to match target_stick_expr.
+
+    Computes the target FixedTiledLayout by replacing the current stick
+    coordinate expression with target_stick_expr in the device layout, then
+    appends an entry to restickify_plan[n] for the insert_restickify pass to act on.
+    """
+    dl = arg.layout.device_layout
+    new_sd = matching_dim(ic, target_stick_expr)
+    assert new_sd is not None, (
+        f"Could not find a host dimension matching stick expr {target_stick_expr} in {ic}"
+    )
+    host_size = list(arg.layout.size)
+    host_stride = list(arg.layout.stride)
+    old_sd = dl.dim_map[-1]
+    old_stick_expr = idc[-1]
+    old_stride_map = list(dl.stride_map)
+
+    var_ranges = dict(arg.dep.ranges)
+    print(f"schedule_restickify arg{arg_i}:")
+    print(f"  host_size={host_size} host_stride={host_stride}")
+    print(f"  var_ranges={var_ranges}")
+    print(f"  ic={ic}")
+    print(f"  idc={idc}")
+    print(f"  old_stick_expr={old_stick_expr}  target_stick_expr={target_stick_expr}")
+    print(f"  old_sd={old_sd} (host_size[old_sd]={host_size[old_sd]}, host_stride[old_sd]={host_stride[old_sd]})")
+    print(f"  new_sd={new_sd} (host_size[new_sd]={host_size[new_sd]}, host_stride[new_sd]={host_stride[new_sd]})")
+    print(f"  before: device_size={list(dl.device_size)} dim_map={list(dl.dim_map)} stride_map={old_stride_map}")
+
+    # dim_map is kept for legacy reasons but is not used to derive device_size or stride_map.
+    new_dim_map = [
+        new_sd if x == old_sd else old_sd if x == new_sd else x
+        for x in dl.dim_map
+    ]
+    device_size = restickify_device_size(
+        list(dl.device_size), idc, old_stick_expr, target_stick_expr,
+        host_size, old_sd, new_sd,
+    )
+    stride_map = restickify_stride_map(
+        old_stride_map, list(dl.device_size), idc, old_stick_expr, target_stick_expr,
+        host_size, host_stride, old_sd, new_sd,
+    )
+
+    print(f"  after:  device_size={device_size} dim_map={new_dim_map} stride_map={stride_map}")
+
+    stl = SpyreTensorLayout(device_size, new_dim_map, stride_map, dl.device_dtype)
+
+    target_layout = FixedTiledLayout(
+        arg.layout.device, arg.layout.dtype, arg.layout.size, arg.layout.stride, stl
+    )
+    restickify_plan.setdefault(n, []).append(
+        {"arg_index": arg_i, "target_layout": target_layout}
+    )
+    return target_layout
+
+
+def pointwise_layout(
+    n: SchedulerNode, args: list[SchedNodeArg], restickify_plan: dict
+) -> FixedTiledLayout:
     pw: Pointwise = n.node.data
     output: FixedLayout = n.node.get_layout()
     output_dep = next(iter(n.read_writes.writes))
@@ -162,12 +323,22 @@ def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
         for idc in in_device_coords:
             if idc[-1] != 0:
                 stick_exprs.add(idc[-1])
+        stick_expr = next(iter(stick_exprs)) if stick_exprs else None
 
         if len(stick_exprs) > 1:
-            # TODO: This is a legal PyTorch operation that we cannot execute without inserting restickify operations.
-            raise Unsupported(
-                f"Spyre limitation: pointwise op with nonuniform stick indexing: {stick_exprs}"
+            # This is a legal PyTorch operation that we cannot execute without inserting restickify operations.
+            logger.warning(
+                f"Injecting restickify to resolve pointwise op with nonuniform stick indexing: {stick_exprs}."
             )
+
+            # Arbitrary Choice 1: let arg[0] define the stick variable nd restick all others that have a conflict
+            stick_expr = in_device_coords[0][-1]
+            assert stick_expr != 0, "Expected arg 0 to have non-zero stick indexing expression"
+            for arg_i, (ic, idc, arg) in enumerate(
+                zip(in_coords[1:], in_device_coords[1:], args[1:]), start=1
+            ):
+                if idc[-1] != stick_expr:
+                    schedule_restickify(n, arg, arg_i, stick_expr, ic, idc, restickify_plan)
 
         # If the indexing and device element size are identical
         # across all inputs and the output we can just propagate the device layout.
@@ -196,7 +367,7 @@ def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
                 maybe_stick_dim = None
                 out_stick_dim = -1
             else:
-                maybe_stick_dim = matching_dim(out_coords, next(iter(stick_exprs)))
+                maybe_stick_dim = matching_dim(out_coords, stick_expr)
                 out_stick_dim = -1 if maybe_stick_dim is None else maybe_stick_dim
 
             dim_order = [
@@ -228,7 +399,9 @@ def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
         return result
 
 
-def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLayout:
+def reduction_layout(
+    n: SchedulerNode, args: list[SchedNodeArg], restickify_plan: dict
+) -> FixedTiledLayout:
     red: Reduction = n.node.data
     output: FixedLayout = n.node.get_layout()
     output_dep = next(iter(n.read_writes.writes))
@@ -252,14 +425,37 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
                 f"{red.reduction_type}: failed to map stick_dims to host coords"
             )
 
-        if (
-            x_stick_dim != len(x.layout.size) - 1
-            or y_stick_dim != len(y.layout.size) - 1
-        ):
-            # TODO: This is a legal PyTorch operation that we cannot execute without inserting restickify operations.
-            raise Unsupported(
-                f"Spyre limitation: {red.reduction_type} requires restickify"
+        # Hardware stick constraints (DF16):
+        #   Input1 (x): stick on reduction_dim (the x coord that does NOT appear in output)
+        #   Input2 (y): stick on generated_dim (the y coord that appears in output)
+        #   Output:     stick on generated_dim
+        # Restickify whichever input has its stick on the wrong dim.
+        if matching_dim(out_coords, x_stick_expr) is not None:
+            # x's stick is on a dim that appears in the output — move it to reduction_dim
+            reduction_coord = next(
+                c for c in x_coords if matching_dim(out_coords, c) is None
             )
+            logger.warning(
+                f"Injecting restickify on {red.reduction_type} x input to move stick to reduction_dim"
+            )
+            tl = schedule_restickify(n, x, 0, reduction_coord, x_coords, x_dev_coords, restickify_plan)
+            x_stick_expr = device_coordinates(tl, x.dep)[-1]
+        # y's stick must be on the generated_dim, i.e. a dim that appears in the output.
+        # If y_stick_expr doesn't appear in out_coords, y needs restickifying.
+        if matching_dim(out_coords, y_stick_expr) is None:
+            logger.warning(
+                f"Injecting restickify on {red.reduction_type} y input to move stick to generated_dim"
+            )
+            # Target is the generated_dim: the y coord that appears in the output
+            # but NOT in x (distinguishes generated_dim from noreuse/batch dims).
+            generated_coord = next(
+                c for c in y_coords
+                if matching_dim(out_coords, c) is not None
+                and matching_dim(x_coords, c) is None
+            )
+            tl = schedule_restickify(n, y, 1, generated_coord, y_coords, y_dev_coords, restickify_plan)
+            y_stick_expr = device_coordinates(tl, y.dep)[-1]
+
         out_stick_dim = matching_dim(out_coords, y_stick_expr)
         if out_stick_dim is None:
             raise Unsupported(
@@ -330,7 +526,7 @@ def generic_layout(n: ExternKernelSchedulerNode) -> FixedTiledLayout:
 
 def propagate_spyre_tensor_layouts(
     nodes: list[BaseSchedulerNode],
-) -> list[BaseSchedulerNode]:
+) -> tuple[list[BaseSchedulerNode], dict[BaseSchedulerNode, list[dict[str, Any]]]]:
     # Convert InputBuffers from FixedLayout to FixedTiledLayouts
     if len(V.graph.graph_input_names) > 0:
         for name, real_input in zip(V.graph.graph_input_names, V.get_real_inputs()):
@@ -362,16 +558,16 @@ def propagate_spyre_tensor_layouts(
     # Nodes are in topological order (guarenteed by caller).
     # Visit them and use the inputs' FixedTiledLayouts and the operation being
     # performed by the node to convert its output FixedLayout to a FixedTiledLayout.
-
+    restickify_plan: dict[BaseSchedulerNode, list[dict[str, Any]]] = {}
     it = iter(nodes)
     for n in it:
         if isinstance(n, SchedulerNode) and isinstance(n.node, ComputedBuffer):
             n.node.decide_layout()
             if isinstance(n.node.data, Pointwise):
-                output_layout = pointwise_layout(n, get_mem_deps(n))
+                output_layout = pointwise_layout(n, get_mem_deps(n), restickify_plan)
                 n.node.layout = output_layout
             elif isinstance(n.node.data, Reduction):
-                output_layout = reduction_layout(n, get_mem_deps(n))
+                output_layout = reduction_layout(n, get_mem_deps(n), restickify_plan)
                 n.node.layout = output_layout
             else:
                 logger.warning(f"Warning: unhandled node type {type(n.node)}")
@@ -394,4 +590,4 @@ def propagate_spyre_tensor_layouts(
         else:
             logger.warning(f"unhandled scheduler node type {type(n)}")
 
-    return nodes
+    return nodes, restickify_plan

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -438,43 +438,32 @@ def reduction_layout(
         #   Input1 (x): stick on reduction_dim (the x coord that does NOT appear in output)
         #   Input2 (y): stick on generated_dim (the y coord that appears in output)
         #   Output:     stick on generated_dim
-        # Restickify whichever input has its stick on the wrong dim.
-        reduction_dim = next(
-            d for d, c in enumerate(x_coords) if matching_dim(out_coords, c) is None
-        )
-        generated_dim = next(
-            d
-            for d, c in enumerate(y_coords)
-            if matching_dim(out_coords, c) is not None
-            and matching_dim(x_coords, c) is None
-        )
-
-        if x_stick_dim != reduction_dim:
+        if matching_dim(out_coords, x_stick_expr) is not None:
             logger.warning(
                 f"Injecting restickify on {red.reduction_type} x input to move stick to reduction_dim"
             )
+            reduction_coord = next(
+                c
+                for c in x_coords
+                if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is None
+            )
             tl = schedule_restickify(
-                n,
-                x,
-                0,
-                x_coords[reduction_dim],
-                x_coords,
-                x_dev_coords,
-                restickify_plan,
+                n, x, 0, reduction_coord, x_coords, x_dev_coords, restickify_plan
             )
             x_stick_expr = device_coordinates(tl, x.dep)[-1]
-        if y_stick_dim != generated_dim:
+        if matching_dim(out_coords, y_stick_expr) is None:
             logger.warning(
                 f"Injecting restickify on {red.reduction_type} y input to move stick to generated_dim"
             )
+            generated_coord = next(
+                c
+                for c in y_coords
+                if len(c.free_symbols) > 0
+                and matching_dim(out_coords, c) is not None
+                and matching_dim(x_coords, c) is None
+            )
             tl = schedule_restickify(
-                n,
-                y,
-                1,
-                y_coords[generated_dim],
-                y_coords,
-                y_dev_coords,
-                restickify_plan,
+                n, y, 1, generated_coord, y_coords, y_dev_coords, restickify_plan
             )
             y_stick_expr = device_coordinates(tl, y.dep)[-1]
 

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -80,14 +80,14 @@ def restickify_device_size(
     - Last device dim (stick): size is always stick_size
     - Dims involving old_var (outer stick): size becomes host_size[new_sd] // stick_size
     - Dims involving new_var (non-stick for new_sd): size becomes host_size[old_sd]
-    - Constant zero (degenerate outer stick when host_size[old_sd] == stick_size): host_size[new_sd] // stick_size
-    All other dims are unchanged.
+    - coord==0 with no explicit outer stick: degenerate outer stick (host_size[old_sd] == stick_size);
+      absorbs the new outer stick when host_size[new_sd] > stick_size
+    - All other dims: unchanged
     """
     old_var = next(iter(old_stick_expr.free_symbols))
     new_var = next(iter(target_stick_expr.free_symbols))
-    # Detect whether there is an explicit outer-stick dim for old_var in idc (any non-last dim
-    # containing old_var). If not, old_sd fits in one stick (host_size[old_sd] <= stick_size)
-    # and any size-1 placeholder adjacent to the new_var dim should absorb the new outer stick.
+    # True when old_sd has an explicit outer-stick dim (host_size[old_sd] > stick_size).
+    # False means old_sd fit in one stick: the degenerate outer stick has coord==0, size==1.
     has_old_outer_stick = any(
         old_var in idc[j].free_symbols for j in range(len(idc) - 1)
     )
@@ -96,18 +96,17 @@ def restickify_device_size(
         if j == len(idc) - 1:
             # Last device dim is always the stick, size is always stick_size.
             result.append(stick_size)
-            print(f"  device_size[{j}]: last(stick) -> {stick_size}")
         elif old_var in coord.free_symbols:
             result.append(host_size[new_sd] // stick_size)
         elif new_var in coord.free_symbols:
             result.append(host_size[old_sd])
-        elif coord == sympy.S.Zero and old_device_size[j] != 1:
-            # Degenerate outer stick: host_size[old_sd] == stick_size so floor(var/stick_size) == 0.
-            # Distinguished from size-1 host dims (which also produce coord==0) by device_size[j] != 1.
-            result.append(host_size[new_sd] // stick_size)
-        elif coord == sympy.S.Zero and old_device_size[j] == 1 and not has_old_outer_stick and host_size[new_sd] > stick_size:
-            # Size-1 placeholder that should absorb the new outer stick when old_sd fits in one
-            # stick (no explicit floor(old_var/stick) dim) but new_sd requires tiling.
+        elif (
+            coord == sympy.S.Zero
+            and not has_old_outer_stick
+            and host_size[new_sd] > stick_size
+        ):
+            # Degenerate outer stick (host_size[old_sd] == stick_size, so floor(old_var/64) == 0).
+            # This placeholder absorbs the new outer stick when new_sd requires tiling.
             result.append(host_size[new_sd] // stick_size)
         else:
             result.append(old_device_size[j])
@@ -134,6 +133,8 @@ def restickify_stride_map(
     """
     old_var = next(iter(old_stick_expr.free_symbols))
     new_var = next(iter(target_stick_expr.free_symbols))
+    # True when old_sd has an explicit outer-stick dim (host_size[old_sd] > stick_size).
+    # False means old_sd fit in one stick: the degenerate outer stick has coord==0, size==1.
     has_old_outer_stick = any(
         old_var in idc[j].free_symbols for j in range(len(idc) - 1)
     )
@@ -143,14 +144,20 @@ def restickify_stride_map(
             # Last device dim is always the stick; stride_map is the host stride of new_sd.
             result.append(host_stride[new_sd])
         elif old_var in coord.free_symbols:
-            result.append(old_stride_map[j] * host_stride[new_sd] // host_stride[old_sd])
+            result.append(
+                old_stride_map[j] * host_stride[new_sd] // host_stride[old_sd]
+            )
         elif new_var in coord.free_symbols:
-            result.append(old_stride_map[j] * host_stride[old_sd] // host_stride[new_sd])
-        elif coord == sympy.S.Zero and old_device_size[j] != 1:
-            # Degenerate outer stick: host_size[old_sd] == stick_size so floor(var/stick_size) == 0.
-            result.append(old_stride_map[j] * host_stride[new_sd] // host_stride[old_sd])
-        elif coord == sympy.S.Zero and old_device_size[j] == 1 and not has_old_outer_stick and host_size[new_sd] > stick_size:
-            # Size-1 placeholder absorbing the new outer stick.
+            result.append(
+                old_stride_map[j] * host_stride[old_sd] // host_stride[new_sd]
+            )
+        elif (
+            coord == sympy.S.Zero
+            and not has_old_outer_stick
+            and host_size[new_sd] > stick_size
+        ):
+            # Degenerate outer stick (host_size[old_sd] == stick_size, so floor(old_var/64) == 0).
+            # This placeholder absorbs the new outer stick when new_sd requires tiling.
             result.append(host_stride[new_sd] * stick_size)
         else:
             result.append(old_stride_map[j])
@@ -165,7 +172,7 @@ def schedule_restickify(
     ic: list,
     idc: list,
     restickify_plan: dict,
-) -> None:
+) -> FixedTiledLayout:
     """Record a restickify needed for arg to match target_stick_expr.
 
     Computes the target FixedTiledLayout by replacing the current stick
@@ -183,32 +190,30 @@ def schedule_restickify(
     old_stick_expr = idc[-1]
     old_stride_map = list(dl.stride_map)
 
-    var_ranges = dict(arg.dep.ranges)
-    print(f"schedule_restickify arg{arg_i}:")
-    print(f"  host_size={host_size} host_stride={host_stride}")
-    print(f"  var_ranges={var_ranges}")
-    print(f"  ic={ic}")
-    print(f"  idc={idc}")
-    print(f"  old_stick_expr={old_stick_expr}  target_stick_expr={target_stick_expr}")
-    print(f"  old_sd={old_sd} (host_size[old_sd]={host_size[old_sd]}, host_stride[old_sd]={host_stride[old_sd]})")
-    print(f"  new_sd={new_sd} (host_size[new_sd]={host_size[new_sd]}, host_stride[new_sd]={host_stride[new_sd]})")
-    print(f"  before: device_size={list(dl.device_size)} dim_map={list(dl.dim_map)} stride_map={old_stride_map}")
-
     # dim_map is kept for legacy reasons but is not used to derive device_size or stride_map.
     new_dim_map = [
-        new_sd if x == old_sd else old_sd if x == new_sd else x
-        for x in dl.dim_map
+        new_sd if x == old_sd else old_sd if x == new_sd else x for x in dl.dim_map
     ]
     device_size = restickify_device_size(
-        list(dl.device_size), idc, old_stick_expr, target_stick_expr,
-        host_size, old_sd, new_sd,
+        list(dl.device_size),
+        idc,
+        old_stick_expr,
+        target_stick_expr,
+        host_size,
+        old_sd,
+        new_sd,
     )
     stride_map = restickify_stride_map(
-        old_stride_map, list(dl.device_size), idc, old_stick_expr, target_stick_expr,
-        host_size, host_stride, old_sd, new_sd,
+        old_stride_map,
+        list(dl.device_size),
+        idc,
+        old_stick_expr,
+        target_stick_expr,
+        host_size,
+        host_stride,
+        old_sd,
+        new_sd,
     )
-
-    print(f"  after:  device_size={device_size} dim_map={new_dim_map} stride_map={stride_map}")
 
     stl = SpyreTensorLayout(device_size, new_dim_map, stride_map, dl.device_dtype)
 
@@ -333,12 +338,16 @@ def pointwise_layout(
 
             # Arbitrary Choice 1: let arg[0] define the stick variable nd restick all others that have a conflict
             stick_expr = in_device_coords[0][-1]
-            assert stick_expr != 0, "Expected arg 0 to have non-zero stick indexing expression"
+            assert stick_expr != 0, (
+                "Expected arg 0 to have non-zero stick indexing expression"
+            )
             for arg_i, (ic, idc, arg) in enumerate(
                 zip(in_coords[1:], in_device_coords[1:], args[1:]), start=1
             ):
                 if idc[-1] != stick_expr:
-                    schedule_restickify(n, arg, arg_i, stick_expr, ic, idc, restickify_plan)
+                    schedule_restickify(
+                        n, arg, arg_i, stick_expr, ic, idc, restickify_plan
+                    )
 
         # If the indexing and device element size are identical
         # across all inputs and the output we can just propagate the device layout.
@@ -430,30 +439,43 @@ def reduction_layout(
         #   Input2 (y): stick on generated_dim (the y coord that appears in output)
         #   Output:     stick on generated_dim
         # Restickify whichever input has its stick on the wrong dim.
-        if matching_dim(out_coords, x_stick_expr) is not None:
-            # x's stick is on a dim that appears in the output — move it to reduction_dim
-            reduction_coord = next(
-                c for c in x_coords if matching_dim(out_coords, c) is None
-            )
+        reduction_dim = next(
+            d for d, c in enumerate(x_coords) if matching_dim(out_coords, c) is None
+        )
+        generated_dim = next(
+            d
+            for d, c in enumerate(y_coords)
+            if matching_dim(out_coords, c) is not None
+            and matching_dim(x_coords, c) is None
+        )
+
+        if x_stick_dim != reduction_dim:
             logger.warning(
                 f"Injecting restickify on {red.reduction_type} x input to move stick to reduction_dim"
             )
-            tl = schedule_restickify(n, x, 0, reduction_coord, x_coords, x_dev_coords, restickify_plan)
+            tl = schedule_restickify(
+                n,
+                x,
+                0,
+                x_coords[reduction_dim],
+                x_coords,
+                x_dev_coords,
+                restickify_plan,
+            )
             x_stick_expr = device_coordinates(tl, x.dep)[-1]
-        # y's stick must be on the generated_dim, i.e. a dim that appears in the output.
-        # If y_stick_expr doesn't appear in out_coords, y needs restickifying.
-        if matching_dim(out_coords, y_stick_expr) is None:
+        if y_stick_dim != generated_dim:
             logger.warning(
                 f"Injecting restickify on {red.reduction_type} y input to move stick to generated_dim"
             )
-            # Target is the generated_dim: the y coord that appears in the output
-            # but NOT in x (distinguishes generated_dim from noreuse/batch dims).
-            generated_coord = next(
-                c for c in y_coords
-                if matching_dim(out_coords, c) is not None
-                and matching_dim(x_coords, c) is None
+            tl = schedule_restickify(
+                n,
+                y,
+                1,
+                y_coords[generated_dim],
+                y_coords,
+                y_dev_coords,
+                restickify_plan,
             )
-            tl = schedule_restickify(n, y, 1, generated_coord, y_coords, y_dev_coords, restickify_plan)
             y_stick_expr = device_coordinates(tl, y.dep)[-1]
 
         out_stick_dim = matching_dim(out_coords, y_stick_expr)
@@ -526,7 +548,7 @@ def generic_layout(n: ExternKernelSchedulerNode) -> FixedTiledLayout:
 
 def propagate_spyre_tensor_layouts(
     nodes: list[BaseSchedulerNode],
-) -> tuple[list[BaseSchedulerNode], dict[BaseSchedulerNode, list[dict[str, Any]]]]:
+) -> list[BaseSchedulerNode]:
     # Convert InputBuffers from FixedLayout to FixedTiledLayouts
     if len(V.graph.graph_input_names) > 0:
         for name, real_input in zip(V.graph.graph_input_names, V.get_real_inputs()):
@@ -590,4 +612,5 @@ def propagate_spyre_tensor_layouts(
         else:
             logger.warning(f"unhandled scheduler node type {type(n)}")
 
-    return nodes, restickify_plan
+    V.graph.restickify_plan = restickify_plan
+    return nodes

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -14,7 +14,6 @@
 
 # This file contains inductor passes that are only needed as temp fixes
 
-from typing import cast
 import torch
 from torch._inductor.pattern_matcher import (
     Arg,

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -27,28 +27,6 @@ from torch._inductor.pattern_matcher import (
 aten = torch.ops.aten
 
 
-def relayout_linear_weights(graph: torch.fx.Graph) -> None:
-    """
-    Transpose and realize nn.Linear weights so that they are compatible
-    with the backend compiler as it is today. In the future, this pass
-    should be eliminated for performance reasons when possible.
-    """
-
-    for node in graph.nodes:
-        if node.op == "call_function" and node.target == aten.mm.default:
-            input_t, kernel_t = node.args
-            input_t = cast(torch.fx.Node, input_t)
-            kernel_t = cast(torch.fx.Node, kernel_t)
-            if not kernel_t.meta["val"].is_contiguous():
-                with graph.inserting_before(node):
-                    contiguous_node = graph.call_function(
-                        aten.clone.default,
-                        args=(kernel_t,),
-                        kwargs={"memory_format": torch.contiguous_format},
-                    )
-                    node.update_arg(1, contiguous_node)
-
-
 _RESHAPE_OPS = (
     aten.view.default,
     aten.reshape.default,

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -187,49 +187,33 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
     at::Tensor tmp_0;
     if (arg.dim() == 0) {
       tmp_0 = (at::ones({1}, arg.dtype()) * arg).to(arg.device());
-      auto tensor = createInputTensor(gl, tmp_0.storage().data_ptr().get(), i,
-                                      (args.size() >= 3) ? 2 : 1);
+      auto tensor =
+          createInputTensor(gl, tmp_0.storage().data_ptr().get(), i, 1);
       tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                               tmp_0.storage().data_ptr().get_context())
                               ->owner);
       sen_inputs.push_back(tensor);
     } else {
-      auto tensor = createInputTensor(gl, arg.storage().data_ptr().get(), i,
-                                      (args.size() >= 3) ? 2 : 1);
+      auto tensor = createInputTensor(gl, arg.storage().data_ptr().get(), i, 1);
       tensor.SetSpyreData(
           static_cast<SharedOwnerCtx *>(arg.storage().data_ptr().get_context())
               ->owner);
       sen_inputs.push_back(tensor);
     }
   }
-  auto tensor = createOutputTensor(gl, args.back().storage().data_ptr().get(),
-                                   0, (args.size() >= 3) ? 2 : 1);
+  auto tensor =
+      createOutputTensor(gl, args.back().storage().data_ptr().get(), 0, 1);
   tensor.SetSpyreData(static_cast<SharedOwnerCtx *>(
                           args.back().storage().data_ptr().get_context())
                           ->owner);
   sen_outputs.push_back(tensor);
 
   // Execute device init
-  if (args.size() == 6) {
-    // Filling in segment 5 adds another input to the device init supernode
-    status =
-        gl.Predict(sendnn::Outputs(), {sen_inputs[1], sen_outputs.front()}, 1);
-    if (!status.IsOk()) throw std::runtime_error(status.Message());
-    status = gl.Compute(sen_outputs, sen_inputs, 2);
-    if (!status.IsOk()) throw std::runtime_error(status.Message());
-  } else if (args.size() >= 3) {
-    status = gl.Predict(sendnn::Outputs(), {sen_inputs[1]}, 1);
-    if (!status.IsOk()) throw std::runtime_error(status.Message());
+  status = gl.Predict(sendnn::Outputs(), sendnn::Inputs(), 0);
+  if (!status.IsOk()) throw std::runtime_error(status.Message());
 
-    status = gl.Compute(sen_outputs, sen_inputs, 2);
-    if (!status.IsOk()) throw std::runtime_error(status.Message());
-  } else {
-    status = gl.Predict(sendnn::Outputs(), sendnn::Inputs(), 0);
-    if (!status.IsOk()) throw std::runtime_error(status.Message());
-
-    status = gl.Compute(sen_outputs, sen_inputs, 1);
-    if (!status.IsOk()) throw std::runtime_error(status.Message());
-  }
+  status = gl.Compute(sen_outputs, sen_inputs, 1);
+  if (!status.IsOk()) throw std::runtime_error(status.Message());
 
   return;
 }


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Currently stickify.py raises a runtime exception when operations are performed with incompatible stick dimensions.  This PR fixes the incompatibility by inserting a restickify operation as needed.  The algorithm is as follows:

**Stage 1**:  `propagate_spyre_tensor_layouts` modified to identify conflicts for conflicting input args, select a desired new layout for each conflict, and record that layout in a "restickify_plan" 

**Stage 2**:  `insert_restickify`  execute the restickify plan by inserting a node to perform restickify for all conflicts identified in stage 1.  This is performed in the loop-level IR and implemented such that the downstream node's layout (host size and stride) remains unchanged.


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/738

#### Special notes for your reviewer:

- I was able to remove `contiguous()` from the `spyre_linear` decomposition as well as `relayout_linear_weights` from `temp_passes` as restickify handles it automatically
- No global optimization is performed to select (a) which arg to restickify or (b) what layout to use for the non-stick dimensions.  Being left for future work
- Methods `restickify_device_size` and `restickify_stride_map` could use review and possibly move elsewhere. `restickify_tests.py` caught several already but there could be more
- Validation on Granite is TBD due to flex errors while running

#### Does this PR introduce a user-facing change?
no
#### Additional note:
