### PR TITLE
Address redundant torch compile invocations

### DIFF
--- a/codegen/templates/base.jinja2
+++ b/codegen/templates/base.jinja2
@@ -15,7 +15,7 @@
 #}
 @torch.library.register_kernel("aten::{{ template_data.reg_name | replace('"', '')}}", ["spyre"])
 @compile_once({{ template_data.torch_prefix }}.{{ template_data.torch_func_name }}, dynamic=False)
-def spyre__{{ template_data.op_name }}({{ signature_in }}, compiled = None){% if returns|length > 0 %} -> {{ signature_out }}{% endif %}:
+def spyre__{{ template_data.op_name }}({{ signature_in }}, compiled=None){% if returns|length > 0 %} -> {{ signature_out }}{% endif %}:
     {% if scalar_arg_names|length > 0 %}
     # Convert scalar arguments to tensors on Spyre device
     {% for scalar_name in scalar_arg_names %}

--- a/codegen/templates/base.jinja2
+++ b/codegen/templates/base.jinja2
@@ -14,7 +14,8 @@
   limitations under the License.
 #}
 @torch.library.register_kernel("aten::{{ template_data.reg_name | replace('"', '')}}", ["spyre"])
-def spyre__{{ template_data.op_name }}({{ signature_in }}){% if returns|length > 0 %} -> {{ signature_out }}{% endif %}:
+@compile_once({{ template_data.torch_prefix }}.{{ template_data.torch_func_name }}, dynamic=False)
+def spyre__{{ template_data.op_name }}({{ signature_in }}, compiled = None){% if returns|length > 0 %} -> {{ signature_out }}{% endif %}:
     {% if scalar_arg_names|length > 0 %}
     # Convert scalar arguments to tensors on Spyre device
     {% for scalar_name in scalar_arg_names %}
@@ -24,10 +25,8 @@ def spyre__{{ template_data.op_name }}({{ signature_in }}){% if returns|length >
     {% endif %}
     {% if "out" in overload_name %}
     # Out variant
-    compiled_{{ operator_name }} = torch.compile({{ template_data.torch_prefix }}.{{ template_data.torch_func_name }}, dynamic=False)
-    return compiled_{{ operator_name }}({{ arg_names }}, out=out)
+    return compiled({{ arg_names }}, out=out)
     {% else %}
     # Standard variant
-    compiled_{{ operator_name }} = torch.compile({{ template_data.torch_prefix }}.{{ template_data.torch_func_name }}, dynamic=False)
-    return compiled_{{ operator_name }}({{ arg_names }})
+    return compiled({{ arg_names }})
     {% endif %}

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -18,6 +18,22 @@ import torch_spyre._C as _C
 import warnings
 
 
+# Decorator to keep track of compiled varient
+def compile_once(op, **compile_kwargs):
+    def decorator(fn):
+        compiled = None
+
+        def wrapper(*args, **kwargs):
+            nonlocal compiled
+            if compiled is None:
+                compiled = torch.compile(op, **compile_kwargs)
+            return fn(*args, compiled=compiled, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 def maybe_wrap_dim(dim: int, ndims: int) -> int:
     if dim < 0:
         return dim + ndims
@@ -25,17 +41,17 @@ def maybe_wrap_dim(dim: int, ndims: int) -> int:
 
 
 @torch.library.register_kernel("aten::mm", ["spyre"])  # type:ignore
-def spyre__mm(self: torch.Tensor, mat2: torch.Tensor) -> torch.Tensor:
-    compiled_mm = torch.compile(torch.mm, dynamic=False)
-    return compiled_mm(self, mat2)
+@compile_once(torch.mm, dynamic=False)
+def spyre__mm(self: torch.Tensor, mat2: torch.Tensor, compiled) -> torch.Tensor:
+    return compiled(self, mat2)
 
 
 @torch.library.register_kernel("aten::mm.out", ["spyre"])  # type:ignore
+@compile_once(torch.mm, dynamic=False)
 def spyre__mm_out(
-    self: torch.Tensor, mat2: torch.Tensor, out: torch.Tensor
+    self: torch.Tensor, mat2: torch.Tensor, out: torch.Tensor, compiled
 ) -> torch.Tensor:
-    compiled_mm = torch.compile(torch.mm, dynamic=False)
-    return compiled_mm(self, mat2, out=out)
+    return compiled(self, mat2, out=out)
 
 
 @torch.library.register_kernel("aten::fill_.Scalar", ["spyre"])  # type:ignore
@@ -72,17 +88,21 @@ def spyre__zero_(self: torch.Tensor) -> torch.Tensor:
 
 
 @torch.library.register_kernel("aten::silu.out", ["spyre"])  # type:ignore
-def spyre__silu_out(self: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
+@compile_once(torch.ops.aten.silu.out, dynamic=False)
+def spyre__silu_out(
+    self: torch.Tensor, out: torch.Tensor = None, compiled=None
+) -> torch.Tensor:
     # Out variant
-    compiled_silu = torch.compile(torch.ops.aten.silu.out, dynamic=False)
-    return compiled_silu(self, out=out)
+    return compiled(self, out=out)
 
 
 @torch.library.register_kernel("aten::mish.out", ["spyre"])  # type:ignore
-def spyre__mish_out(self: torch.Tensor, out: torch.Tensor = None) -> torch.Tensor:
+@compile_once(torch.ops.aten.mish.out, dynamic=False)
+def spyre__mish_out(
+    self: torch.Tensor, out: torch.Tensor = None, compiled=None
+) -> torch.Tensor:
     # Out variant
-    compiled_mish = torch.compile(torch.ops.aten.mish.out, dynamic=False)
-    return compiled_mish(self, out=out)
+    return compiled(self, out=out)
 
 
 @torch.library.register_kernel("aten::uniform_", "spyre")  # type:ignore

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -16,13 +16,15 @@ import torch
 import torch_spyre.ops.fallbacks  # noqa: F401
 import torch_spyre._C as _C
 import warnings
+import functools
 
 
-# Decorator to keep track of compiled varient
+# Decorator to keep track of compiled variant
 def compile_once(op, **compile_kwargs):
     def decorator(fn):
         compiled = None
 
+        @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             nonlocal compiled
             if compiled is None:


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
<!--
Please describe your changes
-->
In eager mode execution torch.compile was being called redundantly instead of using cache due to being nested within functions.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
Fixes #788 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
As the issue describes, we will see reduced overhead from torch.compile in eager mode.

#### Additional note:
