### PR TITLE
left-padding support for pad

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -840,6 +840,38 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     cached_randn((2, 3, 64), dtype=torch.float16),
                     (0, 0, 0, 2),
                 ),
+                "2d_last_dim_left_stick_aligned": (
+                    cached_randn((3, 64), dtype=torch.float16),
+                    (64, 0),
+                ),
+                "2d_last_dim_left_two_sticks": (
+                    cached_randn((3, 64), dtype=torch.float16),
+                    (128, 0),
+                ),
+                "2d_last_dim_left_and_right_stick_aligned": (
+                    cached_randn((3, 64), dtype=torch.float16),
+                    (64, 64),
+                ),
+                "2d_dim0_left": (
+                    cached_randn((3, 64), dtype=torch.float16),
+                    (0, 0, 2, 0),
+                ),
+                "2d_dim0_left_only": (
+                    cached_randn((3, 64), dtype=torch.float16),
+                    (0, 0, 1, 0),
+                ),
+                "3d_dim0_left": (
+                    cached_randn((2, 3, 64), dtype=torch.float16),
+                    (0, 0, 0, 0, 2, 0),
+                ),
+                "3d_dim1_left": (
+                    cached_randn((2, 3, 64), dtype=torch.float16),
+                    (0, 0, 1, 0),
+                ),
+                "4d_dim0_left": (
+                    cached_randn((2, 3, 4, 64), dtype=torch.float16),
+                    (0, 0, 0, 0, 0, 0, 1, 0),
+                ),
             },
         },
         (

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -620,13 +620,20 @@ def pad_decomp(
             f"Spyre (pad={pad})"
         )
 
-    # Left-padding requires shifting the output start address by the left amount,
-    # which is not yet supported. Tracked in:
-    # https://github.com/torch-spyre/torch-spyre/issues/1480
-    if any(pad[2 * i] > 0 for i in range(n_dims_padded)):
-        raise Unsupported(
-            f"constant_pad_nd: left-padding is not supported on Spyre (pad={pad})"
-        )
+    # Left-padding on the last (stick) dimension shifts the output start address
+    # by `left` elements. The hardware can only express this in whole sticks, so
+    # `left` must be a multiple of the stick size (64 fp16 elements).
+    # Sub-stick left-padding on the last dimension is tracked in:
+    # https://github.com/torch-spyre/torch-spyre/issues/1464
+    last_dim_left = pad[0]
+    if last_dim_left > 0:
+        elems_per_stick = 128 // input.element_size()
+        if last_dim_left % elems_per_stick != 0:
+            raise Unsupported(
+                f"constant_pad_nd: sub-stick left-padding on the last dimension is "
+                f"not supported on Spyre (pad={pad}, left={last_dim_left}, "
+                f"stick_size={elems_per_stick})"
+            )
 
     # Build the padded output shape and collect which dimensions need padding.
     scalar = torch.ops.spyre.full([1], value, input.device, dtype=input.dtype)


### PR DESCRIPTION

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [X] cleanup

#### What this PR does:
- Replaced broad left-padding rejection with narrow sub-stick check
- Only rejects left-padding when left % 64 != 0 on the last dimension
- Left-padding on non-last dimensions now works
- Stick-aligned left-padding on last dimension now works
- Added 8 test cases covering all working left-padding scenarios

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
