### PR TITLE
fix: device_count() and guard _lazy_init()

### DIFF
--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -51,6 +51,8 @@ class _SpyreImpl:
         return super().__getattribute__(name)
 
     def _lazy_init(self):
+        if not self.is_available():
+            raise RuntimeError("Spyre runtime is not available")
         if self._initialized:
             return
         with _runtime_init_lock:

--- a/torch_spyre/csrc/spyre_device_enum.cpp
+++ b/torch_spyre/csrc/spyre_device_enum.cpp
@@ -120,7 +120,9 @@ std::vector<SpyreDeviceInfo> buildDeviceList() {
   // Priority:
   //   1. SPYRE_VISIBLE_DEVICES — explicit user/admin override
   //   2. PCIDEVICE_IBM_COM_AIU_PF — set by K8s device plugin
-  //   3. Full PCI bus scan
+  //   3. If PCIDEVICE_IBM_COM_AIU_PF not set:
+  //      - AIU_WORLD_SIZE > 0: Full PCI bus scan
+  //      - AIU_WORLD_SIZE == 0 or unset: empty list
   const char* env = std::getenv("SPYRE_VISIBLE_DEVICES");
   const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
 
@@ -133,9 +135,21 @@ std::vector<SpyreDeviceInfo> buildDeviceList() {
     DEBUGINFO("spyre_device_enum: PCIDEVICE_IBM_COM_AIU_PF =", k8s_env, "->",
               visible_bus_ids.size(), "devices");
   } else {
-    visible_bus_ids = all_bus_ids;
-    DEBUGINFO("spyre_device_enum: found", visible_bus_ids.size(),
-              "Spyre devices via PCI scan");
+    const char* world_size_env = std::getenv("AIU_WORLD_SIZE");
+    int world_size = 0;
+    if (world_size_env && world_size_env[0] != '\0') {
+      world_size = std::stoi(world_size_env);
+    }
+    if (world_size > 0) {
+      visible_bus_ids = all_bus_ids;
+      DEBUGINFO("spyre_device_enum: found", visible_bus_ids.size(),
+                "Spyre devices via PCI scan");
+    } else {
+      visible_bus_ids.clear();
+      DEBUGINFO(
+          "spyre_device_enum: PCIDEVICE_IBM_COM_AIU_PF not set and "
+          "AIU_WORLD_SIZE is 0, returning empty device list");
+    }
   }
 
   std::vector<SpyreDeviceInfo> devices;


### PR DESCRIPTION
Part of the issue https://github.com/torch-spyre/torch-spyre/issues/1289

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### Issues

Part of the CI/CD efforts - https://github.com/torch-spyre/torch-spyre/issues/1289. There two issues as listed below

1. When a CPU only pod is spawned in a spyre node, the device_count() is incorrectly reported this is due to the last else case being executed providing all the PCIe devices resulting in 12 as device count, rather it has to be 0. 
2. Runtime init is not guarded due to which the error propagates into deeptools and down the stack.

#### What this PR does:

This PR solves the aforementioned 2 issues like below
1. We will make use of `AIU_WORLD_SIZE ` env variable along with existing set of environment variables  - `SPYRE_VISIBLE_DEVICES` and `PCIDEVICE_IBM_COM_AIU_PF` to derive device_count correctly. For the case mentioned above in issue (1) none of SPYRE_VISIBLE_DEVICES or PCIDEVICE_IBM_COM_AIU_PF is set due to which it falls into provide entire registered PCIe spyre device on that node which is now handled correctly with the use of `AIU_WORLD_SIZE`. This will also allow for a behaviour similar to `CUDA_VISIBLE_DEVICES`.
2. We will guard the `_lazy_init` to check if the runtime available before proceeding. 

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/1289


