### PR TITLE
POC: Support multiple ops in a single loop body

### DIFF
--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -442,6 +442,29 @@ class SpyreKernel(Kernel[CSEVariable]):
             for input in value.arguments:
                 if isinstance(input, TensorAccess):
                     args.append(self.create_tensor_arg(True, input.name, input))
+                elif isinstance(input, PointwiseOp):
+                    # Handle nested PointwiseOp here: This argument is an output of another preceding op in the same loop body
+
+                    # Create and allocate an intermediate buffer to store the preceding op's output
+                    tmp_buf = torch._inductor.ir.ComputedBuffer(
+                        layout=input.arguments[-1].layout,
+                        name=None,
+                        data=None,
+                    )
+                    tmp_buf_name = V.graph.register_buffer(tmp_buf, set_name=True)
+                    V.graph.wrapper_code.codegen_allocation(tmp_buf)
+
+                    # Recursively call `store` to execute the preceding op and store its output into the intermediate buffer
+                    self.store(tmp_buf_name, index, input, mode)
+
+                    # Use the intermediate buffer as an input argument to the current op
+                    args.append(
+                        self.create_tensor_arg(
+                            True,
+                            tmp_buf_name,
+                            TensorAccess(tmp_buf_name, index, layout),
+                        )
+                    )
                 else:
                     raise Unsupported(f"unexpected argument {input} to {value.op}")
             args.append(self.create_tensor_arg(False, real_dst_name, dst))


### PR DESCRIPTION
This PR is a proof‑of‑concept to demonstrate the idea discussed in #1639. It is not intended to be merged.

The goal of this PR is to show that we can successfully compile code paths where a single loop body contains multiple ops, which is a pattern that can arise during lowering (for example, due to implicit type promotion).

#### Example
Consider the following loop body, which contains multiple ops (load, to_dtype, and store) within a single loop:

For loop body like this:
```python
class op1_loop_body:
    var_ranges = {p0: 64}
    index0 = p0
    def body(self, ops):
        get_index = self.get_index('index0')
        load = ops.load('buf0', get_index)
        to_dtype = ops.to_dtype(load, torch.float16, src_dtype = torch.bool)
        get_index_1 = self.get_index('index0')
        store = ops.store('buf1', get_index_1, to_dtype, None)
        return store
```

With the changes in this PR, this loop body can be compiled into code like the following:

```python
    def call(self, args):
        arg0_1, arg1_1 = args
        args.clear()
        assert_size_stride(arg0_1, (64, ), (1, ))
        assert_size_stride(arg1_1, (64, ), (1, ))
        buf2 = spyre_empty_with_layout((64, ), (1, ), torch.bool, SpyreTensorLayout(device_size=[1, 64], dim_map =[0, 0], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16))
        buf0 = spyre_empty_with_layout((64, ), (1, ), torch.bool, SpyreTensorLayout(device_size=[1, 64], dim_map =[0, 0], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16))
        buf1 = spyre_empty_with_layout((64, ), (1, ), torch.float16, SpyreTensorLayout(device_size=[1, 64], dim_map =[0, 0], stride_map =[64, 1], device_dtype=DataFormats.SEN169_FP16))
        # [Provenance debug handles] sdsc_fused__to_copy_le_0:1
        sdsc_fused__to_copy_le_0.run(arg0_1, arg1_1, buf0, buf2, buf1)
        del arg0_1
        del arg1_1
        return (buf1, )
```

This PR is intended to validate the feasibility of handling multi‑op loop bodies and to inform the design discussion in
- #1639
