### PR TITLE
Update device_count() to use flex::getNumDevices()

### DIFF
--- a/tests/test_device_enum.py
+++ b/tests/test_device_enum.py
@@ -17,43 +17,9 @@
 import os
 import subprocess
 import sys
-from pathlib import Path
 from typing import Optional
 
 import pytest
-
-
-# Spyre PCI vendor/device IDs (must match spyre_device_enum.cpp)
-SPYRE_VENDOR_ID = 0x1014  # IBM
-SPYRE_DEVICE_ID = 0x06A7  # Spyre Accelerator
-
-
-def discover_spyre_pci_bus_ids() -> list[str]:
-    """
-    Discover Spyre PCI bus IDs by scanning /sys/bus/pci/devices/.
-
-    Returns list of PCI bus IDs (e.g., ['0000:29:00.0', '0000:3c:00.0'])
-    """
-    sysfs_path = Path("/sys/bus/pci/devices")
-    if not sysfs_path.exists():
-        return []
-
-    bus_ids = []
-    for device_dir in sysfs_path.iterdir():
-        try:
-            vendor_file = device_dir / "vendor"
-            device_file = device_dir / "device"
-
-            if vendor_file.exists() and device_file.exists():
-                vendor = int(vendor_file.read_text().strip(), 16)
-                device = int(device_file.read_text().strip(), 16)
-
-                if vendor == SPYRE_VENDOR_ID and device == SPYRE_DEVICE_ID:
-                    bus_ids.append(device_dir.name)
-        except (OSError, ValueError):
-            continue
-
-    return bus_ids
 
 
 def get_device_count_in_subprocess(env_vars: Optional[dict] = None) -> int:
@@ -71,7 +37,7 @@ print(torch.spyre.device_count())
     if env_vars is not None:
         env.update(env_vars)
         # Remove env vars that might interfere if not specified
-        for key in ["SPYRE_VISIBLE_DEVICES", "PCIDEVICE_IBM_COM_AIU_PF"]:
+        for key in ["SPYRE_DEVICES", "AIU_WORLD_SIZE"]:
             if key not in env_vars:
                 env.pop(key, None)
 
@@ -95,59 +61,74 @@ print(torch.spyre.device_count())
 class TestDeviceEnumEnvVars:
     """Test environment variable handling for device enumeration."""
 
-    def test_default_pci_scan(self):
-        """Test default PCI bus scan - verifies hardware is detected."""
+    def test_no_env_vars(self):
+        """Test No env vars → returns total devices."""
         count = get_device_count_in_subprocess({})
-        assert count > 0, "No Spyre devices found via PCI scan"
+        assert count > 0
+
+    def test_aiu_world_size_smaller_equal_total(self):
+        """Test AIU_WORLD_SIZE → returns AIU_WORLD_SIZE."""
+        count = get_device_count_in_subprocess({"AIU_WORLD_SIZE": "1"})
+        assert count == 1
+
+    def test_aiu_world_size_larger_total(self):
+        """Test AIU_WORLD_SIZE larger than total devices → returns total devices."""
+        total = get_device_count_in_subprocess({})
+        aiu_world_size = total + 1
+        count = get_device_count_in_subprocess({"AIU_WORLD_SIZE": str(aiu_world_size)})
+        assert count == total
 
     def test_spyre_visible_devices_single(self):
-        """Test SPYRE_VISIBLE_DEVICES with single index."""
-        count = get_device_count_in_subprocess({"SPYRE_VISIBLE_DEVICES": "0"})
+        """Test SPYRE_DEVICES with single index."""
+        count = get_device_count_in_subprocess({"SPYRE_DEVICES": "0"})
         assert count == 1
 
-    def test_spyre_visible_devices_multiple(self):
-        """Test SPYRE_VISIBLE_DEVICES with multiple indices."""
-        # Check total count first
+    @pytest.mark.parametrize(
+        "devices_str,expected_count,min_devices,description",
+        [
+            ("0,1", 2, 2, "basic multiple devices"),
+            ("0,1,1", 2, 2, "duplicates should be deduplicated"),
+            ("1,0", 2, 2, "out-of-order indices"),
+            ("0, {total_plus_one}", 1, 2, "out-of-range index should be filtered out"),
+        ],
+    )
+    def test_spyre_visible_devices_multiple(
+        self, devices_str, expected_count, min_devices, description
+    ):
+        """Test SPYRE_DEVICES with various scenarios."""
+        # Check if we have enough devices for this test
         total = get_device_count_in_subprocess({})
