### PR TITLE
Migrate Spyre DMA implementation to be Graph-free and use FlexAllocator and CompositeAddress

### DIFF
--- a/torch_spyre/_C.pyi
+++ b/torch_spyre/_C.pyi
@@ -19,8 +19,7 @@ __all__: list[str] = [
     "as_strided_with_layout",
     "convert_artifacts",
     "empty_with_layout",
-    "copy_device_to_host",
-    "copy_host_to_device",
+    "copy_tensor",
     "encode_constant",
     "free_runtime",
     "get_device_dtype",
@@ -241,23 +240,14 @@ def as_strided_with_layout(
     arg4: SpyreTensorLayout,
 ) -> torch.Tensor: ...
 def convert_artifacts(arg0: str) -> None: ...
-def copy_host_to_device(self: torch.Tensor, dst: torch.Tensor) -> None:
+def copy_tensor(
+    self: torch.Tensor, dst: torch.Tensor, non_blocking: bool = False
+) -> None:
     """
-    Copy tensor from host to device using DMA.
+    Copy tensor
 
     Args:
-        self: Source tensor on CPU
-        dst: Destination tensor on Spyre device
-    """
-    ...
-
-def copy_device_to_host(self: torch.Tensor, dst: torch.Tensor) -> None:
-    """
-    Copy tensor from device to host using DMA.
-
-    Args:
-        self: Source tensor on Spyre device
-        dst: Destination tensor on CPU
+        self or dst: one of that must be on spyre device
     """
     ...
 

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -20,7 +20,7 @@ from torch_spyre._C import (
     get_spyre_tensor_layout,
     empty_with_layout,
     spyre_empty_with_layout,
-    copy_host_to_device,
+    copy_tensor,
 )
 
 from torch._dynamo.guards import GuardBuilder
@@ -106,7 +106,7 @@ def _patch_tensor_for_spyre():
             )
 
             if self.device.type == "cpu":
