### PR TITLE
Use AIU_WORLD_RANK_* as primary device discovery source 

### DIFF
--- a/tests/test_device_enum.py
+++ b/tests/test_device_enum.py
@@ -69,6 +69,10 @@ print(torch.spyre.device_count())
 """
     env = os.environ.copy()
     if env_vars is not None:
+        # Remove AIU_WORLD_RANK_* env vars to prevent parent interference
+        for key in list(env.keys()):
+            if key.startswith("AIU_WORLD_RANK_"):
+                del env[key]
         env.update(env_vars)
         # Remove env vars that might interfere if not specified
         for key in ["SPYRE_VISIBLE_DEVICES", "PCIDEVICE_IBM_COM_AIU_PF"]:
@@ -125,15 +129,19 @@ class TestDeviceEnumEnvVars:
         count = get_device_count_in_subprocess({"PCIDEVICE_IBM_COM_AIU_PF": bus_ids[0]})
         assert count == 1
 
-    def test_env_var_priority(self):
-        """SPYRE_VISIBLE_DEVICES takes priority over PCIDEVICE_IBM_COM_AIU_PF."""
+    def test_spyre_visible_devices_filters_k8s(self):
+        """SPYRE_VISIBLE_DEVICES filters the PCIDEVICE_IBM_COM_AIU_PF list."""
+        bus_ids = discover_spyre_pci_bus_ids()
+        if len(bus_ids) < 2:
+            pytest.skip("Need at least 2 Spyre devices")
+
         count = get_device_count_in_subprocess(
             {
                 "SPYRE_VISIBLE_DEVICES": "0",
-                "PCIDEVICE_IBM_COM_AIU_PF": "invalid_bus_id",
+                "PCIDEVICE_IBM_COM_AIU_PF": ",".join(bus_ids[:2]),
             }
         )
-        assert count == 1, "SPYRE_VISIBLE_DEVICES should take priority"
+        assert count == 1, "SPYRE_VISIBLE_DEVICES should filter the device list"
 
     def test_k8s_invalid_pci_bus_id_filtered(self):
         """Invalid PCI bus IDs are filtered out, count equals valid IDs only."""
@@ -148,6 +156,64 @@ class TestDeviceEnumEnvVars:
 
         # Count should be 1 (invalid ID filtered out)
         assert count == 1, f"Expected 1 (invalid ID filtered), got {count}"
+
+    def test_aiu_world_rank_discovery(self):
+        """AIU_WORLD_RANK_* env vars are used for device discovery."""
+        bus_ids = discover_spyre_pci_bus_ids()
+        if len(bus_ids) < 2:
+            pytest.skip("Need at least 2 Spyre devices")
+
+        count = get_device_count_in_subprocess(
+            {
+                "AIU_WORLD_RANK_0": bus_ids[0],
+                "AIU_WORLD_RANK_1": bus_ids[1],
+            }
+        )
+        assert count == 2
+
+    def test_aiu_world_rank_priority_over_pci_scan(self):
+        """AIU_WORLD_RANK_* takes priority over PCI bus scan."""
+        bus_ids = discover_spyre_pci_bus_ids()
+        if not bus_ids:
+            pytest.skip("No Spyre devices found via sysfs scan")
+
+        # Set only one AIU_WORLD_RANK — should see 1 device even if
+        # PCI scan would find more.
+        count = get_device_count_in_subprocess({"AIU_WORLD_RANK_0": bus_ids[0]})
+        assert count == 1, "AIU_WORLD_RANK_* should take priority over PCI scan"
+
+    def test_spyre_visible_devices_filters_aiu_world_rank(self):
+        """SPYRE_VISIBLE_DEVICES filters the AIU_WORLD_RANK_* list."""
+        bus_ids = discover_spyre_pci_bus_ids()
+        if len(bus_ids) < 2:
+            pytest.skip("Need at least 2 Spyre devices")
+
+        count = get_device_count_in_subprocess(
+            {
+                "AIU_WORLD_RANK_0": bus_ids[0],
+                "AIU_WORLD_RANK_1": bus_ids[1],
+                "SPYRE_VISIBLE_DEVICES": "0",
+            }
+        )
+        assert count == 1, "SPYRE_VISIBLE_DEVICES should filter AIU_WORLD_RANK_* list"
+
+    def test_aiu_world_rank_priority_over_k8s(self):
+        """AIU_WORLD_RANK_* takes priority over PCIDEVICE_IBM_COM_AIU_PF."""
+        bus_ids = discover_spyre_pci_bus_ids()
+        if len(bus_ids) < 2:
+            pytest.skip("Need at least 2 Spyre devices")
+
+        # AIU_WORLD_RANK sets 1 device, PCIDEVICE_IBM_COM_AIU_PF sets 2.
+        # AIU_WORLD_RANK should win.
+        count = get_device_count_in_subprocess(
+            {
+                "AIU_WORLD_RANK_0": bus_ids[0],
+                "PCIDEVICE_IBM_COM_AIU_PF": ",".join(bus_ids[:2]),
+            }
+        )
+        assert count == 1, (
+            "AIU_WORLD_RANK_* should take priority over PCIDEVICE_IBM_COM_AIU_PF"
+        )
 
 
 if __name__ == "__main__":

--- a/torch_spyre/csrc/spyre_device_enum.cpp
+++ b/torch_spyre/csrc/spyre_device_enum.cpp
@@ -42,6 +42,20 @@ int readSysfsHex(const std::string& path) {
   return val;
 }
 
+// Scan AIU_WORLD_RANK_* env vars for device discovery.
+// These are set by login scripts in all environments (OpenShift & bare metal).
+// Returns PCI bus IDs in rank order, stopping at the first gap.
+std::vector<std::string> scanEnvRanks() {
+  std::vector<std::string> bus_ids;
+  for (int i = 0;; ++i) {
+    std::string key = "AIU_WORLD_RANK_" + std::to_string(i);
+    const char* val = std::getenv(key.c_str());
+    if (!val || val[0] == '\0') break;
+    bus_ids.push_back(val);
+  }
+  return bus_ids;
+}
+
 // Scan /sys/bus/pci/devices/ for all Spyre accelerators.
 // Returns PCI bus IDs sorted lexicographically.
 std::vector<std::string> scanPciBus() {
@@ -114,30 +128,43 @@ std::vector<std::string> parseVisibleDevices(
 }
 
 std::vector<SpyreDeviceInfo> buildDeviceList() {
-  std::vector<std::string> all_bus_ids = scanPciBus();
-  std::vector<std::string> visible_bus_ids;
+  // Step 1: Discover all available devices.
+  // Priority: AIU_WORLD_RANK_* > PCIDEVICE_IBM_COM_AIU_PF > PCI bus scan
+  std::vector<std::string> all_bus_ids = scanEnvRanks();
+  const char* discovery_source = nullptr;
 
-  // Priority:
-  //   1. SPYRE_VISIBLE_DEVICES — explicit user/admin override
-  //   2. PCIDEVICE_IBM_COM_AIU_PF — set by K8s device plugin
-  //   3. Full PCI bus scan
+  if (!all_bus_ids.empty()) {
+    discovery_source = "AIU_WORLD_RANK_*";
+  } else {
+    const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
+    if (k8s_env && k8s_env[0] != '\0') {
+      // Validate K8s bus IDs against PCI scan — filters out any IDs
+      // that don't match real hardware on this host.
+      std::vector<std::string> pci_bus_ids = scanPciBus();
+      all_bus_ids = parseVisibleDevices(k8s_env, pci_bus_ids);
+      discovery_source = "PCIDEVICE_IBM_COM_AIU_PF";
+    } else {
+      all_bus_ids = scanPciBus();
+      discovery_source = "PCI bus scan";
+    }
+  }
+
+  DEBUGINFO("spyre_device_enum:", discovery_source, "found", all_bus_ids.size(),
+            "devices");
+
+  // Step 2: Apply SPYRE_VISIBLE_DEVICES filter.
+  std::vector<std::string> visible_bus_ids;
   const char* env = std::getenv("SPYRE_VISIBLE_DEVICES");
-  const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
 
   if (env && env[0] != '\0') {
     visible_bus_ids = parseVisibleDevices(env, all_bus_ids);
     DEBUGINFO("spyre_device_enum: SPYRE_VISIBLE_DEVICES =", env, "->",
               visible_bus_ids.size(), "devices");
-  } else if (k8s_env && k8s_env[0] != '\0') {
-    visible_bus_ids = parseVisibleDevices(k8s_env, all_bus_ids);
-    DEBUGINFO("spyre_device_enum: PCIDEVICE_IBM_COM_AIU_PF =", k8s_env, "->",
-              visible_bus_ids.size(), "devices");
   } else {
     visible_bus_ids = all_bus_ids;
-    DEBUGINFO("spyre_device_enum: found", visible_bus_ids.size(),
-              "Spyre devices via PCI scan");
   }
 
+  // Step 3: Build device info list.
   std::vector<SpyreDeviceInfo> devices;
   devices.reserve(visible_bus_ids.size());
   for (int i = 0; i < static_cast<int>(visible_bus_ids.size()); ++i) {
@@ -167,38 +194,32 @@ void ensureSpyreDevicesEnv() {
     return;
   }
 
-  // If no K8s or user override is active, let flex use its default scan.
-  const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
-  const char* user_env = std::getenv("SPYRE_VISIBLE_DEVICES");
-  if ((!k8s_env || k8s_env[0] == '\0') && (!user_env || user_env[0] == '\0')) {
-    return;
-  }
+  const auto& visible = getVisibleDevices();
+  if (visible.empty()) return;
 
   // Set AIU_WORLD_RANK_<i> env vars with the PCI bus IDs of visible devices.
   // flex's CreatePciId reads RANK (set by torchrun), then calls
   // RdmaGetPCIeAddress(rank) which checks AIU_WORLD_RANK_<id> and passes
   // the PCI bus ID directly to senlib::SenPci::pf(pci_address).
   //
-  // This avoids senlib index mapping entirely — we pass the exact PCI bus ID.
-  const auto& visible = getVisibleDevices();
-
+  // overwrite=1: SPYRE_VISIBLE_DEVICES may have re-indexed the list, so
+  // the mapping from index to PCI bus ID may differ from what the login
+  // script originally set.
   for (const auto& dev : visible) {
     std::string env_name = "AIU_WORLD_RANK_" + std::to_string(dev.index);
-    setenv(env_name.c_str(), dev.pci_bus_id.c_str(), /*overwrite=*/0);
+    setenv(env_name.c_str(), dev.pci_bus_id.c_str(), /*overwrite=*/1);
     DEBUGINFO("spyre_device_enum: set", env_name, "=", dev.pci_bus_id);
   }
 
-  // Also set SPYRE_DEVICES as sequential indices so flex's
+  // Set SPYRE_DEVICES as sequential indices so flex's
   // RdmaGetPCIeAddress uses the correct rank-to-index mapping.
   std::string spyre_devices;
   for (int i = 0; i < static_cast<int>(visible.size()); ++i) {
     if (!spyre_devices.empty()) spyre_devices += ',';
     spyre_devices += std::to_string(i);
   }
-  if (!spyre_devices.empty()) {
-    setenv("SPYRE_DEVICES", spyre_devices.c_str(), /*overwrite=*/0);
-    DEBUGINFO("spyre_device_enum: synthesized SPYRE_DEVICES =", spyre_devices);
-  }
+  setenv("SPYRE_DEVICES", spyre_devices.c_str(), /*overwrite=*/0);
+  DEBUGINFO("spyre_device_enum: synthesized SPYRE_DEVICES =", spyre_devices);
 }
 
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_device_enum.h
+++ b/torch_spyre/csrc/spyre_device_enum.h
@@ -34,12 +34,16 @@ struct SpyreDeviceInfo {
 
 // Returns the list of Spyre devices visible to this process.
 //
-// Priority:
-//   1. SPYRE_VISIBLE_DEVICES env var — comma-separated PCI bus IDs or
-//      0-based indices (e.g. "0,1,2" or "0000:29:00.0,0000:2a:00.0")
+// Discovery priority (full device list):
+//   1. AIU_WORLD_RANK_* env vars — set by login scripts in all environments,
+//      scanned as _0, _1, ... until a gap
 //   2. PCIDEVICE_IBM_COM_AIU_PF env var — set by K8s device plugin,
 //      comma-separated PCI bus IDs
 //   3. Full PCI bus scan via /sys/bus/pci/devices/
+//
+// Filter (applied on top of the discovered list):
+//   SPYRE_VISIBLE_DEVICES env var — comma-separated PCI bus IDs or
+//   0-based indices (e.g. "0,1" or "0000:29:00.0,0000:2a:00.0")
 //
 // The result is cached after the first call.
 const std::vector<SpyreDeviceInfo>& getVisibleDevices();
@@ -47,9 +51,12 @@ const std::vector<SpyreDeviceInfo>& getVisibleDevices();
 // Convenience: returns the number of visible Spyre devices.
 int getVisibleDeviceCount();
 
-// If SPYRE_DEVICES is not already set, and PCIDEVICE_IBM_COM_AIU_PF is
-// available, synthesize SPYRE_DEVICES from the K8s-assigned PCI bus IDs
-// so that flex picks the correct physical cards.
+// Ensure AIU_WORLD_RANK_* and SPYRE_DEVICES env vars are set correctly
+// for flex, based on the visible device list from getVisibleDevices().
+//
+// If SPYRE_DEVICES is already set, this is a no-op.  Otherwise it
+// overwrites AIU_WORLD_RANK_<i> to match the (potentially filtered)
+// visible device list and sets SPYRE_DEVICES to sequential indices.
 //
 // Must be called before flex::initializeRuntime().
 void ensureSpyreDevicesEnv();


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

  Flex relies on `AIU_WORLD_RANK_*` env vars to resolve which physical device to open. `torch-spyre` needs to (1) report the correct number of available devices via `device_count`, and (2) select the right device via `set_device`. Previously (PR #1380 ), torch-spyre discovered devices via PCIDEVICE_IBM_COM_AIU_PF and fell back to PCI scanning. 
                                                                         
  This PR aligns torch-spyre's device discovery with the preset AIU_WORLD_RANK_* environment variables, giving them the highest precedence.
                                                                                                                                                                                              
 **Device discovery** (highest to lowest precedence):                                                                                                                                            
  - AIU_WORLD_RANK_* env vars — set by login scripts, available in all environments (OpenShift and bare metal)                                                                                
  - PCIDEVICE_IBM_COM_AIU_PF — K8s device plugin (fallback for OpenShift without login scripts)                                                                                               
  - PCI bus scan — last-resort fallback                                                        
                                                                                                                                                                                              
  **Device filtering**: 
  - SPYRE_VISIBLE_DEVICES filters the discovered list. When set, ensureSpyreDevicesEnv() overwrites AIU_WORLD_RANK_* and sets SPYRE_DEVICES to match the filtered list, so flex sees the same 
  subset.   

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
