### PR TITLE
fix: is_available returns False due to skipping of initialization

### DIFF
--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -109,9 +109,7 @@ class _SpyreImpl:
         if self._is_in_bad_fork():
             return True
         else:
-            return not hasattr(self, "_C") or (
-                self._C is not None and getattr(self._C, "is_available", lambda: True)()
-            )
+            return self.device_count() > 0
 
     def is_initialized(self):
         return self._initialized and not self._is_in_bad_fork()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`torch.accelerator.is_available()` returns False due to lazy init. This PR deliberately does the initialisation if this API is accessed. This also fixes `torch.accelerator.current_accelerator(check_available=True)` which now returns the device when device is available.

#### Which issue(s) this PR is related to:

Fixes #1289
