### PR TITLE
Move stickification, scratchpad allocation and core division to pre-scheduler passes

### DIFF
--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -14,9 +14,8 @@
 
 import os
 import sys
-from typing import Callable, List, Optional
+from typing import Any, Optional
 
-from torch._inductor.ir import Operation
 from torch.utils._config_module import install_config_module
 
 lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
@@ -27,6 +26,7 @@ sencores: int = int(os.getenv("SENCORES", "32"))
 
 # Pre-scheduling custom pass: runs on list[Operation] immediately before the
 # Scheduler is constructed (via the _update_scheduler monkey-patch).
-pre_scheduling_custom_pass: Optional[Callable[[List[Operation]], None]] = None
+# Expected signature: Callable[[list[Operation]], None]
+pre_scheduling_custom_pass: Optional[Any] = None
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -14,7 +14,9 @@
 
 import os
 import sys
+from typing import Callable, List, Optional
 
+from torch._inductor.ir import Operation
 from torch.utils._config_module import install_config_module
 
 lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
@@ -22,5 +24,9 @@ lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
+
+# Pre-scheduling custom pass: runs on list[Operation] immediately before the
+# Scheduler is constructed (via the _update_scheduler monkey-patch).
+pre_scheduling_custom_pass: Optional[Callable[[List[Operation]], None]] = None
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-from typing import Any, Optional
 
 from torch.utils._config_module import install_config_module
 
@@ -23,10 +22,5 @@ lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
-
-# Pre-scheduling custom pass: runs on list[Operation] immediately before the
-# Scheduler is constructed (via the _update_scheduler monkey-patch).
-# Expected signature: Callable[[list[Operation]], None]
-pre_scheduling_custom_pass: Optional[Any] = None
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -304,6 +304,23 @@ def prioritize_dimensions(
     return priority, min_splits
 
 
+def _resolve_layout(op: ComputedBuffer) -> "FixedTiledLayout":
+    """Return the FixedTiledLayout for op, unwrapping MutationLayoutSHOULDREMOVE.
+
+    Mutation ops keep MutationLayoutSHOULDREMOVE at pre-scheduler time so the
+    scheduler can identify them as in-place writes.  Their target buffer already
+    has a FixedTiledLayout assigned by propagate_spyre_tensor_layouts, so
+    real_layout() gives us the correct device layout for core division.
+    """
+    layout = op.get_layout()
+    if isinstance(layout, MutationLayoutSHOULDREMOVE):
+        layout = layout.real_layout()
+    assert isinstance(layout, FixedTiledLayout), (
+        f"Expected FixedTiledLayout for {op.get_name()}, got {type(layout)}"
+    )
+    return layout
+
+
 def divide_pointwise_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores):
     if max_cores == 1:
         return
@@ -315,7 +332,7 @@ def divide_pointwise_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores)
 
     input_tds = [TensorDep(a.dep, a.layout) for a in args]
     rw = op.get_read_writes()
-    output_td = TensorDep(next(iter(rw.writes)), op.get_layout())
+    output_td = TensorDep(next(iter(rw.writes)), _resolve_layout(op))
 
     adjust_it_space_for_sticks(it_space, input_tds + [output_td])
 
@@ -355,7 +372,7 @@ def divide_reduction_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores)
 
     input_tds = [TensorDep(a.dep, a.layout) for a in args]
     rw = op.get_read_writes()
-    output_td = TensorDep(next(iter(rw.writes)), op.get_layout())
+    output_td = TensorDep(next(iter(rw.writes)), _resolve_layout(op))
 
     # Adjust all stick dimension variables (inputs and output) to count sticks
     adjust_it_space_for_sticks(it_space, input_tds + [output_td])
