### PR TITLE
[TESTING] fix: restore deleted test methods on restricted classes before re-injection in OOT wrapper

### DIFF
--- a/tests/configs/test_profiler_config.yaml
+++ b/tests/configs/test_profiler_config.yaml
@@ -1,0 +1,90 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_ROOT}/test/profiler/test_memory_profiler.py
+      unlisted_test_mode: skip
+      tests:
+        - names:
+            - TestMemoryProfilerTimeline::test_memory_timeline_no_id
+            - TestMemoryProfiler::test_config_check
+            - TestDataFlow::test_match_schemas
+            - TestDataFlow::test_match_schemas_backward
+            - TestDataFlow::test_match_schemas_tensorlist
+            - TestDataFlow::test_data_flow_graph_with_annotations
+            - TestDataFlow::test_data_flow_graph_non_op_allocations
+            - TestDataFlow::test_data_flow_graph_simple
+            - TestDataFlow::test_data_flow_graph_simple_inplace
+            - TestDataFlow::test_data_flow_graph_simple_backward
+            - TestDataFlow::test_data_flow_graph_complicated
+            - TestDataFlow::test_data_flow_graph_stacked
+            - TestMemoryProfilerE2E::test_inputs_fwd
+            - TestMemoryProfilerE2E::test_inputs_fwd_lazy
+            - TestMemoryProfilerE2E::test_inputs_fwd_bwd
+            - TestMemoryProfilerE2E::test_lazily_initialized
+            - TestMemoryProfilerE2E::test_manual_optimizer_step
+            - TestMemoryProfilerE2E::test_categories_e2e_simple_fwd
+            - TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd
+            - TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd_step
+            - TestMemoryProfilerE2E::test_categories_e2e_simple_module_fwd
+            - TestMemoryProfilerE2E::test_categories_e2e_simple_module_fwd_bwd
+            - TestMemoryProfilerE2E::test_categories_e2e_simple_module_fwd_bwd_step
+            - TestMemoryProfilerE2E::test_categories_e2e_sequential_fwd
+            - TestMemoryProfilerE2E::test_categories_e2e_sequential_fwd_bwd
+            - TestMemoryProfilerE2E::test_memory_timeline
+            - TestMemoryProfilerE2E::test_parameters_and_gradients
+            - TestMemoryProfilerE2E::test_parameters_and_gradients_set_to_none
+            - TestIdentifyGradients::test_extract_gradients_from_module
+            - TestIdentifyGradients::test_extract_gradients_from_optimizer_set_to_none
+            - TestIdentifyGradients::test_extract_gradients_from_module_and_optimizer
+            - TestIdentifyGradients::test_extract_gradients_from_optimizer
+            - TestIdentifyGradients::test_extract_gradients_low_level
+          mode: mandatory_success
+
+
+    - path: ${TORCH_ROOT}/test/profiler/test_profiler.py
+      unlisted_test_mode: skip
+      tests:
+        - names:
+            - TestProfiler::test_override_time_units
+            - TestProfiler::test_source
+            - TestProfiler::test_tensorboard_trace_handler
+            - TestProfiler::test_user_annotation
+            - TestProfiler::test_export_stacks
+            - TestProfiler::test_profiler_metadata
+            - TestProfiler::test_profiler_op_event_args
+            - TestProfiler::test_profiler_op_event_kwargs
+            - TestProfiler::test_profiler_strides
+            - TestProfiler::test_profiler_correlation_id
+            - TestProfiler::test_nested_tensor_with_shapes
+            - TestProfiler::test_concrete_inputs_profiling
+            - TestProfiler::test_concrete_inputs_profiling_toggling
+            - TestProfiler::test_record_function_fast
+            - TestProfiler::test_profiler_time_scale
+            - TestProfiler::test_schedule_function_count
+            - TestProfiler::test_lazy_build_tree
+            - TestProfiler::test_skip_first_wait
+            - TestProfiler::test_forked_process
+            - TestProfiler::test_python_gc_event
+            - TestProfiler::test_profiler_pattern_match_helper
+            - TestProfiler::test_profiler_synchronized_dataloader_pattern
+            # - test_profiler_conv2d_bias_followed_by_batchnorm2d_pattern
+            - TestExperimentalUtils::test_utils_intervals_overlap
+            - TestExperimentalUtils::test_utils_compute_queue_depth
+            - TestExperimentalUtils::test_utils_compute_queue_depth_when_no_cuda_events
+            - TestExperimentalUtils::test_utils_get_optimizable_events
+            - TestExperimentalUtils::test_profiler_name_pattern
+            - TestExperimentalUtils::test_dfs
+            - TestExperimentalUtils::test_bfs
+            - TestExperimentalUtils::test_utils_compute_self_time
+            - TestProfiler::test_source_multithreaded
+            - TestProfiler::test_module_hierarchy
+            - TestProfiler::test_oom_tracing
+            - TestProfiler::test_profiler_tracing
+            - TestProfiler::test_profiler_type
+            - TestProfiler::test_profiler_disable_fwd_bwd_link
+            - TestProfiler::test_profiler_fwd_bwd_link
+            - TestProfiler::test_flops
+            - TestProfiler::test_high_level_trace
+            - TestProfiler::test_kineto_profiler_api
+            - TestProfiler::test_kineto_profiler_multiple_steppers
+            - TestProfilerITT::test_custom_module_input_op_ids
+          mode: mandatory_success

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -10,6 +10,11 @@
 # the missing instantiate_device_type_tests() calls so the OOT framework
 # can control those classes via the YAML config.  The wrapper is deleted
 # after the run.  No upstream files are modified.
