### PR TITLE
Enable fp32 overwrite operations

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -824,6 +824,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     cached_randn((2, 4, 8, 64), dtype=torch.float16),
                     cached_randn((2, 4, 8, 128), dtype=torch.float16),
                 ),
+                "4d_dim3_fp32": (
+                    3,
+                    cached_randn((2, 4, 3, 64), dtype=torch.float32),
+                    cached_randn((2, 4, 3, 32), dtype=torch.float32),
+                ),
             },
         },
         (

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -46,6 +46,7 @@ SPYRE_FP32_OPS = [
     "exx2",
     "layernormnorm",
     "identity",
+    "overwrite",
 ]
 
 LAYOUT_LABELS = ["INPUT", "OUTPUT", "KERNEL", "KERNEL_IDX"]


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds overwrite to the list of operations with fp32 support to enable `torch.cat` and `torch.nn.functional.pad` with fp32 inputs. A test for fp32 `torch.cat` is added.

#### Which issue(s) this PR is related to:

Fixes #1369 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