@@ -396,10 +413,6 @@ def core_division_planning(
         if op.is_no_op():
             pass
         elif isinstance(op, ComputedBuffer):
-            if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
-                # Mutation ops keep their MutationLayoutSHOULDREMOVE until after
-                # scheduler init; core division is not applicable to them.
-                continue
             rw = op.get_read_writes()
             args = get_mem_deps_from_rw(rw)
             if isinstance(op.data, Pointwise):

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -148,9 +148,14 @@ def adjust_it_space_for_sticks(
 
     For each tensor, find the variable that indexes its stick dimension and
     convert its size in it_space from elements to sticks. This ensures core
-    division treats sticks as atomic units. Adjusts each variable at most once.
+    division treats sticks as atomic units.
+
+    When tensors of different dtypes share a stick variable (e.g. a float16
+    input and an int64 argmax output), the smallest elems_per_stick is used
+    so the adjustment is conservative.
     """
-    adjusted: dict[Symbol, int] = {}  # stick_var -> elems_per_stick used
+    # Pass 1: find the smallest elems_per_stick per stick variable.
+    min_elems: dict[Symbol, int] = {}
     for td in tensor_deps:
         stick_expr = td.device_coords[-1]
         if len(stick_expr.free_symbols) != 1:
@@ -159,20 +164,17 @@ def adjust_it_space_for_sticks(
         if stick_var not in it_space:
             continue
         elems_per_stick = td.layout.device_layout.elems_per_stick()
-        if stick_var in adjusted:
-            assert adjusted[stick_var] == elems_per_stick, (
-                f"Conflicting elems_per_stick for iteration variable {stick_var}: "
-                f"previously seen {adjusted[stick_var]}, now {elems_per_stick}. "
-                f"Mixed-dtype tensors sharing a stick variable are not supported."
-            )
-            continue
-        # FIXME: here we assume padding to a full stick. It may not always be the
-        #        case and we shouldn use a more robust way of computing the number
-        #        of sticks
+        if stick_var not in min_elems or elems_per_stick < min_elems[stick_var]:
+            min_elems[stick_var] = elems_per_stick
+
+    # Pass 2: adjust each variable once using the minimum.
+    for stick_var, elems_per_stick in min_elems.items():
+        # FIXME: here we assume padding to a full stick. It may not always be
+        #        the case and we should use a more robust way of computing the
+        #        number of sticks
         it_space[stick_var] = (
             it_space[stick_var] + elems_per_stick - 1
         ) // elems_per_stick
-        adjusted[stick_var] = elems_per_stick
 
 
 def must_split_vars(
@@ -397,13 +399,6 @@ def core_division_planning(
             if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
                 # Mutation ops keep their MutationLayoutSHOULDREMOVE until after
                 # scheduler init; core division is not applicable to them.
-                continue
-            layout = op.get_layout()
-            if not layout.dtype.is_floating_point:
-                # Integer-output buffers are index outputs (e.g. argmax) that are
-                # computed as part of the corresponding value reduction (e.g. max).
-                # The scheduler eliminates dead index nodes before running core
-                # division; we skip them here to match that behaviour.
                 continue
             rw = op.get_read_writes()
             args = get_mem_deps_from_rw(rw)

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -151,11 +151,12 @@ def adjust_it_space_for_sticks(
     division treats sticks as atomic units.
 
     When tensors of different dtypes share a stick variable (e.g. a float16
-    input and an int64 argmax output), the smallest elems_per_stick is used
-    so the adjustment is conservative.
+    input and an int64 argmax output), the largest elems_per_stick is used
+    so the adjustment is conservative (fewer sticks → smaller adjusted size →
+    fewer cores assigned to the stick dimension).
     """
-    # Pass 1: find the smallest elems_per_stick per stick variable.
-    min_elems: dict[Symbol, int] = {}
+    # Pass 1: find the largest elems_per_stick per stick variable.
+    max_elems: dict[Symbol, int] = {}
     for td in tensor_deps:
         stick_expr = td.device_coords[-1]
         if len(stick_expr.free_symbols) != 1:
@@ -164,11 +165,11 @@ def adjust_it_space_for_sticks(
         if stick_var not in it_space:
             continue
         elems_per_stick = td.layout.device_layout.elems_per_stick()
-        if stick_var not in min_elems or elems_per_stick < min_elems[stick_var]:
-            min_elems[stick_var] = elems_per_stick
+        if stick_var not in max_elems or elems_per_stick > max_elems[stick_var]:
+            max_elems[stick_var] = elems_per_stick
 
-    # Pass 2: adjust each variable once using the minimum.
-    for stick_var, elems_per_stick in min_elems.items():
+    # Pass 2: adjust each variable once using the maximum.
+    for stick_var, elems_per_stick in max_elems.items():
         # FIXME: here we assume padding to a full stick. It may not always be
         #        the case and we should use a more robust way of computing the
         #        number of sticks

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -20,16 +20,13 @@ from sympy import Expr, Symbol
 import torch
 from torch._inductor.ir import (
     ComputedBuffer,
+    ExternKernel,
     FallbackKernel,
     MultiOutput,
+    MutationLayoutSHOULDREMOVE,
+    Operation,
     Pointwise,
     Reduction,
-)
-from torch._inductor.scheduler import (
-    BaseSchedulerNode,
-    ExternKernelSchedulerNode,
-    SchedulerNode,
-    NopKernelSchedulerNode,
 )
 
 from torch._inductor.dependencies import MemoryDep
@@ -37,7 +34,12 @@ from torch._inductor.dependencies import MemoryDep
 from .errors import Unsupported
 from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
-from .pass_utils import SchedNodeArg, get_mem_deps, device_coordinates, iteration_space
+from .pass_utils import (
+    SchedNodeArg,
+    get_mem_deps_from_rw,
+    device_coordinates,
+    iteration_space_from_op,
+)
 from .logging_utils import get_inductor_logger
 from . import config
 import logging
@@ -300,13 +302,18 @@ def prioritize_dimensions(
     return priority, min_splits
 
 
-def divide_pointwise_op(n: SchedulerNode, args: list[SchedNodeArg], max_cores):
+def divide_pointwise_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores):
     if max_cores == 1:
         return
 
-    it_space = iteration_space(n)
+    it_space = iteration_space_from_op(op)
+    # Save raw (element-unit) sizes before stick adjustment for use in
+    # map_ir_splits_to_scheduler at codegen time.
+    it_space_raw_sizes = [int(v) for v in it_space.values()]
+
     input_tds = [TensorDep(a.dep, a.layout) for a in args]
-    output_td = TensorDep(next(iter(n.read_writes.writes)), n.node.get_layout())
+    rw = op.get_read_writes()
+    output_td = TensorDep(next(iter(rw.writes)), op.get_layout())
 
     adjust_it_space_for_sticks(it_space, input_tds + [output_td])
 
@@ -321,26 +328,32 @@ def divide_pointwise_op(n: SchedulerNode, args: list[SchedNodeArg], max_cores):
     cores_used = math.prod(splits.values())
 
     if cores_used > 1:
-        n.op_it_space_splits = splits
+        op.op_it_space_splits = list(splits.values())
+        op.op_it_space_sizes = it_space_raw_sizes
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                f"pointwise work_division {n.node.get_name()}: cores={cores_used}, "
+                f"pointwise work_division {op.get_name()}: cores={cores_used}, "
                 f"iteration_space={it_space}, priorities={priorities}, "
-                f"min_splits={min_splits}, op_it_space_splits={n.op_it_space_splits}"
+                f"min_splits={min_splits}, op_it_space_splits={op.op_it_space_splits}"
             )
 
 
-def divide_reduction_op(n: SchedulerNode, args: list[SchedNodeArg], max_cores):
+def divide_reduction_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores):
     if max_cores == 1:
         return
 
-    red: Reduction = n.node.data
+    red: Reduction = op.data
     is_matmul = red.reduction_type in (MATMUL_REDUCTION_OP, BATCH_MATMUL_OP)
 
-    it_space = iteration_space(n)
+    it_space = iteration_space_from_op(op)
+    # Save raw (element-unit) sizes before stick adjustment for use in
+    # map_ir_splits_to_scheduler at codegen time.
+    it_space_raw_sizes = [int(v) for v in it_space.values()]
+
     input_tds = [TensorDep(a.dep, a.layout) for a in args]
-    output_td = TensorDep(next(iter(n.read_writes.writes)), n.node.get_layout())
+    rw = op.get_read_writes()
+    output_td = TensorDep(next(iter(rw.writes)), op.get_layout())
 
     # Adjust all stick dimension variables (inputs and output) to count sticks
     adjust_it_space_for_sticks(it_space, input_tds + [output_td])
@@ -357,50 +370,56 @@ def divide_reduction_op(n: SchedulerNode, args: list[SchedNodeArg], max_cores):
 
     cores_used = math.prod(splits.values())
     if cores_used > 1:
-        n.op_it_space_splits = splits
+        op.op_it_space_splits = list(splits.values())
+        op.op_it_space_sizes = it_space_raw_sizes
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                f"reduction work_division {n.node.get_name()}: cores={cores_used}, "
+                f"reduction work_division {op.get_name()}: cores={cores_used}, "
                 f"iteration_space={it_space}, priorities={priorities}, "
-                f"min_splits={min_splits}, op_it_space_splits={n.op_it_space_splits}"
+                f"min_splits={min_splits}, op_it_space_splits={op.op_it_space_splits}"
             )
 
 
 def core_division_planning(
-    nodes: list[BaseSchedulerNode],
-) -> list[BaseSchedulerNode]:
-    # Nodes are in topological order (guaranteed by caller).
+    operations: list[Operation],
+) -> None:
+    # Operations are in topological order (guaranteed by GraphLowering).
     max_cores = config.sencores
     if max_cores > 32 or max_cores < 1:
         raise Unsupported(f"invalid SENCORES value {max_cores}")
 