+#
+# Additionally, classes that ARE passed to instantiate_device_type_tests()
+# upstream but with an `only_for` kwarg restricting them to specific devices
+# (e.g. only_for=DEVICE_LIST_SUPPORT_PROFILING_TEST) are re-injected into
+# the wrapper without `only_for`, so the spyre/privateuse1 device is included.
 
 
 set -euo pipefail
@@ -251,18 +256,35 @@ echo ""
 
 # ---------------------------------------------------------------------------
 # 8. AST analyzer
-#    Returns JSON: {all, device_type, parametrized, uncontrolled, plain_no_device}
+#    Returns JSON with these keys:
+#      all                   - ALL TestCase subclass names found in the file
+#      device_type           - classes passed to instantiate_device_type_tests()
+#                              WITHOUT an only_for kwarg (fully open; already
+#                              handled for all devices including spyre)
+#      device_type_restricted
+#                            - classes passed to instantiate_device_type_tests()
+#                              WITH an only_for kwarg (restricted to specific
+#                              devices; privateuse1/spyre is typically excluded,
+#                              so these classes need re-injection without only_for)
+#      parametrized          - classes passed to instantiate_parametrized_tests()
+#      uncontrolled          - TestCase subclasses not passed to ANY instantiate_*
+#                              call at all (need fresh injection)
+#      needs_injection       - union of uncontrolled + device_type_restricted
+#                              (all classes that require a wrapper injection)
+#      plain_no_device       - subset of needs_injection whose test methods have
+#                              no `device` parameter
 #
-#    "uncontrolled" = ALL TestCase subclasses not yet passed to
-#    instantiate_device_type_tests(), regardless of whether their test
-#    methods take a `device` arg or not.  ALL of these get wrapper injection.
-#
-#   
-#      When the YAML says mode:skip or unlisted_test_mode:skip, TorchTestBase
-#      replaces the test method with a unittest.SkipTest wrapper BEFORE the
-#      test body ever executes -- the `device` arg is never passed to the
-#      original method.  The framework therefore controls all such tests via
-#      the YAML, including plain TestCase classes.
+#   Re-inject restricted classes
+#     When upstream calls:
+#     instantiate_device_type_tests(Cls, globals(), only_for=SOME_LIST)
+#     the framework only generates device-specific subclasses for the devices
+#     listed in SOME_LIST.  If "privateuse1"/"spyre" is absent from that list,
+#     no spyre variant is ever created and TorchTestBase never sees the class.
+#     Re-injecting via the wrapper (without only_for) lets TorchTestBase
+#     control the class through the YAML config like any other test class.
+#     Example: TestMemoryProfilerTimeline is called with
+#       only_for=DEVICE_LIST_SUPPORT_PROFILING_TEST
+#     which typically excludes privateuse1.
 # ---------------------------------------------------------------------------
 _ANALYZER_PY='
 import ast, sys, json
@@ -278,6 +300,10 @@ def class_methods_info(classdef):
                 has_device = True
             methods.append(node.name)
     return has_device, methods
