### PR TITLE
bfloat16 → dl16 mapping to enable tensor movement on Spyre device

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -274,21 +274,33 @@ class TestSpyre(TestCase):
 
     def test_allocation_and_copy_dtypes(self):
         # allocation and device to host cases
-        for dtype in [torch.float16, torch.float32, torch.bool, torch.int8]:
+        for dtype in [
+            torch.float16,
+            torch.float32,
+            torch.bool,
+            torch.int8,
+            torch.bfloat16,
+        ]:
             x = torch.empty(64, dtype=dtype, device="spyre")
             x.cpu()
 
-        for dtype in [torch.bfloat16, torch.float64]:
+        for dtype in [torch.float64]:
             with self.assertRaises(RuntimeError):
                 x = torch.empty(64, dtype=dtype, device="spyre")
                 x.cpu()
 
         # allocation and host to device cases
-        for dtype in [torch.float16, torch.float32, torch.bool, torch.int8]:
+        for dtype in [
+            torch.float16,
+            torch.float32,
+            torch.bool,
+            torch.int8,
+            torch.bfloat16,
+        ]:
             x = torch.empty(64, dtype=dtype)
             x.to("spyre")
 
-        for dtype in [torch.bfloat16, torch.float64]:
+        for dtype in [torch.float64]:
             with self.assertRaises(RuntimeError):
                 x = torch.empty(64, dtype=dtype)
                 x.to("spyre")

--- a/torch_spyre/csrc/types_mapping.h
+++ b/torch_spyre/csrc/types_mapping.h
@@ -70,7 +70,7 @@ inline std::pair<DataFormats, DataFormats> stringToDTDataFormatPair(
           {"int32", {DataFormats::IEEE_INT32, DataFormats::IEEE_INT32}},
           {"int64", {DataFormats::IEEE_INT64, DataFormats::IEEE_INT32}},
           {"bool", {DataFormats::BOOL, DataFormats::SEN169_FP16}},
-          {"bfloat16", {DataFormats::BFLOAT16, DataFormats::BFLOAT16}},
+          {"bfloat16", {DataFormats::BFLOAT16, DataFormats::SEN169_FP16}},
           {"quint8", {DataFormats::SENUINT32, DataFormats::SENUINT32}},
           {"qint8", {DataFormats::SENINT8, DataFormats::SENINT8}},
           {"quint4x2", {DataFormats::SENUINT2, DataFormats::SENUINT2}},
@@ -163,7 +163,7 @@ stringToSenDatatypePair(const std::string& type_name) {
           // bfloat
           {"bfloat16",
            {sendnn::sen_datatype_enum::bfloat16,
-            sendnn::sen_datatype_enum::bfloat16}},
+            sendnn::sen_datatype_enum::sen_fp16}},
           {"bfloat16_compute",
            {sendnn::sen_datatype_enum::bfloat16,
             sendnn::sen_datatype_enum::float32}},


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR introduces support for mapping bfloat16 (bf16) tensors to dl16 (SEN FP16) within the Spyre backend, enabling seamless tensor movement to and from the Spyre device.

``(dt-inductor) [rishirajg@rishirajg-spyre-dev-pf model-enablement]$ python test-bf16.py 
original: tensor([1.0000, 2.0000, 3.1406, 4.0000], dtype=torch.bfloat16)
on spyre: tensor([1.0000, 2.0000, 3.1406, 4.0000], dtype=torch.bfloat16, device='spyre:0')
back on cpu: tensor([1.0000, 2.0000, 3.1406, 4.0000], dtype=torch.bfloat16)``

#### Which issue(s) this PR is related to:
#401 

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

cc : @pradghos @ani300 