-    it = iter(nodes)
-    for n in it:
-        if isinstance(n, SchedulerNode) and isinstance(n.node, ComputedBuffer):
-            if isinstance(n.node.data, Pointwise):
-                divide_pointwise_op(n, get_mem_deps(n), max_cores)
-            elif isinstance(n.node.data, Reduction):
-                divide_reduction_op(n, get_mem_deps(n), max_cores)
+    it = iter(operations)
+    for op in it:
+        if op.is_no_op():
+            pass
+        elif isinstance(op, ComputedBuffer):
+            if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+                # Mutation ops keep their MutationLayoutSHOULDREMOVE until after
+                # scheduler init; core division is not applicable to them.
+                continue
+            layout = op.get_layout()
+            if not layout.dtype.is_floating_point:
+                # Integer-output buffers are index outputs (e.g. argmax) that are
+                # computed as part of the corresponding value reduction (e.g. max).
+                # The scheduler eliminates dead index nodes before running core
+                # division; we skip them here to match that behaviour.
+                continue
+            rw = op.get_read_writes()
+            args = get_mem_deps_from_rw(rw)
+            if isinstance(op.data, Pointwise):
+                divide_pointwise_op(op, args, max_cores)
+            elif isinstance(op.data, Reduction):
+                divide_reduction_op(op, args, max_cores)
             else:
                 # Core division not supported on other IRNode types
                 pass
-        elif isinstance(n, ExternKernelSchedulerNode):
-            if isinstance(n.node, FallbackKernel):
-                n = next(it, None)
-                if not (
-                    isinstance(n, ExternKernelSchedulerNode)
-                    and isinstance(n.node, MultiOutput)
-                ):
-                    raise RuntimeError("FallbackKernel must be followed by MultiOutput")
-
-                # Core division not supported on fallback kernels
-                pass
-            else:
-                logger.warning(f"unhandled node type {type(n.node)}")
-        elif isinstance(n, NopKernelSchedulerNode):
-            pass
+        elif isinstance(op, FallbackKernel):
+            op = next(it, None)
+            if not isinstance(op, MultiOutput):
+                raise RuntimeError("FallbackKernel must be followed by MultiOutput")
+            # Core division not supported on fallback kernels
+        elif isinstance(op, ExternKernel):
+            logger.warning(f"unhandled node type {type(op)}")
         else:
-            logger.warning(f"unhandled scheduler node type {type(n)}")
-
-    return nodes
+            logger.warning(f"unhandled operation type {type(op)}")

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -18,7 +18,7 @@ from typing import NamedTuple
 import sympy
 from torch._inductor.ir import FixedLayout, Pointwise, Reduction
 from torch._inductor.scheduler import SchedulerNode
-from torch._inductor.dependencies import MemoryDep
+from torch._inductor.dependencies import MemoryDep, ReadWrites
 from torch._inductor.virtualized import V
 from torch_spyre._inductor.errors import Unsupported
 
@@ -34,6 +34,18 @@ class SchedNodeArg(NamedTuple):
 def get_mem_deps(n: SchedulerNode) -> list[SchedNodeArg]:
     res: list[SchedNodeArg] = []
     for arg in n.read_writes.reads:
+        if isinstance(arg, MemoryDep):
+            buf = V.graph.get_buffer(arg.name)
+            layout = buf.get_layout()
+            if not isinstance(layout, FixedTiledLayout):
+                raise RuntimeError(f"{buf} does not have FixedTiledLayout")
+            res.append(SchedNodeArg(arg, layout))
+    return res
+
+
+def get_mem_deps_from_rw(read_writes: ReadWrites) -> list[SchedNodeArg]:
+    res: list[SchedNodeArg] = []
+    for arg in read_writes.reads:
         if isinstance(arg, MemoryDep):
             buf = V.graph.get_buffer(arg.name)
             layout = buf.get_layout()

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -16,7 +16,7 @@ from typing import NamedTuple
 
 
 import sympy
-from torch._inductor.ir import FixedLayout, Pointwise, Reduction
+from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise, Reduction
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.dependencies import MemoryDep, ReadWrites
 from torch._inductor.virtualized import V
@@ -77,3 +77,81 @@ def iteration_space(n: SchedulerNode) -> dict[sympy.Symbol, sympy.Expr]:
         return next(iter(n.read_writes.reads)).ranges.copy()
     else:
         raise Unsupported("Unexpected node type")
+
+
+def iteration_space_from_op(op: ComputedBuffer) -> dict[sympy.Symbol, sympy.Expr]:
+    """Pre-scheduler version of iteration_space: uses op.get_read_writes() instead
+    of SchedulerNode.read_writes."""
+    rw = op.get_read_writes()
+    if isinstance(op.data, Pointwise):
+        return next(iter(rw.writes)).ranges.copy()
+    elif isinstance(op.data, Reduction):
+        return next(iter(rw.reads)).ranges.copy()
+    else:
+        raise Unsupported("Unexpected node type")
+
+
+def map_ir_splits_to_scheduler(
+    ir_sizes: list[int],
+    ir_splits: list[int],
+    sched_it_space: dict[sympy.Symbol, sympy.Expr],
+) -> dict[sympy.Symbol, int]:
+    """Map positional IR-level core-division splits to scheduler-level symbol keys.
+
+    At pre-scheduler time, core_division stores splits as a list[int] parallel to
+    the IR-level iteration-space dimensions (in natural/declaration order).  At
+    codegen time the Scheduler has renamed and possibly reordered or merged those
+    dimensions via ``simplify_and_reorder``.
+
+    The scheduler sorts dimensions by decreasing stride.  For contiguous row-major
+    tensors this equals natural order, but broadcast operands (stride=0) can cause
+    the scheduler to reorder non-broadcast dims ahead of others.
+
+    Strategy: sort BOTH the IR (size, split) pairs AND the scheduler (size, symbol)
+    pairs by decreasing size using a stable sort.  After sorting, IR and scheduler
+    dims align positionally:
+
+    - Distinct sizes: sort uniquely resolves the mapping and handles reordering.
+    - Duplicate sizes: Python's stable sort preserves relative order among equal
+      elements, which matches the scheduler's tie-breaking by original position.
+    - Fewer scheduler dims (merging occurred): after sort-aligning, greedily consume
+      consecutive IR dims whose sizes multiply to each scheduler dim's size.
+    """
+    sched_syms = list(sched_it_space.keys())
+    sched_sizes = [int(v) for v in sched_it_space.values()]
+
+    # Sort IR dims by decreasing size (stable: preserves relative order for ties).
+    sorted_ir = sorted(zip(ir_sizes, ir_splits), key=lambda p: p[0], reverse=True)
+    sorted_ir_sizes = [p[0] for p in sorted_ir]
+    sorted_ir_splits = [p[1] for p in sorted_ir]
+
+    # Sort scheduler dims by decreasing size (stable: same tie-breaking rule).
+    sorted_sched = sorted(
+        zip(sched_sizes, sched_syms), key=lambda p: p[0], reverse=True
+    )
+    sorted_sched_sizes = [p[0] for p in sorted_sched]
+    sorted_sched_syms = [p[1] for p in sorted_sched]
+
+    if len(sorted_ir_sizes) == len(sorted_sched_sizes):
+        # Common case: no merging. 1-to-1 positional match on sorted dims.
+        return {sym: split for sym, split in zip(sorted_sched_syms, sorted_ir_splits)}
+
+    # Dimension merging occurred.  After size-sorting, the scheduler's merged dims
+    # correspond to consecutive runs of IR dims with matching size-products.
+    result: dict[sympy.Symbol, int] = {}
+    ir_idx = 0
+    for sym, sched_size in zip(sorted_sched_syms, sorted_sched_sizes):
+        product_size = 1
+        product_split = 1
+        while ir_idx < len(sorted_ir_sizes) and product_size < sched_size:
+            product_size *= sorted_ir_sizes[ir_idx]
+            product_split *= sorted_ir_splits[ir_idx]
+            ir_idx += 1
+        assert product_size == sched_size, (
+            f"Cannot map IR dims to scheduler dims: "
+            f"ir_sizes={ir_sizes}, sched_sizes={sched_sizes}"
+        )
+        result[sym] = product_split
+
+    assert ir_idx == len(sorted_ir_sizes), "Not all IR dimensions consumed"
+    return result

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -32,7 +32,10 @@ from .temp_passes import (
     relayout_linear_weights,
     replace_scalar_with_tensor,
 )