+
+def _call_has_only_for_kwarg(call_node):
+    """Return True if the Call node has an `only_for` keyword argument."""
+    return any(kw.arg == "only_for" for kw in call_node.keywords)
 
 def analyze(path):
     try:
@@ -302,35 +328,63 @@ def analyze(path):
                     all_classes[node.name] = has_device
                     break
 
-    device_type_instantiated = set()
+    # Classify instantiate_device_type_tests() calls:
+    #   without only_for  -> fully open, framework already controls all devices
+    #   with    only_for  -> restricted; spyre/privateuse1 likely excluded
+    device_type_open       = set()   # no only_for kwarg
+    device_type_restricted = set()   # has only_for kwarg
     parametrized_instantiated = set()
+
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call): continue
+        if not isinstance(node, ast.Call):
+            continue
         func = node.func
         fname = ""
         if isinstance(func, ast.Name):        fname = func.id
         elif isinstance(func, ast.Attribute): fname = func.attr
+
         if fname == "instantiate_device_type_tests" and node.args:
             arg = node.args[0]
-            if isinstance(arg, ast.Name): device_type_instantiated.add(arg.id)
+            if isinstance(arg, ast.Name):
+                cls_name = arg.id
+                if _call_has_only_for_kwarg(node):
+                    device_type_restricted.add(cls_name)
+                else:
+                    device_type_open.add(cls_name)
         elif fname == "instantiate_parametrized_tests" and node.args:
             arg = node.args[0]
-            if isinstance(arg, ast.Name): parametrized_instantiated.add(arg.id)
+            if isinstance(arg, ast.Name):
+                parametrized_instantiated.add(arg.id)
 
-    already_handled = device_type_instantiated | parametrized_instantiated
-    uncontrolled = sorted(set(all_classes) - already_handled)
+    # A class that appears in BOTH open and restricted sets (e.g. the file
+    # calls instantiate_device_type_tests twice for the same class, once with
+    # only_for and once without) is treated as open: the open call already
+    # covers all devices including spyre.
+    device_type_restricted -= device_type_open
 
-    # Plain classes (no device arg in any test method) within uncontrolled
+    # "Fully handled" = open device_type + parametrized
+    # (restricted is NOT fully handled for spyre)
+    fully_handled = device_type_open | parametrized_instantiated
+
+    # uncontrolled: never passed to any instantiate_* call
+    uncontrolled = sorted(set(all_classes) - fully_handled - device_type_restricted)
+
+    # needs_injection: everything the wrapper must re-inject
+    needs_injection = sorted(set(uncontrolled) | device_type_restricted)
+
+    # Plain classes (no device arg in any test method) within needs_injection
     plain_no_device = sorted(
-        cls for cls in uncontrolled if not all_classes[cls]
+        cls for cls in needs_injection if not all_classes.get(cls, False)
     )
 
     print(json.dumps({
-        "all":                  sorted(all_classes),
-        "device_type":          sorted(device_type_instantiated),
-        "parametrized":         sorted(parametrized_instantiated),
-        "uncontrolled":         uncontrolled,
-        "plain_no_device":      plain_no_device,
+        "all":                    sorted(all_classes),
+        "device_type":            sorted(device_type_open),
+        "device_type_restricted": sorted(device_type_restricted),
+        "parametrized":           sorted(parametrized_instantiated),
+        "uncontrolled":           uncontrolled,
+        "needs_injection":        needs_injection,
+        "plain_no_device":        plain_no_device,
     }))
 
 analyze(sys.argv[1])
@@ -339,13 +393,28 @@ analyze(sys.argv[1])
 # ---------------------------------------------------------------------------
 # 9. Wrapper generator
 #
-#    For any test file that has uncontrolled classes (of ANY kind), generate
-#    a temporary wrapper .py placed beside the original so that conftest.py
-#    discovery, relative imports, and sys.path all work identically.
+#    For any test file that has classes needing injection (uncontrolled OR
+#    device_type_restricted), generate a temporary wrapper .py placed beside
+#    the original so that conftest.py discovery, relative imports, and
+#    sys.path all work identically.
 #
 #    The wrapper star-imports the original module (picking up all existing
 #    instantiate_* calls) then appends one instantiate_device_type_tests()
-#    call per uncontrolled class.
+#    call per class that needs injection.
+#
+#    Two categories of injected classes:
+#
+#    1. uncontrolled  -- classes never passed to any instantiate_* call.
+#       Fresh injection; TorchTestBase sees them for the first time.
+#
+#    2. device_type_restricted -- classes already called upstream with
+#       only_for=..., but that only_for list excludes privateuse1/spyre.
+#       The upstream call produced zero spyre-device subclasses.  The wrapper
+#       re-calls instantiate_device_type_tests() without only_for so
+#       TorchTestBase generates the spyre variant and can apply YAML config.
+#       The upstream subclasses for other devices (cuda, cpu, etc.) remain
+#       untouched in the global scope from the star-import; our call adds
+#       the spyre variant alongside them.
 #
 #    Safety for plain (no-device) classes:
 #      TorchTestBase._should_run() replaces test methods with a SkipTest
@@ -355,7 +424,7 @@ analyze(sys.argv[1])
 #      listed as mandatory_success/xfail a warning is emitted (it would
 #      fail at runtime with a device-arg TypeError).
 #
-#    Naming:  <original_stem>__oot_wrapper.py  (deleted by EXIT trap)
+#    Naming:  <original_stem>__oot_wrapper.py  (cleaned up by EXIT trap)
 # ---------------------------------------------------------------------------
 
 WRAPPER_FILES=()
@@ -390,25 +459,33 @@ import json,sys; d=json.load(sys.stdin); print(d.get('error',''))
         return 0
     fi
 
