### PR TITLE
Add initial offset support in view-based ops

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1620,6 +1620,33 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 # ),
             }
         },
+        ("test_split", "test_split_cpu"): {
+            "ops_dict": {
+                "split3": lambda dim, index, x: (
+                    torch.split(x, x.size()[dim] // 3, dim=dim)[index].clone(),
+                ),
+            },
+            "param_sets": {
+                "1d0s0": (0, 0, cached_randn((384,), dtype=torch.float16)),
+                "1d0s1": (0, 1, cached_randn((384,), dtype=torch.float16)),
+                "1d0s2": (0, 2, cached_randn((384,), dtype=torch.float16)),
+                "2d0s0": (0, 0, cached_randn((9, 384), dtype=torch.float16)),
+                "2d0s1": (0, 1, cached_randn((9, 384), dtype=torch.float16)),
+                "2d0s2": (0, 2, cached_randn((9, 384), dtype=torch.float16)),
+                "2d1s0": (1, 0, cached_randn((9, 384), dtype=torch.float16)),
+                "2d1s1": (1, 1, cached_randn((9, 384), dtype=torch.float16)),
+                "2d1s2": (1, 2, cached_randn((9, 384), dtype=torch.float16)),
+                "3d0s0": (0, 0, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d0s1": (0, 1, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d0s2": (0, 2, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d1s0": (1, 0, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d1s1": (1, 1, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d1s2": (1, 2, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d2s0": (2, 0, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d2s1": (2, 1, cached_randn((9, 15, 384), dtype=torch.float16)),
+                "3d2s2": (2, 2, cached_randn((9, 15, 384), dtype=torch.float16)),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -2189,6 +2216,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 return result.item()
 
             compare_with_cpu(fn, x, y, cpu_compile=False)
+
+    def test_split_cpu(self, op, dim, index, x):
+        def fn(x):
+            return op(dim, index, x)
+
+        compare_with_cpu(fn, x, run_eager=False, cpu_compile=False)
 
 
 if __name__ == "__main__":

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -80,6 +80,43 @@ class TestCoordinates(TestCase):
         )
         self.assertEqual(cx, [p0, 0, p1])
 
+        # split(x, dim=0, sections=3)[1]: offset = 5760 * 3 = 17280
+        cx = compute_coordinates(
+            [9, 15, 384],
+            [5760, 384, 1],
+            {p0: 3, p1: 15, p2: 384},
+            5760 * p0 + 384 * p1 + p2 + 17280,
+        )
+        self.assertEqual(cx, [p0 + 3, p1, p2])
+
+        # split(x, dim=1, sections=3)[1]: offset = 384 * 5 = 1920
+        cx = compute_coordinates(
+            [9, 15, 384],
+            [5760, 384, 1],
+            {p0: 9, p1: 5, p2: 384},
+            5760 * p0 + 384 * p1 + p2 + 1920,
+        )
+        self.assertEqual(cx, [p0, p1 + 5, p2])
+
+        # split(x, dim=2, sections=3)[1]: offset = 1 * 128 = 128
+        cx = compute_coordinates(
+            [9, 15, 384],
+            [5760, 384, 1],
+            {p0: 9, p1: 15, p2: 128},
+            5760 * p0 + 384 * p1 + p2 + 128,
+        )
+        self.assertEqual(cx, [p0, p1, p2 + 128])
+
+        # offset spanning dimentions
+        cx = compute_coordinates(
+            [10, 20, 30],
+            [600, 30, 1],
+            {p0: 10, p1: 20, p2: 30},
+            600 * p0 + 30 * p1 + p2 + 1855,
+        )
+        # offset 1855 = 3*600 + 1*30 + 25*1
+        self.assertEqual(cx, [p0 + 3, p1 + 1, p2 + 25])
+
     def test_compute_device_coordinates(self):
         # B, S, E -> B, E/H, S, H
         cx = compute_coordinates(
@@ -98,6 +135,52 @@ class TestCoordinates(TestCase):
             4096 * p0 + p1,
         )
         self.assertEqual(cx, [p0 % 256, p1 // 64, p0 // 256, p1 % 64])
+
+        # split(x, dim=0, sections=3)[1]: offset = 5760 * 3 = 17280
+        cx = compute_coordinates(
+            [15, 6, 9, 64],
+            [384, 64, 5760, 1],
+            {p0: 3, p1: 15, p2: 384},
+            5760 * p0 + 384 * p1 + p2 + 17280,
+        )
+        self.assertEqual(cx, [p1, p2 // 64, p0 + 3, p2 % 64])
+
+        # split(x, dim=1, sections=3)[1]: offset = 384 * 5 = 1920
+        cx = compute_coordinates(
+            [15, 6, 9, 64],
+            [384, 64, 5760, 1],
+            {p0: 9, p1: 5, p2: 384},
+            5760 * p0 + 384 * p1 + p2 + 1920,
+        )
+        self.assertEqual(cx, [p1 + 5, p2 // 64, p0, p2 % 64])
+
+        # split(x, dim=2, sections=3)[1]: offset = 1 * 128 = 128
+        cx = compute_coordinates(
+            [15, 6, 9, 64],
+            [384, 64, 5760, 1],
+            {p0: 9, p1: 15, p2: 128},
+            5760 * p0 + 384 * p1 + p2 + 128,
+        )
+        self.assertEqual(cx, [p1, p2 // 64 + 2, p0, p2 % 64])
+
+        # non-contiguous strides wit offset
+        cx = compute_coordinates(
+            [256, 64, 2, 64],
+            [4096, 64, 1048576, 1],
+            {p0: 2, p1: 32, p2: 256, p3: 128},
+            1048576 * p0 + 128 * p1 + 4096 * p2 + p3 + 200,
+        )
+        # offset 200 = 0*1048576 + 0*4096 + 3*64 + 8*1
+        self.assertEqual(cx, [p2, 2 * p1 + p3 // 64 + 3, p0, p3 % 64 + 8])
+
+        # spliting the stick dimention
+        cx = compute_coordinates(
+            [15, 6, 9, 64],
+            [384, 64, 5760, 1],
+            {p0: 9, p1: 15, p2: 128},
+            5760 * p0 + 384 * p1 + p2 + 128,
+        )
+        self.assertEqual(cx, [p1, p2 // 64 + 2, p0, p2 % 64])
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -257,7 +257,6 @@ def _create_sdsc_tensors(
     use_op_dims = not _is_matmul(op_spec.op)
 
     missing_dim = None
-    backGap: dict[Symbol, int] = {}
     overwrite_infos: dict = (
         dict(op_spec.op_info.get("overwrite_infos", {})) if op_spec.op_info else {}
     )
@@ -284,6 +283,7 @@ def _create_sdsc_tensors(
         scales: dict = {}
         strides: dict = {}
         offsets: dict = {}
+        backGap: dict[Symbol, int] = {}
         max_dim_sizes: dict = {}
         reduced_dims: list = []
         use_adjusted_size = op_spec.op == "overwrite" and not arg.is_input
@@ -318,6 +318,22 @@ def _create_sdsc_tensors(
                     use_adjusted_size = False
                     break
 
+            dev_dim_size = arg.device_size[-dim_idx - 2]
+            it_dim_size = iteration_space[dim]
+            if dim == stick_dim:
+                stick_size = arg.device_dtype.elems_per_stick()
+                dev_dim_size *= stick_size
+                it_dim_size = ((it_dim_size - 1) // stick_size + 1) * stick_size
+
+            if dev_dim_size > it_dim_size and "overwrite_infos" not in op_spec.op_info:
+                # TODO: overwrite and view offsets cannot be used together until the
+                # overwrite operator is refactored to use coordinate expression offsets
+                dim_coord = arg.device_coordinates[-dim_idx - 2]
+                dim_offset = int(dim_coord.as_coeff_Add()[0])
+                offsets[dim] = dim_offset * dim_device_stride
+                backGap[dim] = dev_dim_size - it_dim_size
+                strides[dim] = strides[dim] / dev_dim_size * it_dim_size
+
             max_dim_sizes[dim] = -1
 
         effective_stick = op_stick_dim if stick_dim is None else stick_dim
@@ -338,7 +354,7 @@ def _create_sdsc_tensors(
                 max_dim_sizes=max_dim_sizes,
                 allocation=arg.allocation,
                 start_address=addr,
-                backGap=backGap if not arg.is_input else {},
+                backGap=backGap,
             )
         )
 

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -42,18 +42,8 @@ def compute_coordinates(
                 next_stride[i] = stride[j]
     # compute coordinate expressions
     coordinates = [sympy.S.Zero] * n
-    vars = index.free_symbols
-    for var in vars:
-        if var_ranges[var] <= 1:
-            continue  # ignore var with trivial range
-        # isolate current var
-        term = index.subs({v: 0 for v in vars - {var}})
-        # compute index({var=1}) and index({var=var_ranges[var]})
-        # TODO: handle non-zero offset in index
-        # https://github.com/torch-spyre/torch-spyre/issues/1333
-        assert term.subs(var, 0) == 0, f"Non-zero offset in index expression {index}"
-        step = term.subs(var, 1)
-        limit = term.subs(var, var_ranges[var])
+
+    def add_term(var, step, limit):
         # find primary dim with largest stride less than or equal to step
         primary_stride = 0
         primary_dim = -1
@@ -80,6 +70,23 @@ def compute_coordinates(
             )
         else:
             coordinates[primary_dim] += var * step // primary_stride
+
+    vars = index.free_symbols
+    offset = index.xreplace({v: 0 for v in vars})
+    if offset > 0:
+        index = index - offset
+        add_term(var=offset, step=sympy.S.One, limit=sympy.oo)
+
+    for var in vars:
+        if var_ranges[var] <= 1:
+            continue  # ignore var with trivial range
+        # isolate current var
+        term = index.xreplace({v: 0 for v in vars - {var}})
+        # compute index({var=1}) and index({var=var_ranges[var]})
+        step = term.xreplace({var: 1})
+        limit = term.xreplace({var: var_ranges[var]})
+        add_term(var=var, step=step, limit=limit)
+
     return coordinates
 
 
@@ -127,9 +134,9 @@ def matching_dim(coords: list[sympy.Expr], expr: sympy.Expr) -> Optional[int]:
 @dataclass(order=True)
 class Term:
     """
-    A term num*(var%mod)//den in a coordinate expression.
+    A term num*(var%mod)//den + offset in a coordinate expression.
     Includes the size of the dimension the expression is intended for.
-    Zero is represented as Term(None, None, None, None, dim_size).
+    Zero is represented as Term(None, None, None, None, dim_size, 0).
     """
 
     num: sympy.Expr | None  # numerator
@@ -137,6 +144,7 @@ class Term:
     var: sympy.Expr | None  # variable
     mod: sympy.Expr | None  # modulo
     dim_size: sympy.Expr
+    offset: sympy.Expr = sympy.S.Zero  # offset
 
 
 def normalize_coordinates(
@@ -149,7 +157,6 @@ def normalize_coordinates(
 
     If mod is absent from term assume term does not overflow dim_size.
     Assume num or den is 1.
-    Assume no offset: coordinate(0, .., 0) = 0.
 
     Break each expression into list of terms.
     If expr has no mod, use var_range instead.
@@ -165,18 +172,16 @@ def normalize_coordinates(
         # sympy uses floor to encode integer divisions, remove
         expr = coordinate.replace(sympy.floor, lambda x: x)
         vars = expr.free_symbols
-        # TODO: handle non-zero offset in coordinate expression
-        # https://github.com/torch-spyre/torch-spyre/issues/1333
-        assert expr.subs({var: sympy.S.Zero for var in vars}) == 0, (
-            f"Non-zero offset in coordinate expression {expr}"
-        )
+        offset = expr.xreplace({var: sympy.S.Zero for var in vars})
         if len(vars) == 0:
+            # TODO: Support size-1 dimensions with non-zero offset
+            assert offset == 0
             terms.append(Term(None, None, None, None, dim_size))
             continue
         dim_terms = []  # terms for current dimension
         for var in vars:
             # extract term for each var
-            term = expr.subs({v: 0 for v in vars - {var}})
+            term = expr.xreplace({v: 0 for v in vars - {var}}) - offset
             # pattern match expression tree, there is small number of possibilities
             if term.is_symbol:
                 dim_terms.append(
@@ -202,6 +207,10 @@ def normalize_coordinates(
 
         # sort dim_terms in increasing num order
         dim_terms.sort()
+
+        for dim_term in dim_terms[::-1]:
+            dim_term.offset = offset // dim_term.num
+            offset %= dim_term.num
 
         # split dims with n>1 terms
         split_dim_terms = []
@@ -238,6 +247,7 @@ def normalize_coordinates(
             fused_term.num = term.num
             fused_term.den = term.den
             fused_term.dim_size *= term.dim_size
+            fused_term.offset += term.offset
         else:
             if fused_term.dim_size > 1:
                 fused_terms.append(fused_term)
@@ -278,7 +288,7 @@ def align_tensors(
         stick_dim.append(terms[-1].var)
         stick_size.append(terms[-1].dim_size)
         all_terms.append(terms)
-        for num, den, var, mod, dim_size in [astuple(term) for term in terms]:
+        for num, den, var, mod, dim_size, offset in [astuple(term) for term in terms]:
             if var is not None:
                 if den != stick_size[-1] or var != stick_dim[-1]:
                     # add den to splits unless stick dim and stick size
@@ -324,7 +334,9 @@ def align_tensors(
     for j, terms in enumerate(all_terms):
         size = []
         coordinates = []
-        for num, den, var, mod, dim_size in [astuple(term) for term in terms[:-1]]:
+        for num, den, var, mod, dim_size, offset in [
+            astuple(term) for term in terms[:-1]
+        ]:
             # for each term except last one (stick dim)
             if var is None:
                 # dimension is not iterated over, keep as is
@@ -346,19 +358,23 @@ def align_tensors(
                 else:
                     # upper bound of iteration range is split
                     size.append(splits[var][i + 1] // splits[var][i])
-                coordinates.append(remap[var][i])
+                coordinates.append(remap[var][i] + offset // splits[var][i])
+                offset %= splits[var][i]
             if var == stick_dim[j] and den == stick_size[j] and den not in splits[var]:
                 # outer stick dim
                 size[-1] //= den
-                coordinates[-1] //= den
+                (offset, term) = coordinates[-1].as_coeff_Add()
+                coordinates[-1] = term // den + offset
             if num > 1:
                 # iteration skips over elements in dim, realize gap as new dimension
                 size.append(num)
                 coordinates.append(sympy.S.Zero)
         # add stick dim
-        num, den, var, mod, dim_size = astuple(terms[-1])
+        num, den, var, mod, dim_size, offset = astuple(terms[-1])
         size.append(dim_size)
-        coordinates.append(var % dim_size if var is not None else sympy.S.Zero)
+        coordinates.append(
+            (var % dim_size if var is not None else sympy.S.Zero) + offset
+        )
         new_tensors.append({"size": size, "coordinates": coordinates})
 
     # decide desired rank for all tensors


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds initial offset/gap support to compute_coordinates() in views.py, enabling basic handling of index expressions with constant offsets. This is a foundational change to support tensor split operations and other view operations that produce offsets.

This PR's offset support is tested limitedly. For example:
- Size-1 dimensions with non-zero offset

The intent of this PR is to enable incremental development of offset/gap support across the compilation pipeline:

This PR add changes in the following files for basic offset/gap support.
 - views.py (coordinate computation)
 - superdsc.py (codegen using `backGapCore_`)
 - test_inductor_ops.py (tests for `torch.split`)
 
Follow-up PRs will address these remaining issues:
- Generalized view support
  * #1548
- Eager mode support
  * #894
- Splitting stick dimensions at offsets that do not align with stick boundaries (this requires realization)
  * #1464
- Integration with data-copy operations (i.e. overwrite)
  * #1549 

This approach allows us to complete end-to-end implementation for simple cases while building toward full generalization.

#### Which issue(s) this PR is related to:

- #1333

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

`torch.split` works with this PR.

#### Additional note:

<details>

<summary>pytest</summary>

```
(dt-inductor) [yohei@yohei-spyre-dev torch-spyre]$ pytest tests
================================================== test session starts ==================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yohei/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9, xdist-3.8.0
collected 573 items

tests/inductor/test_building_blocks.py ....                                                                       [  0%]
tests/inductor/test_cache.py .                                                                                    [  0%]
tests/inductor/test_codegen.py ...                                                                                [  1%]
tests/inductor/test_inductor_decomp.py ...                                                                        [  1%]
tests/inductor/test_inductor_fx_passes.py .......                                                                 [  3%]
tests/inductor/test_inductor_ops.py ....s........................................................................ [ 16%]
................................................................................................................. [ 36%]
................................................................................................................. [ 56%]
................................................................................................................. [ 75%]
...........................................................                                                       [ 86%]
tests/inductor/test_logging.py ....                                                                               [ 86%]
tests/tensor/test_coordinates.py ..                                                                               [ 87%]
tests/tensor/test_tensor_layout.py ................                                                               [ 89%]
tests/test_fallbacks.py ........                                                                                  [ 91%]
tests/test_modules.py .sssss.                                                                                     [ 92%]
tests/test_regex.py .                                                                                             [ 92%]
tests/test_spyre.py ..s..ss.............                                                                          [ 96%]
tests/test_spyre_lazy_silent.py .                                                                                 [ 96%]
tests/test_stream.py .....................                                                                        [100%]

=================================================== warnings summary ====================================================
tests/inductor/test_inductor_ops.py::TestOps::test_fill_scalar_1d
tests/inductor/test_inductor_ops.py::TestOps::test_zeros_aligned
tests/inductor/test_inductor_ops.py::TestOps::test_zeros_padded
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:165: FallbackWarning: torch.ops.spyre.full is falling back to cpu
    warn_fallback("torch.ops.spyre.full")

tests/inductor/test_inductor_ops.py::TestOps::test_isin_scalar_tensor_out_cpu
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/ops/fallbacks.py:262: UserWarning: An output with one or more elements was resized since it had shape [], which does not match the required output shape [0]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (Triggered internally at /home/yohei/dt-inductor/pytorch/aten/src/ATen/native/Resize.cpp:31.)
    return torch.isin(

tests/test_spyre.py::TestSpyre::test_ones_factory
tests/test_spyre.py::TestSpyre::test_printing
  /home/yohei/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:196: FallbackWarning: torch.ops.spyre.ones_scalar is falling back to cpu
    warn_fallback("torch.ops.spyre.ones_scalar")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ 564 passed, 9 skipped, 6 warnings in 570.33s (0:09:30) =================================
```

</details>
