### PR TITLE
[TESTING] Added torch.half as a valid dtype recognition in the framework

### DIFF
--- a/tests/spyre_test_config_models.py
+++ b/tests/spyre_test_config_models.py
@@ -42,6 +42,7 @@ _VALID_DTYPE_STRINGS = {
     "complex64",
     "complex128",
     "bool",
+    "half",
 }
 
 

--- a/tests/spyre_test_constants.py
+++ b/tests/spyre_test_constants.py
@@ -64,6 +64,7 @@ DTYPE_STR_MAP: Dict[str, torch.dtype] = {
     "complex64": torch.complex64,
     "complex128": torch.complex128,
     "bool": torch.bool,
+    "half": torch.half,
 }
 
 DTYPE_NAMES_ORDERED = sorted(DTYPE_STR_MAP.keys(), key=len, reverse=True)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- cleanup

#### What this PR does:

Adds `torch.half` as a valid dtype entry in the framework 

#### Does this PR introduce a user-facing change?
No