-    local uncontrolled_str plain_str
-    uncontrolled_str=$(echo "$result" | python3 -c "
-import json,sys; d=json.load(sys.stdin); print(' '.join(d['uncontrolled']))
+    local needs_injection_str plain_str restricted_str uncontrolled_str
+    needs_injection_str=$(echo "$result" | python3 -c "
+import json,sys; d=json.load(sys.stdin); print(' '.join(d['needs_injection']))
 ")
     plain_str=$(echo "$result" | python3 -c "
 import json,sys; d=json.load(sys.stdin); print(' '.join(d['plain_no_device']))
 ")
+    restricted_str=$(echo "$result" | python3 -c "
+import json,sys; d=json.load(sys.stdin); print(' '.join(d['device_type_restricted']))
+")
+    uncontrolled_str=$(echo "$result" | python3 -c "
+import json,sys; d=json.load(sys.stdin); print(' '.join(d['uncontrolled']))
+")
 
-    if [[ -z "$uncontrolled_str" ]]; then
-        return 0   # all classes already framework-controlled
+    if [[ -z "$needs_injection_str" ]]; then
+        return 0   # all classes already fully framework-controlled for spyre
     fi
 
-    read -r -a UNCONTROLLED_CLASSES <<< "$uncontrolled_str"
+    read -r -a NEEDS_INJECTION_CLASSES <<< "$needs_injection_str"
     local -a PLAIN_CLASSES=()
     [[ -n "$plain_str" ]] && read -r -a PLAIN_CLASSES <<< "$plain_str"
+    local -a RESTRICTED_CLASSES=()
+    [[ -n "$restricted_str" ]] && read -r -a RESTRICTED_CLASSES <<< "$restricted_str"
+    local -a UNCONTROLLED_CLASSES=()
+    [[ -n "$uncontrolled_str" ]] && read -r -a UNCONTROLLED_CLASSES <<< "$uncontrolled_str"
 
     # Warn about plain classes -- they are safe only when YAML skips them.
-    # If the user listed any as mandatory_success/xfail they will hit a
-    # device-arg TypeError at runtime.
     if [[ ${#PLAIN_CLASSES[@]} -gt 0 ]]; then
         echo "[spyre_run] NOTE: the following classes have no 'device' arg in their"
         echo "[spyre_run]       test methods. They are safe under mode:skip but will"
@@ -424,73 +501,239 @@ import json,sys; d=json.load(sys.stdin); print(' '.join(d['plain_no_device']))
     module_name="$original_stem"
     wrapper_path="${original_dir}/${original_stem}__oot_wrapper.py"
 
-    echo "[spyre_run] Injecting instantiate_device_type_tests for uncontrolled classes in: $(basename "$test_file")"
-    for cls in "${UNCONTROLLED_CLASSES[@]}"; do
-        echo "[spyre_run]   -> $cls"
-    done
+    # Report uncontrolled classes (never instantiated upstream at all)
+    if [[ ${#UNCONTROLLED_CLASSES[@]} -gt 0 ]]; then
+        echo "[spyre_run] Injecting instantiate_device_type_tests for uncontrolled classes in: $(basename "$test_file")"
+        for cls in "${UNCONTROLLED_CLASSES[@]}"; do
+            echo "[spyre_run]   -> $cls"
+        done
+    fi
+
+    # Report restricted classes (instantiated upstream with only_for, excluding spyre)
+    if [[ ${#RESTRICTED_CLASSES[@]} -gt 0 ]]; then
+        echo "[spyre_run] Re-injecting instantiate_device_type_tests (dropping only_for) for restricted classes in: $(basename "$test_file")"
+        for cls in "${RESTRICTED_CLASSES[@]}"; do
+            echo "[spyre_run]   -> $cls  (upstream: only_for=... excluded privateuse1)"
+        done
+    fi
+
+    local conftest_path
+    conftest_path="${original_dir}/__oot_conftest_${original_stem}.py"
+
     echo "[spyre_run] Generating wrapper: $(basename "$wrapper_path")"
 
-    {
-        echo "# Auto-generated by run_test.sh -- DO NOT EDIT -- deleted after run"
-        echo "# Wrapper for: $test_file"
-        echo "#"
-        echo "# Injects instantiate_device_type_tests() for ALL TestCase subclasses"
-        echo "# not already registered, so TorchTestBase controls them via YAML."
-        echo "# Classes with no 'device' arg are safe when YAML mode is 'skip'."
-        echo ""
-        echo "import sys as _sys, os as _os"
-        echo "_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))"
-        echo ""
-        echo "# Star-import brings in all classes, helpers, and existing"
-        echo "# instantiate_device_type_tests / instantiate_parametrized_tests calls."
-        echo "from ${module_name} import *  # noqa: F401,F403"
-        echo ""
-        echo "import inspect as _inspect"
-        echo "from torch.testing._internal.common_device_type import ("
-        echo "    instantiate_device_type_tests as _instantiate,"
-        echo ")"
-        echo ""
-        echo "# ---------------------------------------------------------------------------"
-        echo "# @staticmethod preservation"
-        echo "#"
-        echo "# instantiate_device_type_tests copies non-test class members via"
-        echo "# getattr(), which UNWRAPS @staticmethod descriptors into plain functions."
-        echo "# When test methods subsequently call self.static_helper(), Python treats"
-        echo "# the plain function as an instance method and injects self as the first"
-        echo "# positional arg, causing:"
-        echo "#   TypeError: Cls.method() takes 0 positional arguments but 1 was given"
-        echo "#"
-        echo "# _restore_staticmethods() uses inspect.getattr_static (which does NOT"
-        echo "# unwrap descriptors) to find all @staticmethod members on the original"
-        echo "# class, then re-applies them on every generated device-specific subclass."
-        echo "# ---------------------------------------------------------------------------"
-        echo "def _restore_staticmethods(original_cls, scope):"
-        echo "    prefix = original_cls.__name__"
-        echo "    for name, obj in list(scope.items()):"
-        echo "        if (isinstance(obj, type)"
-        echo "                and name.startswith(prefix)"
-        echo "                and name != prefix):"
-        echo "            for attr in dir(original_cls):"
-        echo "                desc = _inspect.getattr_static(original_cls, attr, None)"
-        echo "                if isinstance(desc, staticmethod):"
-        echo "                    setattr(obj, attr, desc)"
-        echo ""
-        echo "# Inject instantiate_device_type_tests for every uncontrolled class."
-        echo "# TorchTestBase replaces skipped tests before their body executes so"
-        echo "# the injected device arg never reaches plain-test method bodies."
-        echo "# After each injection, restore @staticmethod descriptors that"
-        echo "# instantiate_device_type_tests unwrapped during member copying."
-        for cls in "${UNCONTROLLED_CLASSES[@]}"; do
-            # Save the class reference before _instantiate deletes it from globals().
-            # instantiate_device_type_tests() calls del scope[class_name] at the end,
-            # so the name is no longer resolvable after the call.
-            echo "_cls_${cls} = ${cls}"
-            echo "_instantiate(_cls_${cls}, globals())"
-            echo "_restore_staticmethods(_cls_${cls}, globals())"
-        done
-    } > "$wrapper_path"
+    # Build the per-class injection block first (pure bash, no heredoc nesting issue).
+    # All classes use _pre_import_classes which is populated before the star-import.
+    local injection_block=""
+    for cls in "${NEEDS_INJECTION_CLASSES[@]}"; do
+        injection_block+="
+_cls_${cls} = _pre_import_classes.get('${cls}')
+if _cls_${cls} is None:
+    raise RuntimeError('Could not find original class ${cls} in pre-import of module ${module_name}')
+globals().setdefault('${cls}', _cls_${cls})
+_instantiate(_cls_${cls}, globals())
+_restore_staticmethods(_cls_${cls}, globals())
+"
+    done
 
-    WRAPPER_FILES+=("$wrapper_path")
+    # Separate quoted lists for restricted vs uncontrolled classes --
+    # each is retrieved differently from the private module.
+    local quoted_restricted_list=""
+    for cls in "${RESTRICTED_CLASSES[@]}"; do
+        quoted_restricted_list+="'${cls}', "
+    done
+    local quoted_uncontrolled_list=""
+    for cls in "${UNCONTROLLED_CLASSES[@]}"; do
+        quoted_uncontrolled_list+="'${cls}', "
+    done
+
+    # Write the wrapper using a heredoc — no quoting issues with embedded text.
+    # WRAPPER_EOF is unquoted so shell variables ($module_name, $test_file,
+    # $quoted_class_list, $injection_block) expand; all other Python lines
+    # contain no $ and are passed through literally.
+    cat > "$wrapper_path" <<WRAPPER_EOF
+# Auto-generated by run_test.sh -- DO NOT EDIT -- deleted after run
+# Wrapper for: $test_file
+#
+# Injects instantiate_device_type_tests() for:
+#   - uncontrolled classes: never passed to any instantiate_* upstream.
+#   - restricted classes: passed upstream with only_for=... that excluded
+#     privateuse1/spyre. Re-injected here WITHOUT only_for so TorchTestBase
+#     can generate the spyre variant and control it via the YAML config.
+# Classes with no 'device' arg are safe when YAML mode is 'skip'.
+
+import sys as _sys, os as _os
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+
+# Ensure the spyre tests directory is on sys.path before any torch imports.
+# torch.testing._internal.common_device_type uses runpy to load
+# TORCH_TEST_DEVICES (spyre_test_base_common.py), which imports spyre_*
+# modules.  Those modules must be findable on sys.path at that point.
+# PYTHONPATH is set by run_test.sh but Python only applies it at interpreter
+# startup -- subsequent imports don't re-read it, so we inject it explicitly.
+for _p in reversed(_os.environ.get('PYTHONPATH', '').split(_os.pathsep)):
+    if _p and _p not in _sys.path:
+        _sys.path.insert(0, _p)
+
+# ---------------------------------------------------------------------------
+# Pre-import: capture original class objects BEFORE the star-import runs the
+# upstream instantiate_device_type_tests() calls that delete them from scope.
+#
+# Two categories require different retrieval strategies:
+#
+# RESTRICTED classes (had only_for=... upstream):
+#   instantiate_device_type_tests deletes the class name from the module
+#   dict at the end of its run, so by the time exec_module() returns the
+#   name is gone.
+#
+#   The module does "from torch.testing._internal.common_device_type import
+#   instantiate_device_type_tests" at the top, binding the real function
+#   directly into the module's namespace at import time.  Patching
+#   _pre_mod.instantiate_device_type_tests after module_from_spec() has no
+#   effect because the binding is resolved during exec_module(), not looked
+#   up dynamically.
+#
+#   Solution: patch the function on the SOURCE MODULE
+#   (torch.testing._internal.common_device_type) before exec_module() runs,
+#   then restore it immediately after.  This intercepts every call site
+#   regardless of how the function was imported.
+#
+# UNCONTROLLED classes (never passed to instantiate_device_type_tests):
+#   Nothing deletes them, so they are still present on _pre_mod after
+#   exec_module() completes.  A plain getattr suffices.
+# ---------------------------------------------------------------------------
+import importlib.util as _ilu
+
+_pre_import_classes = {}
+_restricted_names = set([${quoted_restricted_list}])
+
+def _do_pre_import():
+    """Capture original class objects before the star-import deletes them."""
+    import torch.testing._internal.common_device_type as _cdtype
+
+    real_fn = _cdtype.instantiate_device_type_tests
+
+    def _capturing_instantiate(cls, *args, **kwargs):
+        if cls.__name__ in _restricted_names:
+            # Save the class AND copies of all its test methods BEFORE
+            # the real call deletes them via delattr(generic_test_class, name).
+            # instantiate_device_type_tests mutates the original class by
+            # removing all test methods from it at the end of its run.
+            # We must copy them now so our later re-injection has methods to work with.
+            import copy as _copy
+            _pre_import_classes[cls.__name__] = cls
+            _saved_methods = cls.__name__ + '__saved_tests'
+            _pre_import_classes[_saved_methods] = {
+                name: getattr(cls, name)
+                for name in list(cls.__dict__.keys())
+                if name.startswith('test')
+            }
+        return real_fn(cls, *args, **kwargs)
+
+    # Patch at source so every from-import of instantiate_device_type_tests
+    # picks up the shim during exec_module.
+    _cdtype.instantiate_device_type_tests = _capturing_instantiate
+    try:
+        _private_spec = _ilu.spec_from_file_location(
+            '_oot_pre_${module_name}',
+            _os.path.join(_os.path.dirname(_os.path.abspath(__file__)), '${module_name}.py'),
+        )
+        _pre_mod = _ilu.module_from_spec(_private_spec)
+        _private_spec.loader.exec_module(_pre_mod)
+    finally:
+        _cdtype.instantiate_device_type_tests = real_fn
+
+    # Restricted classes captured via shim; uncontrolled still on _pre_mod.
+    for _name in [${quoted_uncontrolled_list}]:
+        if hasattr(_pre_mod, _name):
+            _pre_import_classes[_name] = getattr(_pre_mod, _name)
+
+_do_pre_import()
+
+# Restore test methods that the real instantiate_device_type_tests deleted
+# from restricted classes via delattr(). Without this, our re-injection call
+# finds an empty class and generates no test variants.
+for _rname in _restricted_names:
+    _saved_key = _rname + '__saved_tests'
+    _saved = _pre_import_classes.get(_saved_key, {})
+    _cls = _pre_import_classes.get(_rname)
+    if _cls is not None and _saved:
+        for _mname, _mfn in _saved.items():
+            if not hasattr(_cls, _mname):
+                setattr(_cls, _mname, _mfn)
+
+# ---------------------------------------------------------------------------
+# Star-import: executes the original module in THIS file's global scope,
+# running all upstream instantiate_* calls (including restricted only_for
+# ones).  After this line, restricted class names are deleted from globals()
+# by the upstream instantiate_device_type_tests(), but _pre_import_classes
+# still holds the original class objects captured above.
+# ---------------------------------------------------------------------------
+from ${module_name} import *  # noqa: F401,F403
+
+import inspect as _inspect
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests as _instantiate,
+)
+
+# ---------------------------------------------------------------------------
+# @staticmethod preservation
+#
+# instantiate_device_type_tests copies non-test class members via
+# getattr(), which UNWRAPS @staticmethod descriptors into plain functions.
+# When test methods subsequently call self.static_helper(), Python treats
+# the plain function as an instance method and injects self as the first
+# positional arg, causing:
+#   TypeError: Cls.method() takes 0 positional arguments but 1 was given
+#
+# _restore_staticmethods() uses inspect.getattr_static (which does NOT
+# unwrap descriptors) to find all @staticmethod members on the original
+# class, then re-applies them on every generated device-specific subclass.
+# ---------------------------------------------------------------------------
+def _restore_staticmethods(original_cls, scope):
+    prefix = original_cls.__name__
+    for name, obj in list(scope.items()):
+        if (isinstance(obj, type)
+                and name.startswith(prefix)
+                and name != prefix):
+            for attr in dir(original_cls):
+                desc = _inspect.getattr_static(original_cls, attr, None)
+                if isinstance(desc, staticmethod):
+                    setattr(obj, attr, desc)
+
+# ---------------------------------------------------------------------------
+# Inject instantiate_device_type_tests for all classes needing injection,
+# using pre-captured class objects from _pre_import_classes.
+#
+# For *restricted* classes: the upstream only_for call produced no spyre
+# subclass. We call again WITHOUT only_for so TorchTestBase generates the
+# privateuse1/spyre variant alongside the existing cuda/cpu ones.
+#
+# For *uncontrolled* classes: first-time injection; TorchTestBase sees them
+# for the first time here.
+#
+# After each injection, restore @staticmethod descriptors that
+# instantiate_device_type_tests unwrapped during member copying.
+#
+${injection_block}
+
+WRAPPER_EOF
+
+    # Generate a conftest.py that patches DEVICE_LIST_SUPPORT_PROFILING_TEST
+    # before pytest collects any tests. This is the only reliable point to
+    # patch it: conftest.py runs before module import during collection, so
+    # the from-import in test_memory_profiler.py has not yet bound the
+    # original tuple. By patching here, every subsequent from-import binds
+    # the list that includes 'privateuse1'.
+    cat > "$conftest_path" <<CONFTEST_EOF
+# Auto-generated by run_test.sh -- DO NOT EDIT -- deleted after run
+import torch.testing._internal.common_utils as _cu
+_dl = getattr(_cu, 'DEVICE_LIST_SUPPORT_PROFILING_TEST', None)
+if _dl is not None and 'privateuse1' not in _dl:
+    _cu.DEVICE_LIST_SUPPORT_PROFILING_TEST = list(_dl) + ['privateuse1']
+CONFTEST_EOF
+
+    WRAPPER_FILES+=("$wrapper_path" "$conftest_path")
     _RUN_FILE="$wrapper_path"
 }
 
@@ -503,16 +746,21 @@ for test_file in "${TEST_FILES[@]}"; do
     original_dir="$(dirname "$test_file")"
     original_stem="$(basename "$test_file" .py)"
     stale_wrapper="${original_dir}/${original_stem}__oot_wrapper.py"
+    stale_conftest="${original_dir}/__oot_conftest_${original_stem}.py"
     if [[ -f "$stale_wrapper" ]]; then
         echo "[spyre_run]   Removing stale wrapper: $stale_wrapper"
         rm -f "$stale_wrapper"
+    fi
+    if [[ -f "$stale_conftest" ]]; then
+        echo "[spyre_run]   Removing stale conftest: $stale_conftest"
+        rm -f "$stale_conftest"
     fi
 done
 
 # ---------------------------------------------------------------------------
 # 11. Build the final run list (original or wrapper per file)
 # ---------------------------------------------------------------------------
-echo "[spyre_run] Checking for uncontrolled TestCase classes..."
+echo "[spyre_run] Checking for uncontrolled/restricted TestCase classes..."
 echo ""
 
 RUN_FILES=()
@@ -546,6 +794,7 @@ for i in "${!RUN_FILES[@]}"; do
         cd "$run_dir"
         python3 -m pytest "$run_basename" "${EXTRA_PYTEST_ARGS[@]}" || true
     )
+
     _exit=$?
     if [[ $_exit -ne 0 ]]; then
         echo "[spyre_run] WARNING: pytest exited with code $_exit for $original_file" >&2


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- bug

#### What this PR does:

Problem: Test classes passed to instantiate_device_type_tests() upstream with an only_for= constraint (e.g. TestMemoryProfilerTimeline with only_for=DEVICE_LIST_SUPPORT_PROFILING_TEST) were silently producing zero tests for the spyre/privateuse1 device.

Root cause: The wrapper's pre-import step runs a private copy of the test module via exec_module to capture the restricted class before the upstream instantiate_device_type_tests call deletes it from the module namespace. However, the real instantiate_device_type_tests also calls delattr(cls, method_name) on every test method of the original class at the end of its run — regardless of only_for. So by the time our shim captured the class, all its test methods had already been stripped. The subsequent re-injection call found an empty class and generated no test variants.

Fix: Inside the capturing shim, save copies of all test methods from restricted classes before delegating to the real instantiate_device_type_tests. After _do_pre_import() completes, restore any missing test methods onto the captured class objects so the re-injection call has a fully-populated class to work with.

Added `test_profiler_config.yaml` v1 version for running upstream pytorch profiler tests (More tests to be listed in a subsequent PR)

#### Which issue(s) this PR is related to:


Fixes #(https://github.com/torch-spyre/torch-spyre/issues/1491)

EPIC: https://github.com/torch-spyre/torch-spyre/issues/1156


#### Does this PR introduce a user-facing change?
NO
