### PR TITLE
clean up and simplify map_ir_splits_to_scheduler

### DIFF
--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -117,41 +117,29 @@ def map_ir_splits_to_scheduler(
     - Fewer scheduler dims (merging occurred): after sort-aligning, greedily consume
       consecutive IR dims whose sizes multiply to each scheduler dim's size.
     """
-    sched_syms = list(sched_it_space.keys())
-    sched_sizes = [int(v) for v in sched_it_space.values()]
-
-    # Sort IR dims by decreasing size (stable: preserves relative order for ties).
     sorted_ir = sorted(zip(ir_sizes, ir_splits), key=lambda p: p[0], reverse=True)
-    sorted_ir_sizes = [p[0] for p in sorted_ir]
-    sorted_ir_splits = [p[1] for p in sorted_ir]
+    sorted_sched = sorted(sched_it_space.items(), key=lambda p: int(p[1]), reverse=True)
 
-    # Sort scheduler dims by decreasing size (stable: same tie-breaking rule).
-    sorted_sched = sorted(
-        zip(sched_sizes, sched_syms), key=lambda p: p[0], reverse=True
-    )
-    sorted_sched_sizes = [p[0] for p in sorted_sched]
-    sorted_sched_syms = [p[1] for p in sorted_sched]
-
-    if len(sorted_ir_sizes) == len(sorted_sched_sizes):
-        # Common case: no merging. 1-to-1 positional match on sorted dims.
-        return {sym: split for sym, split in zip(sorted_sched_syms, sorted_ir_splits)}
+    if len(sorted_ir) == len(sorted_sched):
+        return {sym: split for (sym, _), (_, split) in zip(sorted_sched, sorted_ir)}
 
     # Dimension merging occurred.  After size-sorting, the scheduler's merged dims
     # correspond to consecutive runs of IR dims with matching size-products.
     result: dict[sympy.Symbol, int] = {}
     ir_idx = 0
-    for sym, sched_size in zip(sorted_sched_syms, sorted_sched_sizes):
+    for sym, sched_size in sorted_sched:
+        sched_size = int(sched_size)
         product_size = 1
         product_split = 1
-        while ir_idx < len(sorted_ir_sizes) and product_size < sched_size:
-            product_size *= sorted_ir_sizes[ir_idx]
-            product_split *= sorted_ir_splits[ir_idx]
+        while ir_idx < len(sorted_ir) and product_size < sched_size:
+            product_size *= sorted_ir[ir_idx][0]
+            product_split *= sorted_ir[ir_idx][1]
             ir_idx += 1
         assert product_size == sched_size, (
             f"Cannot map IR dims to scheduler dims: "
-            f"ir_sizes={ir_sizes}, sched_sizes={sched_sizes}"
+            f"ir_sizes={ir_sizes}, sched_sizes={[int(v) for v in sched_it_space.values()]}"
         )
         result[sym] = product_split
 
-    assert ir_idx == len(sorted_ir_sizes), "Not all IR dimensions consumed"
+    assert ir_idx == len(sorted_ir), "Not all IR dimensions consumed"
     return result


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Simplify map_ir_splits_to_scheduler sorting logic

  The changes:
  - sorted_sched is built directly from sched_it_space.items() — no separate size/sym lists
  - The 1-to-1 return unpacks tuples inline with destructuring
  - The merge loop indexes sorted_ir[ir_idx] directly
  - sched_size is cast to int once at the top of the loop body instead of pre-building a separate sizes list

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
