### PR TITLE
log LoopLevelIR before and after pre-scheduling passes

### DIFF
--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import inspect
+import io
+import logging
 from typing import Optional, Any, Callable, List
 from abc import abstractmethod
 
@@ -22,8 +24,10 @@ from torch._inductor.custom_graph_pass import (
     CustomGraphPass,
     get_hash_for_files,
 )
-from torch._inductor.ir import Operation
+from torch._inductor.ir import ComputedBuffer, Operation
 from torch._inductor.scheduler import BaseSchedulerNode
+
+from .logging_utils import get_inductor_logger
 
 from .padding import insert_padding
 from .temp_passes import (
@@ -38,6 +42,25 @@ from .core_division import core_division_planning
 from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
+
+
+logger = get_inductor_logger("passes")
+
+
+def _format_operations(operations: list[Operation]) -> str:
+    buf = io.StringIO()
+    for op in operations:
+        buf.write(f"{op.get_operation_name()}: {type(op).__name__}")
+        if isinstance(op, ComputedBuffer):
+            buf.write(f"\n  layout={op.layout}")
+            if allocation := getattr(op.layout, "allocation", None):
+                buf.write(f"\n  allocation={allocation}")
+            if splits := getattr(op, "op_it_space_splits", None):
+                buf.write(f"\n  op_it_space_splits={splits}")
+                buf.write(f"\n  op_it_space_sizes={op.op_it_space_sizes}")
+            buf.write(f"\n  {op.data}")
+        buf.write("\n\n")
+    return buf.getvalue()
 
 
 def _maybe_run_graph_pass(pass_fn, graph: torch.fx.graph.Graph) -> None:
@@ -184,11 +207,17 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         if not has_spyre_device:
             return
 
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("BEFORE PRE-SCHEDULING\n%s", _format_operations(operations))
+
         propagate_spyre_tensor_layouts(operations)
         insert_restickify(operations)
         core_division_planning(operations)
         if config.lx_planning:
             scratchpad_planning(operations)
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("AFTER PRE-SCHEDULING\n%s", _format_operations(operations))
 
     def uuid(self) -> Optional[Any]:
         files = [


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

log LoopLevelIR before and after pre-scheduling passes.

For example:

```
[INFO] [passes] BEFORE PRE-SCHEDULING
op0: ComputedBuffer
  layout=FixedLayout('spyre:0', torch.float16, size=[512, 1024], stride=[1024, 1])
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0, i1 = index
      tmp0 = ops.load(arg0_1, i1 + 1024 * i0)
      tmp1 = ops.load(arg1_1, i1)
      tmp2 = tmp0 + tmp1
      return tmp2
  ,
  ranges=[512, 1024],
  origin_node=add,
  origins=OrderedSet([add]),
  stack_traces = {,
    File "/home/dgrove/dt-inductor/local-examples/basic_math.py", line 6, in <lambda>,
      lambda a, b, c: a + b - c,,
  ,
  }
)

op1: ComputedBuffer
  layout=FixedLayout('spyre:0', torch.float16, size=[512, 1024], stride=[1024, 1])
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0, i1 = index
      tmp0 = ops.load(buf0, i1 + 1024 * i0)
      tmp1 = ops.load(arg2_1, i1 + 1024 * i0)
      tmp2 = tmp0 - tmp1
      return tmp2
  ,
  ranges=[512, 1024],
  origin_node=sub,
  origins=OrderedSet([sub]),
  stack_traces = {,
    File "/home/dgrove/dt-inductor/local-examples/basic_math.py", line 6, in <lambda>,
      lambda a, b, c: a + b - c,,
  ,
  }
)


[INFO] [passes] AFTER PRE-SCHEDULING
op0: ComputedBuffer
  layout=FixedTiledLayout('spyre:0', torch.float16, size=[512, 1024], stride=[1024, 1], device_layout=SpyreTensorLayout(device_size=[16, 512, 64], dim_map =[1, 0, 1], stride_map =[64, 1024, 1], device_dtype=DataFormats.SEN169_FP16))
  op_it_space_splits=[32, 1]
  op_it_space_sizes=[512, 1024]
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0, i1 = index
      tmp0 = ops.load(arg0_1, i1 + 1024 * i0)
      tmp1 = ops.load(arg1_1, i1)
      tmp2 = tmp0 + tmp1
      return tmp2
  ,
  ranges=[512, 1024],
  origin_node=add,
  origins=OrderedSet([add]),
  stack_traces = {,
    File "/home/dgrove/dt-inductor/local-examples/basic_math.py", line 6, in <lambda>,
      lambda a, b, c: a + b - c,,
  ,
  }
)

op1: ComputedBuffer
  layout=FixedTiledLayout('spyre:0', torch.float16, size=[512, 1024], stride=[1024, 1], device_layout=SpyreTensorLayout(device_size=[16, 512, 64], dim_map =[1, 0, 1], stride_map =[64, 1024, 1], device_dtype=DataFormats.SEN169_FP16))
  op_it_space_splits=[32, 1]
  op_it_space_sizes=[512, 1024]
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0, i1 = index
      tmp0 = ops.load(buf0, i1 + 1024 * i0)
      tmp1 = ops.load(arg2_1, i1 + 1024 * i0)
      tmp2 = tmp0 - tmp1
      return tmp2
  ,
  ranges=[512, 1024],
  origin_node=sub,
  origins=OrderedSet([sub]),
  stack_traces = {,
    File "/home/dgrove/dt-inductor/local-examples/basic_math.py", line 6, in <lambda>,
      lambda a, b, c: a + b - c,,
  ,
  }
)
```


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
