### PR TITLE
Add environment variable-controlled timing to LaunchKernel

### DIFF
--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -26,12 +26,11 @@
 #include <atomic>
 #include <chrono>
 #include <cstdlib>  // std::getenv
-#include <filesystem>
-#include <fstream>
-#include <iomanip>
-#include <sstream>
 #include <flex/compiler_interface/dee_graph_converter.hpp>
 #include <flex/runtime/flex_factory.hpp>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <memory>
 #include <sendnn/graph.hpp>
 #include <sendnn/graph/graph_builder.hpp>
@@ -41,6 +40,7 @@
 #include <sendnn/runtime/runtime_interface.hpp>
 #include <sendnn/tensor/sentensor_info.hpp>
 #include <sendnn/util/status.hpp>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -127,31 +127,33 @@ void freeRuntime() {
 void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
   // Static initialization - happens once per process
   static bool timing_enabled = []() {
-    const char* env = std::getenv("TORCH_SPYRE_TIMING");
+    const char *env = std::getenv("TORCH_SPYRE_TIMING");
     return env && std::string(env) == "1";
   }();
-  
+
   static std::string timing_log_file = []() {
-    const char* env = std::getenv("TORCH_SPYRE_TIMING_LOG");
+    const char *env = std::getenv("TORCH_SPYRE_TIMING_LOG");
     if (!env) return std::string("");
-    
+
     std::string base_path(env);
-    // Add LOCAL_RANK suffix if in distributed setting (consistent with torch-spyre pattern)
-    const char* local_rank_env = std::getenv("LOCAL_RANK");
+    // Add LOCAL_RANK suffix if in distributed setting (consistent with
+    // torch-spyre pattern)
+    const char *local_rank_env = std::getenv("LOCAL_RANK");
     if (local_rank_env) {
       base_path += "_rank_" + std::string(local_rank_env);
     }
     return base_path;
   }();
-  
+
   static std::atomic<uint64_t> invocation_counter{0};
-  uint64_t current_invocation = invocation_counter.fetch_add(1, std::memory_order_relaxed);
-  
+  uint64_t current_invocation =
+      invocation_counter.fetch_add(1, std::memory_order_relaxed);
+
   using Clock = std::chrono::high_resolution_clock;
   using Duration = std::chrono::duration<double, std::milli>;
-  
+
   auto total_start = Clock::now();
-  
+
   // Get global runtime from eager
   auto gl = sendnn::GraphLoader(GlobalRuntime::get());
 
@@ -272,29 +274,37 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
     if (!status.IsOk()) throw std::runtime_error(status.Message());
   }
   auto compute_end = Clock::now();
-  
+
   auto total_end = Clock::now();
-  
+
   // Output timing if enabled
   if (timing_enabled) {
     Duration deser_time = deser_end - deser_start;
     Duration prep_time = prep_end - prep_start;
     Duration compute_time = compute_end - compute_start;
     Duration total_time = total_end - total_start;
-    
-    // Extract kernel directory name from path
-    std::filesystem::path p(g2_path);
-    std::string kernel_name = p.parent_path().filename().string();
-    
+
+    // Extract kernel directory name from path (e.g., "/a/b/kernel/graph.g2" ->
+    // "kernel")
+    std::string kernel_name;
+    auto last_sep = g2_path.rfind('/');
+    if (last_sep != std::string::npos && last_sep > 0) {
+      auto prev_sep = g2_path.rfind('/', last_sep - 1);
+      size_t start = (prev_sep == std::string::npos) ? 0 : prev_sep + 1;
+      kernel_name = g2_path.substr(start, last_sep - start);
+    } else {
+      kernel_name = g2_path;
+    }
+
     std::ostringstream timing_output;
     timing_output << std::fixed << std::setprecision(2);
-    timing_output << "launchKernel #" << current_invocation
-                  << " [" << kernel_name << "] Timing Breakdown:\n"
+    timing_output << "launchKernel #" << current_invocation << " ["
+                  << kernel_name << "] Timing Breakdown:\n"
                   << "  Deserialization: " << deser_time.count() << " ms\n"
                   << "  Preparation:     " << prep_time.count() << " ms\n"
                   << "  Compute:         " << compute_time.count() << " ms\n"
                   << "  Total:           " << total_time.count() << " ms\n";
-    
+
     // Output to file or stderr based on TORCH_SPYRE_TIMING_LOG
     if (!timing_log_file.empty()) {
       std::ofstream log_file(timing_log_file, std::ios::app);

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -23,7 +23,13 @@
 #include <util/sen_data_convert.h>
 #include <util/sendefs.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdlib>  // std::getenv
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
 #include <flex/compiler_interface/dee_graph_converter.hpp>
 #include <flex/runtime/flex_factory.hpp>
 #include <memory>
@@ -119,9 +125,38 @@ void freeRuntime() {
   GlobalRuntime::reset();
 }
 void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
+  // Static initialization - happens once per process
+  static bool timing_enabled = []() {
+    const char* env = std::getenv("TORCH_SPYRE_TIMING");
+    return env && std::string(env) == "1";
+  }();
+  
+  static std::string timing_log_file = []() {
+    const char* env = std::getenv("TORCH_SPYRE_TIMING_LOG");
+    if (!env) return std::string("");
+    
+    std::string base_path(env);
+    // Add LOCAL_RANK suffix if in distributed setting (consistent with torch-spyre pattern)
+    const char* local_rank_env = std::getenv("LOCAL_RANK");
+    if (local_rank_env) {
+      base_path += "_rank_" + std::string(local_rank_env);
+    }
+    return base_path;
+  }();
+  
+  static std::atomic<uint64_t> invocation_counter{0};
+  uint64_t current_invocation = invocation_counter.fetch_add(1, std::memory_order_relaxed);
+  
+  using Clock = std::chrono::high_resolution_clock;
+  using Duration = std::chrono::duration<double, std::milli>;
+  
+  auto total_start = Clock::now();
+  
   // Get global runtime from eager
   auto gl = sendnn::GraphLoader(GlobalRuntime::get());
 
+  // Section 1: Deserialization
+  auto deser_start = Clock::now();
   // Load compiled kernel
   auto g2 = sendnn::Graph();
   sendnn::Deserialize(&g2, g2_path);
@@ -168,7 +203,10 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
       }
     }
   }
+  auto deser_end = Clock::now();
 
+  // Section 2: Preparation
+  auto prep_start = Clock::now();
   // Load/parse patched G2 graph
   auto status = gl.LoadGraph(g2, false);
   if (!status.IsOk()) throw std::runtime_error(status.Message());
@@ -208,7 +246,10 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
                           args.back().storage().data_ptr().get_context())
                           ->owner);
   sen_outputs.push_back(tensor);
+  auto prep_end = Clock::now();
 
+  // Section 3: Compute
+  auto compute_start = Clock::now();
   // Execute device init
   if (args.size() == 6) {
     // Filling in segment 5 adds another input to the device init supernode
@@ -230,7 +271,47 @@ void launchKernel(std::string g2_path, std::vector<at::Tensor> args) {
     status = gl.Compute(sen_outputs, sen_inputs, 1);
     if (!status.IsOk()) throw std::runtime_error(status.Message());
   }
-
+  auto compute_end = Clock::now();
+  
+  auto total_end = Clock::now();
+  
+  // Output timing if enabled
+  if (timing_enabled) {
+    Duration deser_time = deser_end - deser_start;
+    Duration prep_time = prep_end - prep_start;
+    Duration compute_time = compute_end - compute_start;
+    Duration total_time = total_end - total_start;
+    
+    // Extract kernel directory name from path
+    std::filesystem::path p(g2_path);
+    std::string kernel_name = p.parent_path().filename().string();
+    
+    std::ostringstream timing_output;
+    timing_output << std::fixed << std::setprecision(2);
+    timing_output << "launchKernel #" << current_invocation
+                  << " [" << kernel_name << "] Timing Breakdown:\n"
+                  << "  Deserialization: " << deser_time.count() << " ms\n"
+                  << "  Preparation:     " << prep_time.count() << " ms\n"
+                  << "  Compute:         " << compute_time.count() << " ms\n"
+                  << "  Total:           " << total_time.count() << " ms\n";
+    
+    // Output to file or stderr based on TORCH_SPYRE_TIMING_LOG
+    if (!timing_log_file.empty()) {
+      std::ofstream log_file(timing_log_file, std::ios::app);
+      if (log_file.is_open()) {
+        log_file << timing_output.str();
+        log_file.close();
+      } else {
+        // Fallback to stderr if file can't be opened
+        std::cerr << "Warning: Could not open timing log file: "
+                  << timing_log_file << "\n";
+        std::cerr << timing_output.str();
+      }
+    } else {
+      // Default: output to stderr
+      std::cerr << timing_output.str();
+    }
+  }
   return;
 }
 


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- Add TORCH_SPYRE_TIMING environment variable (disabled by default)
- Capture timing for 4 phases: Deserialization, Preparation, Compute, Total
- Output to stderr or configurable file via `TORCH_SPYRE_TIMING_LOG`, `TORCH_SPYRE_TIMING_LOG`, and can recognize `LOCAL_RANK` for multi-rank case
- Structured output with kernel name, invocation number, duration in ms
- Zero performance overhead when disabled (static initialization)
- Thread-safe implementation using std::atomic
- Replace timing.hpp with std::chrono to avoid module import crashes

This is an interim solution pending P3-27 implementation.


#### Which issue(s) this PR is related to:
Fixes #1445 
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
Enable time tracking example
##### Enable timing (output to stderr)

```bash
export TORCH_SPYRE_TIMING=1
python examples/softmax.py
```

##### Enable timing with file logging

```bash
export TORCH_SPYRE_TIMING=1
export TORCH_SPYRE_TIMING_LOG=/tmp/timing.log
python examples/softmax.py
```

##### Distributed training (auto-adds rank suffix)

```bash
export TORCH_SPYRE_TIMING=1
export TORCH_SPYRE_TIMING_LOG=/tmp/timing
export LOCAL_RANK=0
python examples/softmax.py
# Creates: /tmp/timing_rank_0
```

#### Does this PR introduce a user-facing change?

#### Additional note:
