### PR TITLE
print op_it_space_splits in more readable format in IR dump

### DIFF
--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -39,6 +39,7 @@ from . import config
 from .stickify import propagate_mutation_layouts, propagate_spyre_tensor_layouts
 from .insert_restickify import insert_restickify
 from .core_division import core_division_planning
+from .pass_utils import apply_splits_from_index_coeff, iteration_space_from_op
 from .scratchpad import scratchpad_planning
 from .fusion import spyre_fuse_nodes
 from .constants import DEVICE_NAME
@@ -57,7 +58,14 @@ def _format_operations(operations: list[Operation]) -> str:
             if allocation := getattr(op.layout, "allocation", None):
                 buf.write(f"\n  allocation={allocation}")
             if splits := getattr(op, "op_it_space_splits", None):
-                buf.write(f"\n  op_it_space_splits={splits}")
+                rw = op.get_read_writes()
+                write_index = next(iter(rw.writes)).index
+                read_index = next((d.index for d in rw.reads), write_index)
+                it_space = iteration_space_from_op(op)
+                readable_splits = apply_splits_from_index_coeff(
+                    splits, write_index, read_index, it_space
+                )
+                buf.write(f"\n  op_it_space_splits={readable_splits}")
             buf.write(f"\n  {op.data}")
         buf.write("\n\n")
     return buf.getvalue()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Improve the IR dump of op_it_space_splits to use iteration variables instead of the encoded format.

```
op1: ComputedBuffer
  layout=FixedTiledLayout('spyre:0', torch.float16, size=[512, 1024], stride=[1024, 1], device_layout=SpyreTensorLayout(device_size=[16, 512, 64], dim_map =[1, 0, 1], stride_map =[64, 1024, 1], device_dtype=DataFormats.SEN169_FP16))
  op_it_space_splits={d0: 32, d1: 1}
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0, i1 = index
      tmp0 = ops.load(buf0, i1 + 1024 * i0)
      tmp1 = ops.load(arg2_1, i1 + 1024 * i0)
      tmp2 = tmp0 - tmp1
      return tmp2
  ,
  ranges=[512, 1024],
  origin_node=sub,
  origins=OrderedSet([sub]),
  stack_traces = {,
    File "/home/dgrove/dt-inductor/local-examples/basic_math.py", line 6, in <lambda>,
      lambda a, b, c: a + b - c,,
  ,
  }
)
```

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
