### PR TITLE
bugfix[tests]: run cpu_compile with right flags

### DIFF
--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -691,7 +691,7 @@ def compare_with_cpu(
 
         if cpu_compile:
             cpu_other_result = _compile_and_run(
-                fn, get_args(), "cpu", needs_device=needs_device, compile=compiled
+                fn, get_args(), "cpu", needs_device=needs_device, compile=True
             )
             _assert_results_close(
                 spyre_result,


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Currently some tests in inductor depend on this helper function to run tests against CPU (eager and compile). There is a mistake in the flags being passed to the Compile version - which means some checks are not being done.

#### Which issue(s) this PR is related to:

No issue. But related to: 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

#### Additional note:

This increases test runtime by 2 min, since additional checks are being done.