### PR TITLE
generate fake symbols for tensor offsets in superdsc

### DIFF
--- a/tests/inductor/test_bundle_loop.py
+++ b/tests/inductor/test_bundle_loop.py
@@ -1,0 +1,338 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for generate_bundle / bundle.mlir with LoopSpec entries.
+
+These tests exercise bundle.py without a Spyre device or running the backend
+compiler.  compile_op_spec is mocked so no actual SDSC JSON generation is
+needed, and bundle artifacts are written to a temporary directory.
+"""
+
+import os
+import tempfile
+import unittest
+from sympy import Integer, Symbol
+from unittest.mock import patch
+
+from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, UnimplementedOp
+from torch_spyre._inductor.codegen.bundle import (
+    generate_bundle,
+    _collect_op_specs,
+    _collect_loop_counts,
+    _mlir_count_value,
+)
+from torch_spyre.execution.async_compile import _find_unimplemented
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_op_spec(name: str) -> OpSpec:
+    """Return a minimal OpSpec sufficient for testing."""
+    return OpSpec(
+        op=name,
+        is_reduction=False,
+        iteration_space={},
+        args=[],
+        op_info={},
+    )
+
+
+def _fake_compile_op_spec(idx: int, op_spec: OpSpec, symbols, symbol_id_offset=0):
+    """Stub that returns (json, [], []) — no real SDSC compilation."""
+    return {f"{idx}_{op_spec.op}": {"op": op_spec.op}}, [], []
+
+
+def _read_mlir(output_dir: str) -> str:
+    with open(os.path.join(output_dir, "bundle.mlir")) as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _collect_op_specs
+# ---------------------------------------------------------------------------
+
+
+class TestCollectOpSpecs(unittest.TestCase):
+    def test_flat_list(self):
+        a, b = _make_op_spec("a"), _make_op_spec("b")
+        result: list[OpSpec] = []
+        _collect_op_specs([a, b], result)
+        self.assertEqual(result, [a, b])
+
+    def test_single_loop(self):
+        a, b = _make_op_spec("a"), _make_op_spec("b")
+        loop = LoopSpec(count=Integer(4), body=[a, b])
+        result: list[OpSpec] = []
+        _collect_op_specs([loop], result)
+        self.assertEqual(result, [a, b])
+
+    def test_nested_loop(self):
+        a = _make_op_spec("a")
+        b = _make_op_spec("b")
+        inner = LoopSpec(count=Integer(2), body=[b])
+        outer = LoopSpec(count=Integer(4), body=[a, inner])
+        result: list[OpSpec] = []
+        _collect_op_specs([outer], result)
+        self.assertEqual(result, [a, b])
+
+    def test_mixed_flat_and_loop(self):
+        a, b, c = _make_op_spec("a"), _make_op_spec("b"), _make_op_spec("c")
+        loop = LoopSpec(count=Integer(3), body=[b])
+        result: list[OpSpec] = []
+        _collect_op_specs([a, loop, c], result)
+        self.assertEqual(result, [a, b, c])
+
+    def test_empty(self):
+        result: list[OpSpec] = []
+        _collect_op_specs([], result)
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# Tests for _collect_loop_counts
+# ---------------------------------------------------------------------------
+
+
+class TestCollectLoopCounts(unittest.TestCase):
+    def test_no_loops(self):
+        a = _make_op_spec("a")
+        counts = _collect_loop_counts([a])
+        self.assertEqual(counts, [])
+
+    def test_single_loop(self):
+        loop = LoopSpec(count=Integer(4), body=[])
+        counts = _collect_loop_counts([loop])
+        self.assertEqual(counts, [Integer(4)])
+
+    def test_nested_loops_depth_first_order(self):
+        inner = LoopSpec(count=Integer(2), body=[])
+        outer = LoopSpec(count=Integer(4), body=[inner])
+        counts = _collect_loop_counts([outer])
+        self.assertEqual(counts, [Integer(4), Integer(2)])
+
+    def test_two_sequential_loops(self):
+        loop0 = LoopSpec(count=Integer(4), body=[])
+        loop1 = LoopSpec(count=Integer(8), body=[])
+        counts = _collect_loop_counts([loop0, loop1])
+        self.assertEqual(counts, [Integer(4), Integer(8)])
+
+
+# ---------------------------------------------------------------------------
+# Tests for _mlir_count_value
+# ---------------------------------------------------------------------------
+
+
+class TestMlirCountValue(unittest.TestCase):
+    def test_integer_count(self):
+        self.assertEqual(_mlir_count_value(Integer(4)), "arith.constant 4 : index")
+
+    def test_integer_count_one(self):
+        self.assertEqual(_mlir_count_value(Integer(1)), "arith.constant 1 : index")
+
+    def test_symbolic_count_raises(self):
+        k = Symbol("K")
+        with self.assertRaises(NotImplementedError):
+            _mlir_count_value(k)
+
+
+# ---------------------------------------------------------------------------
+# Tests for generate_bundle (mlir output) — compile_op_spec mocked
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBundleMlir(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.patch = patch(
+            "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+            side_effect=_fake_compile_op_spec,
+        )
+        self.patch.start()
+
+    def tearDown(self):
+        self.patch.stop()
+
+    def _bundle(self, specs):
+        generate_bundle("test_kernel", self.tmpdir, specs)
+        return _read_mlir(self.tmpdir)
+
+    def test_flat_ops_no_loop(self):
+        a, b = _make_op_spec("a"), _make_op_spec("b")
+        mlir = self._bundle([a, b])
+        self.assertIn("sdscbundle.sdsc_execute", mlir)
+        self.assertNotIn("scf.for", mlir)
+        self.assertNotIn("%c0", mlir)
+        self.assertEqual(mlir.count("sdsc_execute"), 2)
+
+    def test_single_loop_emits_scf_for(self):
+        a, b = _make_op_spec("a"), _make_op_spec("b")
+        loop = LoopSpec(count=Integer(4), body=[a, b])
+        mlir = self._bundle([loop])
+        self.assertIn("scf.for", mlir)
+        self.assertIn("arith.constant 4 : index", mlir)
+        self.assertIn("%c0", mlir)
+        self.assertIn("%c1", mlir)
+        self.assertEqual(mlir.count("sdsc_execute"), 2)
+
+    def test_single_loop_structure(self):
+        a = _make_op_spec("a")
+        loop = LoopSpec(count=Integer(3), body=[a])
+        mlir = self._bundle([loop])
+        for_pos = mlir.index("scf.for")
+        exec_pos = mlir.index("sdsc_execute")
+        close_pos = mlir.rindex("}")
+        self.assertLess(for_pos, exec_pos)
+        self.assertLess(exec_pos, close_pos)
+
+    def test_flat_op_before_and_after_loop(self):
+        before = _make_op_spec("before")
+        body = _make_op_spec("body")
+        after = _make_op_spec("after")
+        loop = LoopSpec(count=Integer(2), body=[body])
+        mlir = self._bundle([before, loop, after])
+        self.assertIn("scf.for", mlir)
+        self.assertEqual(mlir.count("sdsc_execute"), 3)
+
+    def test_nested_loops(self):
+        a = _make_op_spec("a")
+        b = _make_op_spec("b")
+        inner = LoopSpec(count=Integer(2), body=[b])
+        outer = LoopSpec(count=Integer(4), body=[a, inner])
+        mlir = self._bundle([outer])
+        self.assertEqual(mlir.count("scf.for"), 2)
+        self.assertIn("arith.constant 4 : index", mlir)
+        self.assertIn("arith.constant 2 : index", mlir)
+        self.assertEqual(mlir.count("sdsc_execute"), 2)
+        outer_pos = mlir.index("scf.for")
+        inner_pos = mlir.index("scf.for", outer_pos + 1)
+        self.assertLess(outer_pos, inner_pos)
+
+    def test_sdsc_json_files_written_depth_first(self):
+        a = _make_op_spec("a")
+        b = _make_op_spec("b")
+        loop = LoopSpec(count=Integer(2), body=[a, b])
+        generate_bundle("test_kernel", self.tmpdir, [loop])
+        written = sorted(f for f in os.listdir(self.tmpdir) if f.endswith(".json"))
+        self.assertEqual(len(written), 2)
+
+    def test_empty_specs_writes_minimal_bundle(self):
+        mlir = self._bundle([])
+        self.assertIn("func.func @sdsc_bundle", mlir)
+        self.assertIn("return", mlir)
+        self.assertNotIn("sdsc_execute", mlir)
+        self.assertNotIn("scf.for", mlir)
+
+    def test_symbolic_count_raises(self):
+        k = Symbol("K")
+        a = _make_op_spec("a")
+        loop = LoopSpec(count=k, body=[a])
+        with self.assertRaises(NotImplementedError):
+            self._bundle([loop])
+
+
+# ---------------------------------------------------------------------------
+# Tests for _find_unimplemented
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnimplemented(unittest.TestCase):
+    def test_no_unimplemented(self):
+        a = _make_op_spec("a")
+        self.assertIsNone(_find_unimplemented([a]))
+
+    def test_flat_unimplemented(self):
+        unimp = UnimplementedOp(op="missing")
+        a = _make_op_spec("a")
+        result = _find_unimplemented([a, unimp])
+        self.assertIs(result, unimp)
+
+    def test_unimplemented_inside_loop(self):
+        unimp = UnimplementedOp(op="missing")
+        loop = LoopSpec(count=Integer(4), body=[unimp])
+        result = _find_unimplemented([loop])
+        self.assertIs(result, unimp)
+
+    def test_unimplemented_in_nested_loop(self):
+        unimp = UnimplementedOp(op="missing")
+        inner = LoopSpec(count=Integer(2), body=[unimp])
+        outer = LoopSpec(count=Integer(4), body=[inner])
+        result = _find_unimplemented([outer])
+        self.assertIs(result, unimp)
+
+    def test_returns_first_found(self):
+        u1 = UnimplementedOp(op="first")
+        u2 = UnimplementedOp(op="second")
+        result = _find_unimplemented([u1, u2])
+        self.assertIs(result, u1)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBundleMlirSnapshot(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.patch = patch(
+            "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+            side_effect=_fake_compile_op_spec,
+        )
+        self.patch.start()
+
+    def tearDown(self):
+        self.patch.stop()
+
+    def _bundle(self, specs):
+        generate_bundle("test_kernel", self.tmpdir, specs)
+        return _read_mlir(self.tmpdir)
+
+    def test_single_loop_snapshot(self):
+        a = _make_op_spec("a")
+        loop = LoopSpec(count=Integer(8), body=[a])
+        mlir = self._bundle([loop])
+        expected = (
+            "module {\n"
+            "\tfunc.func @sdsc_bundle() {\n"
+            "\t\t%c0 = arith.constant 0 : index\n"
+            "\t\t%c1 = arith.constant 1 : index\n"
+            "\t\t%loop_bound_0 = arith.constant 8 : index\n"
+            "\t\tscf.for %i_0 = %c0 to %loop_bound_0 step %c1 {\n"
+            '\t\t\tsdscbundle.sdsc_execute () {sdsc_filename="sdsc_0.json", "symbol_ids"=[]}\n'
+            "\t\t}\n"
+            "\t\treturn\n"
+            "\t}\n"
+            "}\n"
+        )
+        self.assertEqual(mlir, expected)
+
+    def test_flat_snapshot(self):
+        a = _make_op_spec("a")
+        mlir = self._bundle([a])
+        expected = (
+            "module {\n"
+            "\tfunc.func @sdsc_bundle() {\n"
+            '\t\tsdscbundle.sdsc_execute () {sdsc_filename="sdsc_0.json", "symbol_ids"=[]}\n'
+            "\t\treturn\n"
+            "\t}\n"
+            "}\n"
+        )
+        self.assertEqual(mlir, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -26,29 +26,49 @@ logger = get_inductor_logger("sdsc_compile")
 def generate_bundle(kernel_name: str, output_dir: str, specs: list[OpSpec]):
     """Output the SDSC Bundle for the OpSpecs in the given output_dir for the OpSpecs"""
 
-    # 1. Generate SDSC.json for each OpSpec
+    # 1. Generate SDSC.json for each OpSpec.  symbols is the global deduplicated
+    #    list of offset values for arith.constant declarations.  symbol_id_offset
+    #    ensures each SDSC's negative symbol ids are unique across the bundle.
+    symbols: list[int] = []
     sdscs_json = []
+    symbol_id_offset = 0
     for idx, ks in enumerate(specs):
-        sdsc_json = compile_op_spec(idx, ks)
-        sdscs_json.append(sdsc_json)
+        sdsc_json, local_symbol_values = compile_op_spec(
+            idx, ks, symbols, symbol_id_offset
+        )
+        symbol_id_offset += len(local_symbol_values)
+        sdscs_json.append((sdsc_json, local_symbol_values))
 
     # Write JSON SDSCs to file system
-    files = []
-    for sdsc_json in sdscs_json:
-        sdsc_name = next(iter(sdsc_json))
-        file_name = f"sdsc_{sdsc_name}.json"
-        files.append(file_name)
-        with open(os.path.join(output_dir, file_name), "w") as file:
+    for idx, (sdsc_json, _) in enumerate(sdscs_json):
+        with open(os.path.join(output_dir, f"sdsc_{idx}.json"), "w") as file:
             logger.info(f"Generating {file.name}")
             json.dump(sdsc_json, file, indent=2)
 
-    # Generate bundle.mlir
+    # Generate bundle.mlir.  One arith.constant per unique offset value.
+    # symbol_ids are globally unique negative integers across all sdsc_execute
+    # ops; the JSON for each SDSC uses the same ids via symbol_id_offset.
     with open(os.path.join(output_dir, "bundle.mlir"), "w") as file:
         logger.info(f"Generating {file.name}")
         file.write("module {\n")
         file.write("\tfunc.func @sdsc_bundle() {\n")
-        for f in files:
-            file.write('\t\tsdscbundle.sdsc_execute () {sdsc_filename="' + f + '"}\n')
+        for sym_idx, value in enumerate(symbols):
+            file.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
+        id_offset = 0
+        for idx, (_, local_symbol_values) in enumerate(sdscs_json):
+            sym_names = [f"%sym_{symbols.index(v) + 1}" for v in local_symbol_values]
+            symbol_ids = [-(id_offset + i + 1) for i in range(len(local_symbol_values))]
+            id_offset += len(local_symbol_values)
+            file.write(
+                "\t\tsdscbundle.sdsc_execute ("
+                + ", ".join(sym_names)
+                + ') {sdsc_filename="sdsc_'
+                + f"{idx}"
+                + '.json", '
+                + '"symbol_ids"=['
+                + ", ".join([str(i) for i in symbol_ids])
+                + "]}\n"
+            )
         file.write("\t\treturn\n")
         file.write("\t}\n")
         file.write("}\n")

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -14,61 +14,452 @@
 
 import json
 import os
+from typing import Any
+
+import sympy
 
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec
-from torch_spyre._inductor.op_spec import OpSpec
+from torch_spyre._inductor.op_spec import LoopSpec, OpSpec
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 
 
 logger = get_inductor_logger("sdsc_compile")
 
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
 
-def generate_bundle(kernel_name: str, output_dir: str, specs: list[OpSpec]):
-    """Output the SDSC Bundle for the OpSpecs in the given output_dir for the OpSpecs"""
+# Compiled SDSC entry: (json_dict, base_symbol_values, affine_strides)
+#   base_symbol_values: list[int] of base HBM byte offsets registered in the
+#                       global symbols table for this SDSC
+#   affine_strides:     list[dict] parallel to SDSCSpec.args —
+#                       {tiled_sym: stride_bytes} for tiled HBM tensors,
+#                       empty dict for non-tiled / lx tensors
+_CompiledEntry = tuple[Any, list[int], list[dict]]
 
-    # 1. Generate SDSC.json for each OpSpec.  symbols is the global deduplicated
-    #    list of offset values for arith.constant declarations.  symbol_id_offset
-    #    ensures each SDSC's negative symbol ids are unique across the bundle.
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_bundle(kernel_name: str, output_dir: str, specs: list):
+    """Output the SDSC Bundle for the OpSpecs in output_dir.
+
+    ``specs`` is a list of ``OpSpec | LoopSpec`` entries (nested ``LoopSpec``
+    entries are supported).  ``LoopSpec`` entries produce ``scf.for`` loops in
+    the generated ``bundle.mlir``, with ``affine.apply`` expressions computing
+    per-iteration tensor start addresses for tiled dimensions.
+    """
+    # -----------------------------------------------------------------------
+    # Pass 1: compile all OpSpecs depth-first.
+    # Populates the global deduplicated ``symbols`` list of base HBM addresses
+    # and writes one ``sdsc_N.json`` file per OpSpec.
+    # -----------------------------------------------------------------------
     symbols: list[int] = []
-    sdscs_json = []
-    symbol_id_offset = 0
-    for idx, ks in enumerate(specs):
-        sdsc_json, local_symbol_values = compile_op_spec(
-            idx, ks, symbols, symbol_id_offset
-        )
-        symbol_id_offset += len(local_symbol_values)
-        sdscs_json.append((sdsc_json, local_symbol_values))
+    compiled: list[_CompiledEntry] = []
+    sdsc_counter = [0]
+    symbol_id_offset_counter = [0]
 
-    # Write JSON SDSCs to file system
-    for idx, (sdsc_json, _) in enumerate(sdscs_json):
-        with open(os.path.join(output_dir, f"sdsc_{idx}.json"), "w") as file:
-            logger.info(f"Generating {file.name}")
-            json.dump(sdsc_json, file, indent=2)
+    _compile_specs(
+        specs, symbols, compiled, sdsc_counter, symbol_id_offset_counter, output_dir
+    )
 
-    # Generate bundle.mlir.  One arith.constant per unique offset value.
-    # symbol_ids are globally unique negative integers across all sdsc_execute
-    # ops; the JSON for each SDSC uses the same ids via symbol_id_offset.
-    with open(os.path.join(output_dir, "bundle.mlir"), "w") as file:
-        logger.info(f"Generating {file.name}")
-        file.write("module {\n")
-        file.write("\tfunc.func @sdsc_bundle() {\n")
-        for sym_idx, value in enumerate(symbols):
-            file.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
-        id_offset = 0
-        for idx, (_, local_symbol_values) in enumerate(sdscs_json):
-            sym_names = [f"%sym_{symbols.index(v) + 1}" for v in local_symbol_values]
-            symbol_ids = [-(id_offset + i + 1) for i in range(len(local_symbol_values))]
-            id_offset += len(local_symbol_values)
-            file.write(
-                "\t\tsdscbundle.sdsc_execute ("
-                + ", ".join(sym_names)
-                + ') {sdsc_filename="sdsc_'
-                + f"{idx}"
-                + '.json", '
-                + '"symbol_ids"=['
-                + ", ".join([str(i) for i in symbol_ids])
-                + "]}\n"
+    # -----------------------------------------------------------------------
+    # Pass 2: emit bundle.mlir.
+    # -----------------------------------------------------------------------
+
+    # Collect loop bounds and affine maps needed across the whole tree.
+    loop_bounds: list[sympy.Expr] = []
+    _collect_loop_bounds(specs, loop_bounds)
+
+    # Affine map deduplication: stride_key -> map index (0-based).
+    # A stride_key is a tuple of (stride,) values — one per loop variable at
+    # the nesting depth where the op lives.  For a single-level loop with one
+    # tiled sym the key is (stride_bytes,).
+    affine_map_index: dict[tuple, int] = {}
+    _collect_affine_maps(specs, compiled, iter(compiled), [], affine_map_index)
+
+    compiled_iter = iter(compiled)
+    addr_counter = [0]
+
+    with open(os.path.join(output_dir, "bundle.mlir"), "w") as f:
+        logger.info(f"Generating {f.name}")
+
+        # Module-level affine map definitions (deduped).
+        for stride_key, map_idx in sorted(affine_map_index.items(), key=lambda x: x[1]):
+            dims = len(stride_key)
+            dim_args = ", ".join(f"d{i}" for i in range(dims))
+            terms = " + ".join(f"{stride_key[i]}*d{i}" for i in range(dims))
+            f.write(
+                f"#map_{map_idx} = affine_map<({dim_args})[s0] -> (s0 + {terms})>\n"
             )
-        file.write("\t\treturn\n")
-        file.write("\t}\n")
-        file.write("}\n")
+
+        f.write("module {\n")
+        f.write("\tfunc.func @sdsc_bundle() {\n")
+
+        # Standard loop constants (only emitted when there are loops).
+        if loop_bounds:
+            f.write("\t\t%c0 = arith.constant 0 : index\n")
+            f.write("\t\t%c1 = arith.constant 1 : index\n")
+            for lb_idx, lb in enumerate(loop_bounds):
+                f.write(f"\t\t%loop_bound_{lb_idx} = {_mlir_count_value(lb)}\n")
+
+        # One arith.constant per unique base address.
+        for sym_idx, value in enumerate(symbols):
+            f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
+
+        # Recursive body emission.
+        loop_bound_idx = [0]
+        _emit_specs(
+            specs,
+            compiled_iter,
+            loop_bounds,
+            loop_bound_idx,
+            symbols,
+            affine_map_index,
+            addr_counter,
+            [],
+            f,
+            indent=2,
+        )
+
+        f.write("\t\treturn\n")
+        f.write("\t}\n")
+        f.write("}\n")
+
+
+# ---------------------------------------------------------------------------
+# Pass 1 helpers
+# ---------------------------------------------------------------------------
+
+
+def _compile_specs(
+    specs: list,
+    symbols: list[int],
+    compiled: list,
+    sdsc_counter: list,
+    symbol_id_offset_counter: list,
+    output_dir: str,
+) -> None:
+    """Recursively compile all OpSpecs in specs depth-first."""
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            _compile_specs(
+                entry.body,
+                symbols,
+                compiled,
+                sdsc_counter,
+                symbol_id_offset_counter,
+                output_dir,
+            )
+        elif isinstance(entry, OpSpec):
+            idx = sdsc_counter[0]
+            sdsc_counter[0] += 1
+            sdsc_json, local_sym_values, affine_strides = compile_op_spec(
+                idx, entry, symbols, symbol_id_offset_counter[0]
+            )
+            symbol_id_offset_counter[0] += len(local_sym_values)
+            compiled.append((sdsc_json, local_sym_values, affine_strides))
+            file_name = f"sdsc_{idx}.json"
+            with open(os.path.join(output_dir, file_name), "w") as f:
+                logger.info(f"Generating {f.name}")
+                json.dump(sdsc_json, f, indent=2)
+        # UnimplementedOp and other types are silently skipped.
+
+
+# ---------------------------------------------------------------------------
+# Loop-bound collection
+# ---------------------------------------------------------------------------
+
+
+def _collect_loop_bounds(specs: list, bounds: list) -> None:
+    """Collect loop trip counts depth-first (same order as loop var naming)."""
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            bounds.append(entry.count)
+            _collect_loop_bounds(entry.body, bounds)
+
+
+# ---------------------------------------------------------------------------
+# Affine map deduplication
+# ---------------------------------------------------------------------------
+
+
+def _collect_affine_maps(
+    specs: list,
+    compiled: list,
+    compiled_iter,
+    loop_var_depth: list,
+    affine_map_index: dict,
+) -> None:
+    """Walk the spec tree and register unique affine stride keys."""
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            _collect_affine_maps(
+                entry.body,
+                compiled,
+                compiled_iter,
+                loop_var_depth + [len(loop_var_depth)],
+                affine_map_index,
+            )
+        elif isinstance(entry, OpSpec):
+            _, _, affine_strides = next(compiled_iter)
+            for tensor_strides in affine_strides:
+                if not tensor_strides:
+                    continue
+                # Build stride key from the tiled symbols present in this tensor,
+                # in the order they appear in affine_strides dict.
+                stride_key = tuple(tensor_strides.values())
+                if stride_key not in affine_map_index:
+                    affine_map_index[stride_key] = len(affine_map_index)
+
+
+# ---------------------------------------------------------------------------
+# Pass 2 helpers
+# ---------------------------------------------------------------------------
+
+
+def _mlir_count_value(count: sympy.Expr) -> str:
+    """Return an MLIR value expression for a loop trip count."""
+    if isinstance(count, (sympy.Integer, int)):
+        return f"arith.constant {int(count)} : index"
+    raise NotImplementedError(
+        f"Symbolic loop counts are not yet supported in bundle.mlir generation: {count}"
+    )
+
+
+def _emit_specs(
+    specs: list,
+    compiled_iter,
+    loop_bounds: list,
+    loop_bound_idx: list,
+    symbols: list[int],
+    affine_map_index: dict,
+    addr_counter: list,
+    loop_vars: list,
+    f,
+    indent: int,
+) -> None:
+    """Recursively emit MLIR ops for specs into file f."""
+    tab = "\t" * indent
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            lb_idx = loop_bound_idx[0]
+            loop_bound_idx[0] += 1
+            loop_var = f"%i_{lb_idx}"
+            f.write(
+                f"{tab}scf.for {loop_var} = %c0 to %loop_bound_{lb_idx} step %c1 {{\n"
+            )
+            _emit_specs(
+                entry.body,
+                compiled_iter,
+                loop_bounds,
+                loop_bound_idx,
+                symbols,
+                affine_map_index,
+                addr_counter,
+                loop_vars + [loop_var],
+                f,
+                indent + 1,
+            )
+            f.write(f"{tab}}}\n")
+
+        elif isinstance(entry, OpSpec):
+            sdsc_json, local_sym_values, affine_strides = next(compiled_iter)
+            # Determine the JSON filename from the sdsc_json key.
+            sdsc_name = next(iter(sdsc_json))
+            sdsc_idx = sdsc_name.split("_")[0]
+            sdsc_filename = f"sdsc_{sdsc_idx}.json"
+
+            # Extract symbol_ids from the negative IDs stored in the JSON.
+            symbol_ids = _extract_symbol_ids(sdsc_json)
+
+            # Build operand list: one %sym_N or %addr_N per (tensor, core).
+            operands: list[str] = []
+            for tensor_idx, tensor_strides in enumerate(affine_strides):
+                num_cores = _sdsc_num_cores(sdsc_json)
+                for c in range(num_cores):
+                    addr_str = _emit_tensor_core_addr(
+                        tensor_idx,
+                        c,
+                        tensor_strides,
+                        sdsc_json,
+                        symbols,
+                        affine_map_index,
+                        addr_counter,
+                        loop_vars,
+                        f,
+                        tab,
+                    )
+                    if addr_str is not None:
+                        operands.append(addr_str)
+
+            operand_str = ", ".join(operands)
+            symbol_ids_str = ", ".join(str(i) for i in symbol_ids)
+            f.write(
+                f"{tab}sdscbundle.sdsc_execute ({operand_str}) "
+                f'{{sdsc_filename="{sdsc_filename}", '
+                f'"symbol_ids"=[{symbol_ids_str}]}}\n'
+            )
+
+
+def _extract_symbol_ids(sdsc_json: dict) -> list[int]:
+    """Extract all negative symbol IDs from the SDSC JSON startAddressCoreCorelet_ data."""
+    ids: list[int] = []
+    seen: set[int] = set()
+    for top_val in sdsc_json.values():
+        for dsc_entry in top_val.get("dscs_", []):
+            for op_val in dsc_entry.values():
+                for node in op_val.get("scheduleTree_", []):
+                    if node.get("component_") == "hbm":
+                        data = node.get("startAddressCoreCorelet_", {}).get("data_", {})
+                        for v in data.values():
+                            sym_id = int(v)
+                            if sym_id < 0 and sym_id not in seen:
+                                ids.append(sym_id)
+                                seen.add(sym_id)
+    return ids
+
+
+def _sdsc_num_cores(sdsc_json: dict) -> int:
+    """Extract num_cores from the SDSC JSON."""
+    for top_val in sdsc_json.values():
+        return top_val.get("numCoresUsed_", 1)
+    return 1
+
+
+def _emit_tensor_core_addr(
+    tensor_idx: int,
+    core: int,
+    tensor_strides: dict,
+    sdsc_json: dict,
+    symbols: list[int],
+    affine_map_index: dict,
+    addr_counter: list,
+    loop_vars: list,
+    f,
+    tab: str,
+) -> str | None:
+    """Emit an affine.apply (if tiled) or return %sym_N (if not), or None (if lx).
+
+    Returns the MLIR SSA name to use as an operand to sdsc_execute, or None
+    if the tensor is lx (address baked into JSON, not an operand).
+    """
+    # Look up this tensor's base symbol ID from the JSON.
+    base_sym_id = _get_tensor_core_sym_id(sdsc_json, tensor_idx, core)
+    if base_sym_id is None:
+        # lx tensor — address is baked into JSON, not an operand.
+        return None
+
+    # Map the negative symbol ID back to a %sym_N name.
+    # symbols list index = (-base_sym_id - 1) for globally allocated symbols,
+    # but the actual global index is stored in the symbols list by value.
+    # We need to find which %sym_N corresponds to this symbol ID.
+    base_addr_name = _sym_id_to_mlir_name(base_sym_id, sdsc_json, symbols)
+
+    if not tensor_strides or not loop_vars:
+        # Non-tiled or outside a loop: use the base constant directly.
+        return base_addr_name
+
+    # Tiled tensor inside a loop: emit affine.apply.
+    stride_key = tuple(tensor_strides.values())
+    map_idx = affine_map_index[stride_key]
+    addr_name = f"%addr_{addr_counter[0]}"
+    addr_counter[0] += 1
+    loop_var_str = ", ".join(loop_vars)
+    f.write(
+        f"{tab}{addr_name} = affine.apply #map_{map_idx}"
+        f"({loop_var_str})[{base_addr_name}]\n"
+    )
+    return addr_name
+
+
+def _get_tensor_core_sym_id(sdsc_json: dict, tensor_idx: int, core: int) -> int | None:
+    """Return the symbol ID (negative int) for (tensor_idx, core), or None if lx."""
+    for top_val in sdsc_json.values():
+        for dsc_entry in top_val.get("dscs_", []):
+            for op_val in dsc_entry.values():
+                nodes = op_val.get("scheduleTree_", [])
+                if tensor_idx < len(nodes):
+                    node = nodes[tensor_idx]
+                    if node.get("component_") != "hbm":
+                        return None
+                    data = node.get("startAddressCoreCorelet_", {}).get("data_", {})
+                    key = f"[{core}, 0, 0]"
+                    if key in data:
+                        return int(data[key])
+    return None
+
+
+def _sym_id_to_mlir_name(sym_id: int, sdsc_json: dict, symbols: list[int]) -> str:
+    """Map a negative symbol ID back to a %sym_N MLIR name.
+
+    The mapping is: the N-th unique symbol ID registered for this SDSC (in
+    registration order) maps to %sym_{global_index+1} in the symbols list.
+    We recover the base address value from the compiled entry and look it up
+    in the global symbols list.
+    """
+    # Build the local -> global mapping by collecting all unique symbol IDs
+    # from the JSON in registration order, paired with their position in symbols.
+    # The global %sym_N index is: symbols.index(base_addr_value) + 1.
+    # We have the sym_id but need the base_addr_value.  Since the JSON stores
+    # str(sym_id) as the data value, we collect (sym_id -> base_addr_value) by
+    # cross-referencing with the local_sym_values we stored... but we don't have
+    # them here.  Instead, we rebuild the mapping: the K-th unique negative ID
+    # in the JSON (in ascending absolute value) corresponds to the K-th entry
+    # in local_sym_values.  We get the %sym_N name from the position of that
+    # value in the global symbols list.
+    #
+    # However, we don't have local_sym_values here.  To avoid threading it,
+    # we use the fact that the sdsc_json data values ARE the symbol IDs, and
+    # the global symbols list contains the base addresses in registration order.
+    # The (abs(sym_id) - 1 - offset) within the local group gives the local
+    # index, which maps to the same position in local_sym_values.
+    #
+    # Simpler approach: collect unique sym_ids in order of absolute value,
+    # that order is the same as local registration order, which is also the
+    # order entries were appended to the global symbols list.  Find the first
+    # sym_id in global symbols to get the starting offset.
+    all_sym_ids = _extract_symbol_ids(sdsc_json)
+    if not all_sym_ids:
+        raise RuntimeError(f"No symbol IDs found in SDSC JSON for sym_id={sym_id}")
+    # Sort by absolute value (registration order).
+    ordered = sorted(all_sym_ids, key=lambda x: abs(x))
+    local_idx = ordered.index(sym_id)
+    # The global index of the first symbol for this SDSC.
+    # We locate it by finding the minimum abs value sym_id's global position.
+    # Since local_sym_values are appended to symbols in order, and the first
+    # sym_id has abs value = symbol_id_offset + 1 for this SDSC, the global
+    # position is len(symbols) - len(ordered) + local_idx at registration time.
+    # We can recover this because all symbols are in the global list.
+    # The absolute value of the first registered sym_id for this SDSC minus 1
+    # equals symbol_id_offset at the time of compilation.
+    first_abs = abs(ordered[0])  # = symbol_id_offset + 1
+    global_start = first_abs - 1  # = symbol_id_offset = index into symbols list
+    global_idx = global_start + local_idx
+    return f"%sym_{global_idx + 1}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers re-exported for tests
+# ---------------------------------------------------------------------------
+
+
+def _collect_op_specs(specs: list, result: list) -> None:
+    """Collect all OpSpec leaves depth-first (for tests / async_compile)."""
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            _collect_op_specs(entry.body, result)
+        elif isinstance(entry, OpSpec):
+            result.append(entry)
+
+
+def _collect_loop_counts(specs: list) -> list:
+    """Return loop counts in depth-first order (for tests)."""
+    counts: list = []
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            counts.append(entry.count)
+            counts.extend(_collect_loop_counts(entry.body))
+    return counts

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -30,8 +30,8 @@ logger = get_inductor_logger("sdsc_compile")
 # ---------------------------------------------------------------------------
 
 # Compiled SDSC entry: (json_dict, base_symbol_values, affine_strides)
-#   base_symbol_values: list[int] of base HBM byte offsets registered in the
-#                       global symbols table for this SDSC
+#   base_symbol_values: list[int] of base HBM byte offsets for this SDSC,
+#                       one per registered symbol ID
 #   affine_strides:     list[dict] parallel to SDSCSpec.args —
 #                       {tiled_sym: stride_bytes} for tiled HBM tensors,
 #                       empty dict for non-tiled / lx tensors
@@ -53,8 +53,9 @@ def generate_bundle(kernel_name: str, output_dir: str, specs: list):
     """
     # -----------------------------------------------------------------------
     # Pass 1: compile all OpSpecs depth-first.
-    # Populates the global deduplicated ``symbols`` list of base HBM addresses
-    # and writes one ``sdsc_N.json`` file per OpSpec.
+    # ``symbols`` is indexed by abs(symbol_id)-1: one entry per symbol ID in
+    # registration order, values may repeat across SDSCs.  Writes one
+    # ``sdsc_N.json`` file per OpSpec.
     # -----------------------------------------------------------------------
     symbols: list[int] = []
     compiled: list[_CompiledEntry] = []
@@ -105,7 +106,7 @@ def generate_bundle(kernel_name: str, output_dir: str, specs: list):
             for lb_idx, lb in enumerate(loop_bounds):
                 f.write(f"\t\t%loop_bound_{lb_idx} = {_mlir_count_value(lb)}\n")
 
-        # One arith.constant per unique base address.
+        # One arith.constant per symbol ID (symbols[N] → %sym_{N+1}).
         for sym_idx, value in enumerate(symbols):
             f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
 
@@ -116,7 +117,6 @@ def generate_bundle(kernel_name: str, output_dir: str, specs: list):
             compiled_iter,
             loop_bounds,
             loop_bound_idx,
-            symbols,
             affine_map_index,
             addr_counter,
             [],
@@ -234,7 +234,6 @@ def _emit_specs(
     compiled_iter,
     loop_bounds: list,
     loop_bound_idx: list,
-    symbols: list[int],
     affine_map_index: dict,
     addr_counter: list,
     loop_vars: list,
@@ -256,7 +255,6 @@ def _emit_specs(
                 compiled_iter,
                 loop_bounds,
                 loop_bound_idx,
-                symbols,
                 affine_map_index,
                 addr_counter,
                 loop_vars + [loop_var],
@@ -272,28 +270,39 @@ def _emit_specs(
             sdsc_idx = sdsc_name.split("_")[0]
             sdsc_filename = f"sdsc_{sdsc_idx}.json"
 
-            # Extract symbol_ids from the negative IDs stored in the JSON.
+            # Extract symbol_ids from the negative IDs stored in the JSON
+            # (unique, in registration order).
             symbol_ids = _extract_symbol_ids(sdsc_json)
 
-            # Build operand list: one %sym_N or %addr_N per (tensor, core).
-            operands: list[str] = []
+            # Build affine.apply ops for tiled tensors, tracking which
+            # symbol IDs have been upgraded to per-iteration %addr_N names.
+            sym_id_to_operand: dict[int, str] = {}
             for tensor_idx, tensor_strides in enumerate(affine_strides):
+                if not tensor_strides:
+                    continue
                 num_cores = _sdsc_num_cores(sdsc_json)
                 for c in range(num_cores):
-                    addr_str = _emit_tensor_core_addr(
-                        tensor_idx,
-                        c,
-                        tensor_strides,
-                        sdsc_json,
-                        symbols,
-                        affine_map_index,
-                        addr_counter,
-                        loop_vars,
-                        f,
-                        tab,
+                    base_sym_id = _get_tensor_core_sym_id(sdsc_json, tensor_idx, c)
+                    if base_sym_id is None or base_sym_id in sym_id_to_operand:
+                        continue
+                    stride_key = tuple(tensor_strides.values())
+                    map_idx = affine_map_index[stride_key]
+                    addr_name = f"%addr_{addr_counter[0]}"
+                    addr_counter[0] += 1
+                    base_addr_name = _sym_id_to_mlir_name(base_sym_id)
+                    loop_var_str = ", ".join(loop_vars)
+                    f.write(
+                        f"{tab}{addr_name} = affine.apply #map_{map_idx}"
+                        f"({loop_var_str})[{base_addr_name}]\n"
                     )
-                    if addr_str is not None:
-                        operands.append(addr_str)
+                    sym_id_to_operand[base_sym_id] = addr_name
+
+            # Each operand position matches one symbol_id entry.
+            # Tiled sym_ids use the %addr_N computed above; others use %sym_N.
+            operands = [
+                sym_id_to_operand.get(sid, _sym_id_to_mlir_name(sid))
+                for sid in symbol_ids
+            ]
 
             operand_str = ", ".join(operands)
             symbol_ids_str = ", ".join(str(i) for i in symbol_ids)
@@ -329,52 +338,6 @@ def _sdsc_num_cores(sdsc_json: dict) -> int:
     return 1
 
 
-def _emit_tensor_core_addr(
-    tensor_idx: int,
-    core: int,
-    tensor_strides: dict,
-    sdsc_json: dict,
-    symbols: list[int],
-    affine_map_index: dict,
-    addr_counter: list,
-    loop_vars: list,
-    f,
-    tab: str,
-) -> str | None:
-    """Emit an affine.apply (if tiled) or return %sym_N (if not), or None (if lx).
-
-    Returns the MLIR SSA name to use as an operand to sdsc_execute, or None
-    if the tensor is lx (address baked into JSON, not an operand).
-    """
-    # Look up this tensor's base symbol ID from the JSON.
-    base_sym_id = _get_tensor_core_sym_id(sdsc_json, tensor_idx, core)
-    if base_sym_id is None:
-        # lx tensor — address is baked into JSON, not an operand.
-        return None
-
-    # Map the negative symbol ID back to a %sym_N name.
-    # symbols list index = (-base_sym_id - 1) for globally allocated symbols,
-    # but the actual global index is stored in the symbols list by value.
-    # We need to find which %sym_N corresponds to this symbol ID.
-    base_addr_name = _sym_id_to_mlir_name(base_sym_id, sdsc_json, symbols)
-
-    if not tensor_strides or not loop_vars:
-        # Non-tiled or outside a loop: use the base constant directly.
-        return base_addr_name
-
-    # Tiled tensor inside a loop: emit affine.apply.
-    stride_key = tuple(tensor_strides.values())
-    map_idx = affine_map_index[stride_key]
-    addr_name = f"%addr_{addr_counter[0]}"
-    addr_counter[0] += 1
-    loop_var_str = ", ".join(loop_vars)
-    f.write(
-        f"{tab}{addr_name} = affine.apply #map_{map_idx}"
-        f"({loop_var_str})[{base_addr_name}]\n"
-    )
-    return addr_name
-
-
 def _get_tensor_core_sym_id(sdsc_json: dict, tensor_idx: int, core: int) -> int | None:
     """Return the symbol ID (negative int) for (tensor_idx, core), or None if lx."""
     for top_val in sdsc_json.values():
@@ -392,53 +355,14 @@ def _get_tensor_core_sym_id(sdsc_json: dict, tensor_idx: int, core: int) -> int 
     return None
 
 
-def _sym_id_to_mlir_name(sym_id: int, sdsc_json: dict, symbols: list[int]) -> str:
-    """Map a negative symbol ID back to a %sym_N MLIR name.
+def _sym_id_to_mlir_name(sym_id: int) -> str:
+    """Map a negative symbol ID to a %sym_N MLIR name.
 
-    The mapping is: the N-th unique symbol ID registered for this SDSC (in
-    registration order) maps to %sym_{global_index+1} in the symbols list.
-    We recover the base address value from the compiled entry and look it up
-    in the global symbols list.
+    Symbol IDs are assigned sequentially across the whole bundle starting at
+    -1, and symbols[abs(id)-1] holds the corresponding value.  So %sym_N where
+    N = abs(sym_id) is always correct.
     """
-    # Build the local -> global mapping by collecting all unique symbol IDs
-    # from the JSON in registration order, paired with their position in symbols.
-    # The global %sym_N index is: symbols.index(base_addr_value) + 1.
-    # We have the sym_id but need the base_addr_value.  Since the JSON stores
-    # str(sym_id) as the data value, we collect (sym_id -> base_addr_value) by
-    # cross-referencing with the local_sym_values we stored... but we don't have
-    # them here.  Instead, we rebuild the mapping: the K-th unique negative ID
-    # in the JSON (in ascending absolute value) corresponds to the K-th entry
-    # in local_sym_values.  We get the %sym_N name from the position of that
-    # value in the global symbols list.
-    #
-    # However, we don't have local_sym_values here.  To avoid threading it,
-    # we use the fact that the sdsc_json data values ARE the symbol IDs, and
-    # the global symbols list contains the base addresses in registration order.
-    # The (abs(sym_id) - 1 - offset) within the local group gives the local
-    # index, which maps to the same position in local_sym_values.
-    #
-    # Simpler approach: collect unique sym_ids in order of absolute value,
-    # that order is the same as local registration order, which is also the
-    # order entries were appended to the global symbols list.  Find the first
-    # sym_id in global symbols to get the starting offset.
-    all_sym_ids = _extract_symbol_ids(sdsc_json)
-    if not all_sym_ids:
-        raise RuntimeError(f"No symbol IDs found in SDSC JSON for sym_id={sym_id}")
-    # Sort by absolute value (registration order).
-    ordered = sorted(all_sym_ids, key=lambda x: abs(x))
-    local_idx = ordered.index(sym_id)
-    # The global index of the first symbol for this SDSC.
-    # We locate it by finding the minimum abs value sym_id's global position.
-    # Since local_sym_values are appended to symbols in order, and the first
-    # sym_id has abs value = symbol_id_offset + 1 for this SDSC, the global
-    # position is len(symbols) - len(ordered) + local_idx at registration time.
-    # We can recover this because all symbols are in the global list.
-    # The absolute value of the first registered sym_id for this SDSC minus 1
-    # equals symbol_id_offset at the time of compilation.
-    first_abs = abs(ordered[0])  # = symbol_id_offset + 1
-    global_start = first_abs - 1  # = symbol_id_offset = index into symbols list
-    global_idx = global_start + local_idx
-    return f"%sym_{global_idx + 1}"
+    return f"%sym_{abs(sym_id)}"
 
 
 # ---------------------------------------------------------------------------

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -205,7 +205,7 @@ def gen_coord_info_value(
     )
 
 
-def generate_sdsc(idx, sdsc_spec):
+def generate_sdsc(idx, sdsc_spec, symbols: list[int], symbol_id_offset: int = 0):
     out_idx = len(sdsc_spec.args) - 1
     core_id_to_wk_slice = {
         str(c): {
@@ -214,6 +214,18 @@ def generate_sdsc(idx, sdsc_spec):
         }
         for c in range(sdsc_spec.num_cores)
     }
+
+    # local_symbols maps offset value -> globally-unique negative symbol id.
+    # symbol_id_offset ensures ids are unique across all SDSCs in the bundle.
+    local_symbols: dict[int, int] = {}
+
+    def offset_as_symbol(s):
+        if s not in local_symbols:
+            if s not in symbols:
+                symbols.append(s)
+            local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
+        return local_symbols[s]
+
     return {
         f"{idx}_{sdsc_spec.opfunc}": {
             "sdscFoldProps_": [{"factor_": 1, "label_": "time"}],
@@ -291,6 +303,7 @@ def generate_sdsc(idx, sdsc_spec):
                                 "component_": "lx"
                                 if "lx" in tensor.allocation
                                 else "hbm",
+                                "isStartAddrSymbolic_": 1,
                                 "layoutDimOrder_": [
                                     str(dim)
                                     for dim in sdsc_spec.layouts[tensor.layout][
@@ -319,13 +332,15 @@ def generate_sdsc(idx, sdsc_spec):
                                     ],
                                     "data_": {
                                         f"[{c}, 0, 0]": str(
-                                            tensor.start_address
-                                            + core_idx_to_slice_offset(
-                                                tensor,
-                                                core_id_to_wk_slice[str(c)],
-                                                sdsc_spec.work_slices,
+                                            offset_as_symbol(
+                                                tensor.start_address
+                                                + core_idx_to_slice_offset(
+                                                    tensor,
+                                                    core_id_to_wk_slice[str(c)],
+                                                    sdsc_spec.work_slices,
+                                                )
+                                                * num_bytes(tensor.data_format)
                                             )
-                                            * num_bytes(tensor.data_format)
                                         )
                                         if "lx" not in tensor.allocation
                                         else str(tensor.start_address)
@@ -421,4 +436,4 @@ def generate_sdsc(idx, sdsc_spec):
                 }
             ],
         }
-    }
+    }, list(local_symbols.keys())

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -253,13 +253,18 @@ def generate_sdsc(
     # symbol_id_offset ensures ids are unique across all SDSCs in the bundle.
     # For tiled tensors the base is the iteration-0 address (tiled dims contribute 0);
     # for non-tiled tensors it is the full per-core address (as before).
+    #
+    # NOTE: no cross-SDSC deduplication — each call to offset_as_symbol within
+    # this SDSC gets its own sequential ID and appends to symbols.  Two SDSCs
+    # that happen to share a base address will emit two separate arith.constant
+    # declarations in bundle.mlir.  This keeps symbol IDs contiguous with the
+    # symbols list indices: symbols[abs(id)-1] is always the value for id.
     local_symbols: dict[int, int] = {}
 
     def offset_as_symbol(s):
         if s not in local_symbols:
-            if s not in symbols:
-                symbols.append(s)
             local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
+            symbols.append(s)
         return local_symbols[s]
 
     # Compute per-tensor affine strides and register base addresses in symbols.

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -205,7 +205,41 @@ def gen_coord_info_value(
     )
 
 
-def generate_sdsc(idx, sdsc_spec, symbols: list[int], symbol_id_offset: int = 0):
+def _tiled_byte_stride(tensor, tiled_sym, iteration_space) -> int:
+    """Byte stride per loop iteration for a single tiled dimension.
+
+    The coarse_tile pass already divided iteration_space[tiled_sym].range by
+    the loop count, so that range is the per-iteration element count.  The full
+    per-iteration byte advancement is:
+        per_iter_elems * device_stride_for_dim * bytes_per_element
+    """
+    per_iter_range = iteration_space[tiled_sym]
+    return int(
+        per_iter_range * tensor.strides[tiled_sym] * num_bytes(tensor.data_format)
+    )
+
+
+def generate_sdsc(
+    idx,
+    sdsc_spec,
+    symbols: list[int],
+    symbol_id_offset: int = 0,
+    tiled_symbols=None,
+):
+    """Generate SDSC JSON for one OpSpec.
+
+    Returns a 3-tuple ``(sdsc_json, base_symbol_values, affine_strides)``:
+    - ``sdsc_json``: the JSON dict to write to ``sdsc_N.json``
+    - ``base_symbol_values``: list of base HBM byte offsets (one per
+      (tensor, core) pair for non-lx tensors) registered in ``symbols``
+    - ``affine_strides``: list (parallel to ``sdsc_spec.args``) of dicts
+      ``{tiled_sym: stride_bytes}`` for tiled HBM tensors; empty dict for
+      non-tiled or lx tensors.  Used by ``bundle.py`` to emit
+      ``affine.apply`` ops inside ``scf.for`` loops.
+    """
+    if tiled_symbols is None:
+        tiled_symbols = []
+
     out_idx = len(sdsc_spec.args) - 1
     core_id_to_wk_slice = {
         str(c): {
@@ -215,8 +249,10 @@ def generate_sdsc(idx, sdsc_spec, symbols: list[int], symbol_id_offset: int = 0)
         for c in range(sdsc_spec.num_cores)
     }
 
-    # local_symbols maps offset value -> globally-unique negative symbol id.
+    # local_symbols maps base HBM byte offset -> globally-unique negative symbol id.
     # symbol_id_offset ensures ids are unique across all SDSCs in the bundle.
+    # For tiled tensors the base is the iteration-0 address (tiled dims contribute 0);
+    # for non-tiled tensors it is the full per-core address (as before).
     local_symbols: dict[int, int] = {}
 
     def offset_as_symbol(s):
@@ -226,214 +262,270 @@ def generate_sdsc(idx, sdsc_spec, symbols: list[int], symbol_id_offset: int = 0)
             local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
         return local_symbols[s]
 
-    return {
-        f"{idx}_{sdsc_spec.opfunc}": {
-            "sdscFoldProps_": [{"factor_": 1, "label_": "time"}],
-            "sdscFolds_": {
-                "dim_prop_func": [{"Affine": {"alpha_": 1, "beta_": 0}}],
-                "dim_prop_attr": [{"factor_": 1, "label_": "time"}],
-                "data_": {"[0]": "0"},
-            },
-            "coreFoldProp_": {"factor_": sdsc_spec.num_cores, "label_": "core"},
-            "coreletFoldProp_": {"factor_": 1, "label_": "corelet"},
-            "numCoresUsed_": sdsc_spec.num_cores,
-            "coreIdToDsc_": {str(c): 0 for c in range(sdsc_spec.num_cores)},
-            "numWkSlicesPerDim_": {
-                str(dim): num_wk_slices
-                for dim, num_wk_slices in sdsc_spec.work_slices.items()
-            },
-            "coreIdToWkSlice_": core_id_to_wk_slice,
-            "coreIdToDscSchedule": {
-                str(c): [[-1, 0, 0, 0]] for c in range(sdsc_spec.num_cores)
-            },
-            "dscs_": [
-                {
-                    sdsc_spec.opfunc: {
-                        "numCoresUsed_": sdsc_spec.num_cores,
-                        "numCoreletsUsed_": 1,
-                        "coreIdsUsed_": [c for c in range(sdsc_spec.num_cores)],
-                        "N_": {
-                            "name_": "n",
-                            **{
-                                str(dim) + "_": size
-                                for dim, size in sdsc_spec.iteration_space.items()
+    # Compute per-tensor affine strides and register base addresses in symbols.
+    # affine_strides[i] is {tiled_sym: stride_bytes} for tensor i (empty if non-tiled/lx).
+    affine_strides: list[dict] = []
+    for tensor in sdsc_spec.args:
+        if "lx" in tensor.allocation:
+            affine_strides.append({})
+            continue
+        tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
+        if not tensor_tiled:
+            # Non-tiled HBM: register full per-core addresses (existing behavior).
+            for c in range(sdsc_spec.num_cores):
+                full_addr = tensor.start_address + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                ) * num_bytes(tensor.data_format)
+                offset_as_symbol(full_addr)
+            affine_strides.append({})
+        else:
+            # Tiled HBM: base address = start + non-tiled core offset (tiled dims @ iter 0).
+            strides_for_tensor = {}
+            for s in tensor_tiled:
+                strides_for_tensor[s] = _tiled_byte_stride(
+                    tensor, s, sdsc_spec.iteration_space
+                )
+            for c in range(sdsc_spec.num_cores):
+                base_addr = tensor.start_address + core_idx_to_slice_offset(
+                    tensor,
+                    # Zero out the tiled dims so we get the iteration-0 base.
+                    {
+                        k: (0 if k in [str(s) for s in tensor_tiled] else v)
+                        for k, v in core_id_to_wk_slice[str(c)].items()
+                    },
+                    sdsc_spec.work_slices,
+                ) * num_bytes(tensor.data_format)
+                offset_as_symbol(base_addr)
+            affine_strides.append(strides_for_tensor)
+
+    # Build startAddressCoreCorelet_ data using symbol IDs (base or full address).
+    def _start_addr_data(tensor):
+        if "lx" in tensor.allocation:
+            return {
+                f"[{c}, 0, 0]": str(tensor.start_address)
+                for c in range(sdsc_spec.num_cores)
+            }
+        tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
+        result = {}
+        for c in range(sdsc_spec.num_cores):
+            if not tensor_tiled:
+                addr = tensor.start_address + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                ) * num_bytes(tensor.data_format)
+            else:
+                addr = tensor.start_address + core_idx_to_slice_offset(
+                    tensor,
+                    {
+                        k: (0 if k in [str(s) for s in tensor_tiled] else v)
+                        for k, v in core_id_to_wk_slice[str(c)].items()
+                    },
+                    sdsc_spec.work_slices,
+                ) * num_bytes(tensor.data_format)
+            result[f"[{c}, 0, 0]"] = str(offset_as_symbol(addr))
+        return result
+
+    return (
+        {
+            f"{idx}_{sdsc_spec.opfunc}": {
+                "sdscFoldProps_": [{"factor_": 1, "label_": "time"}],
+                "sdscFolds_": {
+                    "dim_prop_func": [{"Affine": {"alpha_": 1, "beta_": 0}}],
+                    "dim_prop_attr": [{"factor_": 1, "label_": "time"}],
+                    "data_": {"[0]": "0"},
+                },
+                "coreFoldProp_": {"factor_": sdsc_spec.num_cores, "label_": "core"},
+                "coreletFoldProp_": {"factor_": 1, "label_": "corelet"},
+                "numCoresUsed_": sdsc_spec.num_cores,
+                "coreIdToDsc_": {str(c): 0 for c in range(sdsc_spec.num_cores)},
+                "numWkSlicesPerDim_": {
+                    str(dim): num_wk_slices
+                    for dim, num_wk_slices in sdsc_spec.work_slices.items()
+                },
+                "coreIdToWkSlice_": core_id_to_wk_slice,
+                "coreIdToDscSchedule": {
+                    str(c): [[-1, 0, 0, 0]] for c in range(sdsc_spec.num_cores)
+                },
+                "dscs_": [
+                    {
+                        sdsc_spec.opfunc: {
+                            "numCoresUsed_": sdsc_spec.num_cores,
+                            "numCoreletsUsed_": 1,
+                            "coreIdsUsed_": [c for c in range(sdsc_spec.num_cores)],
+                            "N_": {
+                                "name_": "n",
+                                **{
+                                    str(dim) + "_": size
+                                    for dim, size in sdsc_spec.iteration_space.items()
+                                },
                             },
-                        },
-                        "coordinateMasking_": {
-                            str(dim): mask_range
-                            for dim, mask_range in sdsc_spec.coordinate_masking.items()
-                        },
-                        "maskingConstId_": 0 if sdsc_spec.coordinate_masking else -1,
-                        "dataStageParam_": {
-                            "0": {
-                                "ss_": {
-                                    "name_": "core",
-                                    **{
-                                        str(dim) + "_": size
-                                        // sdsc_spec.work_slices[dim]
-                                        for dim, size in sdsc_spec.iteration_space.items()
-                                    },
-                                },
-                                "el_": {
-                                    "name_": "core",
-                                    **{
-                                        str(dim) + "_": size
-                                        // sdsc_spec.work_slices[dim]
-                                        for dim, size in sdsc_spec.iteration_space.items()
-                                    },
-                                },
-                            }
-                        },
-                        "primaryDsInfo_": {
-                            label: {
-                                "layoutDimOrder_": [
-                                    str(dim) for dim in layout_info["dim_order"]
-                                ],
-                                "stickDimOrder_": [str(layout_info["stick_dim_order"])],
-                                "stickSize_": [layout_info["stick_size"]],
-                            }
-                            for label, layout_info in sdsc_spec.layouts.items()
-                        },
-                        "scheduleTree_": [
-                            {
-                                "nodeType_": "allocate",
-                                "name_": f"allocate-Tensor{i}_{'lx' if 'lx' in tensor.allocation else 'hbm'}",
-                                "prev_": "",
-                                "ldsIdx_": i,
-                                "component_": "lx"
-                                if "lx" in tensor.allocation
-                                else "hbm",
-                                "isStartAddrSymbolic_": 1,
-                                "layoutDimOrder_": [
-                                    str(dim)
-                                    for dim in sdsc_spec.layouts[tensor.layout][
-                                        "dim_order"
-                                    ]
-                                ],
-                                "maxDimSizes_": [
-                                    tensor.max_dim_sizes[dim]
-                                    for dim in sdsc_spec.layouts[tensor.layout][
-                                        "dim_order"
-                                    ]
-                                ],
-                                "startAddressCoreCorelet_": {
-                                    "dim_prop_func": [
-                                        {"Map": {}},
-                                        {"Const": {}},
-                                        {"Const": {}},
-                                    ],
-                                    "dim_prop_attr": [
-                                        {
-                                            "factor_": sdsc_spec.num_cores,
-                                            "label_": "core",
-                                        },
-                                        {"factor_": 1, "label_": "corelet"},
-                                        {"factor_": 1, "label_": "time"},
-                                    ],
-                                    "data_": {
-                                        f"[{c}, 0, 0]": str(
-                                            offset_as_symbol(
-                                                tensor.start_address
-                                                + core_idx_to_slice_offset(
-                                                    tensor,
-                                                    core_id_to_wk_slice[str(c)],
-                                                    sdsc_spec.work_slices,
-                                                )
-                                                * num_bytes(tensor.data_format)
-                                            )
-                                        )
-                                        if "lx" not in tensor.allocation
-                                        else str(tensor.start_address)
-                                        for c in range(sdsc_spec.num_cores)
-                                        #  lx addr is baked into tensor.start_addr already
-                                    },
-                                },
-                                **(
-                                    {
-                                        "backGapCore_": {
-                                            str(dim): {
-                                                "-1": str(gap)  # HBM is -1
-                                            }
-                                            for dim, gap in tensor.backGap.items()
-                                        }
-                                    }
-                                    if tensor.backGap
-                                    else {}
-                                ),
-                                "coordinates_": {
-                                    "coordInfo": {
-                                        str(dim): gen_coord_info_value(
-                                            size=sdsc_spec.iteration_space[dim]
+                            "coordinateMasking_": {
+                                str(dim): mask_range
+                                for dim, mask_range in sdsc_spec.coordinate_masking.items()
+                            },
+                            "maskingConstId_": 0
+                            if sdsc_spec.coordinate_masking
+                            else -1,
+                            "dataStageParam_": {
+                                "0": {
+                                    "ss_": {
+                                        "name_": "core",
+                                        **{
+                                            str(dim) + "_": size
                                             // sdsc_spec.work_slices[dim]
-                                            if (tensor.scales[dim] == 1)
-                                            else 1,
-                                            nsplits=sdsc_spec.work_slices[dim]
-                                            if (tensor.scales[dim] == 1)
-                                            else 1,
-                                            elems_per_stick=tensor.data_format.elems_per_stick(),
-                                            is_stick_dim=(
-                                                sdsc_spec.layouts[tensor.layout][
-                                                    "stick_dim_order"
-                                                ].has(dim)
-                                            ),
-                                            is_stick_reduction=(
-                                                tensor.scales[dim] == -2
-                                            ),
-                                        )
+                                            for dim, size in sdsc_spec.iteration_space.items()
+                                        },
+                                    },
+                                    "el_": {
+                                        "name_": "core",
+                                        **{
+                                            str(dim) + "_": size
+                                            // sdsc_spec.work_slices[dim]
+                                            for dim, size in sdsc_spec.iteration_space.items()
+                                        },
+                                    },
+                                }
+                            },
+                            "primaryDsInfo_": {
+                                label: {
+                                    "layoutDimOrder_": [
+                                        str(dim) for dim in layout_info["dim_order"]
+                                    ],
+                                    "stickDimOrder_": [
+                                        str(layout_info["stick_dim_order"])
+                                    ],
+                                    "stickSize_": [layout_info["stick_size"]],
+                                }
+                                for label, layout_info in sdsc_spec.layouts.items()
+                            },
+                            "scheduleTree_": [
+                                {
+                                    "nodeType_": "allocate",
+                                    "name_": f"allocate-Tensor{i}_{'lx' if 'lx' in tensor.allocation else 'hbm'}",
+                                    "prev_": "",
+                                    "ldsIdx_": i,
+                                    "component_": "lx"
+                                    if "lx" in tensor.allocation
+                                    else "hbm",
+                                    "isStartAddrSymbolic_": 1,
+                                    "layoutDimOrder_": [
+                                        str(dim)
                                         for dim in sdsc_spec.layouts[tensor.layout][
                                             "dim_order"
                                         ]
+                                    ],
+                                    "maxDimSizes_": [
+                                        tensor.max_dim_sizes[dim]
+                                        for dim in sdsc_spec.layouts[tensor.layout][
+                                            "dim_order"
+                                        ]
+                                    ],
+                                    "startAddressCoreCorelet_": {
+                                        "dim_prop_func": [
+                                            {"Map": {}},
+                                            {"Const": {}},
+                                            {"Const": {}},
+                                        ],
+                                        "dim_prop_attr": [
+                                            {
+                                                "factor_": sdsc_spec.num_cores,
+                                                "label_": "core",
+                                            },
+                                            {"factor_": 1, "label_": "corelet"},
+                                            {"factor_": 1, "label_": "time"},
+                                        ],
+                                        "data_": _start_addr_data(tensor),
                                     },
-                                    "coreIdToWkSlice_": {},
-                                },
-                            }
-                            for i, tensor in enumerate(sdsc_spec.args)
-                        ],
-                        "labeledDs_": [
-                            {
-                                "ldsIdx_": i,
-                                "dsName_": f"Tensor{i}",
-                                "dsType_": tensor.layout,
-                                "scale_": [
-                                    tensor.scales[dim]
-                                    for dim in sdsc_spec.layouts[tensor.layout][
-                                        "dim_order"
-                                    ]
-                                ],
-                                "wordLength": num_bytes(tensor.data_format),
-                                "dataFormat_": tensor.data_format.name,
-                                "memOrg_": {
-                                    "hbm": {"isPresent": 1},
-                                    "lx": {"isPresent": 1},
+                                    **(
+                                        {
+                                            "backGapCore_": {
+                                                str(dim): {
+                                                    "-1": str(gap)  # HBM is -1
+                                                }
+                                                for dim, gap in tensor.backGap.items()
+                                            }
+                                        }
+                                        if tensor.backGap
+                                        else {}
+                                    ),
+                                    "coordinates_": {
+                                        "coordInfo": {
+                                            str(dim): gen_coord_info_value(
+                                                size=sdsc_spec.iteration_space[dim]
+                                                // sdsc_spec.work_slices[dim]
+                                                if (tensor.scales[dim] == 1)
+                                                else 1,
+                                                nsplits=sdsc_spec.work_slices[dim]
+                                                if (tensor.scales[dim] == 1)
+                                                else 1,
+                                                elems_per_stick=tensor.data_format.elems_per_stick(),
+                                                is_stick_dim=(
+                                                    sdsc_spec.layouts[tensor.layout][
+                                                        "stick_dim_order"
+                                                    ].has(dim)
+                                                ),
+                                                is_stick_reduction=(
+                                                    tensor.scales[dim] == -2
+                                                ),
+                                            )
+                                            for dim in sdsc_spec.layouts[tensor.layout][
+                                                "dim_order"
+                                            ]
+                                        },
+                                        "coreIdToWkSlice_": {},
+                                    },
                                 }
-                                if "lx" not in tensor.allocation
-                                else {"lx": {"isPresent": 1}},
-                            }
-                            for i, tensor in enumerate(sdsc_spec.args)
-                        ],
-                        "constantInfo_": generate_constant_info(
-                            sdsc_spec.data_format,
-                            sdsc_spec.constants,
-                            sdsc_spec.num_cores,
-                        ),
-                        "computeOp_": [
-                            {
-                                "exUnit": sdsc_spec.execution_unit,
-                                "opFuncName": sdsc_spec.opfunc,
-                                "attributes_": {
-                                    "dataFormat_": sdsc_spec.data_format.name,
-                                    "fidelity_": "regular",
-                                },
-                                "location": "Inner",
-                                "inputLabeledDs": [
-                                    f"Tensor{i}-idx{i}"
-                                    for i in range(sdsc_spec.num_inputs)
-                                ],
-                                "outputLabeledDs": [f"Tensor{out_idx}-idx{out_idx}"],
-                            }
-                        ],
+                                for i, tensor in enumerate(sdsc_spec.args)
+                            ],
+                            "labeledDs_": [
+                                {
+                                    "ldsIdx_": i,
+                                    "dsName_": f"Tensor{i}",
+                                    "dsType_": tensor.layout,
+                                    "scale_": [
+                                        tensor.scales[dim]
+                                        for dim in sdsc_spec.layouts[tensor.layout][
+                                            "dim_order"
+                                        ]
+                                    ],
+                                    "wordLength": num_bytes(tensor.data_format),
+                                    "dataFormat_": tensor.data_format.name,
+                                    "memOrg_": {
+                                        "hbm": {"isPresent": 1},
+                                        "lx": {"isPresent": 1},
+                                    }
+                                    if "lx" not in tensor.allocation
+                                    else {"lx": {"isPresent": 1}},
+                                }
+                                for i, tensor in enumerate(sdsc_spec.args)
+                            ],
+                            "constantInfo_": generate_constant_info(
+                                sdsc_spec.data_format,
+                                sdsc_spec.constants,
+                                sdsc_spec.num_cores,
+                            ),
+                            "computeOp_": [
+                                {
+                                    "exUnit": sdsc_spec.execution_unit,
+                                    "opFuncName": sdsc_spec.opfunc,
+                                    "attributes_": {
+                                        "dataFormat_": sdsc_spec.data_format.name,
+                                        "fidelity_": "regular",
+                                    },
+                                    "location": "Inner",
+                                    "inputLabeledDs": [
+                                        f"Tensor{i}-idx{i}"
+                                        for i in range(sdsc_spec.num_inputs)
+                                    ],
+                                    "outputLabeledDs": [
+                                        f"Tensor{out_idx}-idx{out_idx}"
+                                    ],
+                                }
+                            ],
+                        }
                     }
-                }
-            ],
-        }
-    }, list(local_symbols.keys())
+                ],
+            }
+        },
+        list(local_symbols.keys()),
+        affine_strides,
+    )

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -657,7 +657,13 @@ def parse_op_spec(op_spec: OpSpec) -> SDSCSpec:
 
 def compile_op_spec(
     idx: int, op_spec: OpSpec, symbols: list[int], symbol_id_offset: int = 0
-) -> tuple[Any, list[int]]:
+) -> tuple[Any, list[int], list[dict]]:
     sdsc_spec = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
-    return generate_sdsc(idx, sdsc_spec, symbols, symbol_id_offset)
+    return generate_sdsc(
+        idx,
+        sdsc_spec,
+        symbols,
+        symbol_id_offset,
+        tiled_symbols=op_spec.tiled_symbols,
+    )

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -655,7 +655,9 @@ def parse_op_spec(op_spec: OpSpec) -> SDSCSpec:
     )
 
 
-def compile_op_spec(idx: int, op_spec: OpSpec) -> Any:
+def compile_op_spec(
+    idx: int, op_spec: OpSpec, symbols: list[int], symbol_id_offset: int = 0
+) -> tuple[Any, list[int]]:
     sdsc_spec = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
-    return generate_sdsc(idx, sdsc_spec)
+    return generate_sdsc(idx, sdsc_spec, symbols, symbol_id_offset)

--- a/torch_spyre/_inductor/op_spec.py
+++ b/torch_spyre/_inductor/op_spec.py
@@ -55,6 +55,10 @@ class OpSpec:
         iteration_space: The iteration space of the operation. The values are tuples of (range, work_division).
         args: The input and output arguments to the operation.
         op_info: A dictionary of auxiliary information whose content is operation-specific.
+        tiled_symbols: Iteration-space symbols divided by the enclosing loop's count.
+            Empty for ops that are not inside a LoopSpec.  The runtime computes the
+            per-iteration tensor base offset for symbol ``s`` as
+            ``loop_var * iteration_space[s].range * strides[s] * bytes_per_elem``.
     """
 
     op: str
@@ -62,11 +66,31 @@ class OpSpec:
     iteration_space: dict[Symbol, tuple[Expr, int]]
     args: Sequence[TensorArg]
     op_info: dict[str, Any]
+    tiled_symbols: list[Symbol] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
 class UnimplementedOp:
     op: str
+
+
+@dataclasses.dataclass
+class LoopSpec:
+    """A counted loop whose body is a sequence of ops, possibly nested.
+
+    Attributes:
+        count: Trip count of the loop. May be a symbolic shape expression.
+        body: The operations to execute each iteration. Each element may be
+            an OpSpec, UnimplementedOp, or a nested LoopSpec.
+
+    Per-op tiling information (which iteration-space symbols are divided by
+    ``count``) is recorded on each ``OpSpec.tiled_symbols`` rather than here,
+    because different body ops may tile different dimensions.
+    """
+
+    count: Expr
+    # list[OpSpec | UnimplementedOp | LoopSpec]
+    body: list[Any]
 
 
 def spyre_constant_tensor(const_val, device, dtype=torch.float16):

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -19,7 +19,7 @@ import subprocess
 
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch_spyre._inductor.logging_utils import get_inductor_logger
-from torch_spyre._inductor.op_spec import OpSpec, UnimplementedOp
+from torch_spyre._inductor.op_spec import LoopSpec, UnimplementedOp
 from torch_spyre._inductor.codegen.bundle import generate_bundle
 from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
 
@@ -33,22 +33,33 @@ def get_output_dir(kernel_name: str):
     return kernel_output_dir
 
 
+def _find_unimplemented(specs: list):
+    """Return the first UnimplementedOp in specs (recursing into LoopSpec), or None."""
+    for entry in specs:
+        if isinstance(entry, UnimplementedOp):
+            return entry
+        if isinstance(entry, LoopSpec):
+            found = _find_unimplemented(entry.body)
+            if found is not None:
+                return found
+    return None
+
+
 class SpyreAsyncCompile:
     def __init__(self) -> None:
         pass
 
-    def sdsc(self, kernel_name: str, specs: list[OpSpec | UnimplementedOp]):
-        unimp = [s for s in specs if isinstance(s, UnimplementedOp)]
-        if len(unimp) != 0:
+    def sdsc(self, kernel_name: str, specs: list):
+        unimp = _find_unimplemented(specs)
+        if unimp is not None:
             logger.warning(
-                f"WARNING: Compiling unimplemented {unimp[0].op} to runtime exception"
+                f"WARNING: Compiling unimplemented {unimp.op} to runtime exception"
             )
-            return SpyreUnimplementedRunner(kernel_name, unimp[0].op)
+            return SpyreUnimplementedRunner(kernel_name, unimp.op)
 
-        # Generate SDSC Bundle from OpSpecs
+        # Generate SDSC Bundle from specs (may contain LoopSpec entries).
         output_dir = get_output_dir(kernel_name)
-        op_specs = [s for s in specs if isinstance(s, OpSpec)]
-        generate_bundle(kernel_name, output_dir, op_specs)
+        generate_bundle(kernel_name, output_dir, specs)
 
         # Invoke backend compiler of SDSC Bundle
         subprocess.run(["dxp_standalone", "--bundle", "-d", output_dir], check=True)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This implements the "fake_symbol" code generation for the frontend compiler as described in https://github.com/torch-spyre/interface-specs/blob/main/0248-SdscBundleSpec/examples/3-single-fake-sym.mlir. 


I've attached the generated artifacts for the softmax example with SENCORES=1 and SENCORES=32. 

[softmax_sencore_1.tgz](https://github.com/user-attachments/files/26693172/softmax_sencore_1.tgz)

[softmax_sencore_32.tgz](https://github.com/user-attachments/files/26693174/softmax_sencore_32.tgz)

#### Which issue(s) this PR is related to:

This is a piece of #1505. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