-from .stickify import propagate_mutation_layouts
+from . import config
+from .stickify import propagate_mutation_layouts, propagate_spyre_tensor_layouts
+from .core_division import core_division_planning
+from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
 
@@ -175,11 +178,6 @@ class CustomPreSchedulingPasses(CustomGraphPass):
     """
 
     def __call__(self, operations: list[Operation]) -> None:
-        from .stickify import propagate_spyre_tensor_layouts
-        from .core_division import core_division_planning
-        from .scratchpad import scratchpad_planning
-        from . import config
-
         has_spyre_device = any(
             op.get_device() is not None and op.get_device().type == DEVICE_NAME
             for op in operations
@@ -193,10 +191,6 @@ class CustomPreSchedulingPasses(CustomGraphPass):
             scratchpad_planning(operations)
 
     def uuid(self) -> Optional[Any]:
-        from .stickify import propagate_spyre_tensor_layouts
-        from .core_division import core_division_planning
-        from .scratchpad import scratchpad_planning
-
         files = [
             inspect.getfile(propagate_spyre_tensor_layouts),
             inspect.getfile(core_division_planning),

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -166,25 +166,40 @@ class CustomPostFusionPasses(CustomNodePassBase):
         return [spyre_fuse_nodes]
 
 
-def pre_scheduling_passes(operations: list[Operation]) -> None:
-    """Spyre-specific passes that run on IR operations immediately before the
+class CustomPreSchedulingPasses(CustomGraphPass):
+    """
+    Spyre-specific passes that run on IR operations immediately before the
     Scheduler is constructed (via the _update_scheduler monkey-patch).
 
     Operations are in topological order (guaranteed by GraphLowering).
     """
-    from .stickify import propagate_spyre_tensor_layouts
-    from .core_division import core_division_planning
-    from .scratchpad import scratchpad_planning
-    from . import config
 
-    has_spyre_device = any(
-        op.get_device() is not None and op.get_device().type == DEVICE_NAME
-        for op in operations
-    )
-    if not has_spyre_device:
-        return
+    def __call__(self, operations: list[Operation]) -> None:
+        from .stickify import propagate_spyre_tensor_layouts
+        from .core_division import core_division_planning
+        from .scratchpad import scratchpad_planning
+        from . import config
 
-    propagate_spyre_tensor_layouts(operations)
-    core_division_planning(operations)
-    if config.lx_planning:
-        scratchpad_planning(operations)
+        has_spyre_device = any(
+            op.get_device() is not None and op.get_device().type == DEVICE_NAME
+            for op in operations
+        )
+        if not has_spyre_device:
+            return
+
+        propagate_spyre_tensor_layouts(operations)
+        core_division_planning(operations)
+        if config.lx_planning:
+            scratchpad_planning(operations)
+
+    def uuid(self) -> Optional[Any]:
+        from .stickify import propagate_spyre_tensor_layouts
+        from .core_division import core_division_planning
+        from .scratchpad import scratchpad_planning
+
+        files = [
+            inspect.getfile(propagate_spyre_tensor_layouts),
+            inspect.getfile(core_division_planning),
+            inspect.getfile(scratchpad_planning),
+        ]
+        return get_hash_for_files(tuple(dict.fromkeys(files + [__file__])))

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -31,7 +31,7 @@ from .temp_passes import (
     relayout_linear_weights,
     replace_scalar_with_tensor,
 )
-from .stickify import propagate_spyre_tensor_layouts
+from .stickify import propagate_mutation_layouts
 from .core_division import core_division_planning
 from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
@@ -152,7 +152,7 @@ class CustomPreFusionPasses(CustomNodePassBase):
     """
 
     def get_passes(self):
-        return [propagate_spyre_tensor_layouts]
+        return [propagate_mutation_layouts]
 
 
 class CustomPostFusionPasses(CustomNodePassBase):

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -22,6 +22,7 @@ from torch._inductor.custom_graph_pass import (
     CustomGraphPass,
     get_hash_for_files,
 )
+from torch._inductor.ir import Operation
 from torch._inductor.scheduler import BaseSchedulerNode
 
 from .padding import insert_padding
@@ -32,11 +33,8 @@ from .temp_passes import (
     replace_scalar_with_tensor,
 )
 from .stickify import propagate_mutation_layouts
-from .core_division import core_division_planning
-from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
-from . import config
 
 
 def _maybe_run_graph_pass(pass_fn, graph: torch.fx.graph.Graph) -> None:
@@ -160,22 +158,33 @@ class CustomPostFusionPasses(CustomNodePassBase):
     This inductor extension point enables Spyre-specific passes to run over
     the graph of LoopLevelIR nodes immediately after Inductor's fusion pass runs.
 
-    core_division_planning must run here (not pre-fusion) because inductor's
-    fusion pass renames the iteration-space symbols in MemoryDep.ranges between
-    the two phases.  Storing op_it_space_splits before that rename causes a
-    symbol mismatch at codegen time, silently dropping all work-division splits.
-
     The list of nodes is guarenteed by the caller to be in topological order.
     The returned list of nodes must also be in topological order.
     """
 
     def get_passes(self):
