### PR TITLE
Padding should also be applied to mm and bmm

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -149,9 +149,10 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             "param_sets": make_param_dict(
                 [
                     ((67, 256), (256, 128)),
-                    # Fails for now, pending deeptools reduce fixes
-                    # ((67, 67,), (67, 67)),
-                    # ((67, 255), (255, 128)),
+                    # Padding
+                    ((55, 2), (2, 99)),
+                    ((67, 67), (67, 67)),
+                    ((67, 255), (255, 128)),
                 ]
             ),
         },
@@ -162,6 +163,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     ((3, 1, 256), (3, 256, 128)),
                     ((3, 17, 256), (3, 256, 128)),
                     ((2, 256, 1), (2, 1, 128)),
+                    # Padding
+                    ((2, 55, 2), (2, 2, 99)),
+                    ((2, 99, 65), (2, 65, 55)),
                 ]
             ),
         },

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -57,7 +57,11 @@ def pad_arg(graph: torch.fx.Graph, node: torch.fx.Node, arg_i: int, dim: int) ->
 
 def insert_padding(graph: torch.fx.Graph) -> None:
     for node in list(graph.nodes):
-        if node.op == "call_function" and node.target == torch.matmul:
+        if node.op == "call_function" and node.target in [
+            torch.matmul,
+            torch.mm,
+            torch.bmm,
+        ]:
             args = node.args
             if not all(isinstance(arg, torch.fx.Node) for arg in args):
                 continue


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

#1503 applied padding to `torch.matmul`.  We want the same logic applied to `torch.mm` and `torch.bmm`.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
