### PR TITLE
Disable buffer reuse with 

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -139,7 +139,6 @@ def test_4arg_at_x_y_bt(tensors_multiarg):
     _compare(lambda a, b, x, y: a.t() + x + y + b.t(), A, B, X, Y)
 
 
-
 def test_4arg_a_bt_c_d_square():
     s = 128
     A = torch.randn((s, s), dtype=torch.float16)

--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -139,6 +139,16 @@ def test_4arg_at_x_y_bt(tensors_multiarg):
     _compare(lambda a, b, x, y: a.t() + x + y + b.t(), A, B, X, Y)
 
 
+
+def test_4arg_a_bt_c_d_square():
+    s = 128
+    A = torch.randn((s, s), dtype=torch.float16)
+    B = torch.randn((s, s), dtype=torch.float16)
+    C = torch.randn((s, s), dtype=torch.float16)
+    D = torch.randn((s, s), dtype=torch.float16)
+    _compare(lambda a, b, c, d: a + b.t() + c + d, A, B, C, D)
+
+
 # 3D tests
 SIZES_3D = [(2, 256, 128), (4, 128, 64)]
 

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -95,6 +95,7 @@ def enable_spyre_context(
         "unroll_reductions_threshold": 1,
         # Disable fusing of mm + permute/transpose for now.
         "permute_fusion": False,
+        "disable_buffer_reuse": True,  # For now, as buffer reuse does not consider stride_map.
     }
 
     from torch._inductor.ir import Loops

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -95,7 +95,7 @@ def enable_spyre_context(
         "unroll_reductions_threshold": 1,
         # Disable fusing of mm + permute/transpose for now.
         "permute_fusion": False,
-        "disable_buffer_reuse": True,  # For now, as buffer reuse does not consider stride_map.
+        "allow_buffer_reuse": False,  # For now, as buffer reuse does not consider stride_map.
     }
 
     from torch._inductor.ir import Loops


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Inductor does not consider the stride_map when making decisions whether to reuse buffers, so it is broken.
This PR disables buffer reuse for now.  No need to fix because @avery-blanchard has a pr coming soon that replaces all of this.



#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

For example, without disabling buffer reuse:  `buf2` below has `stride_map =[64, 128, 1]` and then gets reused to store `buf3` which has `stride_map =[8192, 1, 128]`, resulting in the tensor being pulled off the device incorrectly

````
        buf3 = spyre_empty_with_layout((128, 128), (128, 1), torch.float16, SpyreTensorLayout(device_size=[2, 128, 64], dim_map =[0, 1, 0], stride_map =[8192, 1, 128], device_dtype=DataFormats.SEN169_FP16))
        buf0 = spyre_empty_with_layout((128, 128), (128, 1), torch.float16, SpyreTensorLayout(device_size=[2, 128, 64], dim_map =[1, 0, 1], stride_map =[64, 128, 1], device_dtype=DataFormats.SEN169_FP16))
        buf1 = spyre_empty_with_layout((128, 128), (128, 1), torch.float16, SpyreTensorLayout(device_size=[2, 128, 64], dim_map =[1, 0, 1], stride_map =[64, 128, 1], device_dtype=DataFormats.SEN169_FP16))
        # [Provenance debug handles] sdsc_fused_add_t_0:1
        sdsc_fused_add_t_0.run(arg0_1, arg1_1, arg2_1, buf3, buf0, buf1)
        del arg0_1
        del arg1_1
        del arg2_1
        del buf0
        buf2 = buf3; del buf3  # reuse
        # [Provenance debug handles] sdsc_fused_add_1:2
        sdsc_fused_add_1.run(buf1, arg3_1, buf2)
        del arg3_1
        return (buf2, )
````