-        # core_division_planning and scratchpad_planning must precede
-        # spyre_fuse_nodes because the latter wraps SchedulerNodes into
-        # FusedSchedulerNodes, making them invisible to those passes'
-        # isinstance(n, SchedulerNode) checks.
-        passes = [core_division_planning]
-        if config.lx_planning:
-            passes.append(scratchpad_planning)
-        passes.append(spyre_fuse_nodes)
-        return passes
+        return [spyre_fuse_nodes]
+
+
+def pre_scheduling_passes(operations: list[Operation]) -> None:
+    """Spyre-specific passes that run on IR operations immediately before the
+    Scheduler is constructed (via the _update_scheduler monkey-patch).
+
+    Operations are in topological order (guaranteed by GraphLowering).
+    """
+    from .stickify import propagate_spyre_tensor_layouts
+    from .core_division import core_division_planning
+    from .scratchpad import scratchpad_planning
+    from . import config
+
+    has_spyre_device = any(
+        op.get_device() is not None and op.get_device().type == DEVICE_NAME
+        for op in operations
+    )
+    if not has_spyre_device:
+        return
+
+    propagate_spyre_tensor_layouts(operations)
+    core_division_planning(operations)
+    if config.lx_planning:
+        scratchpad_planning(operations)

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -81,8 +81,6 @@ def enable_spyre_context(
         CustomPreSchedulingPasses,
     )
 
-    from torch_spyre._inductor import config as spyre_config
-
     # *) Inductor config tweaks (saved/restored)
     new_config = {
         "split_reductions": False,
@@ -97,11 +95,6 @@ def enable_spyre_context(
         "unroll_reductions_threshold": 1,
         # Disable fusing of mm + permute/transpose for now.
         "permute_fusion": False,
-    }
-
-    # *) Spyre config tweaks (saved/restored)
-    new_spyre_config = {
-        "pre_scheduling_custom_pass": CustomPreSchedulingPasses(),
     }
 
     from torch._inductor.ir import Loops
@@ -120,10 +113,10 @@ def enable_spyre_context(
     # allowing the passes to modify the graph IR (buffers, inputs, constants).
     old_update_scheduler = GraphLowering._update_scheduler
 
+    _pre_scheduling_pass = CustomPreSchedulingPasses()
+
     def _spyre_update_scheduler(self: GraphLowering) -> None:
-        pre_scheduling_pass = spyre_config.pre_scheduling_custom_pass
-        if pre_scheduling_pass is not None:
-            pre_scheduling_pass(self.operations)
+        _pre_scheduling_pass(self.operations)
         old_update_scheduler(self)
 
     GraphLowering._update_scheduler = _spyre_update_scheduler  # type: ignore[method-assign]
@@ -135,7 +128,6 @@ def enable_spyre_context(
         V.set_real_inputs(example_inputs),
         V.set_choices_handler(SpyreHeuristics()),
         torch._inductor.config.patch(new_config),
-        spyre_config.patch(new_spyre_config),
     ):
         try:
             yield spyre_context_decompositions

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -15,9 +15,12 @@
 from contextlib import contextmanager
 
 import torch
+from torch._inductor.graph import GraphLowering
 from torch._inductor.utils import InputType
 from torch._inductor.virtualized import V
 from typing import Callable, Optional
+
+from .constants import DEVICE_NAME
 
 
 @contextmanager
@@ -107,6 +110,22 @@ def enable_spyre_context(
     # disable mul_softmax_pattern and div_softmax_pattern for now
     joint_graph.pass_patterns.pop()
 
+    # Inject the layout propagation pass before the Scheduler is constructed,
+    # allowing the pass to modify the graph IR (buffers, inputs, constants).
+    old_update_scheduler = GraphLowering._update_scheduler
+
+    def _spyre_update_scheduler(self: GraphLowering) -> None:
+        from torch_spyre._inductor.stickify import propagate_spyre_tensor_layouts
+
+        if any(
+            op.get_device() is not None and op.get_device().type == DEVICE_NAME
+            for op in self.operations
+        ):
+            propagate_spyre_tensor_layouts(self.operations)
+        old_update_scheduler(self)
+
+    GraphLowering._update_scheduler = _spyre_update_scheduler  # type: ignore[method-assign]
+
     with (
         spyre_data_types(),
         enable_spyre_lowerings(),
@@ -120,3 +139,4 @@ def enable_spyre_context(
         finally:
             joint_graph.pass_patterns[:] = origin_pass
             Loops.has_large_inner_fn = old_loop
+            GraphLowering._update_scheduler = old_update_scheduler  # type: ignore[method-assign]

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -20,8 +20,6 @@ from torch._inductor.utils import InputType
 from torch._inductor.virtualized import V
 from typing import Callable, Optional
 
-from .constants import DEVICE_NAME
-
 
 @contextmanager
 def spyre_data_types():
@@ -110,18 +108,14 @@ def enable_spyre_context(
     # disable mul_softmax_pattern and div_softmax_pattern for now
     joint_graph.pass_patterns.pop()
 
-    # Inject the layout propagation pass before the Scheduler is constructed,
-    # allowing the pass to modify the graph IR (buffers, inputs, constants).
+    # Inject the pre_scheduling_passes before the Scheduler is constructed,
+    # allowing the passes to modify the graph IR (buffers, inputs, constants).
     old_update_scheduler = GraphLowering._update_scheduler
 
     def _spyre_update_scheduler(self: GraphLowering) -> None:
-        from torch_spyre._inductor.stickify import propagate_spyre_tensor_layouts
+        from torch_spyre._inductor.passes import pre_scheduling_passes
 
-        if any(
-            op.get_device() is not None and op.get_device().type == DEVICE_NAME
-            for op in self.operations
-        ):
-            propagate_spyre_tensor_layouts(self.operations)
+        pre_scheduling_passes(self.operations)
         old_update_scheduler(self)
 
     GraphLowering._update_scheduler = _spyre_update_scheduler  # type: ignore[method-assign]

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -78,7 +78,10 @@ def enable_spyre_context(
         CustomPostPasses,
         CustomPreFusionPasses,
         CustomPostFusionPasses,
+        CustomPreSchedulingPasses,
     )
+
+    from torch_spyre._inductor import config as spyre_config
 
     # *) Inductor config tweaks (saved/restored)
     new_config = {
@@ -94,6 +97,11 @@ def enable_spyre_context(
         "unroll_reductions_threshold": 1,
         # Disable fusing of mm + permute/transpose for now.
         "permute_fusion": False,
+    }
+
+    # *) Spyre config tweaks (saved/restored)
+    new_spyre_config = {
+        "pre_scheduling_custom_pass": CustomPreSchedulingPasses(),
     }
 
     from torch._inductor.ir import Loops
@@ -113,9 +121,9 @@ def enable_spyre_context(
     old_update_scheduler = GraphLowering._update_scheduler
 
     def _spyre_update_scheduler(self: GraphLowering) -> None:
-        from torch_spyre._inductor.passes import pre_scheduling_passes
-
-        pre_scheduling_passes(self.operations)
+        pre_scheduling_pass = spyre_config.pre_scheduling_custom_pass
+        if pre_scheduling_pass is not None:
+            pre_scheduling_pass(self.operations)
         old_update_scheduler(self)
 
     GraphLowering._update_scheduler = _spyre_update_scheduler  # type: ignore[method-assign]
@@ -127,6 +135,7 @@ def enable_spyre_context(
         V.set_real_inputs(example_inputs),
         V.set_choices_handler(SpyreHeuristics()),
         torch._inductor.config.patch(new_config),
+        spyre_config.patch(new_spyre_config),
     ):
         try:
             yield spyre_context_decompositions

--- a/torch_spyre/_inductor/scratchpad.py
+++ b/torch_spyre/_inductor/scratchpad.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import math
 
 from torch._inductor.ir import (
     ComputedBuffer,
-)
-from torch._inductor.scheduler import (
-    BaseSchedulerNode,
-    SchedulerNode,
+    MutationLayoutSHOULDREMOVE,
+    Operation,
 )
 from torch._inductor.virtualized import V
 from . import config
@@ -158,18 +157,19 @@ class ScratchPadAllocator:
     # TODO add dealloc and defrag mechanism to allocator later
 
 
-def mem_usage_by_node(n: SchedulerNode):
-    """Get a summary of memory usage of the input node"""
+def mem_usage_by_op(op: ComputedBuffer):
+    """Get a summary of memory usage of the input operation."""
+    rw = op.get_read_writes()
     mem_usage = {}
-    for r_or_w, buf_memDeps in enumerate([n.read_writes.reads, n.read_writes.writes]):
-        for buf_memDep in buf_memDeps:
-            buf = V.graph.get_buffer(buf_memDep.name)
+    for is_input, deps in [(True, rw.reads), (False, rw.writes)]:
+        for dep in deps:
+            buf = V.graph.get_buffer(dep.name)
             dev_layout = buf.layout.device_layout  # this is device layout
             dev_size = (
                 math.prod(dev_layout.device_size[:-1]) * 128
             )  # num_sticks * bytes_per_stick
-            mem_usage[buf_memDep.name] = {
-                "is_input": r_or_w == 0,
+            mem_usage[dep.name] = {
+                "is_input": is_input,
                 "size": dev_size,
             }
 
@@ -177,29 +177,30 @@ def mem_usage_by_node(n: SchedulerNode):
 
 
 def consider_for_scratchpad(
-    n: SchedulerNode,
+    op: ComputedBuffer,
     alloc: ScratchPadAllocator,
     idx: int,
-    is_last_node: bool,
+    is_last_op: bool,
 ):
-    # 1. summarize both inputs and output sizes used by this node.
-    mem_usage = mem_usage_by_node(n)
+    # 1. summarize both inputs and output sizes used by this operation.
+    mem_usage = mem_usage_by_op(op)
 
     # 2. if alloc successful, lx info will be added to corresponding FixedTiledLayout,
     # which will be used in generate_sdsc() later.
-    org_op_name = n.node.origin_node.name
-    alloc.try_allocate(mem_usage, idx, org_op_name, is_last_node)
+    org_op_name = op.origin_node.name
+    alloc.try_allocate(mem_usage, idx, org_op_name, is_last_op)
 
 
-def buf_end_of_life_analysis(nodes: list[BaseSchedulerNode]):
+def buf_end_of_life_analysis(operations: list[Operation]):
     """
     First, find out the last time each buffer was used. {buf1: idx_last_used, ...}
     Turn it into {idx_last_used+1:[buf1, ], ...}, ie. buffers to be deleted at given idx
     """
     last_used: dict = {}
-    for idx, n in enumerate(nodes):
-        for buf in n.used_buffer_names():  # just buf names
-            last_used[buf] = idx
+    for idx, op in enumerate(operations):
+        rw = op.get_read_writes()
+        for dep in itertools.chain(rw.reads, rw.writes):
+            last_used[dep.name] = idx
 
     bufs_to_dealloc_at_idx: dict = {}
     for buf, idx in last_used.items():
@@ -213,22 +214,22 @@ def buf_end_of_life_analysis(nodes: list[BaseSchedulerNode]):
 
 
 def scratchpad_planning(
-    nodes: list[BaseSchedulerNode],
-) -> list[BaseSchedulerNode]:
-    # Nodes are in topological order (guarenteed by caller).
-    # Work division has already been done.
-    # Stickification has already been done (therefore all ComputedBeffers have FixedTiledLayouts)
+    operations: list[Operation],
+) -> None:
+    # Operations are in topological order (guaranteed by GraphLowering).
+    # Core division has already been done.
+    # Stickification has already been done (therefore all ComputedBuffers have FixedTiledLayouts)
 
     alloc = ScratchPadAllocator()
 
-    node_idx_to_dealloc_bufs = buf_end_of_life_analysis(nodes)
+    op_idx_to_dealloc_bufs = buf_end_of_life_analysis(operations)
 
-    for idx, n in enumerate(nodes):
+    for idx, op in enumerate(operations):
         # release unneeded LX allocations before actual planning
-        alloc.deallocate(node_idx_to_dealloc_bufs.get(idx, []))
-        is_last_node = idx == len(nodes) - 1
+        alloc.deallocate(op_idx_to_dealloc_bufs.get(idx, []))
+        is_last_op = idx == len(operations) - 1
 
-        if isinstance(n, SchedulerNode) and isinstance(n.node, ComputedBuffer):
-            consider_for_scratchpad(n, alloc, idx, is_last_node)
-    # print(alloc.lx_usage_hist)
-    return nodes
+        if isinstance(op, ComputedBuffer):
+            if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+                continue
+            consider_for_scratchpad(op, alloc, idx, is_last_op)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -39,7 +39,7 @@ from .constants import (
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
-from .pass_utils import iteration_space
+from .pass_utils import iteration_space, map_ir_splits_to_scheduler
 from .views import compute_coordinates, align_tensors
 from .logging_utils import get_inductor_logger
 from .op_spec import OpSpec, TensorArg
@@ -357,11 +357,17 @@ class SpyreKernel(Kernel[CSEVariable]):
             ]:
                 raise Unsupported(f"operation on {arg.device_dtype}")
 
-        core_division: dict[sympy.Symbol, int] = {}
-        if hasattr(self.current_node, "op_it_space_splits"):
-            core_division = self.current_node.op_it_space_splits  # type: ignore[union-attr]
-
         it_space = iteration_space(self.current_node)
+
+        ir_node = self.current_node.node  # ComputedBuffer
+        core_division: dict[sympy.Symbol, int] = {}
+        if hasattr(ir_node, "op_it_space_splits"):
+            core_division = map_ir_splits_to_scheduler(
+                ir_node.op_it_space_sizes,
+                ir_node.op_it_space_splits,
+                it_space,
+            )
+
         it_space_extended = {
             k: (v, core_division.get(k, 1)) for k, v in it_space.items()
         }

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -19,21 +19,20 @@ import torch
 from .logging_utils import get_inductor_logger
 from torch._inductor.ir import (
     ComputedBuffer,
+    ExternKernel,
     FallbackKernel,
     FixedLayout,
     InputBuffer,
+    MutationLayoutSHOULDREMOVE,
     MultiOutput,
+    Operation,
     Pointwise,
     Reduction,
     StorageBox,
     TensorBox,
 )
-from torch._inductor.scheduler import (
-    BaseSchedulerNode,
-    SchedulerNode,
-    ExternKernelSchedulerNode,
-    NopKernelSchedulerNode,
-)
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.virtualized import V
 
 from torch_spyre._C import (
@@ -46,7 +45,7 @@ from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
-    get_mem_deps,
+    get_mem_deps_from_rw,
     host_coordinates,
     device_coordinates,
 )
@@ -62,11 +61,13 @@ def same_device_size(t1: torch.dtype, t2: torch.dtype) -> bool:
     return get_elem_in_stick(t1) == get_elem_in_stick(t2)
 
 
-def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLayout:
-    pw: Pointwise = n.node.data
-    output: FixedLayout = n.node.get_layout()
-    output_dep = next(iter(n.read_writes.writes))
-    origin_node = next(iter(pw.origins))
+def pointwise_layout(
+    data: Pointwise,
+    output: FixedLayout,
+    output_dep: MemoryDep,
+    args: list[SchedNodeArg],
+) -> FixedTiledLayout:
+    origin_node = next(iter(data.origins))
     op = origin_node.target
 
     if len(args) == 1:
@@ -228,13 +229,15 @@ def pointwise_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
         return result
 
 
-def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLayout:
-    red: Reduction = n.node.data
-    output: FixedLayout = n.node.get_layout()
-    output_dep = next(iter(n.read_writes.writes))
+def reduction_layout(
+    data: Reduction,
+    output: FixedLayout,
+    output_dep: MemoryDep,
+    args: list[SchedNodeArg],
+) -> FixedTiledLayout:
     if (
-        red.reduction_type == MATMUL_REDUCTION_OP
-        or red.reduction_type == BATCH_MATMUL_OP
+        data.reduction_type == MATMUL_REDUCTION_OP
+        or data.reduction_type == BATCH_MATMUL_OP
     ):
         x = args[0]
         y = args[1]
@@ -249,7 +252,7 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
         y_stick_dim = matching_dim(y_coords, y_stick_expr)
         if x_stick_dim is None or y_stick_dim is None:
             raise Unsupported(
-                f"{red.reduction_type}: failed to map stick_dims to host coords"
+                f"{data.reduction_type}: failed to map stick_dims to host coords"
             )
 
         if (
@@ -258,12 +261,12 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
         ):
             # TODO: This is a legal PyTorch operation that we cannot execute without inserting restickify operations.
             raise Unsupported(
-                f"Spyre limitation: {red.reduction_type} requires restickify"
+                f"Spyre limitation: {data.reduction_type} requires restickify"
             )
         out_stick_dim = matching_dim(out_coords, y_stick_expr)
         if out_stick_dim is None:
             raise Unsupported(
-                f"{red.reduction_type}: failed to map output stick_dim to host coords {out_coords} {y_stick_expr}"
+                f"{data.reduction_type}: failed to map output stick_dim to host coords {out_coords} {y_stick_expr}"
             )
 
         out_dims = len(output.size)
@@ -276,7 +279,7 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
         return FixedTiledLayout(
             output.device, output.dtype, output.size, output.stride, stl
         )
-    elif red.reduction_type == "exx2":
+    elif data.reduction_type == "exx2":
         x = args[0]
         x_coords = host_coordinates(x.layout, x.dep)
         x_dev_coords = device_coordinates(x.layout, x.dep)
@@ -312,15 +315,15 @@ def reduction_layout(n: SchedulerNode, args: list[SchedNodeArg]) -> FixedTiledLa
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                f"{red.reduction_type} layout: in:{list(args[0].layout.size)} -> out:{list(result.size)}, "
+                f"{data.reduction_type} layout: in:{list(args[0].layout.size)} -> out:{list(result.size)}, "
                 f"device_size={list(result.device_layout.device_size)}"
             )
 
         return result
 
 
-def generic_layout(n: ExternKernelSchedulerNode) -> FixedTiledLayout:
-    output: FixedLayout = n.node.get_layout()
+def generic_layout(op: Operation) -> FixedTiledLayout:
+    output: FixedLayout = op.get_layout()
     # Use the generic stick format
     stl = SpyreTensorLayout(output.size, output.dtype)
     return FixedTiledLayout(
@@ -329,8 +332,8 @@ def generic_layout(n: ExternKernelSchedulerNode) -> FixedTiledLayout:
 
 
 def propagate_spyre_tensor_layouts(
-    nodes: list[BaseSchedulerNode],
-) -> list[BaseSchedulerNode]:
+    operations: list[Operation],
+) -> None:
     # Convert InputBuffers from FixedLayout to FixedTiledLayouts
     if len(V.graph.graph_input_names) > 0:
         for name, real_input in zip(V.graph.graph_input_names, V.get_real_inputs()):
@@ -359,39 +362,73 @@ def propagate_spyre_tensor_layouts(
                     ptl.device, ptl.dtype, ptl.size, ptl.stride, stl
                 )
 
-    # Nodes are in topological order (guarenteed by caller).
+    # Operations are in topological order (guaranteed by GraphLowering).
     # Visit them and use the inputs' FixedTiledLayouts and the operation being
-    # performed by the node to convert its output FixedLayout to a FixedTiledLayout.
+    # performed to convert each output FixedLayout to a FixedTiledLayout.
 
-    it = iter(nodes)
-    for n in it:
-        if isinstance(n, SchedulerNode) and isinstance(n.node, ComputedBuffer):
-            n.node.decide_layout()
-            if isinstance(n.node.data, Pointwise):
-                output_layout = pointwise_layout(n, get_mem_deps(n))
-                n.node.layout = output_layout
-            elif isinstance(n.node.data, Reduction):
-                output_layout = reduction_layout(n, get_mem_deps(n))
-                n.node.layout = output_layout
+    it = iter(operations)
+    for op in it:
+        if op.is_no_op():
+            op.layout = generic_layout(op)
+        elif isinstance(op, ComputedBuffer):
+            if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+                # Mutation ops (e.g. spyre.overwrite) must keep their
+                # MutationLayoutSHOULDREMOVE so the scheduler correctly
+                # treats them as in-place writes to the target buffer.
+                # Their FixedTiledLayout is assigned later in
+                # propagate_mutation_layouts, after the scheduler has
+                # set up mutation tracking.
+                continue
+            op.decide_layout()
+            rw = op.get_read_writes()
+            output_dep = next(iter(rw.writes))
+            args = get_mem_deps_from_rw(rw)
+            output = op.get_layout()
+            if isinstance(op.data, Pointwise):
+                op.layout = pointwise_layout(op.data, output, output_dep, args)
+            elif isinstance(op.data, Reduction):
+                op.layout = reduction_layout(op.data, output, output_dep, args)
             else:
-                logger.warning(f"Warning: unhandled node type {type(n.node)}")
-        elif isinstance(n, ExternKernelSchedulerNode):
-            if isinstance(n.node, FallbackKernel):
-                n = next(it, None)
-                if not (
-                    isinstance(n, ExternKernelSchedulerNode)
-                    and isinstance(n.node, MultiOutput)
-                ):
-                    raise RuntimeError("FallbackKernel must be followed by MultiOutput")
-
-                output_layout = generic_layout(n)
-                n.node.layout = output_layout
-            else:
-                logger.warning(f"unhandled node type {type(n.node)}")
-        elif isinstance(n, NopKernelSchedulerNode):
-            output_layout = generic_layout(n)
-            n.node.layout = output_layout
+                logger.warning(f"Warning: unhandled node type {type(op.data)}")
+        elif isinstance(op, FallbackKernel):
+            op = next(it, None)
+            if not isinstance(op, MultiOutput):
+                raise RuntimeError("FallbackKernel must be followed by MultiOutput")
+            op.layout = generic_layout(op)
+        elif isinstance(op, ExternKernel):
+            logger.warning(f"unhandled node type {type(op)}")
         else:
-            logger.warning(f"unhandled scheduler node type {type(n)}")
+            logger.warning(f"unhandled operation type {type(op)}")
+
+
+def propagate_mutation_layouts(
+    nodes: list,
+) -> list:
+    """
+    Second phase of layout propagation for mutation ops.
+
+    ComputedBuffers with MutationLayoutSHOULDREMOVE are skipped in
+    propagate_spyre_tensor_layouts because the scheduler needs to see the
+    mutation layout during its initialisation to set up mutation tracking.
+    This pass runs as a _pre_fusion_custom_pass (after scheduler init) to
+    assign FixedTiledLayout to those remaining mutation ops.
+    """
+    from .pass_utils import get_mem_deps
+
+    for n in nodes:
+        if not (isinstance(n, SchedulerNode) and isinstance(n.node, ComputedBuffer)):
+            continue
+        if not isinstance(n.node.layout, MutationLayoutSHOULDREMOVE):
+            continue
+        if isinstance(n.node.data, Pointwise):
+            rw = n.read_writes
+            output_dep = next(iter(rw.writes))
+            args = get_mem_deps(n)
+            output = n.node.get_layout()
+            n.node.layout = pointwise_layout(n.node.data, output, output_dep, args)
+        else:
+            logger.warning(
+                f"propagate_mutation_layouts: unhandled mutation op {type(n.node.data)}"
+            )
 
     return nodes


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
  **Summary**                                                   
                                                                                                                                                                  
  Previously, three key compilation passes ran during Inductor's scheduler                                                                                        
  construction — after SchedulerNode objects had been created from the IR.                                                                                        
  This PR moves all three to run at the IR level, immediately before the                                                                                          
  Scheduler is constructed. The refactoring also reorganizes how these passes                                                                                     
  are registered, bringing them into line with the existing pass-group pattern. 
                                                                         
                                                                                                                                                                  
  **Motivation**                                                                                                                                                      
                                                                                                                                                                  
  Running these passes at                                                                                       
  scheduler time coupled those passes tightly to BaseSchedulerNode and
  SchedulerNode APIs. It also made it extremely challenging to perform
  significant graph graph transformations, as Inductor is not designed for
  new nodes to be inserted in the FX Graph after the scheduler is created. 
  Furthermore, by operating on list[Operation] (Inductor's IR-level                                                                                        
  operation list) instead, the passes are simpler, more testable, and run at                                                                                      
  the right conceptual stage: layout and work-division decisions belong to IR                                                                                     
  lowering, not scheduling.

  Doing this does require an additional monkey patch to Inductor, as there is no existing 
  extension point to allow backend specific passes to be added between GraphLowering
  and Scheduling.  However, it enables significantly simpler graph transformations
  at the LoopLevelIR level which were not possible using the existing extension points,
  which were both inside the Scheduler.                                                                                                                      
                                                                                                                                                                  
  **Changes**                                                   

  Pass execution stage (stickify.py, core_division.py, scratchpad.py)                                                                                             
   
  - propagate_spyre_tensor_layouts, core_division_planning, and                                                                                                   
  scratchpad_planning now accept list[Operation] and return None instead
  of consuming and returning list[BaseSchedulerNode].                                                                                                             
  - All three iterate over IR-level ComputedBuffer, FallbackKernel,
  ExternKernel, and no-op operations directly, removing the dependency on                                                                                         
  scheduler node types (SchedulerNode, ExternKernelSchedulerNode,
  NopKernelSchedulerNode).
  - pointwise_layout and reduction_layout in stickify.py are decoupled
  from SchedulerNode: they now receive data, output, output_dep, and
  args as explicit parameters, making them callable from both the pre-
  scheduler path and the existing propagate_mutation_layouts post-scheduler
  pass.

  Mapping pre-scheduler splits to scheduler symbols (pass_utils.py)                                                                                               
   
  - core_division_planning now stores splits as a positional list[int]                                                                                            
  (op_it_space_splits) paired with raw element-unit sizes (op_it_space_sizes)
  on the ComputedBuffer IR node, rather than a dict[Symbol, int] keyed by                                                                                         
  scheduler symbols (which don't exist yet at IR time).                                                                                                           
  - Added iteration_space_from_op(op: ComputedBuffer) — the pre-scheduler                                                                                         
  counterpart to the existing iteration_space(n: SchedulerNode).                                                                                                  
  - Added map_ir_splits_to_scheduler(ir_sizes, ir_splits, sched_it_space) which                                                                                   
  maps the positional IR-level splits to scheduler-symbol keys at codegen time.                                                                                   
  The mapping sorts both sides by decreasing dimension size (stable sort) to
  correctly handle dim reordering caused by broadcast inputs, as well as
  duplicate sizes and scheduler dim-merging.
  - spyre_kernel.py updated to call map_ir_splits_to_scheduler when reading
  core-division splits from the IR node.

  Pass registration (passes.py, patches.py, config.py)

  - Replaced the pre_scheduling_passes plain function with a
  CustomPreSchedulingPasses class following the same CustomGraphPass
  pattern as CustomPreFusionPasses and CustomPostFusionPasses.
  - Added pre_scheduling_custom_pass to torch_spyre._inductor.config (default
  None) so the pass is wired through the same config-patch mechanism as all                                                                                       
  other Spyre pass groups, without requiring a new upstream Inductor config key.
  - _spyre_update_scheduler in patches.py is now a generic three-line                                                                                             
  dispatcher: it reads spyre_config.pre_scheduling_custom_pass and calls it                                                                                       
  if set, keeping all Spyre-specific logic in passes.py.           

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
