### PR TITLE
Test coverage for scalar/constant operations

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -2121,8 +2121,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             return x
 
         # RuntimeError: Error: In-device copy not implemented.
+        # ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1381
         if execution_mode == "eager":
-            pytest.skip(reason="spyre__fill_scalar crashes with SIGBUS in eager mode - in-device copy not implemented")
+            pytest.xfail(reason="spyre__fill_scalar crashes with SIGBUS in eager mode - in-device copy not implemented")
     
         compare_with_cpu(
             fn, x,

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1413,8 +1413,16 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         },
         ("test_fill_scalar", "test_fill_scalar_cpu"): {
             "param_sets": {
-                "1d_eager": (5.0, torch.tensor([1, -2, 3], dtype=torch.float16), "eager"),
-                "1d_compiled": (5.0, torch.tensor([1, -2, 3], dtype=torch.float16), "compiled"),
+                "1d_eager": (
+                    5.0,
+                    torch.tensor([1, -2, 3], dtype=torch.float16),
+                    "eager",
+                ),
+                "1d_compiled": (
+                    5.0,
+                    torch.tensor([1, -2, 3], dtype=torch.float16),
+                    "compiled",
+                ),
             },
         },
         ("test_addmm_scaled", "test_addmm_scaled_cpu"): {
@@ -2123,12 +2131,15 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         # RuntimeError: Error: In-device copy not implemented.
         # ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1381
         if execution_mode == "eager":
-            pytest.xfail(reason="spyre__fill_scalar crashes with SIGBUS in eager mode - in-device copy not implemented")
-    
+            pytest.xfail(
+                reason="spyre__fill_scalar crashes with SIGBUS in eager mode - in-device copy not implemented"
+            )
+
         compare_with_cpu(
-            fn, x,
+            fn,
+            x,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1413,7 +1413,8 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         },
         ("test_fill_scalar", "test_fill_scalar_cpu"): {
             "param_sets": {
-                "1d": (5.0, torch.tensor([1, -2, 3], dtype=torch.float16)),
+                "1d_eager": (5.0, torch.tensor([1, -2, 3], dtype=torch.float16), "eager"),
+                "1d_compiled": (5.0, torch.tensor([1, -2, 3], dtype=torch.float16), "compiled"),
             },
         },
         ("test_addmm_scaled", "test_addmm_scaled_cpu"): {
@@ -2113,14 +2114,21 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         compare_with_cpu(fn, needs_device=True, cpu_compile=False)
 
-    def test_fill_scalar_cpu(self, value, x):
+    def test_fill_scalar_cpu(self, value, x, execution_mode):
         def fn(x):
             x = x.clone()
             x.fill_(value)
             return x
 
-        # spyre__fill_scalar crashes with SIGBUS in eager mode
-        compare_with_cpu(fn, x, run_eager=False)
+        # RuntimeError: Error: In-device copy not implemented.
+        if execution_mode == "eager":
+            pytest.skip(reason="spyre__fill_scalar crashes with SIGBUS in eager mode - in-device copy not implemented")
+    
+        compare_with_cpu(
+            fn, x,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_addmm_scaled_cpu(self, alpha, input, mat1, mat2):

--- a/tests/inductor/test_inductor_scalar.py
+++ b/tests/inductor/test_inductor_scalar.py
@@ -1,0 +1,458 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import math
+import pytest
+
+from utils_inductor import (
+    cached_randn,
+    compare_with_cpu
+)
+
+@pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+@pytest.mark.parametrize("execution_mode", ["eager", "compiled"])
+class TestTensorScalarCoreArithmetic:
+    """
+    Core tensor–scalar arithmetic on Spyre vs CPU
+    """
+    
+    torch.manual_seed(0xAFFE)
+
+    @pytest.mark.skip("Spyre backend does not support dtype ComplexFloat (torch.complex64)")
+    def test_complex64_add_mul_div_python_complex_scalars(self, execution_mode):
+        """
+        ``complex64`` tensor with Python ``complex`` scalars: ``+ (1+2j)``, ``* (3-4j)``, ``/ (0.5+0.5j)``.
+        """
+        def complex_ops(x):
+            # Complex scalar addition
+            y1 = x + (1+2j)
+            # Complex scalar multiplication
+            y2 = y1 * (3-4j)
+            # Complex scalar division
+            y3 = y2 / (0.5+0.5j)
+            return y3
+        
+        x = torch.randn(10, 10, dtype=torch.complex64)
+        compare_with_cpu(
+            complex_ops, x,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+        
+    def test_fp16_fp32_tensors_fp32_literal_and_fp64_scalar_tensor(self, execution_mode):
+        """
+        ``fp16 * 2.5`` (Python scalar) and ``fp32 + tensor(1.5, float64)``; tuple return.
+        """
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: FP64 scalar tensor missing device_tensor_layout on graph input")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: IndexError during FP64 scalar tensor processing")
+
+        def mixed_precision_ops(x_fp16, x_fp32):
+            # FP16 tensor with FP32 scalar
+            y1 = x_fp16 * 2.5  # scalar is FP32 by default
+            # FP32 tensor with explicit FP64 scalar
+            y2 = x_fp32 + torch.tensor(1.5, dtype=torch.float64)
+            return y1.float(), y2
+        
+        x_fp16 = cached_randn((10, 10), dtype=torch.float16)
+        x_fp32 = cached_randn((10, 10), differentiation=1, dtype=torch.float32)
+        compare_with_cpu(
+            mixed_precision_ops,
+            x_fp16, x_fp32, atol=0.01, rtol=0.01,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    @pytest.mark.skip("Spyre backend: 0-dim tensor becomes 1-dim - torch.Size([1]) instead of torch.Size([])")
+    def test_scalar_add_mul_sub_zero_one_and_ndim_tensors(self, execution_mode):
+        """
+        One scalar Python op per rank: 0-D ``+1``, 1-D ``*2.5``, 3-D ``-3``.
+        """
+        def broadcasting_ops(x0, x1, x2):
+            # 0-dim tensor with scalar
+            y0 = x0 + 1.0
+            # 1-dim tensor with scalar
+            y1 = x1 * 2.5
+            # Multi-dim tensor with scalar
+            y2 = x2 - 3.0
+            return y0, y1, y2
+        
+        x0 = torch.tensor(5.0)  # 0-dim
+        x1 = cached_randn((10))  # 1-dim
+        x2 = cached_randn((10, 10, 10))  # 3-dim
+        compare_with_cpu(
+            broadcasting_ops,
+            x0, x1, x2,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_inplace_add_mul_div_scalar_after_clone(self, execution_mode):
+        """
+        ``clone()`` then ``add_(1)``, ``mul_(2)``, ``div_(0.5)`` (in-place scalar chain).
+        """
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: In-device copy (.clone()) not implemented")
+        def inplace_ops(x):
+            y = x.clone()
+            y.add_(1.0)
+            y.mul_(2.0)
+            y.div_(0.5)
+            return y
+        
+        x = cached_randn((10, 10))
+        compare_with_cpu(
+            inplace_ops,
+            x,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_parenthesized_chain_add_mul_sub_div_scalars(self, execution_mode):
+        """
+        ``((x + 1.5) * 2.0 - 0.5) / 3.0`` — single expression, Python float constants.
+        """
+        def chained_ops(x):
+            return ((x + 1.5) * 2.0 - 0.5) / 3.0
+        
+        x = cached_randn((10, 10))
+        compare_with_cpu(
+            chained_ops,
+            x,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+
+@pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+@pytest.mark.parametrize("execution_mode", ["eager", "compiled"])
+class TestSdpaScalarHyperparameters:
+    """
+    Scaled dot-product attention (SDPA) variants on Spyre: scalar hyperparameters
+    (mask fill value, dropout ``p``, temperature divisor, additive score bias, window size)
+    and mask patterns (full, local, causal). Names reflect the *implemented* math, not
+    full model recipes.
+
+    **Scalar constant vs 0-D tensor “scalar”** (for Inductor / constant-args coverage):
+
+    - **Python scalar constant**: a literal or ``float`` used directly, e.g.
+      ``masked_fill(..., -1.0e4)`` — typically folded as a constant in the graph.
+    - **0-D tensor scalar**: ``torch.tensor(-1.0e4, dtype=torch.float16)`` — one element,
+      may follow a different lowering path than a bare Python float.
+    """
+
+    torch.manual_seed(0xAFFE)
+
+    # Small shapes (B,H,S,D) keep memory down and reduce backend-specific FP16 overflow issues.
+    _MASK_SMALL = dict(b=1, h=2, s=32, d=16)
+
+    def test_sdpa_masked_fill_scalar_constant_finite_neg_fp16(self, execution_mode):
+        """
+        Causal SDPA: ``masked_fill`` with a negative **Python float** ``-1.0e4`` (in-range for FP16).
+
+        Uses a large finite sentinel instead of ``float("-inf")`` so ``compare_with_cpu`` matches
+        reliably on CPU vs Spyre (``-inf`` / huge negatives can diverge across FP16 paths).
+        """
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: IndexError: list index out of range")
+        b, h, s, d = (
+            self._MASK_SMALL["b"],
+            self._MASK_SMALL["h"],
+            self._MASK_SMALL["s"],
+            self._MASK_SMALL["d"],
+        )
+        fill = -1.0e4
+
+        def sdpa_finite_fill(q, k, v):
+            d_k = q.size(-1)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            causal = torch.tril(torch.ones(s, s, dtype=torch.bool, device=scores.device))
+            allowed = causal.view(1, 1, s, s).expand(b, h, s, s)
+            scores = scores.masked_fill(~allowed, fill)
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+
+        q = cached_randn((b, h, s, d), dtype=torch.float16)
+        k = cached_randn((b, h, s, d), dtype=torch.float16, differentiation=1)
+        v = cached_randn((b, h, s, d), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            sdpa_finite_fill,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager"),
+        )
+
+    def test_sdpa_masked_fill_zero_dim_tensor_scalar_fp16(self, execution_mode):
+        """
+        Causal mask with fill = **0-D tensor** ``torch.tensor(-1.0e4, dtype=float16)`` (tensor “scalar”).
+        """
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: IndexError: list index out of range")
+        b, h, s, d = (
+            self._MASK_SMALL["b"],
+            self._MASK_SMALL["h"],
+            self._MASK_SMALL["s"],
+            self._MASK_SMALL["d"],
+        )
+
+        def sdpa_tensor0d_fill(q, k, v):
+            d_k = q.size(-1)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            causal = torch.tril(torch.ones(s, s, dtype=torch.bool, device=scores.device))
+            allowed = causal.view(1, 1, s, s).expand(b, h, s, s)
+            fill = torch.tensor(-1.0e4, dtype=torch.float16, device=scores.device)
+            scores = scores.masked_fill(~allowed, fill)
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+
+        q = cached_randn((b, h, s, d), dtype=torch.float16)
+        k = cached_randn((b, h, s, d), dtype=torch.float16, differentiation=1)
+        v = cached_randn((b, h, s, d), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            sdpa_tensor0d_fill,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager"),
+        )
+
+    def test_sdpa_dropout_scalar_p(self, execution_mode):
+        """SDPA with ``dropout(attn, p=0.1, training=False)`` — scalar dropout probability."""
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: DXP compiler crash (SIGABRT) during attention compilation")
+        
+        def attention_with_dropout(q, k, v):
+            d_k = q.size(-1)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            attn = torch.softmax(scores, dim=-1)
+            # Dropout with scalar rate
+            attn = torch.nn.functional.dropout(attn, p=0.1, training=False)
+            return torch.matmul(attn, v)
+        
+        q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
+        k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
+        v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            attention_with_dropout,
+            q, k, v,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_sdpa_score_temperature_divisor_scalar(self, execution_mode):
+        """SDPA: divide logits by ``(sqrt(d_k) * temperature)`` with scalar ``temperature=2.0``."""
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: DXP compiler crash (SIGABRT) during attention compilation")
+
+        def temperature_attention(q, k, v):
+            d_k = q.size(-1)
+            temperature = 2.0  # Temperature scalar
+            scores = torch.matmul(q, k.transpose(-2, -1)) / (math.sqrt(d_k) * temperature)
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+        
+        q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
+        k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
+        v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            temperature_attention,
+            q, k, v,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    @pytest.mark.parametrize("num_kv_heads", [1, 2])
+    def test_sdpa_broadcast_kv_heads(self, execution_mode, num_kv_heads):
+        """
+        SDPA when K/V have fewer heads than Q: PyTorch **broadcasts** KV heads to Q heads.
+        This is *not* a full GQA/MQA implementation (no explicit KV repeat); it exercises
+        broadcast matmul + scalar ``1/sqrt(d_k)`` on Spyre.
+        """
+        # Handle num_kv_heads=2 case (same error both modes)
+        if num_kv_heads == 2:
+            pytest.skip("Spyre backend: Cannot broadcast K,V heads (2) to Q heads (8) for GQA")
+
+        # Handle num_kv_heads=1 case (different errors per mode)
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: In-device copy not implemented (required for MQA operations)")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: DXP compiler crash during MQA compilation")
+        def sdpa_broadcast_kv(q, k, v):
+            d_k = q.size(-1)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+        
+        q = cached_randn((2, 8, 128, 64), dtype=torch.float16)  # 8 query heads
+        k = cached_randn((2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=1)
+        v = cached_randn((2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            sdpa_broadcast_kv,
+            q, k, v,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_sdpa_local_window_mask_scalar(self, execution_mode):
+        """SDPA: local window via ``masked_fill(..., -inf)``; ``window_size=32`` sets mask support."""
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: masked_fill device propagation error - mask on CPU, tensor on spyre")
+        
+        def local_attention(q, k, v):
+            d_k = q.size(-1)
+            window_size = 32  # Local window scalar
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            # Create local attention mask
+            seq_len = scores.size(-1)
+            mask = torch.ones(seq_len, seq_len, dtype=torch.bool)
+            for i in range(seq_len):
+                start = max(0, i - window_size)
+                end = min(seq_len, i + window_size + 1)
+                mask[i, start:end] = False
+            scores = scores.masked_fill(mask, float('-inf'))
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+        
+        q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
+        k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
+        v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            local_attention,
+            q, k, v,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_sdpa_cross_sequence_length(self, execution_mode):
+        """SDPA with Q seq len ≠ KV seq len (scalar ``1/sqrt(d_k)`` scaling only)."""
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: DXP compiler crash during cross-attention compilation")
+        
+        def cross_attention(q, k, v):
+            d_k = q.size(-1)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+        
+        q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
+        k = cached_randn((2, 8, 256, 64), dtype=torch.float16, differentiation=1)
+        v = cached_randn((2, 8, 256, 64), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            cross_attention,
+            q, k, v,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_sdpa_self_attention_single_tensor(self, execution_mode):
+        """SDPA: Q, K, V all from one tensor ``x`` (scalar ``1/sqrt(d_k)``)."""
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: DXP compiler crash during self-attention compilation")
+        
+        def self_attention(x):
+            # Self attention: Q, K, V all from same source
+            d_k = x.size(-1)
+            scores = torch.matmul(x, x.transpose(-2, -1)) / math.sqrt(d_k)
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, x)
+        
+        x = cached_randn((2, 8, 128, 64), dtype=torch.float16)
+        compare_with_cpu(
+            self_attention,
+            x,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_sdpa_causal_triu_mask_neg_inf(self, execution_mode):
+        """SDPA: causal mask via ``triu`` + ``masked_fill(..., -inf)``."""
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: masked_fill device propagation error - mask on CPU, tensor on spyre:0")
+        def causal_attention(q, k, v):
+            d_k = q.size(-1)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            # Causal mask
+            seq_len = scores.size(-1)
+            mask = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool), diagonal=1)
+            scores = scores.masked_fill(mask, float('-inf'))
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+        
+        q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
+        k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
+        v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            causal_attention,
+            q, k, v,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )
+
+    def test_sdpa_additive_score_bias_scalar(self, execution_mode):
+        """SDPA: add scalar ``0.1`` to all attention logits before softmax."""
+        if execution_mode == "eager":
+            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+        elif execution_mode == "compiled":
+            pytest.skip("Compiled mode: batchmatmul stickification failed - cannot map output stick_dim")
+        
+        def attention_with_bias(q, k, v):
+            d_k = q.size(-1)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
+            # Add scalar bias
+            scores = scores + 0.1
+            attn = torch.softmax(scores, dim=-1)
+            return torch.matmul(attn, v)
+        
+        q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
+        k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
+        v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
+        compare_with_cpu(
+            attention_with_bias,
+            q, k, v,
+            atol=0.1, rtol=0.1,
+            run_compile=(execution_mode == "compiled"),
+            run_eager=(execution_mode == "eager")
+        )

--- a/tests/inductor/test_inductor_scalar.py
+++ b/tests/inductor/test_inductor_scalar.py
@@ -30,7 +30,8 @@ class TestTensorScalarCoreArithmetic:
     
     torch.manual_seed(0xAFFE)
 
-    @pytest.mark.skip("Spyre backend does not support dtype ComplexFloat (torch.complex64)")
+    #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1545
+    @pytest.mark.xfail(reason="Spyre backend does not support dtype ComplexFloat (torch.complex64)")
     def test_complex64_add_mul_div_python_complex_scalars(self, execution_mode):
         """
         ``complex64`` tensor with Python ``complex`` scalars: ``+ (1+2j)``, ``* (3-4j)``, ``/ (0.5+0.5j)``.
@@ -51,20 +52,18 @@ class TestTensorScalarCoreArithmetic:
             run_eager=(execution_mode == "eager")
         )
         
+    #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1228
+    @pytest.mark.xfail(reason="Spyre backend does not support dtype Double (FP64)")
     def test_fp16_fp32_tensors_fp32_literal_and_fp64_scalar_tensor(self, execution_mode):
         """
         ``fp16 * 2.5`` (Python scalar) and ``fp32 + tensor(1.5, float64)``; tuple return.
         """
-        if execution_mode == "eager":
-            pytest.skip("Eager mode: FP64 scalar tensor missing device_tensor_layout on graph input")
-        elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: IndexError during FP64 scalar tensor processing")
 
         def mixed_precision_ops(x_fp16, x_fp32):
             # FP16 tensor with FP32 scalar
             y1 = x_fp16 * 2.5  # scalar is FP32 by default
             # FP32 tensor with explicit FP64 scalar
-            y2 = x_fp32 + torch.tensor(1.5, dtype=torch.float64)
+            y2 = x_fp32 + torch.tensor(1.5, dtype=torch.float64, device = x_fp16.device)
             return y1.float(), y2
         
         x_fp16 = cached_randn((10, 10), dtype=torch.float16)
@@ -75,8 +74,9 @@ class TestTensorScalarCoreArithmetic:
             run_compile=(execution_mode == "compiled"),
             run_eager=(execution_mode == "eager")
         )
-
-    @pytest.mark.skip("Spyre backend: 0-dim tensor becomes 1-dim - torch.Size([1]) instead of torch.Size([])")
+    
+    #TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1172
+    @pytest.mark.xfail(reason="Support 0-dim tensors in Spyre")
     def test_scalar_add_mul_sub_zero_one_and_ndim_tensors(self, execution_mode):
         """
         One scalar Python op per rank: 0-D ``+1``, 1-D ``*2.5``, 3-D ``-3``.
@@ -104,8 +104,9 @@ class TestTensorScalarCoreArithmetic:
         """
         ``clone()`` then ``add_(1)``, ``mul_(2)``, ``div_(0.5)`` (in-place scalar chain).
         """
+        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1558
         if execution_mode == "eager":
-            pytest.skip("Eager mode: In-device copy (.clone()) not implemented")
+            pytest.xfail(reason="Eager mode: 'RuntimeError: In-device copy (.clone()) not implemented'")
         def inplace_ops(x):
             y = x.clone()
             y.add_(1.0)
@@ -143,15 +144,7 @@ class TestSdpaScalarHyperparameters:
     """
     Scaled dot-product attention (SDPA) variants on Spyre: scalar hyperparameters
     (mask fill value, dropout ``p``, temperature divisor, additive score bias, window size)
-    and mask patterns (full, local, causal). Names reflect the *implemented* math, not
-    full model recipes.
-
-    **Scalar constant vs 0-D tensor “scalar”** (for Inductor / constant-args coverage):
-
-    - **Python scalar constant**: a literal or ``float`` used directly, e.g.
-      ``masked_fill(..., -1.0e4)`` — typically folded as a constant in the graph.
-    - **0-D tensor scalar**: ``torch.tensor(-1.0e4, dtype=torch.float16)`` — one element,
-      may follow a different lowering path than a bare Python float.
+    and mask patterns (full, local, causal).
     """
 
     torch.manual_seed(0xAFFE)
@@ -162,14 +155,15 @@ class TestSdpaScalarHyperparameters:
     def test_sdpa_masked_fill_scalar_constant_finite_neg_fp16(self, execution_mode):
         """
         Causal SDPA: ``masked_fill`` with a negative **Python float** ``-1.0e4`` (in-range for FP16).
-
-        Uses a large finite sentinel instead of ``float("-inf")`` so ``compare_with_cpu`` matches
-        reliably on CPU vs Spyre (``-inf`` / huge negatives can diverge across FP16 paths).
         """
+        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
+        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
         elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: IndexError: list index out of range")
+            pytest.xfail(
+                reason="Constant tensor creation fails - IndexError on empty args during layout propagation."
+            )
         b, h, s, d = (
             self._MASK_SMALL["b"],
             self._MASK_SMALL["h"],
@@ -181,8 +175,8 @@ class TestSdpaScalarHyperparameters:
         def sdpa_finite_fill(q, k, v):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
-            causal = torch.tril(torch.ones(s, s, dtype=torch.bool, device=scores.device))
-            allowed = causal.view(1, 1, s, s).expand(b, h, s, s)
+            causal_mask = torch.tril(torch.ones(s, s, dtype=torch.bool)).to(q.device)
+            allowed = causal_mask.view(1, 1, s, s).expand(b, h, s, s)
             scores = scores.masked_fill(~allowed, fill)
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
@@ -205,10 +199,14 @@ class TestSdpaScalarHyperparameters:
         """
         Causal mask with fill = **0-D tensor** ``torch.tensor(-1.0e4, dtype=float16)`` (tensor “scalar”).
         """
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
+        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
         elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: IndexError: list index out of range")
+            pytest.xfail(
+                reason="Constant tensor creation fails - IndexError on empty args during layout propagation."
+            )
         b, h, s, d = (
             self._MASK_SMALL["b"],
             self._MASK_SMALL["h"],
@@ -216,10 +214,9 @@ class TestSdpaScalarHyperparameters:
             self._MASK_SMALL["d"],
         )
 
-        def sdpa_tensor0d_fill(q, k, v):
+        def sdpa_tensor0d_fill(q, k, v, causal):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
-            causal = torch.tril(torch.ones(s, s, dtype=torch.bool, device=scores.device))
             allowed = causal.view(1, 1, s, s).expand(b, h, s, s)
             fill = torch.tensor(-1.0e4, dtype=torch.float16, device=scores.device)
             scores = scores.masked_fill(~allowed, fill)
@@ -229,11 +226,14 @@ class TestSdpaScalarHyperparameters:
         q = cached_randn((b, h, s, d), dtype=torch.float16)
         k = cached_randn((b, h, s, d), dtype=torch.float16, differentiation=1)
         v = cached_randn((b, h, s, d), dtype=torch.float16, differentiation=2)
+        causal_mask = torch.tril(torch.ones(s, s, dtype=torch.bool))
+
         compare_with_cpu(
             sdpa_tensor0d_fill,
             q,
             k,
             v,
+            causal_mask,
             atol=0.1,
             rtol=0.1,
             run_compile=(execution_mode == "compiled"),
@@ -242,10 +242,9 @@ class TestSdpaScalarHyperparameters:
 
     def test_sdpa_dropout_scalar_p(self, execution_mode):
         """SDPA with ``dropout(attn, p=0.1, training=False)`` — scalar dropout probability."""
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
-        elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: DXP compiler crash (SIGABRT) during attention compilation")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
         
         def attention_with_dropout(q, k, v):
             d_k = q.size(-1)
@@ -268,11 +267,10 @@ class TestSdpaScalarHyperparameters:
 
     def test_sdpa_score_temperature_divisor_scalar(self, execution_mode):
         """SDPA: divide logits by ``(sqrt(d_k) * temperature)`` with scalar ``temperature=2.0``."""
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
-        elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: DXP compiler crash (SIGABRT) during attention compilation")
-
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
+        
         def temperature_attention(q, k, v):
             d_k = q.size(-1)
             temperature = 2.0  # Temperature scalar
@@ -291,28 +289,23 @@ class TestSdpaScalarHyperparameters:
             run_eager=(execution_mode == "eager")
         )
 
-    @pytest.mark.parametrize("num_kv_heads", [1, 2])
-    def test_sdpa_broadcast_kv_heads(self, execution_mode, num_kv_heads):
+    def test_sdpa_broadcast_kv_heads(self, execution_mode):
         """
         SDPA when K/V have fewer heads than Q: PyTorch **broadcasts** KV heads to Q heads.
         This is *not* a full GQA/MQA implementation (no explicit KV repeat); it exercises
         broadcast matmul + scalar ``1/sqrt(d_k)`` on Spyre.
         """
-        # Handle num_kv_heads=2 case (same error both modes)
-        if num_kv_heads == 2:
-            pytest.skip("Spyre backend: Cannot broadcast K,V heads (2) to Q heads (8) for GQA")
-
-        # Handle num_kv_heads=1 case (different errors per mode)
+        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1558
         if execution_mode == "eager":
-            pytest.skip("Eager mode: In-device copy not implemented (required for MQA operations)")
-        elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: DXP compiler crash during MQA compilation")
+            pytest.xfail(reason="Eager mode: In-device copy not implemented (required for MQA operations)")
+
         def sdpa_broadcast_kv(q, k, v):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
         
+        num_kv_heads: int = 1
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)  # 8 query heads
         k = cached_randn((2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=1)
         v = cached_randn((2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=2)
@@ -326,10 +319,12 @@ class TestSdpaScalarHyperparameters:
 
     def test_sdpa_local_window_mask_scalar(self, execution_mode):
         """SDPA: local window via ``masked_fill(..., -inf)``; ``window_size=32`` sets mask support."""
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1482
         elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: masked_fill device propagation error - mask on CPU, tensor on spyre")
+            pytest.xfail(reason="Spyre backend does not support type conversion yet during copy.")
         
         def local_attention(q, k, v):
             d_k = q.size(-1)
@@ -337,7 +332,7 @@ class TestSdpaScalarHyperparameters:
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
             # Create local attention mask
             seq_len = scores.size(-1)
-            mask = torch.ones(seq_len, seq_len, dtype=torch.bool)
+            mask = torch.ones(seq_len, seq_len, dtype=torch.bool, device=q.device)
             for i in range(seq_len):
                 start = max(0, i - window_size)
                 end = min(seq_len, i + window_size + 1)
@@ -359,10 +354,9 @@ class TestSdpaScalarHyperparameters:
 
     def test_sdpa_cross_sequence_length(self, execution_mode):
         """SDPA with Q seq len ≠ KV seq len (scalar ``1/sqrt(d_k)`` scaling only)."""
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
-        elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: DXP compiler crash during cross-attention compilation")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
         
         def cross_attention(q, k, v):
             d_k = q.size(-1)
@@ -383,10 +377,9 @@ class TestSdpaScalarHyperparameters:
 
     def test_sdpa_self_attention_single_tensor(self, execution_mode):
         """SDPA: Q, K, V all from one tensor ``x`` (scalar ``1/sqrt(d_k)``)."""
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
-        elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: DXP compiler crash during self-attention compilation")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
         
         def self_attention(x):
             # Self attention: Q, K, V all from same source
@@ -406,16 +399,21 @@ class TestSdpaScalarHyperparameters:
 
     def test_sdpa_causal_triu_mask_neg_inf(self, execution_mode):
         """SDPA: causal mask via ``triu`` + ``masked_fill(..., -inf)``."""
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
+        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
         elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: masked_fill device propagation error - mask on CPU, tensor on spyre:0")
+            pytest.xfail(
+                reason="Constant tensor creation fails - IndexError on empty args during layout propagation."
+            )
+
         def causal_attention(q, k, v):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
             # Causal mask
             seq_len = scores.size(-1)
-            mask = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool), diagonal=1)
+            mask = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool, device=q.device), diagonal=1)
             scores = scores.masked_fill(mask, float('-inf'))
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
@@ -433,10 +431,12 @@ class TestSdpaScalarHyperparameters:
 
     def test_sdpa_additive_score_bias_scalar(self, execution_mode):
         """SDPA: add scalar ``0.1`` to all attention logits before softmax."""
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.skip("Eager mode: aten::_reshape_alias operation not implemented")
+            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
+        #TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1377
         elif execution_mode == "compiled":
-            pytest.skip("Compiled mode: batchmatmul stickification failed - cannot map output stick_dim")
+            pytest.xfail(reason="Compiled mode: batchmatmul stickification failed - cannot map output stick_dim")
         
         def attention_with_bias(q, k, v):
             d_k = q.size(-1)

--- a/tests/inductor/test_inductor_scalar.py
+++ b/tests/inductor/test_inductor_scalar.py
@@ -434,9 +434,6 @@ class TestSdpaScalarHyperparameters:
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
             pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        #TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1377
-        elif execution_mode == "compiled":
-            pytest.xfail(reason="Compiled mode: batchmatmul stickification failed - cannot map output stick_dim")
         
         def attention_with_bias(q, k, v):
             d_k = q.size(-1)

--- a/tests/inductor/test_inductor_scalar.py
+++ b/tests/inductor/test_inductor_scalar.py
@@ -16,10 +16,8 @@ import torch
 import math
 import pytest
 
-from utils_inductor import (
-    cached_randn,
-    compare_with_cpu
-)
+from utils_inductor import cached_randn, compare_with_cpu
+
 
 @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
 @pytest.mark.parametrize("execution_mode", ["eager", "compiled"])
@@ -27,34 +25,40 @@ class TestTensorScalarCoreArithmetic:
     """
     Core tensor–scalar arithmetic on Spyre vs CPU
     """
-    
+
     torch.manual_seed(0xAFFE)
 
-    #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1545
-    @pytest.mark.xfail(reason="Spyre backend does not support dtype ComplexFloat (torch.complex64)")
+    # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1545
+    @pytest.mark.xfail(
+        reason="Spyre backend does not support dtype ComplexFloat (torch.complex64)"
+    )
     def test_complex64_add_mul_div_python_complex_scalars(self, execution_mode):
         """
         ``complex64`` tensor with Python ``complex`` scalars: ``+ (1+2j)``, ``* (3-4j)``, ``/ (0.5+0.5j)``.
         """
+
         def complex_ops(x):
             # Complex scalar addition
-            y1 = x + (1+2j)
+            y1 = x + (1 + 2j)
             # Complex scalar multiplication
-            y2 = y1 * (3-4j)
+            y2 = y1 * (3 - 4j)
             # Complex scalar division
-            y3 = y2 / (0.5+0.5j)
+            y3 = y2 / (0.5 + 0.5j)
             return y3
-        
+
         x = torch.randn(10, 10, dtype=torch.complex64)
         compare_with_cpu(
-            complex_ops, x,
+            complex_ops,
+            x,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
-        
-    #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1228
+
+    # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1228
     @pytest.mark.xfail(reason="Spyre backend does not support dtype Double (FP64)")
-    def test_fp16_fp32_tensors_fp32_literal_and_fp64_scalar_tensor(self, execution_mode):
+    def test_fp16_fp32_tensors_fp32_literal_and_fp64_scalar_tensor(
+        self, execution_mode
+    ):
         """
         ``fp16 * 2.5`` (Python scalar) and ``fp32 + tensor(1.5, float64)``; tuple return.
         """
@@ -63,24 +67,28 @@ class TestTensorScalarCoreArithmetic:
             # FP16 tensor with FP32 scalar
             y1 = x_fp16 * 2.5  # scalar is FP32 by default
             # FP32 tensor with explicit FP64 scalar
-            y2 = x_fp32 + torch.tensor(1.5, dtype=torch.float64, device = x_fp16.device)
+            y2 = x_fp32 + torch.tensor(1.5, dtype=torch.float64, device=x_fp16.device)
             return y1.float(), y2
-        
+
         x_fp16 = cached_randn((10, 10), dtype=torch.float16)
         x_fp32 = cached_randn((10, 10), differentiation=1, dtype=torch.float32)
         compare_with_cpu(
             mixed_precision_ops,
-            x_fp16, x_fp32, atol=0.01, rtol=0.01,
+            x_fp16,
+            x_fp32,
+            atol=0.01,
+            rtol=0.01,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
-    
-    #TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1172
+
+    # TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1172
     @pytest.mark.xfail(reason="Support 0-dim tensors in Spyre")
     def test_scalar_add_mul_sub_zero_one_and_ndim_tensors(self, execution_mode):
         """
         One scalar Python op per rank: 0-D ``+1``, 1-D ``*2.5``, 3-D ``-3``.
         """
+
         def broadcasting_ops(x0, x1, x2):
             # 0-dim tensor with scalar
             y0 = x0 + 1.0
@@ -89,52 +97,58 @@ class TestTensorScalarCoreArithmetic:
             # Multi-dim tensor with scalar
             y2 = x2 - 3.0
             return y0, y1, y2
-        
+
         x0 = torch.tensor(5.0)  # 0-dim
         x1 = cached_randn((10))  # 1-dim
         x2 = cached_randn((10, 10, 10))  # 3-dim
         compare_with_cpu(
             broadcasting_ops,
-            x0, x1, x2,
+            x0,
+            x1,
+            x2,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_inplace_add_mul_div_scalar_after_clone(self, execution_mode):
         """
         ``clone()`` then ``add_(1)``, ``mul_(2)``, ``div_(0.5)`` (in-place scalar chain).
         """
-        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1558
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1558
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: 'RuntimeError: In-device copy (.clone()) not implemented'")
+            pytest.xfail(
+                reason="Eager mode: 'RuntimeError: In-device copy (.clone()) not implemented'"
+            )
+
         def inplace_ops(x):
             y = x.clone()
             y.add_(1.0)
             y.mul_(2.0)
             y.div_(0.5)
             return y
-        
+
         x = cached_randn((10, 10))
         compare_with_cpu(
             inplace_ops,
             x,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_parenthesized_chain_add_mul_sub_div_scalars(self, execution_mode):
         """
         ``((x + 1.5) * 2.0 - 0.5) / 3.0`` — single expression, Python float constants.
         """
+
         def chained_ops(x):
             return ((x + 1.5) * 2.0 - 0.5) / 3.0
-        
+
         x = cached_randn((10, 10))
         compare_with_cpu(
             chained_ops,
             x,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
 
@@ -156,10 +170,12 @@ class TestSdpaScalarHyperparameters:
         """
         Causal SDPA: ``masked_fill`` with a negative **Python float** ``-1.0e4`` (in-range for FP16).
         """
-        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
         elif execution_mode == "compiled":
             pytest.xfail(
                 reason="Constant tensor creation fails - IndexError on empty args during layout propagation."
@@ -201,8 +217,10 @@ class TestSdpaScalarHyperparameters:
         """
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
         elif execution_mode == "compiled":
             pytest.xfail(
                 reason="Constant tensor creation fails - IndexError on empty args during layout propagation."
@@ -244,8 +262,10 @@ class TestSdpaScalarHyperparameters:
         """SDPA with ``dropout(attn, p=0.1, training=False)`` — scalar dropout probability."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+
         def attention_with_dropout(q, k, v):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
@@ -253,40 +273,50 @@ class TestSdpaScalarHyperparameters:
             # Dropout with scalar rate
             attn = torch.nn.functional.dropout(attn, p=0.1, training=False)
             return torch.matmul(attn, v)
-        
+
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
         k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
         v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
         compare_with_cpu(
             attention_with_dropout,
-            q, k, v,
-            atol=0.1, rtol=0.1,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_sdpa_score_temperature_divisor_scalar(self, execution_mode):
         """SDPA: divide logits by ``(sqrt(d_k) * temperature)`` with scalar ``temperature=2.0``."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+
         def temperature_attention(q, k, v):
             d_k = q.size(-1)
             temperature = 2.0  # Temperature scalar
-            scores = torch.matmul(q, k.transpose(-2, -1)) / (math.sqrt(d_k) * temperature)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / (
+                math.sqrt(d_k) * temperature
+            )
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
-        
+
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
         k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
         v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
         compare_with_cpu(
             temperature_attention,
-            q, k, v,
-            atol=0.1, rtol=0.1,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_sdpa_broadcast_kv_heads(self, execution_mode):
@@ -295,37 +325,50 @@ class TestSdpaScalarHyperparameters:
         This is *not* a full GQA/MQA implementation (no explicit KV repeat); it exercises
         broadcast matmul + scalar ``1/sqrt(d_k)`` on Spyre.
         """
-        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1558
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1558
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: In-device copy not implemented (required for MQA operations)")
+            pytest.xfail(
+                reason="Eager mode: In-device copy not implemented (required for MQA operations)"
+            )
 
         def sdpa_broadcast_kv(q, k, v):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
-        
+
         num_kv_heads: int = 1
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)  # 8 query heads
-        k = cached_randn((2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=1)
-        v = cached_randn((2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=2)
+        k = cached_randn(
+            (2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=1
+        )
+        v = cached_randn(
+            (2, num_kv_heads, 128, 64), dtype=torch.float16, differentiation=2
+        )
         compare_with_cpu(
             sdpa_broadcast_kv,
-            q, k, v,
-            atol=0.1, rtol=0.1,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_sdpa_local_window_mask_scalar(self, execution_mode):
         """SDPA: local window via ``masked_fill(..., -inf)``; ``window_size=32`` sets mask support."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1482
         elif execution_mode == "compiled":
-            pytest.xfail(reason="Spyre backend does not support type conversion yet during copy.")
-        
+            pytest.xfail(
+                reason="Spyre backend does not support type conversion yet during copy."
+            )
+
         def local_attention(q, k, v):
             d_k = q.size(-1)
             window_size = 32  # Local window scalar
@@ -337,72 +380,85 @@ class TestSdpaScalarHyperparameters:
                 start = max(0, i - window_size)
                 end = min(seq_len, i + window_size + 1)
                 mask[i, start:end] = False
-            scores = scores.masked_fill(mask, float('-inf'))
+            scores = scores.masked_fill(mask, float("-inf"))
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
-        
+
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
         k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
         v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
         compare_with_cpu(
             local_attention,
-            q, k, v,
-            atol=0.1, rtol=0.1,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_sdpa_cross_sequence_length(self, execution_mode):
         """SDPA with Q seq len ≠ KV seq len (scalar ``1/sqrt(d_k)`` scaling only)."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+
         def cross_attention(q, k, v):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
-        
+
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
         k = cached_randn((2, 8, 256, 64), dtype=torch.float16, differentiation=1)
         v = cached_randn((2, 8, 256, 64), dtype=torch.float16, differentiation=2)
         compare_with_cpu(
             cross_attention,
-            q, k, v,
-            atol=0.1, rtol=0.1,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_sdpa_self_attention_single_tensor(self, execution_mode):
         """SDPA: Q, K, V all from one tensor ``x`` (scalar ``1/sqrt(d_k)``)."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+
         def self_attention(x):
             # Self attention: Q, K, V all from same source
             d_k = x.size(-1)
             scores = torch.matmul(x, x.transpose(-2, -1)) / math.sqrt(d_k)
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, x)
-        
+
         x = cached_randn((2, 8, 128, 64), dtype=torch.float16)
         compare_with_cpu(
             self_attention,
             x,
-            atol=0.1, rtol=0.1,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_sdpa_causal_triu_mask_neg_inf(self, execution_mode):
         """SDPA: causal mask via ``triu`` + ``masked_fill(..., -inf)``."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        #TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+        # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/1334
         elif execution_mode == "compiled":
             pytest.xfail(
                 reason="Constant tensor creation fails - IndexError on empty args during layout propagation."
@@ -413,28 +469,36 @@ class TestSdpaScalarHyperparameters:
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
             # Causal mask
             seq_len = scores.size(-1)
-            mask = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool, device=q.device), diagonal=1)
-            scores = scores.masked_fill(mask, float('-inf'))
+            mask = torch.triu(
+                torch.ones(seq_len, seq_len, dtype=torch.bool, device=q.device),
+                diagonal=1,
+            )
+            scores = scores.masked_fill(mask, float("-inf"))
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
-        
+
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
         k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
         v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
         compare_with_cpu(
             causal_attention,
-            q, k, v,
-            atol=0.1, rtol=0.1,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )
 
     def test_sdpa_additive_score_bias_scalar(self, execution_mode):
         """SDPA: add scalar ``0.1`` to all attention logits before softmax."""
         # TODO: ISSUE https://github.com/torch-spyre/torch-spyre/issues/543
         if execution_mode == "eager":
-            pytest.xfail(reason="Eager mode: aten::_reshape_alias operation not implemented")
-        
+            pytest.xfail(
+                reason="Eager mode: aten::_reshape_alias operation not implemented"
+            )
+
         def attention_with_bias(q, k, v):
             d_k = q.size(-1)
             scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(d_k)
@@ -442,14 +506,17 @@ class TestSdpaScalarHyperparameters:
             scores = scores + 0.1
             attn = torch.softmax(scores, dim=-1)
             return torch.matmul(attn, v)
-        
+
         q = cached_randn((2, 8, 128, 64), dtype=torch.float16)
         k = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=1)
         v = cached_randn((2, 8, 128, 64), dtype=torch.float16, differentiation=2)
         compare_with_cpu(
             attention_with_bias,
-            q, k, v,
-            atol=0.1, rtol=0.1,
+            q,
+            k,
+            v,
+            atol=0.1,
+            rtol=0.1,
             run_compile=(execution_mode == "compiled"),
-            run_eager=(execution_mode == "eager")
+            run_eager=(execution_mode == "eager"),
         )

--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -465,17 +465,45 @@ def compare_with_cpu(
     cpu_compile=None,
     target=None,
     run_eager=True,
+    run_compile=True,
 ):
+
+    """Compare Spyre execution against CPU for one or both Spyre execution paths.
+
+    ``run_compile`` and ``run_eager`` select ``torch.compile`` vs eager on ``DEVICE``
+    (spyre). At least one must be ``True``:
+
+    - **Both** (default): ``run_compile=True``, ``run_eager=True`` — run compiled
+      Spyre, then eager Spyre (same order as before).
+    - **Compiled only**: ``run_compile=True``, ``run_eager=False``.
+    - **Eager only**: ``run_compile=False``, ``run_eager=True``.
+    - **Neither**: raises ``ValueError``.
+
+    When ``cpu_compile`` is True, each selected Spyre path is also compared to CPU
+    using the same compile flag (compiled vs compiled, or eager vs eager).
+
+    Args:
+        run_compile: Run the compiled path on Spyre.
+        run_eager: Run the eager (non-compiled) path on Spyre.
+    """
     # if this flag is explicitly passed in by the test, use it
     if cpu_compile is None:
         # the bool function parses all non-empty strings to true
         # if this env var is set at all, it gets marked as true
         cpu_compile = bool(os.getenv("TEST_COMPARE_CPU_COMPILE"))
-
-    """Compare Spyre execution (compiled and optionally eager) against CPU execution."""
+    
     cpu_result = fn(*args)
 
-    for compiled in [True, False] if run_eager else [True]:
+    # Order: compiled first, then eager (matches prior [True, False] when both on).
+    modes = tuple(
+        compiled
+        for compiled, enabled in ((True, run_compile), (False, run_eager))
+        if enabled
+    )
+    if not modes:
+        raise ValueError("At least one of run_compile or run_eager must be True")
+
+    for compiled in modes:
         mode = "compiled" if compiled else "eager"
         spyre_result = (
             target

--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -467,7 +467,6 @@ def compare_with_cpu(
     run_eager=True,
     run_compile=True,
 ):
-
     """Compare Spyre execution against CPU for one or both Spyre execution paths.
 
     ``run_compile`` and ``run_eager`` select ``torch.compile`` vs eager on ``DEVICE``
@@ -491,7 +490,7 @@ def compare_with_cpu(
         # the bool function parses all non-empty strings to true
         # if this env var is set at all, it gets marked as true
         cpu_compile = bool(os.getenv("TEST_COMPARE_CPU_COMPILE"))
-    
+
     cpu_result = fn(*args)
 
     # Order: compiled first, then eager (matches prior [True, False] when both on).

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -46,7 +46,7 @@ _SCALAR_ROUNDTRIP_DTYPE_CASES = [
 ]
 
 # Applied per parametrized variant (see test_cross_device_copy_scalar_fill).
-# TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1487
+# TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1172
 _SCALAR_FILL_XFAIL = pytest.mark.xfail(reason="Support 0-dim tensors in Spyre")
 
 # TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1153 (to_dtype / Inductor)

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -46,16 +46,27 @@ _SCALAR_ROUNDTRIP_DTYPE_CASES = [
 ]
 
 # Applied per parametrized variant (see test_cross_device_copy_scalar_fill).
-_SCALAR_FILL_SKIP = unittest.skip("TODO: Support 0-dim tensors in Spyre")
+#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1487 
+_SCALAR_FILL_XFAIL = pytest.mark.xfail(reason="Support 0-dim tensors in Spyre")
 
-# Scalar eager `.add(2.0)` after device transfer — per-dtype skips (see test_cross_device_copy_scalar_add).
-# ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1153 (to_dtype / Inductor)
-_SCALAR_ADD_SKIP_TO_DTYPE = unittest.skip(
-    "TODO: Support scalar eager add with to_dtype lowering in Spyre"
+#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1153 (to_dtype / Inductor)
+_SCALAR_ADD_XFAIL_TO_DTYPE = pytest.mark.xfail(
+    reason="Support scalar eager add with to_dtype lowering in Spyre"
 )
-_SCALAR_ADD_SKIP_FP8 = unittest.skip(
-    "TODO: Support scalar eager add for DataFormats.SEN143_FP8 in Spyre"
+#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1474 (DataFormats.SEN143_FP8)
+_SCALAR_ADD_XFAIL_FP8 = pytest.mark.xfail(
+    reason="Support scalar eager add for DataFormats.SEN143_FP8 in Spyre"
 )
+#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/925
+_SCALAR_ADD_SKIP_INT = pytest.mark.skip(
+    reason="Spyre backend does not support int32/int16 dtype - causes segfault/crash in data format converter"
+)
+
+#TODO:ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1588
+_SCALAR_ADD_SKIP_UINT8 = pytest.mark.skip(
+    reason="Spyre hardware requires 128-byte aligned buffers - small uint8 tensors cause alignment violations"
+)
+
 _SCALAR_ADD_FALLBACK_FULL_WARN = r"torch\.ops\.spyre\.full is falling back to cpu"
 
 
@@ -235,8 +246,8 @@ class TestSpyre(TestCase):
     @parametrize(
         "factory_name",
         [
-            subtest("zeros", name="zeros", decorators=[_SCALAR_FILL_SKIP]),
-            subtest("ones", name="ones", decorators=[_SCALAR_FILL_SKIP]),
+            subtest("zeros", name="zeros", decorators=[_SCALAR_FILL_XFAIL]),
+            subtest("ones", name="ones", decorators=[_SCALAR_FILL_XFAIL]),
         ],
     )
     def test_cross_device_copy_scalar_fill(self, factory_name):
@@ -256,17 +267,32 @@ class TestSpyre(TestCase):
             subtest(
                 (torch.int8, lambda: torch.tensor(10, dtype=torch.int8), None),
                 name="int8",
-                decorators=[_SCALAR_ADD_SKIP_TO_DTYPE],
+                decorators=[_SCALAR_ADD_XFAIL_TO_DTYPE],
             ),
             subtest(
                 (torch.bool, lambda: torch.tensor(True, dtype=torch.bool), None),
                 name="bool",
-                decorators=[_SCALAR_ADD_SKIP_TO_DTYPE],
+                decorators=[_SCALAR_ADD_XFAIL_TO_DTYPE],
             ),
             subtest(
                 (torch.int64, lambda: torch.tensor(10, dtype=torch.int64), None),
                 name="int64",
-                decorators=[_SCALAR_ADD_SKIP_TO_DTYPE],
+                decorators=[_SCALAR_ADD_XFAIL_TO_DTYPE],
+            ),
+            subtest(
+                (torch.uint8, lambda: torch.tensor(10, dtype=torch.uint8), None),
+                name="uint8",
+                decorators=[_SCALAR_ADD_SKIP_UINT8],
+            ),
+            subtest(
+                (torch.int16, lambda: torch.tensor(10, dtype=torch.int16), None),
+                name="int16",
+                decorators=[_SCALAR_ADD_SKIP_INT],
+            ),
+            subtest(
+                (torch.int32, lambda: torch.tensor(10, dtype=torch.int32), None),
+                name="int32",
+                decorators=[_SCALAR_ADD_SKIP_INT],
             ),
             subtest(
                 (
@@ -277,7 +303,7 @@ class TestSpyre(TestCase):
                     None,
                 ),
                 name="float8_e4m3fn",
-                decorators=[_SCALAR_ADD_SKIP_FP8],
+                decorators=[_SCALAR_ADD_XFAIL_FP8],
             ),
             subtest(
                 (

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -15,6 +15,7 @@
 # Owner(s): ["module: cpp"]
 
 import os
+import re
 import unittest
 import psutil
 import warnings
@@ -22,9 +23,43 @@ from contextlib import contextmanager
 import pytest
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    set_warn_always_context,
+    subtest,
+    TestCase,
+)
+
+# 0-dim scalar roundtrip: shared dtype × factory lambdas (used by parametrized fill test).
+_SCALAR_ROUNDTRIP_DTYPE_CASES = [
+    (torch.int8, lambda fn: fn((), dtype=torch.float32).to(dtype=torch.int8)),
+    (torch.bool, lambda fn: fn((), dtype=torch.bool)),
+    (torch.int64, lambda fn: fn((), dtype=torch.int64)),
+    (
+        torch.float8_e4m3fn,
+        lambda fn: fn((), dtype=torch.float32).to(dtype=torch.float8_e4m3fn),
+    ),
+    (torch.float16, lambda fn: fn((), dtype=torch.float16)),
+    (torch.float32, lambda fn: fn((), dtype=torch.float32)),
+]
+
+# Applied per parametrized variant (see test_cross_device_copy_scalar_fill).
+_SCALAR_FILL_SKIP = unittest.skip("TODO: Support 0-dim tensors in Spyre")
+
+# Scalar eager `.add(2.0)` after device transfer — per-dtype skips (see test_cross_device_copy_scalar_add).
+# ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1153 (to_dtype / Inductor)
+_SCALAR_ADD_SKIP_TO_DTYPE = unittest.skip(
+    "TODO: Support scalar eager add with to_dtype lowering in Spyre"
+)
+_SCALAR_ADD_SKIP_FP8 = unittest.skip(
+    "TODO: Support scalar eager add for DataFormats.SEN143_FP8 in Spyre"
+)
+_SCALAR_ADD_FALLBACK_FULL_WARN = r"torch\.ops\.spyre\.full is falling back to cpu"
 
 
+@instantiate_parametrized_tests
 class TestSpyre(TestCase):
     def test_initializes(self):
         self.assertEqual(torch._C._get_privateuse1_backend_name(), "spyre")
@@ -66,7 +101,6 @@ class TestSpyre(TestCase):
     def test_str(self):
         a = torch.tensor([1, 2], dtype=torch.float16).to("spyre")
         a_repr = str(a)
-        import regex as re
 
         def normalize_device(s):
             return re.sub(r"(device='spyre):\d+'", r"\1:0'", s)
@@ -81,10 +115,8 @@ class TestSpyre(TestCase):
         a = torch.tensor([1.234242424234, 2], dtype=torch.float16).to("spyre")
         try:
             a_repr = f"{a}"
-        except RuntimeError as re:
-            self.fail(f"Printing tensor failed with runtime error {re}")
-
-        import regex as re
+        except RuntimeError as err:
+            self.fail(f"Printing tensor failed with runtime error {err}")
 
         def normalize_device(s):
             return re.sub(r"(device='spyre):\d+'", r"\1:0'", s)
@@ -105,102 +137,202 @@ class TestSpyre(TestCase):
             print(t)
             print("Tensor printing works!")
         except NotImplementedError as e:
-            print("Printing failed:", e)
-            assert False, "Spyre backend should support tensor printing"
+            self.fail(f"Spyre backend should support tensor printing: {e}")
 
-    @unittest.skip("TODO: Support 0-dim tensors in Spyre")
-    def test_cross_device_copy_scalar(self):
-        # scalar tensor becomes 1D tensor on Spyre
-        a = torch.tensor(10, dtype=torch.float16)
-        # TODO: Remove torch.tensor of add scalar when constants are supported in eager
-        b = (
-            a.to(device="spyre")
-            .add(torch.tensor([2.0], dtype=torch.float16, device="spyre"))
-            .to(device="cpu")
-        )
+    @contextmanager
+    def _device_transfer_warnings(
+        self,
+        expect_downcast_warning=False,
+        ignored_warning_message=None,
+    ):
+        """CPU↔spyre transfer tests: PyTorch-style warn_always + recorded warnings.
+
+        Uses ``set_warn_always_context(True)`` (same as ``TestCase.assertWarnsOnceRegex``)
+        so TORCH_WARN_ONCE behaves consistently, then applies Spyre-specific int64
+        downcast expectations (and optional ignored fallback warnings).
+        """
+        with set_warn_always_context(True):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                if ignored_warning_message is not None:
+                    warnings.filterwarnings(
+                        "ignore",
+                        message=ignored_warning_message,
+                    )
+                yield
+
+        msg = "does not support int64"
+        recorded = [str(w.message) for w in rec]
+        if expect_downcast_warning:
+            self.assertTrue(
+                any(msg in s for s in recorded),
+                f"Expected warning containing '{msg}', got: {recorded}",
+            )
+        else:
+            self.assertEqual(len(recorded), 0, f"Expected no warnings, got: {recorded}")
+
+    def _assert_roundtrip_close(self, x_original, x_roundtrip, dtype):
+        if dtype == torch.float8_e4m3fn:
+            torch.testing.assert_close(
+                x_original.float(),
+                x_roundtrip.float(),
+            )
+        else:
+            torch.testing.assert_close(
+                x_original,
+                x_roundtrip,
+                rtol=2e-3,
+                atol=1e-5,
+                check_dtype=False,
+            )
+
+    def _assert_zero_dim_roundtrip(self, x_original, x_roundtrip, dtype):
+        self.assertEqual(x_original.ndim, 0)
+        self.assertEqual(x_original.numel(), 1)
+        self.assertEqual(x_roundtrip.ndim, 0)
+        self.assertEqual(x_roundtrip.numel(), 1)
+        self._assert_roundtrip_close(x_original, x_roundtrip, dtype)
+
+    def _roundtrip_to_spyre_and_back(self, x, expect_warning=False):
+        self.assertEqual(x.device.type, "cpu", "initial device is not cpu")
+
+        with self._device_transfer_warnings(expect_downcast_warning=expect_warning):
+            x_spyre = x.to("spyre")
+
+        self.assertEqual(x_spyre.device.type, "spyre", "to device is not spyre")
+        self.assertEqual(x_spyre.dtype, x.dtype)
+
+        return x_spyre.to("cpu")
+
+    def _run_scalar_add_case(self, dtype, scalar_factory, ignored_warning_message=None):
+        dtypes_with_downcast_warning = {torch.int64}
+        a = scalar_factory()
+        self.assertEqual(a.ndim, 0)
+        self.assertEqual(a.numel(), 1)
+
+        with self._device_transfer_warnings(
+            expect_downcast_warning=dtype in dtypes_with_downcast_warning,
+            ignored_warning_message=ignored_warning_message,
+        ):
+            b = a.to(device="spyre").add(2.0).to(device="cpu")
+
         self.assertEqual(b.ndim, 1)
         self.assertEqual(b.numel(), 1)
-        self.assertEqual(b.item(), a + 2)
+
+        expected = a + 2
+        if dtype == torch.float8_e4m3fn:
+            torch.testing.assert_close(b.float(), expected.reshape(1).float())
+        else:
+            torch.testing.assert_close(
+                b,
+                expected.reshape(1),
+                rtol=2e-3,
+                atol=1e-5,
+                check_dtype=False,
+            )
+
+    # ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1187
+    @parametrize(
+        "factory_name",
+        [
+            subtest("zeros", name="zeros", decorators=[_SCALAR_FILL_SKIP]),
+            subtest("ones", name="ones", decorators=[_SCALAR_FILL_SKIP]),
+        ],
+    )
+    def test_cross_device_copy_scalar_fill(self, factory_name):
+        tensor_factory = getattr(torch, factory_name)
+        for dtype, scalar_factory in _SCALAR_ROUNDTRIP_DTYPE_CASES:
+            x = scalar_factory(tensor_factory)
+            x_cpu = self._roundtrip_to_spyre_and_back(
+                x, expect_warning=dtype in {torch.int64}
+            )
+            self._assert_zero_dim_roundtrip(x, x_cpu, dtype)
+
+    # Scalar 0-dim: spyre -> add(2.) -> cpu. int8/bool/int64: Inductor to_dtype in add (#1153).
+    # float8: SEN143_FP8 unsupported. float16/float32: pass; ignore known full() CPU fallback warn.
+    @parametrize(
+        "dtype, scalar_factory, ignored_warning_message",
+        [
+            subtest(
+                (torch.int8, lambda: torch.tensor(10, dtype=torch.int8), None),
+                name="int8",
+                decorators=[_SCALAR_ADD_SKIP_TO_DTYPE],
+            ),
+            subtest(
+                (torch.bool, lambda: torch.tensor(True, dtype=torch.bool), None),
+                name="bool",
+                decorators=[_SCALAR_ADD_SKIP_TO_DTYPE],
+            ),
+            subtest(
+                (torch.int64, lambda: torch.tensor(10, dtype=torch.int64), None),
+                name="int64",
+                decorators=[_SCALAR_ADD_SKIP_TO_DTYPE],
+            ),
+            subtest(
+                (
+                    torch.float8_e4m3fn,
+                    lambda: torch.tensor(10.0, dtype=torch.float32).to(
+                        dtype=torch.float8_e4m3fn
+                    ),
+                    None,
+                ),
+                name="float8_e4m3fn",
+                decorators=[_SCALAR_ADD_SKIP_FP8],
+            ),
+            subtest(
+                (
+                    torch.float16,
+                    lambda: torch.tensor(10, dtype=torch.float16),
+                    _SCALAR_ADD_FALLBACK_FULL_WARN,
+                ),
+                name="float16",
+            ),
+            subtest(
+                (
+                    torch.float32,
+                    lambda: torch.tensor(10, dtype=torch.float32),
+                    _SCALAR_ADD_FALLBACK_FULL_WARN,
+                ),
+                name="float32",
+            ),
+        ],
+    )
+    def test_cross_device_copy_scalar_add(
+        self, dtype, scalar_factory, ignored_warning_message
+    ):
+        self._run_scalar_add_case(
+            dtype,
+            scalar_factory,
+            ignored_warning_message=ignored_warning_message,
+        )
 
     def test_cross_device_copy(self):
         a = torch.rand(10, dtype=torch.float16)
-        # TODO: Remove torch.tensor of add scalar when constants are supported in eager
         b = (
             a.to(device="spyre")
-            .add(torch.tensor([2.0], dtype=torch.float16, device="spyre"))
+            .add(2.0)
             .to(device="cpu")
         )
         self.assertEqual(b, a + 2)
 
     def test_cross_device_copy_dtypes(self):
-        @contextmanager
-        def check_downcast_warning(expect_warning=False):
-            with warnings.catch_warnings(record=True) as rec:
-                warnings.simplefilter("always")
-                yield
+        dtype_configs = {
+            torch.int8: lambda: (torch.rand(64, 64) * 100).to(dtype=torch.int8),
+            torch.bool: lambda: torch.randint(0, 2, (64, 64), dtype=torch.bool),
+            torch.int64: lambda: torch.randint(-32768, 32767, (64, 64), dtype=torch.int64),
+            torch.float8_e4m3fn: lambda: torch.rand(64, 64).to(dtype=torch.float8_e4m3fn),
+            torch.float16: lambda: torch.rand(64, 64, dtype=torch.float16),
+            torch.float32: lambda: torch.rand(64, 64, dtype=torch.float32),
+        }
 
-            msg = "does not support int64"
-            recorded = [str(w.message) for w in rec]
-            if expect_warning:
-                assert any(msg in record for record in recorded), (
-                    f"Expected one warning containing '{msg}', got: {recorded}"
-                )
-            else:
-                assert len(rec) == 0, f"Expected no warnings, got: {recorded}"
+        dtypes_with_downcast_warning = {torch.int64}
 
-        dtypes = [
-            torch.float8_e4m3fn,
-            torch.int8,
-            torch.int64,
-            torch.float16,
-            torch.float32,
-            torch.bool,
-        ]
-        for dtype in dtypes:
-            x = None
-            expect_warning = False
-            if dtype in [torch.int8]:
-                x = torch.rand(64, 64) * 100
-                x = x.to(dtype=dtype)
-            elif dtype in [torch.bool]:
-                x = torch.randint(0, 2, (64, 64), dtype=dtype)
-            elif dtype in [torch.int64]:
-                expect_warning = True
-                x = torch.randint(-32768, 32767, (64, 64), dtype=dtype)
-            elif dtype in [torch.float8_e4m3fn]:
-                x = torch.rand(64, 64)
-                x = x.to(dtype=dtype)
-            else:
-                x = torch.rand(64, 64, dtype=dtype)
-            assert x.device.type == "cpu", "initial device is not cpu"
-
-            prev_warn_always = torch.is_warn_always_enabled()
-            torch.set_warn_always(True)
-            with check_downcast_warning(expect_warning):
-                x_spyre = x.to("spyre")
-            torch.set_warn_always(prev_warn_always)
-
-            assert x_spyre.device.type == "spyre", "to device is not spyre"
-            assert x_spyre.dtype == x.dtype
-            x_cpu = x_spyre.to("cpu")
-            custom_rtol = 2e-3
-            custom_atol = 1e-5
-            try:
-                if dtype in [torch.float8_e4m3fn]:
-                    from torch.testing import assert_close
-
-                    assert_close(x.float(), x_cpu.float())
-                else:
-                    torch.testing.assert_close(
-                        x,
-                        x_cpu,
-                        rtol=custom_rtol,
-                        atol=custom_atol,
-                        check_dtype=False,  # You may need this if the dtypes are different after conversion
-                    )
-                print(f"Tensors are close with custom tolerance for dtype={dtype}.")
-            except AssertionError as e:
-                print(f"Tensors are NOT close for dtype={dtype}! Details:\n{e}")
+        for dtype, tensor_factory in dtype_configs.items():
+            x = tensor_factory()
+            x_cpu = self._roundtrip_to_spyre_and_back(
+                x, expect_warning=dtype in dtypes_with_downcast_warning
+            )
+            self._assert_roundtrip_close(x, x_cpu, dtype)
 
     @unittest.skip("Skip for now")
     def test_data_dependent_output(self):
@@ -220,57 +352,64 @@ class TestSpyre(TestCase):
         x = torch.tensor([1, 2], dtype=torch.float16, device="spyre")
         y = torch.tensor([1, 2], dtype=torch.float16)
         x_storage_nbytes = x.untyped_storage().nbytes()
-        assert x_storage_nbytes == 128
-        assert x_storage_nbytes != y.untyped_storage().nbytes(), "failed allocation"
+        self.assertEqual(x_storage_nbytes, 128)
+        self.assertNotEqual(
+            x_storage_nbytes,
+            y.untyped_storage().nbytes(),
+            "spyre vs cpu allocation size should differ",
+        )
 
     def test_spyre_round_trip(self):
         dtypes = [torch.float16]
         for dtype in dtypes:
             x = torch.tensor([1, 2], dtype=dtype)
-            assert x.device.type == "cpu", "initial device is not cpu"
+            self.assertEqual(x.device.type, "cpu", "initial device is not cpu")
             x_spyre = x.to("spyre")
-            assert x_spyre.device.type == "spyre", "to device is not spyre"
+            self.assertEqual(x_spyre.device.type, "spyre", "to device is not spyre")
             x_cpu = x_spyre.to("cpu")
-            (
-                torch.testing.assert_close(x, x_cpu),
-                f"round trip copy produces incorrect results for dtype={dtype}",
+            torch.testing.assert_close(
+                x,
+                x_cpu,
+                msg=f"round trip copy produces incorrect results for dtype={dtype}",
             )
 
     def test_default_on_import(self):
         import torch_spyre  # noqa: F401
 
-        assert torch.spyre.get_downcast_warning() is True
+        self.assertTrue(torch.spyre.get_downcast_warning())
 
     def test_set_get_roundtrip(self):
         import torch_spyre  # noqa: F401
 
         torch.spyre.set_downcast_warning(False)
-        assert torch.spyre.get_downcast_warning() is False
+        self.assertFalse(torch.spyre.get_downcast_warning())
         torch.spyre.set_downcast_warning(True)
-        assert torch.spyre.get_downcast_warning() is True
+        self.assertTrue(torch.spyre.get_downcast_warning())
 
     def test_warning_emitted_when_enabled(self):
         import torch_spyre  # noqa: F401
 
-        torch.set_warn_always(True)
         t = torch.randint(-32768, 32767, (64, 64), dtype=torch.int64)
         torch.spyre.set_downcast_warning(True)
-        with warnings.catch_warnings(record=True) as rec:
-            warnings.simplefilter("always")
-            t2 = t.to(device="spyre")  # noqa: F841
-        # At least one UserWarning captured
-        assert any("does not support int64" in str(w.message) for w in rec)
+        with set_warn_always_context(True):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                t.to(device="spyre")
+        self.assertTrue(
+            any("does not support int64" in str(w.message) for w in rec),
+            msg="expected int64 downcast warning when enabled",
+        )
 
     def test_warning_suppressed_when_disabled(self):
         import torch_spyre  # noqa: F401
 
-        torch.set_warn_always(True)
         torch.spyre.set_downcast_warning(False)
         t = torch.randint(-32768, 32767, (64, 64), dtype=torch.int64)
-        with warnings.catch_warnings(record=True) as rec:
-            warnings.simplefilter("always")
-            t2 = t.to(device="spyre")  # noqa: F841
-        assert len(rec) == 0
+        with set_warn_always_context(True):
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                t.to(device="spyre")
+        self.assertEqual(len(rec), 0)
 
     def test_allocation_and_copy_dtypes(self):
         # allocation and device to host cases
@@ -300,10 +439,8 @@ class TestSpyre(TestCase):
             x.detach().cpu()
 
     def test_hooks_on_import(self):
-        import torch
-
         dev = torch._C._get_accelerator()
-        assert str(dev) == "spyre"
+        self.assertEqual(str(dev), "spyre")
 
     def test_memory_allocated(self):
         torch.spyre.memory.reset_peak_memory_stats()

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -15,7 +15,7 @@
 # Owner(s): ["module: cpp"]
 
 import os
-import re
+import regex as re
 import unittest
 import psutil
 import warnings
@@ -46,23 +46,23 @@ _SCALAR_ROUNDTRIP_DTYPE_CASES = [
 ]
 
 # Applied per parametrized variant (see test_cross_device_copy_scalar_fill).
-#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1487 
+# TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1487
 _SCALAR_FILL_XFAIL = pytest.mark.xfail(reason="Support 0-dim tensors in Spyre")
 
-#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1153 (to_dtype / Inductor)
+# TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1153 (to_dtype / Inductor)
 _SCALAR_ADD_XFAIL_TO_DTYPE = pytest.mark.xfail(
     reason="Support scalar eager add with to_dtype lowering in Spyre"
 )
-#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1474 (DataFormats.SEN143_FP8)
+# TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1474 (DataFormats.SEN143_FP8)
 _SCALAR_ADD_XFAIL_FP8 = pytest.mark.xfail(
     reason="Support scalar eager add for DataFormats.SEN143_FP8 in Spyre"
 )
-#TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/925
+# TODO: ISSUE: https://github.com/torch-spyre/torch-spyre/issues/925
 _SCALAR_ADD_SKIP_INT = pytest.mark.skip(
     reason="Spyre backend does not support int32/int16 dtype - causes segfault/crash in data format converter"
 )
 
-#TODO:ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1588
+# TODO:ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1588
 _SCALAR_ADD_SKIP_UINT8 = pytest.mark.skip(
     reason="Spyre hardware requires 128-byte aligned buffers - small uint8 tensors cause alignment violations"
 )
@@ -334,19 +334,19 @@ class TestSpyre(TestCase):
 
     def test_cross_device_copy(self):
         a = torch.rand(10, dtype=torch.float16)
-        b = (
-            a.to(device="spyre")
-            .add(2.0)
-            .to(device="cpu")
-        )
+        b = a.to(device="spyre").add(2.0).to(device="cpu")
         self.assertEqual(b, a + 2)
 
     def test_cross_device_copy_dtypes(self):
         dtype_configs = {
             torch.int8: lambda: (torch.rand(64, 64) * 100).to(dtype=torch.int8),
             torch.bool: lambda: torch.randint(0, 2, (64, 64), dtype=torch.bool),
-            torch.int64: lambda: torch.randint(-32768, 32767, (64, 64), dtype=torch.int64),
-            torch.float8_e4m3fn: lambda: torch.rand(64, 64).to(dtype=torch.float8_e4m3fn),
+            torch.int64: lambda: torch.randint(
+                -32768, 32767, (64, 64), dtype=torch.int64
+            ),
+            torch.float8_e4m3fn: lambda: torch.rand(64, 64).to(
+                dtype=torch.float8_e4m3fn
+            ),
             torch.float16: lambda: torch.rand(64, 64, dtype=torch.float16),
             torch.float32: lambda: torch.rand(64, 64, dtype=torch.float32),
         }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR significantly expands test coverage for operations with scalar and constant arguments in the Torch-Spyre backend, addressing Issue #[1074](https://github.com/torch-spyre/torch-spyre/issues/1074) and also supports scalar tensors #[1334](https://github.com/torch-spyre/torch-spyre/issues/1334). It adds comprehensive test suites that validate scalar operation behavior across both eager and compiled execution modes.

**Key Changes:**
- **New test file:** `test_inductor_scalar.py` with 30 test cases covering core arithmetic and attention operations
- **Enhanced:** `test_spyre.py` with 8 cross-device scalar copy tests
- **Enhanced:** `test_inductor_ops.py` with scalar fill operation test
- **Enhanced:** `utils_inductor.py` with execution mode test helper

**Test Coverage:**
- 30+ test executions (with parametrization across eager/compiled modes)
- Core scalar arithmetic operations (addition, multiplication, division, in-place ops)
- Scaled Dot-Product Attention (SDPA) with scalar hyperparameters
- Cross-device scalar transfers with multiple dtypes
- Mixed precision operations (FP16/FP32/FP64)

**Current Status: ** `test_inductor_scalar.py`
- 8 tests passing (10% pass rate)
- 22 tests expected failed.
- All failures mapped to existing GitHub issues with clear xfail markers

**Test Execution Logs:**
`test_spyre.py`:
```
pytest test_spyre.py 
============================================== test session starts ==============================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/mahalakshmip/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 33 items                                                                                              

test_spyre_new.py ..s..x..xssxxsxxs.....F..........                                                       [100%]
============================================ short test summary info ============================================
FAILED test_spyre_new.py::TestSpyre::test_instantiate_device_type_tests_mro - AssertionError: Expected _TestMROCheckPRIVATEUSE1 in namespace, got []
======================== 1 failed, 21 passed, 5 skipped, 6 xfailed, 4 warnings in 16.56s ========================
```
`test_inductor_ops.py`:
```
pytest -s -v inductor/test_inductor_ops.py::TestOps::test_fill_scalar_1d_compiled
============================================== test session starts ==============================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /home/mahalakshmip/dt-inductor/.venv/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/mahalakshmip/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 1 item                                                                                                

inductor/test_inductor_ops.py::TestOps::test_fill_scalar_1d_compiled PASSED

=============================================== warnings summary ================================================
tests/inductor/test_inductor_ops.py::TestOps::test_fill_scalar_1d_compiled
  /home/mahalakshmip/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:165: FallbackWarning: torch.ops.spyre.full is falling back to cpu
    warn_fallback("torch.ops.spyre.full")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== 1 passed, 1 warning in 69.89s (0:01:09) ====================================
(dt-inductor) [mahalakshmip@mahalakshmip-spyre-dev-pf tests]$ pytest -s -v inductor/test_inductor_ops.py::TestOps::test_fill_scalar_1d_eager
============================================== test session starts ==============================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /home/mahalakshmip/dt-inductor/.venv/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/mahalakshmip/torch-spyre
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 1 item                                                                                                

inductor/test_inductor_ops.py::TestOps::test_fill_scalar_1d_eager XFAIL (spyre__fill_scalar crashes w...)

============================================== 1 xfailed in 16.80s ==============================================
```
`test_inductor_scalar.py`:
```
pytest test_inductor_scalar.py 
============================================= test session starts =============================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/mahalakshmip/torch-spyre
configfile: pyproject.toml
plugins: html-4.2.0, metadata-3.1.1
collected 30 items                                                                                            

test_inductor_scalar_1.py xxxxxxx...xxxxx.x.x.xxx.x.xxx.                                                [100%]

================================== 9 passed, 21 xfailed in 260.74s (0:04:20) ==================================
```

This is a test-only PR with no production code changes. The low initial pass rate is expected and intentional, providing a comprehensive test suite that will be incrementally enabled as backend capabilities improve.

#### Which issue(s) this PR is related to:

Fixes #1074

**Test cases Error Related Issues:**
- #1334 - Support scalar tensors
- #1172 - Scalar tensor conversion from Spyre to CPU
- #1153 - to_dtype support in Inductor
- #1474 - FP8 support
- #925 - int32 and int16 support
- #1588 - uint8 alignment
- #1187 - 0-dim tensor support
- #1381 #1558 - in-device copy
- #1545 - complex data type
- #543 - reshape support
- #1228 - dtype Double support

**Context:**
This PR builds upon the scalar/constant support implementation in PR #[915](https://github.com/torch-spyre/torch-spyre/issues/915) (addressing Issue #[238](https://github.com/torch-spyre/torch-spyre/issues/238)) and also supports scalar tensor test cases #[1334](https://github.com/torch-spyre/torch-spyre/issues/1334), providing extensive validation to ensure comprehensive scenario coverage and identify any regressions.

**Acceptance Criteria Alignment (Issue #1074):**
- Covers PyTorch operators with scalar positional arguments and scalar as a tensor.
- Tests all scalar data types (int8, int64, bool, float16/32/64, float8, complex64)
- Tests both eager and compile execution modes
- All tests include CPU accuracy checks with `compare_with_cpu()`
- All failing tests documented with clear root-cause notes

#### Does this PR introduce a user-facing change?

No. This is a test-only PR that expands test coverage for scalar/constant operations. It does not modify any production code or user-facing APIs.

#### Additional note:
The test suite is designed for incremental enablement - as each backend issue is resolved, the corresponding tests can be enabled by simply removing the xfail/skip markers.