### PR TITLE
simulate deadcode_elimination in scratchpad_planning

### DIFF
--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -16,7 +16,13 @@ from typing import NamedTuple
 
 
 import sympy
-from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise, Reduction
+from torch._inductor.ir import (
+    ComputedBuffer,
+    FixedLayout,
+    Operation,
+    Pointwise,
+    Reduction,
+)
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.dependencies import MemoryDep, ReadWrites
 from torch._inductor.virtualized import V
@@ -89,6 +95,33 @@ def iteration_space_from_op(op: ComputedBuffer) -> dict[sympy.Symbol, sympy.Expr
         return next(iter(rw.reads)).ranges.copy()
     else:
         raise Unsupported("Unexpected node type")
+
+
+def live_operations(operations: list[Operation]) -> frozenset[str]:
+    """Return the set of operation names that are transitively needed by the
+    graph outputs.
+
+    The scheduler performs dead-code elimination after it is constructed, but
+    some passes run before the scheduler.  Computing only the live set here
+    avoids processing operations (e.g. the index output of argmax) that the
+    scheduler would later eliminate.
+
+    A buffer is live if it appears in V.graph.get_output_names() or if it is
+    read by a live operation.  We walk the operation list in reverse
+    (topological order) to propagate liveness backwards.
+    """
+    live_bufs: set[str] = set(V.graph.get_output_names())
+    live_ops: set[str] = set()
+
+    for op in reversed(operations):
+        rw = op.get_read_writes()
+        writes = {dep.name for dep in rw.writes}
+        if writes & live_bufs:
+            live_ops.add(op.get_operation_name())
+            for dep in rw.reads:
+                live_bufs.add(dep.name)
+
+    return frozenset(live_ops)
 
 
 def map_ir_splits_to_scheduler(

--- a/torch_spyre/_inductor/scratchpad.py
+++ b/torch_spyre/_inductor/scratchpad.py
@@ -22,6 +22,7 @@ from torch._inductor.ir import (
 )
 from torch._inductor.virtualized import V
 from . import config
+from .pass_utils import live_operations
 
 
 OPS_GOOD_FOR_LX_REUSE = {"input": {"sub", "div"}, "output": {"max", "sum"}}
@@ -222,6 +223,7 @@ def scratchpad_planning(
 
     alloc = ScratchPadAllocator()
 
+    live_ops = live_operations(operations)
     op_idx_to_dealloc_bufs = buf_end_of_life_analysis(operations)
 
     for idx, op in enumerate(operations):
@@ -231,5 +233,7 @@ def scratchpad_planning(
 
         if isinstance(op, ComputedBuffer):
             if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+                continue
+            if op.get_operation_name() not in live_ops:
                 continue
             consider_for_scratchpad(op, alloc, idx, is_last_op)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds a live_operations helper to pass_utils.py that performs a backwards liveness analysis on Operations. 
Uses this to avoid allocating unused tensors to the scratch pad.

This is needed because when we run pre-Scheduling, we don't get to benefit from its DCE pass. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