-        if total < 2:
-            pytest.skip("Need at least 2 devices")
+        if total < min_devices:
+            pytest.skip(f"Need at least {min_devices} devices for: {description}")
 
-        count = get_device_count_in_subprocess({"SPYRE_VISIBLE_DEVICES": "0,1"})
-        assert count == 2
-
-    def test_k8s_pci_device_env(self):
-        """Test PCIDEVICE_IBM_COM_AIU_PF (K8s device plugin)."""
-        bus_ids = discover_spyre_pci_bus_ids()
-        if not bus_ids:
-            pytest.skip("No Spyre devices found via sysfs scan")
-
-        # Test with single PCI bus ID
-        count = get_device_count_in_subprocess({"PCIDEVICE_IBM_COM_AIU_PF": bus_ids[0]})
-        assert count == 1
-
-    def test_env_var_priority(self):
-        """SPYRE_VISIBLE_DEVICES takes priority over PCIDEVICE_IBM_COM_AIU_PF."""
-        count = get_device_count_in_subprocess(
-            {
-                "SPYRE_VISIBLE_DEVICES": "0",
-                "PCIDEVICE_IBM_COM_AIU_PF": "invalid_bus_id",
-            }
+        resolved_devices_str = devices_str.format(total_plus_one=total + 1)
+        count = get_device_count_in_subprocess({"SPYRE_DEVICES": resolved_devices_str})
+        assert count == expected_count, (
+            f"SPYRE_DEVICES='{resolved_devices_str}' ({description}) "
+            f"should return {expected_count}, got {count}"
         )
-        assert count == 1, "SPYRE_VISIBLE_DEVICES should take priority"
 
-    def test_k8s_invalid_pci_bus_id_filtered(self):
-        """Invalid PCI bus IDs are filtered out, count equals valid IDs only."""
-        bus_ids = discover_spyre_pci_bus_ids()
-        if not bus_ids:
-            pytest.skip("No Spyre devices found via sysfs scan")
+    @pytest.mark.parametrize(
+        "aiu_world_size,spyre_devices,expected_count,min_devices,description",
+        [
+            ("2", "0", 1, 2, "AIU_WORLD_SIZE=2, SPYRE_DEVICES=0"),
+            ("2", "0,1", 2, 2, "AIU_WORLD_SIZE=2, SPYRE_DEVICES=0,1"),
+        ],
+    )
+    def test_aiu_world_size_with_spyre_devices(
+        self, aiu_world_size, spyre_devices, expected_count, min_devices, description
+    ):
+        """Test AIU_WORLD_SIZE with SPYRE_DEVICES combinations."""
+        total = get_device_count_in_subprocess({})
+        if total < min_devices:
+            pytest.skip(f"Need at least {min_devices} devices for: {description}")
 
-        # Use first valid PCI bus ID + append an invalid one
-        valid_id = bus_ids[0]
-        env_val = f"{valid_id},0000:ff:ff.ff"
-        count = get_device_count_in_subprocess({"PCIDEVICE_IBM_COM_AIU_PF": env_val})
-
-        # Count should be 1 (invalid ID filtered out)
-        assert count == 1, f"Expected 1 (invalid ID filtered), got {count}"
+        count = get_device_count_in_subprocess(
+            {"AIU_WORLD_SIZE": aiu_world_size, "SPYRE_DEVICES": spyre_devices}
+        )
+        assert count == expected_count, (
+            f"{description} should return {expected_count}, got {count}"
+        )
 
 
 if __name__ == "__main__":

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -86,14 +86,11 @@ void _startRuntime() {
   } else if (const char *lr = std::getenv("LOCAL_RANK")) {
     logical_device_id = std::atoi(lr);
   }
-  ensureSpyreDevicesEnv();
 
-  const auto &devices = getVisibleDevices();
-  if (logical_device_id >= 0 &&
-      logical_device_id < static_cast<int>(devices.size())) {
-    DEBUGINFO("logical_device_id =", logical_device_id,
-              "-> PCI bus ID =", devices[logical_device_id].pci_bus_id);
-  }
+  const int num_devices = getVisibleDeviceCount();
+  TORCH_CHECK(logical_device_id < num_devices,
+              "Device index out of bounds. logical_device_id=",
+              logical_device_id, ", number of visible devices=", num_devices);
 
   std::shared_ptr<Runtime> runtime;
   auto s = flex::initializeRuntime(&runtime, logical_device_id);
@@ -101,10 +98,7 @@ void _startRuntime() {
   if (runtime) {
     GlobalRuntime::set(runtime);
     DEBUGINFO(s);
-    std::string env_key = "AIU_WORLD_RANK_" + std::to_string(logical_device_id);
-    const char *pci = std::getenv(env_key.c_str());
-    DEBUGINFO("runtime started, device PCI bus ID:",
-              pci ? pci : "(default/senlib)");
+    DEBUGINFO("runtime started with logical_device_id ", logical_device_id);
   } else {
     DEBUGINFO("runtime FAILED TO START.");
     throw std::runtime_error("Failed to initialize Spyre runtime. ");

--- a/torch_spyre/csrc/spyre_device_enum.cpp
+++ b/torch_spyre/csrc/spyre_device_enum.cpp
@@ -16,189 +16,35 @@
 
 #include "spyre_device_enum.h"
 
-#include <dirent.h>
-
-#include <algorithm>
-#include <cstdlib>
-#include <fstream>
-#include <mutex>
-#include <sstream>
-#include <string>
-#include <vector>
-
-#include "logging.h"
+#include <flex/runtime_stream/runtime_entry.hpp>
 
 namespace spyre {
 
-namespace detail {
-
-// Read a hex value from a sysfs file, e.g. /sys/bus/pci/devices/XXX/vendor
-// Returns -1 on failure.
-int readSysfsHex(const std::string& path) {
-  std::ifstream f(path);
-  if (!f.is_open()) return -1;
-  int val = -1;
-  f >> std::hex >> val;
-  return val;
-}
-
-// Scan /sys/bus/pci/devices/ for all Spyre accelerators.
-// Returns PCI bus IDs sorted lexicographically.
-std::vector<std::string> scanPciBus() {
-  std::vector<std::string> bus_ids;
-  const std::string sysfs_path = "/sys/bus/pci/devices";
-  DIR* dir = opendir(sysfs_path.c_str());
-  if (!dir) {
-    DEBUGINFO("spyre_device_enum: cannot open", sysfs_path);
-    return bus_ids;
-  }
-
-  struct dirent* entry;
-  while ((entry = readdir(dir)) != nullptr) {
-    std::string name(entry->d_name);
-    if (name == "." || name == "..") continue;
-
-    std::string dev_dir = sysfs_path + "/" + name;
-    int vendor = readSysfsHex(dev_dir + "/vendor");
-    int device = readSysfsHex(dev_dir + "/device");
-
-    if (vendor == kSpyreVendorId && device == kSpyreDeviceId) {
-      bus_ids.push_back(name);
-    }
-  }
-  closedir(dir);
-
-  std::sort(bus_ids.begin(), bus_ids.end());
-  return bus_ids;
-}
-
-// Parse SPYRE_VISIBLE_DEVICES env var.
-// Accepts comma-separated PCI bus IDs or 0-based integer indices.
-// Returns resolved PCI bus IDs.
-std::vector<std::string> parseVisibleDevices(
-    const std::string& env_val, const std::vector<std::string>& all_bus_ids) {
-  std::vector<std::string> result;
-  std::istringstream ss(env_val);
-  std::string token;
-
-  while (std::getline(ss, token, ',')) {
-    // Trim whitespace
-    while (!token.empty() && token.front() == ' ') token.erase(0, 1);
-    while (!token.empty() && token.back() == ' ') token.pop_back();
-    if (token.empty()) continue;
-
-    // Check if token is a plain integer (index) or a PCI bus ID
-    bool is_index =
-        !token.empty() && std::all_of(token.begin(), token.end(), ::isdigit);
-
-    if (is_index) {
-      int idx = std::stoi(token);
-      if (idx >= 0 && idx < static_cast<int>(all_bus_ids.size())) {
-        result.push_back(all_bus_ids[idx]);
-      } else {
-        DEBUGINFO("spyre_device_enum: SPYRE_VISIBLE_DEVICES index", idx,
-                  "out of range (", all_bus_ids.size(), "devices found)");
-      }
-    } else {
-      // Assume it's a PCI bus ID — validate it exists
-      if (std::find(all_bus_ids.begin(), all_bus_ids.end(), token) !=
-          all_bus_ids.end()) {
-        result.push_back(token);
-      } else {
-        DEBUGINFO("spyre_device_enum: SPYRE_VISIBLE_DEVICES bus ID", token,
-                  "not found among Spyre devices");
-      }
-    }
-  }
-  return result;
-}
-
-std::vector<SpyreDeviceInfo> buildDeviceList() {
-  std::vector<std::string> all_bus_ids = scanPciBus();
-  std::vector<std::string> visible_bus_ids;
-
-  // Priority:
-  //   1. SPYRE_VISIBLE_DEVICES — explicit user/admin override
-  //   2. PCIDEVICE_IBM_COM_AIU_PF — set by K8s device plugin
-  //   3. Full PCI bus scan
-  const char* env = std::getenv("SPYRE_VISIBLE_DEVICES");
-  const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
-
-  if (env && env[0] != '\0') {
-    visible_bus_ids = parseVisibleDevices(env, all_bus_ids);
-    DEBUGINFO("spyre_device_enum: SPYRE_VISIBLE_DEVICES =", env, "->",
-              visible_bus_ids.size(), "devices");
-  } else if (k8s_env && k8s_env[0] != '\0') {
-    visible_bus_ids = parseVisibleDevices(k8s_env, all_bus_ids);
-    DEBUGINFO("spyre_device_enum: PCIDEVICE_IBM_COM_AIU_PF =", k8s_env, "->",
-              visible_bus_ids.size(), "devices");
-  } else {
-    visible_bus_ids = all_bus_ids;
-    DEBUGINFO("spyre_device_enum: found", visible_bus_ids.size(),
-              "Spyre devices via PCI scan");
-  }
-
-  std::vector<SpyreDeviceInfo> devices;
-  devices.reserve(visible_bus_ids.size());
-  for (int i = 0; i < static_cast<int>(visible_bus_ids.size()); ++i) {
-    devices.push_back({visible_bus_ids[i], i});
-  }
-  return devices;
-}
-
-}  // namespace detail
-
-const std::vector<SpyreDeviceInfo>& getVisibleDevices() {
-  static std::once_flag flag;
-  static std::vector<SpyreDeviceInfo> devices;
-  std::call_once(flag, [&]() { devices = detail::buildDeviceList(); });
-  return devices;
-}
-
 int getVisibleDeviceCount() {
-  return static_cast<int>(getVisibleDevices().size());
-}
-
-void ensureSpyreDevicesEnv() {
-  // If SPYRE_DEVICES is already set, flex will use it directly — nothing to do.
-  const char* existing = std::getenv("SPYRE_DEVICES");
-  if (existing && existing[0] != '\0') {
-    DEBUGINFO("spyre_device_enum: SPYRE_DEVICES already set =", existing);
-    return;
-  }
-
-  // If no K8s or user override is active, let flex use its default scan.
-  const char* k8s_env = std::getenv("PCIDEVICE_IBM_COM_AIU_PF");
-  const char* user_env = std::getenv("SPYRE_VISIBLE_DEVICES");
-  if ((!k8s_env || k8s_env[0] == '\0') && (!user_env || user_env[0] == '\0')) {
-    return;
-  }
-
-  // Set AIU_WORLD_RANK_<i> env vars with the PCI bus IDs of visible devices.
-  // flex's CreatePciId reads RANK (set by torchrun), then calls
-  // RdmaGetPCIeAddress(rank) which checks AIU_WORLD_RANK_<id> and passes
-  // the PCI bus ID directly to senlib::SenPci::pf(pci_address).
+  // Get the number of available Spyre devices from the flex runtime.
   //
-  // This avoids senlib index mapping entirely — we pass the exact PCI bus ID.
-  const auto& visible = getVisibleDevices();
-
-  for (const auto& dev : visible) {
-    std::string env_name = "AIU_WORLD_RANK_" + std::to_string(dev.index);
-    setenv(env_name.c_str(), dev.pci_bus_id.c_str(), /*overwrite=*/0);
-    DEBUGINFO("spyre_device_enum: set", env_name, "=", dev.pci_bus_id);
-  }
-
-  // Also set SPYRE_DEVICES as sequential indices so flex's
-  // RdmaGetPCIeAddress uses the correct rank-to-index mapping.
-  std::string spyre_devices;
-  for (int i = 0; i < static_cast<int>(visible.size()); ++i) {
-    if (!spyre_devices.empty()) spyre_devices += ',';
-    spyre_devices += std::to_string(i);
-  }
-  if (!spyre_devices.empty()) {
-    setenv("SPYRE_DEVICES", spyre_devices.c_str(), /*overwrite=*/0);
-    DEBUGINFO("spyre_device_enum: synthesized SPYRE_DEVICES =", spyre_devices);
-  }
+  // This function queries flex::getNumDevices() which determines device count
+  // by:
+  //
+  // 1. For FLEX_DEVICE=PF or VF:
+  //    - Reads total devices in the system without opening any device
+  //    - Adjusts based on AIU_WORLD_SIZE if set (must be <= total devices)
+  //    - If SPYRE_DEVICES is set, parses comma-separated device indices
+  //      and returns the count of valid, unique devices specified
+  //
+  // 2. For FLEX_DEVICE=MOCK:
+  //    - Returns AIU_WORLD_SIZE environment variable value
+  //    - Throws error if AIU_WORLD_SIZE < 1
+  //
+  // Environment Variables:
+  // - AIU_WORLD_SIZE: Number of devices to use (set by the login script and
+  //   matches total devices in most use cases)
+  // - SPYRE_DEVICES: Comma-separated list of device indices to use (e.g.,
+  //   "0,2,3")
+  // - FLEX_DEVICE: Device type ("PF", "VF", or "MOCK")
+  //
+  // @return Number of visible Spyre devices for this process
+  return static_cast<int>(flex::getNumDevices());
 }
 
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_device_enum.h
+++ b/torch_spyre/csrc/spyre_device_enum.h
@@ -16,42 +16,9 @@
 
 #pragma once
 
-#include <cstdint>
-#include <string>
-#include <vector>
-
 namespace spyre {
-
-// PCI vendor/device IDs for IBM Spyre Accelerator
-constexpr uint16_t kSpyreVendorId = 0x1014;  // IBM
-constexpr uint16_t kSpyreDeviceId = 0x06a7;  // Spyre Accelerator
-
-// PCI bus ID, e.g. "0000:29:00.0"
-struct SpyreDeviceInfo {
-  std::string pci_bus_id;
-  int index;  // logical index (0-based)
-};
-
-// Returns the list of Spyre devices visible to this process.
-//
-// Priority:
-//   1. SPYRE_VISIBLE_DEVICES env var — comma-separated PCI bus IDs or
-//      0-based indices (e.g. "0,1,2" or "0000:29:00.0,0000:2a:00.0")
-//   2. PCIDEVICE_IBM_COM_AIU_PF env var — set by K8s device plugin,
-//      comma-separated PCI bus IDs
-//   3. Full PCI bus scan via /sys/bus/pci/devices/
-//
-// The result is cached after the first call.
-const std::vector<SpyreDeviceInfo>& getVisibleDevices();
 
 // Convenience: returns the number of visible Spyre devices.
 int getVisibleDeviceCount();
-
-// If SPYRE_DEVICES is not already set, and PCIDEVICE_IBM_COM_AIU_PF is
-// available, synthesize SPYRE_DEVICES from the K8s-assigned PCI bus IDs
-// so that flex picks the correct physical cards.
-//
-// Must be called before flex::initializeRuntime().
-void ensureSpyreDevicesEnv();
 
 }  // namespace spyre


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

remove torch-spyre device count implementation and instead use flex::getNumDevices to count the number of available devices

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/1452?reload=1


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change? no

#### Additional note:
