### PR TITLE
Adding support for topk operator for dim 0 and k less than 5

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -480,6 +480,18 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             },
         },
+        ("test_topk", "test_topk_cpu"): {
+            "param_sets": {
+                "2d_k4_dim0": (unique_randn_along_dim((64, 256), dim=0), 4, 0),
+                "2d_k4_dim_minusone": (
+                    unique_randn_along_dim((64, 256), dim=-1),
+                    4,
+                    -1,
+                ),
+                # "2d_k4_dim0_lessthanstick": (unique_randn_along_dim((8, 32), dim=0), 4, 0),
+                # "2d_k4_dim_minusone_lessthanstick": (unique_randn_along_dim((1, 32), dim=-1), 4, -1),
+            },
+        },
         ("test_sum_keepdim0", "test_reduce_keepdim0_cpu"): {
             "ops_dict": {
                 "sum": torch.sum,
@@ -3092,6 +3104,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             )
         else:
             compare_with_cpu(lambda x: op(x, dim=dim, keepdim=True), x, run_eager=False)
+
+    def test_topk_cpu(self, x, k: int, dim: int):
+        # torch.topk returns (values, indices); only compare values since
+        # index tie-breaking can differ between backends.
+        # aten::topk is not registered for Spyre eager dispatch.
+        compare_with_cpu(lambda x: torch.topk(x, k, dim=dim)[0], x, run_eager=False)
 
     def test_max_sub_broadcast(self, dim: int, x):
         def fn(x):

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -28,6 +28,7 @@ from torch_spyre._inductor.constants import (
     MATMUL_DIM_LABELS,
     MATMUL_LAYOUT_LABELS,
     SEGMENT_OFFSETS,
+    TOPK_OPS,
 )
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre._inductor.op_spec import OpSpec
@@ -240,6 +241,10 @@ def _is_matmul(op: str) -> bool:
     return op in ("matmul", "batchmatmul")
 
 
+def _is_topk(op: str) -> bool:
+    return op in TOPK_OPS
+
+
 def _get_op_dim_labels(ndim: int, is_matmul: bool) -> list[str]:
     if is_matmul:
         return MATMUL_DIM_LABELS[5 - ndim :]
@@ -270,7 +275,7 @@ def _create_sdsc_tensors(
         max_dim_sizes: dict = {}
         reduced_dims: list = []
         use_adjusted_size = op_spec.op == "overwrite" and not arg.is_input
-        if use_op_dims and dim_order != dims:
+        if use_op_dims and dim_order != dims and not _is_topk(op_spec.op):
             reduced_dims = [d for d in op_dim_order if d not in dim_order]
             dim_order = dim_order + reduced_dims
 
@@ -342,7 +347,12 @@ def _create_sdsc_tensors(
 def _get_op_func(op: str, is_reduction: bool, output_scales: dict) -> str:
     if op == "to_dtype" or op == "overwrite":
         return IDENTITY_OP
-    if is_reduction and not _is_matmul(op) and -2 not in output_scales.values():
+    if (
+        is_reduction
+        and not _is_matmul(op)
+        and not _is_topk(op)
+        and -2 not in output_scales.values()
+    ):
         return op + "nonstick"
     return op
 
@@ -440,6 +450,9 @@ def parse_op_spec(op_spec: OpSpec) -> SDSCSpec:
         constants["samv-maskvalue"] = _get_mask_value(op_spec.op)
 
     num_inputs = len(args[:-1]) if is_matmul or not op_spec.is_reduction else len(args)
+
+    if _is_topk(op_spec.op):
+        num_inputs = 1  # topk has exactly 1 input tensor and 1 output tensor
 
     return SDSCSpec(
         opfunc=_get_op_func(op_spec.op, op_spec.is_reduction, args[-1].scales),

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -46,7 +46,11 @@ SPYRE_FP32_OPS = [
     "layernormnorm",
     "identity",
     "overwrite",
+    "topkvalue",
+    "topkindex",
 ]
+
+TOPK_OPS = {"topkvalue", "topkindex"}
 
 LAYOUT_LABELS = ["OUTPUT", "KERNEL", "INPUT", "KERNEL_IDX"]
 MATMUL_LAYOUT_LABELS = ["INPUT", "KERNEL", "OUTPUT", "KERNEL_IDX"]

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -33,7 +33,7 @@ from torch._inductor.ir import (
 from torch._inductor.dependencies import MemoryDep
 
 from .errors import Unsupported
-from .constants import BATCH_MATMUL_OP
+from .constants import BATCH_MATMUL_OP, TOPK_OPS
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
@@ -572,6 +572,11 @@ def divide_pointwise_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores)
 def divide_reduction_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores):
     red: Reduction = op.data
     is_matmul = red.reduction_type == BATCH_MATMUL_OP
+
+    # Currently we support Topk for k<=4, which can be handled efficiently on single core
+    # TODO: Modification will be required to enable Topk for k>4
+    if red.reduction_type in TOPK_OPS:
+        return
 
     it_space = iteration_space_from_op(op)
     input_tds, output_td = collect_tensor_deps(op, args)

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -125,6 +125,40 @@ def _(
     return x.new_empty(x.size())
 
 
+@torch.library.custom_op("spyre::topkvalue", mutates_args=(), device_types="spyre")
+def topkvalue(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
+    if len(x.size()) != 2:
+        raise Unsupported("topk only implemented for 2-D tensors")
+    pass
+
+
+@topkvalue.register_fake
+def _(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
+    if len(x.size()) != 2:
+        raise Unsupported("topk only implemented for 2-D tensors")
+    norm_dim = dim % len(x.size())
+    out_size = list(x.size())
+    out_size[norm_dim] = k
+    return x.new_empty(out_size)
+
+
+@torch.library.custom_op("spyre::topkindex", mutates_args=(), device_types="spyre")
+def topkindex(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
+    if len(x.size()) != 2:
+        raise Unsupported("topk only implemented for 2-D tensors")
+    pass
+
+
+@topkindex.register_fake
+def _(x: torch.Tensor, k: int, dim: int) -> torch.Tensor:
+    if len(x.size()) != 2:
+        raise Unsupported("topk only implemented for 2-D tensors")
+    norm_dim = dim % len(x.size())
+    out_size = list(x.size())
+    out_size[norm_dim] = k
+    return x.new_empty(out_size, dtype=torch.int64)
+
+
 @torch.library.custom_op("spyre::gelu", mutates_args=(), device_types="spyre")
 def gelu(
     input: torch.Tensor,

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -460,6 +460,19 @@ def spyre_layer_norm(
     return torch.ops.spyre.layernormnorm(input, mean, norm_mean, weight, bias)
 
 
+@register_spyre_decomposition([torch.ops.aten.topk])
+def spyre_topk(
+    input: torch.Tensor,
+    k: int,
+    dim: Optional[int] = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k > 4:
+        raise Unsupported("Topk is not supported for this config")
+    return torch.ops.spyre.topkvalue(input, k, dim), torch.ops.spyre.topkindex(
+        input, k, dim
+    )
+
+
 @register_spyre_decomposition([torch.ops.aten.gelu.default])
 def spyre_gelu(
     input: torch.Tensor,

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -435,6 +435,98 @@ def lower_layernormscale(x, eps):
     return pw
 
 
+@register_spyre_lowering(torch.ops.spyre.topkvalue)
+def lower_topkvalue(x, k, dim):
+    x_size = x.get_size()
+    ndim = len(x_size)
+    # Normalize dim to a positive index.
+    norm_dim = dim % ndim
+    loader = x.make_loader()
+
+    if norm_dim == ndim - 1:
+        # dim=-1 (or last dim): input shape [mb, n_in], reduce along n_in.
+        # ranges=[mb, k]: index=[mb_idx, k_idx], rindex=[n_in_idx].
+        mb = x_size[0]
+        n_in = x_size[1]
+
+        def inner_fn(index, rindex):
+            return loader([index[0], rindex[0]])
+
+        ranges = [mb, k]
+        reduction_ranges = [n_in]
+    else:
+        # dim=0: input shape [n_in, mb], reduce along n_in (dim 0).
+        # ranges=[k, mb]: index=[k_idx, mb_idx], rindex=[n_in_idx].
+        mb = x_size[1]
+
+        def inner_fn(index, rindex):
+            # index = [k_idx, mb_idx], rindex = [n_in_idx]
+            # Load from input at (n_in_idx, mb_idx); k_idx is the output row.
+            return loader([rindex[0], index[1]])
+
+        ranges = [k, mb]
+        reduction_ranges = x_size[:1]
+
+    result = Reduction.create(
+        reduction_type="topkvalue",
+        input_node=x,
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=ranges,
+        reduction_ranges=reduction_ranges,
+    )
+    result.realize()
+    return result
+
+
+@register_spyre_lowering(torch.ops.spyre.topkindex)
+def lower_topkindex(x, k, dim):
+    x_size = x.get_size()
+    ndim = len(x_size)
+    # Normalize dim to a positive index.
+    norm_dim = dim % ndim
+    loader = x.make_loader()
+
+    if norm_dim == ndim - 1:
+        # dim=-1 (or last dim): input shape [mb, n_in], reduce along n_in.
+        # ranges=[mb, k]: index=[mb_idx, k_idx], rindex=[n_in_idx].
+        mb = x_size[0]
+        n_in = x_size[1]
+
+        def inner_fn(index, rindex):
+            return loader([index[0], rindex[0]])
+
+        ranges = [mb, k]
+        reduction_ranges = [n_in]
+    else:
+        # dim=0: input shape [n_in, mb], reduce along n_in (dim 0).
+        # ranges=[k, mb]: index=[k_idx, mb_idx], rindex=[n_in_idx].
+        mb = x_size[1]
+
+        def inner_fn(index, rindex):
+            # index = [k_idx, mb_idx], rindex = [n_in_idx]
+            # Load from input at (n_in_idx, mb_idx); k_idx is the output row.
+            return loader([rindex[0], index[1]])
+
+        ranges = [k, mb]
+        reduction_ranges = x_size[:1]
+
+    result = Reduction.create(
+        reduction_type="topkindex",
+        input_node=x,
+        device=x.get_device(),
+        dst_dtype=x.get_dtype(),
+        src_dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=ranges,
+        reduction_ranges=reduction_ranges,
+    )
+    result.realize()
+    return result
+
+
 @register_spyre_lowering(torch.ops.aten.mean.dim)
 def lower_mean(x, axis=None, keepdim=False, *, dtype=None):
     kwargs = lowering._make_reduction_inner(

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -43,7 +43,7 @@ from torch_spyre._C import (
     get_elem_in_stick,
 )
 from .errors import Unsupported
-from .constants import BATCH_MATMUL_OP
+from .constants import BATCH_MATMUL_OP, TOPK_OPS
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
@@ -512,6 +512,48 @@ def reduction_layout(
         c_stride = [concretize_expr(s) for s in output.stride]
         stl = SpyreTensorLayout(c_size, c_stride, output.dtype, dim_order)
 
+        return FixedTiledLayout(
+            output.device, output.dtype, output.size, output.stride, stl
+        )
+    elif data.reduction_type in TOPK_OPS:
+        x = args[0]
+        x_coords = host_coordinates(x.layout, x.dep)
+        x_dev_coords = device_coordinates(x.layout, x.dep)
+        x_stick_expr = x_dev_coords[-1]
+        out_coords = host_coordinates(output, output_dep)
+        reduction_coord = next(
+            c
+            for c in x_coords
+            if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is None
+        )
+        if matching_dim(x_coords, x_stick_expr) == matching_dim(
+            x_coords, reduction_coord
+        ):
+            # dim=-1: input shape [mb, n_in]; topk hardware requires stick on mb (dim 0),
+            # i.e. the reduction dimension (n_in, last dim) must NOT be the stick.
+            mb_coord = x_coords[0]
+            logger.warning(
+                "Injecting restickify on topk input to move stick from "
+                "reduction dim (n_in) to mb dim"
+            )
+            schedule_restickify(
+                op, x, mb_coord, x_coords, x_dev_coords, restickify_plan
+            )
+            out_stick_dim = matching_dim(out_coords, mb_coord)
+        else:
+            # dim=0: input shape [n_in, mb]; stick is already on mb (dim 1) by
+            # default row-major layout, so no restickify is needed.
+            mb_coord = x_coords[1]
+            out_stick_dim = matching_dim(out_coords, mb_coord)
+        if out_stick_dim is None:
+            out_dim_order = list(range(len(output.size))) + [-1]
+        else:
+            out_dim_order = [d for d in range(len(output.size)) if d != out_stick_dim]
+            out_dim_order = out_dim_order + [out_stick_dim]
+        # Concretize for C++ SpyreTensorLayout constructor.
+        c_size = [concretize_expr(s) for s in output.size]
+        c_stride = [concretize_expr(s) for s in output.stride]
+        stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
         return FixedTiledLayout(
             output.device, output.dtype, output.size, output.stride, stl
         )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR adds comprehensive support for torch.topk operations on Spyre.
<!--
Please describe your changes
-->
1. torch.topk Decomposition (torch_spyre/_inductor/)
decompositions.py: Added spyre_topk to decompose torch.top(input, k, dim):
lowering.py/ir.py : added new ir_dataclass SpyrePointwise that is similar Pointwise but we can pass input dimension
core_division.py: Not to split across cores for topk op
2. torch.topk genereate sdsc (torch_spyre/_inductor/codegen/superdsc.py)
Added _parse_topk_op_spec function to generate sdsc for topk, because format of sdsc of topk is different from that of other pointwise op.
3. Enhanced Test Coverage (tests/inductor/test_inductor_ops.py)
Added comprehensive test cases for torch.topk

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/452
<!--

Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:
https://gist.github.com/Sujit14121993/8959e7af130098784ae0b2fdc0d19b8b
#### Does this PR introduce a user-facing change?

#### Additional note:
