### PR TITLE
Dead code elimination pass for pre-scheduling LoopLevelIR

### DIFF
--- a/torch_spyre/_inductor/deadcode_elimination.py
+++ b/torch_spyre/_inductor/deadcode_elimination.py
@@ -1,0 +1,95 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torch._inductor.ir import (
+    ComputedBuffer,
+    FallbackKernel,
+    MutationLayoutSHOULDREMOVE,
+    Operation,
+)
+from torch._inductor.virtualized import V
+
+
+def live_operations(operations: list[Operation]) -> frozenset[str]:
+    """Return the set of operation names that are transitively needed by the
+    graph outputs.
+
+    A buffer is live if it appears in V.graph.get_output_names() or if it is
+    read by a live operation.  We walk the operation list in reverse
+    (topological order) to propagate liveness backwards.
+    """
+    live_bufs: set[str] = set(V.graph.get_output_names())
+    live_ops: set[str] = set()
+
+    for op in reversed(operations):
+        # Ops with side effects (mutations) are always live; their reads are
+        # also live because they feed the mutation.
+        if _has_side_effects(op):
+            live_ops.add(op.get_operation_name())
+            rw = op.get_read_writes()
+            for dep in rw.reads:
+                live_bufs.add(dep.name)
+            continue
+        rw = op.get_read_writes()
+        writes = {dep.name for dep in rw.writes}
+        if writes & live_bufs:
+            live_ops.add(op.get_operation_name())
+            for dep in rw.reads:
+                live_bufs.add(dep.name)
+
+    return frozenset(live_ops)
+
+
+def _has_side_effects(op: Operation) -> bool:
+    """Return True if op must not be eliminated regardless of whether its
+    outputs are used.
+
+    Mutation ops always have side effects.  FallbackKernel delegates to
+    is_impure on the underlying op overload.  All other op types are pure.
+    """
+    if isinstance(op, ComputedBuffer) and isinstance(
+        op.layout, MutationLayoutSHOULDREMOVE
+    ):
+        return True
+    if isinstance(op, FallbackKernel):
+        return op.has_side_effects()
+    return False
+
+
+def deadcode_elimination(operations: list[Operation]) -> None:
+    """Remove dead operations from the list in-place, mirroring the
+    scheduler's dead_node_elimination but running at pre-scheduler time.
+
+    An operation is dead if none of its output buffers are transitively
+    needed by the graph outputs and it has no side effects.  Dead output
+    buffer names are added to V.graph.removed_buffers so that downstream
+    codegen skips them.
+
+    Operations are expected to be in topological order.  The list is
+    modified in-place; the relative order of surviving operations is
+    preserved.
+    """
+    live_ops = live_operations(operations)
+
+    dead: list[Operation] = []
+    for op in operations:
+        if _has_side_effects(op) or op.get_operation_name() in live_ops:
+            continue
+        dead.append(op)
+
+    for op in dead:
+        rw = op.get_read_writes()
+        for dep in rw.writes:
+            V.graph.removed_buffers.add(dep.name)
+        operations.remove(op)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -16,7 +16,12 @@ from typing import NamedTuple
 
 
 import sympy
-from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise, Reduction
+from torch._inductor.ir import (
+    ComputedBuffer,
+    FixedLayout,
+    Pointwise,
+    Reduction,
+)
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.dependencies import MemoryDep, ReadWrites
 from torch._inductor.virtualized import V

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -42,6 +42,7 @@ from .core_division import core_division_planning
 from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
+from .deadcode_elimination import deadcode_elimination
 
 
 logger = get_inductor_logger("passes")
@@ -210,6 +211,7 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         if logger.isEnabledFor(logging.INFO):
             logger.info("BEFORE PRE-SCHEDULING\n%s", _format_operations(operations))
 
+        deadcode_elimination(operations)
         propagate_spyre_tensor_layouts(operations)
         insert_restickify(operations)
         core_division_planning(operations)
@@ -221,6 +223,7 @@ class CustomPreSchedulingPasses(CustomGraphPass):
 
     def uuid(self) -> Optional[Any]:
         files = [
+            inspect.getfile(deadcode_elimination),
             inspect.getfile(propagate_spyre_tensor_layouts),
             inspect.getfile(insert_restickify),
             inspect.getfile(core_division_planning),


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds a dead code elimination pass to run on the looplevel IR. 
We need this because we are running our spyre optimization passes before Scheduling, which is where 
upstream Inductor does its DCE for loop level IR.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
