### PR TITLE
[TESTING GHA] feat: Github action workflow for running upstream pytorch test - profiler and view ops

### DIFF
--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -10,6 +10,9 @@ on:
       - main
       - anu_ga_upstream_torch_test_workflow  # temporary, remove before merge
 
+  pull_request:
+    branches: [main]      # fires on EVERY commit pushed to a PR
+
   # Allow manual triggering from any branch — useful for testing on a feature
   # branch before raising a PR.
   # To add a new suite later: add its config filename to the matrix below.

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -5,12 +5,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]      # fires on EVERY commit pushed to a PR
+    branches: [main]
 
-  # Allow manual triggering from any branch — useful for testing on a feature
-  # branch before raising a PR.
-  # To add a new suite later: add its config filename to the matrix below.
-  workflow_dispatch: null
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -50,7 +46,32 @@ jobs:
         with:
           path: torch-spyre
 
+      # ---------------------------------------------------------------------------
+      # PyTorch source caching
+      #
+      # Cloning pytorch/pytorch at release/2.10 with all submodules is expensive.
+      # We cache the entire checkout keyed on the latest commit SHA of release/2.10
+      # so the clone only happens when the branch actually updates upstream.
+      #
+      # Cache hit  --> restore from cache, skip checkout (saves several minutes)
+      # Cache miss --> shallow clone + submodules, then save to cache for next run
+      # ---------------------------------------------------------------------------
+      - name: Get latest commit SHA of pytorch release/2.10
+        id: pytorch-sha
+        run: |
+          SHA=$(git ls-remote https://github.com/pytorch/pytorch.git refs/heads/release/2.10 | cut -f1)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "PyTorch release/2.10 HEAD: $SHA"
+
+      - name: Restore PyTorch source from cache
+        id: pytorch-cache
+        uses: actions/cache@v4
+        with:
+          path: pytorch
+          key: pytorch-release-2.10-${{ steps.pytorch-sha.outputs.sha }}
+
       - name: Checkout PyTorch source at release/2.10
+        if: steps.pytorch-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: pytorch/pytorch

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -1,0 +1,79 @@
+name: upstream-pytorch-tests
+
+# on:
+#   # Run automatically on every merge to main
+#   push:
+#     branches: [main]
+on:
+  push:
+    branches:
+      - main
+      - anu_ga_upstream_torch_test_workflow  # temporary, remove before merge
+
+  # Allow manual triggering from any branch — useful for testing on a feature
+  # branch before raising a PR.
+  # To add a new suite later: add its config filename to the matrix below.
+  workflow_dispatch: null
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  upstream-tests:
+    name: ${{ matrix.suite.name }}
+    runs-on: official-aiu-x86-64-arc-runner-set-v3
+    timeout-minutes: 720
+
+    # ---------------------------------------------------------------------------
+    # To add a new upstream test suite, append an entry here:
+    #   - name: <human-readable label shown in the GHA UI>
+    #     config: <filename inside tests/configs/>
+    # ---------------------------------------------------------------------------
+    strategy:
+      fail-fast: false   # run all suites even if one fails
+      matrix:
+        suite:
+          - name: Test View Ops
+            config: test_suite_config.yaml
+          - name: Test Profiler
+            config: test_profiler_config.yaml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Gather environment info
+        run: |
+          echo 'gather info start'
+          pwd
+          ls -la
+          whoami
+          id
+          echo "GHA_RUNNER_POD_NODE_NAME $GHA_RUNNER_POD_NODE_NAME"
+          echo "PATH $PATH"
+          echo "HOME $HOME"
+          python3 --version
+          python3 -c 'import sys; print(sys.path)'
+          echo 'gather info end'
+
+      - name: Install torch-spyre package and dependencies
+        run: |
+          echo 'installing with dependencies, this could take a while...'
+          pip install uv
+          uv sync --all-extras --active --inexact --reinstall-package torch-spyre -v
+
+      - name: Run ${{ matrix.suite.name }} upstream test suite
+        working-directory: tests
+        run: |-
+          echo 'Running ${{ matrix.suite.name }} upstream tests...'
+          bash run_test.sh configs/${{ matrix.suite.config }} -v
+          echo '${{ matrix.suite.name }} upstream tests done'

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -4,10 +4,6 @@ on:
   # Run automatically on every merge to main
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -1,17 +1,16 @@
 name: upstream-pytorch-tests
 
-# on:
-#   # Run automatically on every merge to main
-#   push:
-#     branches: [main]
 on:
+  # Run automatically on every merge to main
   push:
-    branches:
-      - main
-
+    branches: [main]
   pull_request:
     branches: [main]      # fires on EVERY commit pushed to a PR
 
+  # Allow manual triggering from any branch — useful for testing on a feature
+  # branch before raising a PR.
+  # To add a new suite later: add its config filename to the matrix below.
+  workflow_dispatch: null
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,14 +39,27 @@ jobs:
       fail-fast: false   # run all suites even if one fails
       matrix:
         suite:
-          - name: Test View Ops
+          - name: View ops
             config: test_suite_config.yaml
-          - name: Test Profiler
+          - name: Profiler
             config: test_profiler_config.yaml
 
     steps:
-      - name: Checkout repository
+      - name: Checkout torch-spyre repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: torch-spyre
+
+      - name: Checkout PyTorch source at release/2.10
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: pytorch/pytorch
+          ref: release/2.10
+          submodules: recursive
+          path: pytorch
+
+      - name: Set TORCH_ROOT
+        run: echo "TORCH_ROOT=$GITHUB_WORKSPACE/pytorch" >> "$GITHUB_ENV"
 
       - name: Gather environment info
         run: |
@@ -59,18 +71,21 @@ jobs:
           echo "GHA_RUNNER_POD_NODE_NAME $GHA_RUNNER_POD_NODE_NAME"
           echo "PATH $PATH"
           echo "HOME $HOME"
+          echo "TORCH_ROOT $TORCH_ROOT"
           python3 --version
           python3 -c 'import sys; print(sys.path)'
           echo 'gather info end'
 
       - name: Install torch-spyre package and dependencies
+        working-directory: torch-spyre
         run: |
           echo 'installing with dependencies, this could take a while...'
           pip install uv
           uv sync --all-extras --active --inexact --reinstall-package torch-spyre -v
+          uv pip install pydantic
 
       - name: Run ${{ matrix.suite.name }} upstream test suite
-        working-directory: tests
+        working-directory: torch-spyre/tests
         run: |-
           echo 'Running ${{ matrix.suite.name }} upstream tests...'
           bash run_test.sh configs/${{ matrix.suite.config }} -v

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -8,15 +8,10 @@ on:
   push:
     branches:
       - main
-      - anu_ga_upstream_torch_test_workflow  # temporary, remove before merge
 
   pull_request:
     branches: [main]      # fires on EVERY commit pushed to a PR
 
-  # Allow manual triggering from any branch — useful for testing on a feature
-  # branch before raising a PR.
-  # To add a new suite later: add its config filename to the matrix below.
-  workflow_dispatch: null
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- feature

#### What this PR does:

Adds a new GitHub Actions workflow (`.github/workflows/upstream_tests.yaml)` that automatically runs the upstream PyTorch OOT test suites against the spyre device on every merge to main.

- Triggers automatically on every push to main
- Runs each test suite as an independent parallel job using a matrix strategy, so all suites complete in one workflow run and failures in one suite don't block the others (fail-fast: false)
- Each job checks out the repo, installs torch-spyre and its dependencies, then runs run_test.sh from the tests/ directory with the corresponding config file


#### Does this PR introduce a user-facing change? NO

