### PR TITLE
[test] fix inappropriate inheritance in TestSpyreModelOps

### DIFF
--- a/tests/models/test_model_ops.py
+++ b/tests/models/test_model_ops.py
@@ -28,10 +28,10 @@ from torch.testing._internal.opinfo.core import (
     OpInfo,
 )
 from torch.testing._internal.common_device_type import (
-    PrivateUse1TestBase,
     ops,
     instantiate_device_type_tests,
 )
+from torch.testing._internal.common_utils import TestCase
 from op_registry import OP_REGISTRY, OpAdapter
 
 
@@ -110,7 +110,7 @@ _init_model_ops_db()
 seen_case_keys = set()
 
 
-class TestSpyreModelOps(PrivateUse1TestBase):
+class TestSpyreModelOps(TestCase):
     @ops(model_ops_db)
     def test_model_ops_db(
         self,
@@ -221,4 +221,4 @@ class TestSpyreModelOps(PrivateUse1TestBase):
 
 # Instantiate device type tests for the TestSpyreModelOps class
 # This is required for @ops decorator to work properly
-instantiate_device_type_tests(TestSpyreModelOps, globals())
+instantiate_device_type_tests(TestSpyreModelOps, globals(), only_for=("privateuse1",))

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -355,6 +355,37 @@ class TestSpyre(TestCase):
         finally:
             torch.spyre.set_device(orig)
 
+    def test_instantiate_device_type_tests_mro(self):
+        """Verify that instantiate_device_type_tests works with TestCase
+        base class and only_for=("privateuse1",).
+
+        Previously, inheriting from PrivateUse1TestBase caused an MRO
+        conflict when instantiate_device_type_tests tried to create a
+        dynamic subclass that also inherits PrivateUse1TestBase.
+        Using plain TestCase + only_for avoids the conflict.
+        """
+        from torch.testing._internal.common_device_type import (
+            instantiate_device_type_tests,
+        )
+
+        class _TestMROCheck(TestCase):
+            def test_device_is_spyre(self):
+                pass
+
+        ns = {"_TestMROCheck": _TestMROCheck}
+        # This must not raise TypeError about MRO
+        instantiate_device_type_tests(_TestMROCheck, ns, only_for=("privateuse1",))
+
+        # instantiate_device_type_tests should create a class named
+        # _TestMROCheckPRIVATEUSE1 in the namespace
+        assert "_TestMROCheckPRIVATEUSE1" in ns, (
+            f"Expected _TestMROCheckPRIVATEUSE1 in namespace, got {list(ns)}"
+        )
+
+        # The generated class should be instantiable (valid MRO)
+        cls = ns["_TestMROCheckPRIVATEUSE1"]
+        assert issubclass(cls, TestCase)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This PR fixes inappropriate class inheritance and keeps device as `privateuse1`.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Fixes #1513

#### Special notes for your reviewer:

Analysis by Claude Code

```
● Now I see the issue. At line 24 of instantiate_device_type_tests, it creates:                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                    
  device_type_test_class = type(class_name, (base, generic_test_class), {})                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                    
  Where:                                                                                                                                                                                                                                                                                                                                                                                                            
  - base = PrivateUse1TestBase                                                                                                                                                                                                                                                                                                                                                                                      
  - generic_test_class = TestSpyreModelOps                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                    
  But TestSpyreModelOps already inherits from PrivateUse1TestBase. So it tries to create a class with bases (PrivateUse1TestBase, TestSpyreModelOps), which is an MRO conflict because TestSpyreModelOps is a subclass of PrivateUse1TestBase — you can't have a parent appear before its own child in the base list.                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                    
  Let me verify by checking how other tests in the project handle this.                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                    
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                    
● Now let me look at how other test files that use instantiate_device_type_tests with the @ops decorator define their test class — specifically in tests that work correctly.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                    
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                    
● Now I have the full picture. Here's the root cause:                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                    
  Root Cause: MRO (Method Resolution Order) Conflict                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                    
  The error is at test_model_ops.py:224:                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                    
  instantiate_device_type_tests(TestSpyreModelOps, globals())                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                    
  The function instantiate_device_type_tests internally does:                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                    
  device_type_test_class = type(class_name, (base, generic_test_class), {})                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                    
  where base = PrivateUse1TestBase and generic_test_class = TestSpyreModelOps.                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                    
  The problem: TestSpyreModelOps already inherits from PrivateUse1TestBase (line 113):                                                                                                                                                                                                                                                                                                                              
                  
  class TestSpyreModelOps(PrivateUse1TestBase):                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                    
  So Python is asked to create a new class with bases (PrivateUse1TestBase, TestSpyreModelOps). This is an impossible MRO because TestSpyreModelOps is a subclass of PrivateUse1TestBase — a parent class cannot appear before its own child in the linearization order.                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                    
  The Fix                                                                                                                                                                                                                                                                                                                                                                                                           
                  
  TestSpyreModelOps should not inherit from PrivateUse1TestBase directly. The instantiate_device_type_tests function is designed to create a new derived class that mixes the device-type base (PrivateUse1TestBase) with the generic test class. The generic test class should inherit from a plain TestCase instead.                                                                                              
  
  Looking at the codebase, TorchTestBase (in spyre_test_base_common.py:148) extends PrivateUse1TestBase and is used by run_test.sh, but for the @ops + instantiate_device_type_tests pattern, the test class should inherit from TestCase (from torch.testing._internal.common_utils), not from PrivateUse1TestBase.                                                                                                
                  
  The fix is to change line 113 from:                                                                                                                                                                                                                                                                                                                                                                               
                  
  class TestSpyreModelOps(PrivateUse1TestBase):                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                    
  to:
                                                                                                                                                                                                                                                                                                                                                                                                                    
  class TestSpyreModelOps(TestCase):

  (importing TestCase from torch.testing._internal.common_utils or unittest). The instantiate_device_type_tests call will take care of mixing in the correct device-type base class.                                                                                                                                                                                                                                
  
  Would you like me to apply this fix?   
```

Then, asked ` Will this change provide device=cpu instead of privateuse1?`

```
● Good question. Let me trace exactly what instantiate_device_type_tests does with the device type to understand what device value the test will receive.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                    
● Bash(python3 -c "                                                                                                                                                                                                                                                                                                                                                                                                 
      import inspect…)                                                                                                                                                                                                                                                                                                                                                                                              
  ⎿  def instantiate_device_type_tests(                                                                                                                                                                                                                                                                                                                                                                             
         generic_test_class,                                                                                                                                                                                                                                                                                                                                                                                        
         scope,                                                                                                                                                                                                                                                                                                                                                                                                     
     … +76 lines (ctrl+o to expand)                                                                                                                                                                                                                                                                                                                                                                                 
                                           
● Bash(python3 -c "                                                                                                                                                                                                                                                                                                                                                                                                 
      import inspect…)                                                                                                                                                                                                                                                                                                                                                                                              
  ⎿  def get_desired_device_type_test_bases(                                                                                                                                                                                                                                                                                                                                                                        
         except_for=None, only_for=None, include_lazy=False, allow_mps=False, allow_xpu=False                                                                                                                                                                                                                                                                                                                       
     ):                                                                                                                                                                                                                                                                                                                                                                                                             
     … +56 lines (ctrl+o to expand)                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                    
● Bash(python3 -c "                                                                                                                                                                                                                                                                                                                                                                                                 
      from torch.testing._internal.common_device_type import device_type_test_bases…)                                                                                                                                                                                                                                                                                                                               
  ⎿  CPUTestBase: device_type=cpu                                                                                                                                                                                                                                                                                                                                                                                   
     PrivateUse1TestBase: device_type=privateuse1                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                    
● Yes, you're right to be concerned. When TestSpyreModelOps inherits from plain TestCase, instantiate_device_type_tests will iterate over all device type bases — both CPUTestBase and PrivateUse1TestBase — and create two test classes:                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                    
  - TestSpyreModelOpsCPU (with device=cpu)                                                                                                                                                                                                                                                                                                                                                                          
  - TestSpyreModelOpsPRIVATEUSE1 (with device=privateuse1/spyre)                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                    
  The test name you're running has cpu_float16 in it, which means pytest -k is matching the CPU variant. So the test would run, but on CPU — not on the Spyre device.                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                    
  That said, the current code with PrivateUse1TestBase doesn't work at all (MRO crash). Let me check how the test is supposed to be structured — specifically what the test name format looks like and whether it was designed to only run on privateuse1.                                                                                                                                                          
                  
● Bash(python3 -c "                                                                                                                                                                                                                                                                                                                                                                                                 
      from torch.testing._internal.common_device_type import DeviceTypeTestBase…)
  ⎿  class DeviceTypeTestBase(TestCase):      
         device_type: str = "generic_device_type"                                                                                                                                                                                                                                                                                                                                                                   
     … +78 lines (ctrl+o to expand)                                        
                                                                                                                                                                                                                                                                                                                                                                                                                    
● Bash(python3 -c "                         
      import inspect…)                                                                                                                                                                                                                                                                                                                                                                                              
  ⎿      @classmethod                                                                                                                                                                                                                                                                                                                                                                                               
         def instantiate_test(cls, name, test, *, generic_cls=None):                                                                                                                                                                                                                                                                                                                                                
             def instantiate_test_helper(                                                                                                                                                                                                                                                                                                                                                                           
     … +100 lines (ctrl+o to expand)                                                                                                                                                                                                                                                                                                                                                                                
                                           
● Now I can see the full picture. Look at this key part of instantiate_test:                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                    
  cls_device_type = (                                                                                                                                                                                                                                                                                                                                                                                               
      cls.device_type                                                                                                                                                                                                                                                                                                                                                                                               
      if cls.device_type != "privateuse1"
      else torch._C._get_privateuse1_backend_name()                                                                                                                                                                                                                                                                                                                                                                 
  )               
  device_suffix = "_" + cls_device_type

  And the test name becomes: {name}{test_suffix}_{device_type}_{dtype}

  So the test name test_model_ops_db_torch_add_1__gpt-oss-20b_yaml__cpu_float16 has _cpu_ as the device suffix — meaning this test is already the CPU variant. It was collected and intended to run on CPU.

  Now, back to the core question: if we change to TestCase, both CPU and PrivateUse1 variants get created — the CPU one would be test_..._cpu_float16 and the Spyre one would be test_..._spyre_float16. That's actually the intended behavior of the instantiate_device_type_tests framework.                                                                                                                      
   
  The current code inheriting from PrivateUse1TestBase was attempting to create only the privateuse1 variant, but it crashes due to the MRO conflict. There is no way to make this work with instantiate_device_type_tests and PrivateUse1TestBase as the direct parent.                                                                                                                                            
                  
  There are two fix options:                                                                                                                                                                                                                                                                                                                                                                                        
                  
  1. Change to TestCase — both CPU and Spyre tests get generated. CPU tests run on CPU, Spyre tests run on privateuse1/spyre. The _cpu_float16 test you're running would get device="cpu".
  2. Use only_for=("privateuse1",) — restricts to Spyre only:
  class TestSpyreModelOps(TestCase):
      ...
  instantiate_device_type_tests(TestSpyreModelOps, globals(), only_for=("privateuse1",))                                                                                                                                                                                                                                                                                                                            
  2. This would generate only test_..._spyre_float16 tests, no CPU variants.                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                    
  Which approach matches your intent? Do you want both CPU and Spyre test variants, or only Spyre?    
```

Picked up option 2 since no changes to PyTorch package

#### Does this PR introduce a user-facing change?

#### Additional note:

#1514 assigns tests to `cpu`.