-                copy_host_to_device(self, dst)
+                copy_tensor(self, dst, non_blocking=False)
                 return dst
             else:  # device to device copy
                 # If device_layout is the same as self and copy is not True, return self

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -364,13 +364,10 @@ PYBIND11_MODULE(_C, m) {
   m.def("get_elem_in_stick", &spyre::get_elem_in_stick);
   m.def("get_device_dtype", &spyre::get_device_dtype);
 
-  // Memory copy functions
-  m.def("copy_host_to_device", &spyre::copy_host_to_device,
-        "Copy tensor from host to device using DMA", py::arg("self"),
-        py::arg("dst"));
-  m.def("copy_device_to_host", &spyre::copy_device_to_host,
-        "Copy tensor from device to host using DMA", py::arg("self"),
-        py::arg("dst"));
+  // Memory copy function
+  m.def("copy_tensor", &spyre::spyre_copy_from,
+        "Copy tensor between host and device using DMA", py::arg("self"),
+        py::arg("dst"), py::arg("non_blocking") = false);
 
   // Stream management functions
   m.def("get_stream_from_pool", &spyre::getStreamFromPool, py::arg("device"),

--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -15,6 +15,7 @@
  */
 #include "spyre_allocator.h"
 
+#include <memory>
 #include <utility>
 
 #include "logging.h"
@@ -29,12 +30,13 @@ c10::CachingDeviceAllocator::DeviceStats SpyreAllocator::stats_;
 c10::CachingDeviceAllocator::StatTypes SpyreAllocator::stat_types = {
     true, false, false};  // {AGGREGATE, SMALL_POOL, LARGE_POOL}
 
-flex::DeviceMemoryAllocatorPtr SpyreAllocator::getAllocator(
-    unsigned int /*dev_id*/) {
-  // Each process has exactly one runtime with one device handle (index 0).
-  // The PyTorch device index (dev_id) is the logical index across processes,
-  // not an index into the runtime's device handle vector.
-  return GlobalRuntime::get()->GetDeviceHandle(0)->GetDeviceMemoryAllocator();
+std::shared_ptr<flex::FlexAllocator> SpyreAllocator::getFlexAllocator() {
+  // FlexAllocator is owned by RuntimeContext (one per device per process).
+  // RuntimeContext::getAllocator() returns shared_ptr<const FlexAllocator>;
+  // we const_cast to shared_ptr<FlexAllocator> because allocate()/deallocate()
+  // are non-const (internally mutex-protected and thread-safe).
+  auto const_alloc = flex::getFlexRuntimeContext()->getAllocator();
+  return std::const_pointer_cast<flex::FlexAllocator>(const_alloc);
 }
 
 SpyreAllocator& SpyreAllocator::instance() {
@@ -128,12 +130,22 @@ c10::DataPtr SpyreAllocator::allocate(size_t nbytes) {
   if (nbytes == 0) {
     return {nullptr, nullptr, &ReportAndDelete, curr_device};
   }
-  auto allocator = getAllocator(device_id);
-  flex::DeviceMemoryAllocationPtr data;  // a smart-pointer object
-  // NOTE: last argument should be set to 0
-  allocator->TryAllocate(&data, nbytes, 0);
+  // Get shared_ptr to keep FlexAllocator alive during operations
+  auto flex_alloc = getFlexAllocator();
+
+  // Allocate first-class raw storage via CompositeAddress.
+  flex::CompositeAddress composite_addr = flex_alloc->allocate(nbytes);
+
+  // Bridge to the legacy DeviceMemoryAllocationPtr view for existing PF-mode
+  // users that still expect a pointer-like object referring to the same
+  // storage.
+  flex::DeviceMemoryAllocationPtr data =
+      flex_alloc->makeInterimAllocationPtr(composite_addr);
   TORCH_CHECK(data, "Failed to allocate ", nbytes, " bytes on Spyre device.");
-  auto* ctx = new SharedOwnerCtx{std::move(data), device_id, nbytes};
+
+  // Create context with both owner and CompositeAddress
+  auto* ctx = new SharedOwnerCtx(std::move(data), std::move(composite_addr),
+                                 device_id, nbytes);
   void* ctx_void = static_cast<void*>(ctx);
 
   void* data_void = static_cast<void*>(ctx->owner.get());

--- a/torch_spyre/csrc/spyre_allocator.h
+++ b/torch_spyre/csrc/spyre_allocator.h
@@ -19,14 +19,26 @@
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
 
+#include <flex/allocator/alloc_address.hpp>
+#include <flex/allocator/flex_allocator.hpp>
 #include <flex/device_types/device_memory_allocator.hpp>
+#include <memory>
+#include <utility>
 
 namespace spyre {
 
 struct SharedOwnerCtx {
   flex::DeviceMemoryAllocationPtr owner;
+  flex::CompositeAddress composite_addr;
   signed char device_id;
   size_t nbytes;
+
+  SharedOwnerCtx(flex::DeviceMemoryAllocationPtr own,
+                 flex::CompositeAddress addr, signed char dev_id, size_t nb)
+      : owner(std::move(own)),
+        composite_addr(std::move(addr)),
+        device_id(dev_id),
+        nbytes(nb) {}
 };
 
 // A custom allocator for our custom device, which returns a handle to the
@@ -38,7 +50,7 @@ struct SpyreAllocator final : public c10::DeviceAllocator {
   static c10::CachingDeviceAllocator::StatTypes
       stat_types;  // {AGGREGATE, SMALL_POOL, LARGE_POOL}
 
-  flex::DeviceMemoryAllocatorPtr getAllocator(unsigned int dev_id);
+  static std::shared_ptr<flex::FlexAllocator> getFlexAllocator();
 
  public:
   static SpyreAllocator& instance();

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -25,17 +25,10 @@
 #include <c10/util/ArrayRef.h>
 #include <pybind11/pybind11.h>
 #include <torch/library.h>
-#include <util/sen_data_convert.h>
 
 #include <algorithm>
-#include <flex/runtime_graph/graph/graph_builder/flex_graph_builder.hpp>
 #include <map>
 #include <memory>
-#include <sendnn/graph/graph_builder.hpp>
-#include <sendnn/interface/graph_loader.hpp>
-#include <sendnn/runtime/runtime_interface.hpp>
-#include <sendnn/tensor/sentensor_info.hpp>
-#include <sendnn/util/status.hpp>
 #include <string>
 #include <utility>
 #include <vector>
@@ -45,6 +38,7 @@
 #include "spyre_allocator.h"
 #include "spyre_sendnn_utils.h"
 #include "spyre_storage_impl.h"
+#include "spyre_stream.h"
 #include "spyre_tensor_impl.h"
 #include "types_mapping.h"
 
@@ -52,21 +46,8 @@ namespace py = pybind11;
 
 namespace spyre {
 
-using DataConversionStrideInfo = data_conversion_stride_info;
-using DataConversionInfo = data_conversion_info;
-
-/* struct holding the parameters for DMA-based copy
-   size_bytes: number of bytes to transfer
-   src_offset: offset from src base pointer
-   dst_offset: offset from destination base pointer
- */
-struct DMAParameters {
-  const int64_t size_bytes;
-  const off64_t src_offset;
-  const off64_t dst_offset;
-};
-
-/* Generates the dimension mapping between `strides` and `stride_map`.
+/*
+ * CPU stride for a dimension.
  *
  * @param sizes: dimension sizes of the CPU tensor
  * @param strides: dimension strides of the CPU tensor
@@ -352,17 +333,13 @@ auto get_device_stride_infos(c10::IntArrayRef sizes, c10::IntArrayRef strides,
 /*
  * Generate description of data conversion for a tensor.
  *
- * @param tensor: tensor to convert
- * @return data conversion information in string
+ * @param tensor: device-side tensor
+ * @return data conversion information
  */
 auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
-                  int64_t cpu_offset, bool host2device) -> std::string {
-  /*   host2device = true : then 'tensor' is CPU-tensor
-   *   host2device = false: then 'tensor' is Spyre-tensor
-   */
+                  int64_t cpu_offset, bool host2device) -> DataConversionInfo {
   auto str_type = torchScalarToString[tensor->scalar_type()];
   const auto [dtype_cpu, dtype_dev] = stringToDTDataFormatPair(str_type);
-  std::stringstream s;
 
   DataConversionInfo dci{};
   dci.dci_dsName_ = "DCI-Tensor-0";
@@ -395,172 +372,7 @@ auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
 
   dci.input_shape_ = host2device ? cpu_shape : dev_shape;
   dci.output_shape_ = host2device ? dev_shape : cpu_shape;
-  dci.exportJson(s);
-  DEBUGINFO("DataConversionInfo: ", s.str());
-  return s.str();
-}
-
-auto create_dma_graph(const at::Tensor& self, const at::Tensor& dst,
-                      bool host2device)
-    -> std::shared_ptr<sendnn::GraphLoader> {
-  /* self = source
-   * dst  = destination
-   */
-  const at::Tensor* dev_tensor;
-  const at::Tensor* cpu_tensor;
-  if (host2device) {
-    cpu_tensor = &self;
-    dev_tensor = &dst;
-  } else {
-    cpu_tensor = &dst;
-    dev_tensor = &self;
-  }
-
-  auto str_type = torchScalarToString[cpu_tensor->scalar_type()];
-  const auto [sen_dtype_cpu, sen_dtype_dev] = stringToSenDatatypePair(str_type);
-  auto layout = sendnn::TensorLayout::NHWC;
-  SpyreTensorLayout stl = get_spyre_tensor_layout(host2device ? dst : self);
-  sendnn::TensorShape dev_tensor_shape(stl.device_size);
-
-  // ti = transfer info
-  // dci = data conversion info
-  sendnn::TensorInfo cpu_ti(sen_dtype_cpu,
-                            sendnn::TensorShape(cpu_tensor->sizes().vec()),
-                            layout, sendnn::TensorLocation::HOST());
-  sendnn::TensorInfo dev_ti(sen_dtype_dev, dev_tensor_shape, layout,
-                            sendnn::TensorLocation::DEVICE());
-  sendnn::TensorInfo dci_ti(sen_dtype_dev, dev_tensor_shape, layout,
-                            sendnn::TensorLocation::HOST());
-  //  STAGE 1: execution graph
-  sendnn::SubGraph sub_graph;
-  const auto [elem_bytes_cpu, elem_bytes_spyre] =
-      spyre::elementSize(cpu_tensor->scalar_type());
-  int64_t xfer_size = dev_tensor_shape.Volume() * elem_bytes_spyre;
-  {
-    flex::FlexGraphBuilder gb;
-    DMAParameters dma_param{xfer_size, 0, 0};
-    if (host2device) {
-      auto inp_node = gb.PrimaryInput("Input", dci_ti);
-      auto xfer_node = gb.SenDataTransfer(
-          "Host2Sen-Transfer",
-          dev_ti,    // output (holding shape, type, and location DEVICE)
-          inp_node,  // input (node created using PrimaryInput and on HOST)
-          dev_ti.DataSize(), dma_param.src_offset, dma_param.dst_offset);
-      auto out_node = gb.PrimaryOutput("Output", xfer_node);
-    } else {
-      auto inp_node = gb.PrimaryInput("Input", dev_ti);
-      auto xfer_node = gb.SenDataTransfer(
-          "Sen2Host-Transfer",
-          dci_ti,    // output (holding shape, type and location HOST)
-          inp_node,  // input (node created as a result of SenDataTransfer)
-          dev_ti.DataSize(), dma_param.src_offset, dma_param.dst_offset);
-      auto out_node = gb.PrimaryOutput("Output", xfer_node);
-    }
-
-    SEN_THROW_NOK(gb.Finalize(&sub_graph));
-  }
-  sendnn::SubGraph exec_graph;
-  {  // add above subgraph as part of SenFusedDeviceCompute node
-    flex::FlexGraphBuilder gb;
-    auto dci = generate_dci(dev_tensor, stl, cpu_tensor->storage_offset(),
-                            host2device);
-    if (host2device) {
-      auto inp_node = gb.PrimaryInput("Input", cpu_ti);
-      auto dci_node = gb.SenHostCompute("Host2Sen-HostPrep", {dci_ti},
-                                        {inp_node}, "SenDataConvert", dci);
-
-      auto dev_node = gb.SenFusedDeviceCompute("SenFusedDeviceNode_0", {dci_ti},
-                                               {dci_node}, sub_graph);
-      gb.PrimaryOutput("Output", dev_node->OutputPort(0));
-    } else {
-      sendnn::Node* inp_node = gb.PrimaryInput("Input", dci_ti);
-      auto dev_node = gb.SenFusedDeviceCompute("SenFusedDeviceNode_0", {dci_ti},
-                                               {inp_node}, sub_graph);
-      auto dci_node = gb.SenHostCompute("Sen2Host-HostPrep", cpu_ti, dev_node,
-                                        "SenDataConvert", dci);
-
-      gb.PrimaryOutput("Output", dci_node->OutputPort(0));
-    }
-
-    SEN_THROW_NOK(gb.Finalize(&exec_graph));
-  }
-
-  sendnn::SegmentTable segment_table = {
-      sendnn::Segment::PRIMARY_OUT(xfer_size),
-      sendnn::Segment::PRIMARY_IN(xfer_size),
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::INVALID,
-      sendnn::Segment::PROGRAM(128),
-  };
-  // STAGE 2: SenSuperNodeV2 graph
-  sendnn::Graph sn_graph;  // sn = supernode
-  {                        // SenSuperNodeV2 graph
-    flex::FlexGraphBuilder gb;
-
-    sendnn::TensorInfo inp_ti =
-        sendnn::TensorInfo(exec_graph.input_ops_.front()->OutputAt(0));
-    sendnn::TensorInfo out_ti =
-        sendnn::TensorInfo(exec_graph.output_ops_.front()->InputAt(0));
-    sendnn::NodeOrIndexedNode inp_node = gb.PrimaryInput("Input", inp_ti);
-
-    std::string k_uuid = "dma-network";
-    sendnn::attributes::SenPartitionInit part_init;
-    part_init.network_uuid_ = k_uuid;
-    part_init.partition_idx_ = 0;
-    part_init.segment_table_ = segment_table;
-
-    auto sn =
-        gb.SenSuperNodeV2("SenSuperNodeV2_0", {out_ti}, {inp_node}, k_uuid, 0,
-                          1, part_init, exec_graph, {}, false, true, true);
-    gb.PrimaryOutput("Output", {0, sn});
-
-    SEN_THROW_NOK(gb.Finalize(&sn_graph));
-  }
-
-  // STAGE 3:
-  std::shared_ptr<sendnn::GraphLoader> gl;
-  gl = std::make_shared<sendnn::GraphLoader>(GlobalRuntime::get());
-  {
-    SEN_THROW_NOK(gl->LoadGraph(sn_graph));
-    SEN_THROW_NOK(gl->CompileGraph());
-    SEN_THROW_NOK(gl->ParseGraph());
-  }
-  return gl;
-}
-
-void copy_host_to_device(const at::Tensor& self, const at::Tensor& dst) {
-  std::shared_ptr<sendnn::GraphLoader> gl = create_dma_graph(self, dst, true);
-  if (!gl) {
-    DEBUGINFO("GraphLoader is null!");
-    return;
-  }
-  // execute
-  constexpr int sn_idx = 0;
-  constexpr int tensor_idx = 0;
-  auto inp_tensor = createInputTensor(*gl, self.storage().data_ptr().get(),
-                                      tensor_idx, sn_idx);
-  auto* ctx =
-      static_cast<SharedOwnerCtx*>(dst.storage().data_ptr().get_context());
-  flex::DeviceMemoryAllocationPtr& dev_data = ctx->owner;
-  inp_tensor.SetSpyreData(dev_data);  // ctx->owner;
-
-  SEN_THROW_NOK(gl->Copy(sendnn::Outputs(), {inp_tensor}, sn_idx));
-}
-
-void copy_device_to_host(const at::Tensor& self, const at::Tensor& dst) {
-  std::shared_ptr<sendnn::GraphLoader> gl = create_dma_graph(self, dst, false);
-  // execute
-  constexpr int sn_idx = 0;
-  constexpr int tensor_idx = 0;
-  auto out_tensor = createOutputTensor(*gl, dst.storage().data_ptr().get(),
-                                       tensor_idx, sn_idx);
-  auto* ctx =
-      static_cast<SharedOwnerCtx*>(self.storage().data_ptr().get_context());
-  out_tensor.SetSpyreData(ctx->owner);
-  SEN_THROW_NOK(gl->Copy({out_tensor}, sendnn::Inputs(), sn_idx));
+  return dci;
 }
 
 // Empty op needs C++ code and cannot be handled by python side fallback
@@ -661,6 +473,7 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
   DEBUGINFO("SpyreTensorLayout: ", device_layout.toString());
   return tensor;
 }
+
 at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
                                    c10::IntArrayRef stride,
                                    c10::ScalarType dtype,
@@ -696,6 +509,27 @@ at::Tensor& spyre_set_storage(at::Tensor& result, at::Storage storage,
                               c10::IntArrayRef stride) {
   DEBUGINFO("set method");
   return at::cpu::set_(result, storage, storage_offset, size, stride);
+}
+
+/**
+ * This method handles copy between devices. When copying to Spyre, this method
+ * marks the tensor to compute on Spyre, but continue to use CPU tensor for now
+ * such that when we run an op on the tensor on the Spyre, it will have the
+ * proper handle to the Spyre allocation
+ */
+at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
+                           bool non_blocking) {
+  SpyreStream stream;
+  if (dst.is_privateuseone()) {
+    stream = getCurrentStream(dst.device());
+  } else {
+    stream = getCurrentStream(self.device());
+  }
+  stream.copyAsync(self, dst);
+  if (!non_blocking) {
+    stream.synchronize();
+  }
+  return dst;
 }
 
 at::Tensor empty_with_layout(

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -19,6 +19,8 @@
 #include <ATen/ATen.h>
 #include <c10/util/intrusive_ptr.h>
 
+#include "module.h"
+
 namespace spyre {
 
 at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
@@ -27,8 +29,8 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
                                std::optional<c10::Device> device_opt,
                                std::optional<bool> pin_memory_opt);
 
-void copy_host_to_device(const at::Tensor& self, const at::Tensor& dst);
-void copy_device_to_host(const at::Tensor& self, const at::Tensor& dst);
+at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
+                           bool non_blocking);
 
 class SpyreTensorLayout;
 at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
@@ -49,4 +51,6 @@ at::Tensor py_empty_with_layout(
     std::optional<c10::Device> device_opt, std::optional<bool> pin_memory_opt,
     std::optional<c10::MemoryFormat> memory_format_opt);
 
+auto generate_dci(const at::Tensor* tensor, SpyreTensorLayout stl,
+                  int64_t cpu_offset, bool host2device) -> DataConversionInfo;
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -19,12 +19,15 @@
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
 
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
 
+#include "flex/runtime_stream/runtime_operation.hpp"
 #include "logging.h"
 #include "module.h"
+#include "spyre_allocator.h"
 #include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_tensor_impl.h"
@@ -126,9 +129,48 @@ c10::Stream SpyreStream::unwrap() const {
   return stream_;
 }
 
-void SpyreStream::copy_async(const at::Tensor& src,
-                             const at::Tensor& dst) const {
-  // TODO(tmhoangt): place-holder to be implemented in the next PR
+void SpyreStream::copyAsync(const at::Tensor& src,
+                            const at::Tensor& dst) const {
+  DEBUGINFO("src (", src.scalar_type(), ") is on:", src.device());
+  DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
+
+  // TODO(tmhoangt): add type conversion node
+  // Type checking - no type conversion support yet
+  TORCH_CHECK(
+      src.scalar_type() == dst.scalar_type(),
+      "Spyre backend does not support type conversion yet during copy.");
+
+  // Determine copy direction
+  bool host2device = src.is_cpu() && dst.is_privateuseone();
+  bool device2host = src.is_privateuseone() && dst.is_cpu();
+
+  const at::Tensor* dev_tensor = host2device ? &dst : &src;
+  const at::Tensor* cpu_tensor = host2device ? &src : &dst;
+
+  if (host2device || device2host) {
+    // Host-to-device or device-to-host copy
+    void* cpu_ptr = const_cast<void*>(cpu_tensor->storage().data());
+
+    // Get SpyreTensorLayout using the public API
+    SpyreTensorLayout stl = get_spyre_tensor_layout(*dev_tensor);
+
+    // Extract device allocation from Spyre tensor storage
+    auto* spyre_impl =
+        static_cast<SpyreTensorImpl*>(dev_tensor->unsafeGetTensorImpl());
+    auto& storage = spyre_impl->storage();
+    auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
+
+    // Generate data conversion info
+    // So we always pass &src, not cpu_tensor
+    DataConversionInfo dci = generate_dci(
+        dev_tensor, stl, cpu_tensor->storage_offset(), host2device);
+
+    copyAsyncImpl(cpu_ptr, &ctx->composite_addr, dci, host2device);
+
+  } else {
+    TORCH_CHECK(false, "Unsupported copy types: src on ", src.device(),
+                " dst on ", dst.device());
+  }
 }
 
 flex::RuntimeStream* SpyreStream::getRuntimeHandle() const {
@@ -142,10 +184,24 @@ flex::RuntimeStream* SpyreStream::getRuntimeHandle() const {
   return it->second;
 }
 
-void SpyreStream::copy_async_impl(
-    void* cpu_ptr, flex::DeviceMemoryAllocationPtr& device_allocation,
-    int device_id, const DataConversionInfo& dci, bool host2device) const {
-  // TODO(tmhoangt): place-holder to be implemented in the next PR
+void SpyreStream::copyAsyncImpl(void* cpu_ptr,
+                                const flex::CompositeAddress* device_address,
+                                const DataConversionInfo& dci,
+                                bool host2device) const {
+  // Wrap dci in shared_ptr for flex API
+  auto dci_ptr = std::make_shared<data_conversion_info>(dci);
+
+  // Get the flex runtime stream handle
+  flex::RuntimeStream* flex_stream = getRuntimeHandle();
+
+  // Create and launch operation
+  if (host2device) {
+    flex::RuntimeOperationH2D op(cpu_ptr, device_address, dci_ptr);
+    flex_stream->launchOperation(op);
+  } else {
+    flex::RuntimeOperationD2H op(device_address, cpu_ptr, dci_ptr);
+    flex_stream->launchOperation(op);
+  }
 }
 
 void initializeStreamPoolImpl(c10::DeviceIndex device_index) {

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -39,17 +39,16 @@ class SpyreStream {
   bool query() const;        // Check if work completed
   void synchronize() const;  // Block until work done
 
-  void copy_async(const at::Tensor& src, const at::Tensor& dst) const;
+  void copyAsync(const at::Tensor& src, const at::Tensor& dst) const;
 
   // Conversions
   c10::Stream unwrap() const;
 
  private:
   flex::RuntimeStream* getRuntimeHandle() const;
-  void copy_async_impl(void* cpu_ptr,
-                       flex::DeviceMemoryAllocationPtr& device_allocation,
-                       int device_id, const DataConversionInfo& dci,
-                       bool host2device) const;
+  void copyAsyncImpl(void* cpu_ptr,
+                     const flex::CompositeAddress* device_address,
+                     const DataConversionInfo& dci, bool host2device) const;
 };
 
 /**

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -143,11 +143,10 @@ def spyre__copy_from(self, dst, non_blocking=False):
     if self.numel() == 0:
         return dst
 
-    if self.device.type == "cpu" and dst.device.type == "spyre":
-        _C.copy_host_to_device(self, dst)
-        return dst
-    elif self.device.type == "spyre" and dst.device.type == "cpu":
-        _C.copy_device_to_host(self, dst)
+    if (self.device.type == "cpu" and dst.device.type == "spyre") or (
+        self.device.type == "spyre" and dst.device.type == "cpu"
+    ):
+        _C.copy_tensor(self, dst, non_blocking)
         return dst
     elif self.device.type == "spyre" and self.device == dst.device:
         torch.ops.spyre.copy_from_d2d(self, dst)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

## What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

## What this PR does:

This PR migrates the Spyre backend's memory allocation and DMA copy implementation from the legacy PF-mode allocator to the modern FlexAllocator with CompositeAddress. The changes remove the dependency on graph-based DMA operations and implement direct DMA transfers using the flex runtime.

Key changes include:
- Replacing `DeviceMemoryAllocator` with `FlexAllocator` for memory allocation
- Using `CompositeAddress` as the primary storage management mechanism
- Removing graph-based DMA implementation in favor of direct flex runtime operations
- Updating the copyAsync implementation to use `RuntimeOperationH2D`/`RuntimeOperationD2H`
- Device-to-Device is supported (though it is not efficient). 


#### DMA Implementation Rewrite
- Removed all graph-based DMA code that used `sendnn::GraphLoader` and related components
- Implemented direct DMA transfers using `flex::RuntimeOperationH2D` and `flex::RuntimeOperationD2H`
- The copy is now a stream-based op
- Updated `SpyreStream::copyAsync()` to directly call the flex runtime operations
- Changed `copyAsyncImpl()` to accept `CompositeAddress*` instead of `DeviceMemoryAllocationPtr&`


#### Which issue(s) this PR is related to:

Issue #1432 , #1431. 

Issue #80 is also supported; though a more efficient version is needed (device-side operation using dldsc). 

#### Special notes for your reviewer:

This PR requires a companion PR in Flex (832). 

#### Does this PR introduce a user-facing change?

N/A.

#### Additional note:

