### PR TITLE
move insert_padding from pre-grad to post-grad CustomPostPasses

### DIFF
--- a/tests/inductor/test_inductor_fx_passes.py
+++ b/tests/inductor/test_inductor_fx_passes.py
@@ -21,6 +21,40 @@ from utils_inductor import (
     cached_randn,
 )
 
+from torch_spyre._inductor.padding import insert_padding
+
+
+def _make_mm_graph(x_shape, w_shape, dtype=torch.float16):
+    """Build a minimal post-grad FX graph containing a single aten.mm.default node."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty(x_shape, dtype=dtype, device="spyre")
+    w = graph.placeholder("w")
+    w.meta["val"] = torch.empty(w_shape, dtype=dtype, device="spyre")
+    mm = graph.call_function(torch.ops.aten.mm.default, args=(x, w))
+    mm.meta["val"] = torch.empty((x_shape[0], w_shape[1]), dtype=dtype, device="spyre")
+    graph.output(mm)
+    return graph
+
+
+def _make_bmm_graph(x_shape, w_shape, dtype=torch.float16):
+    """Build a minimal post-grad FX graph containing a single aten.bmm.default node."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty(x_shape, dtype=dtype, device="spyre")
+    w = graph.placeholder("w")
+    w.meta["val"] = torch.empty(w_shape, dtype=dtype, device="spyre")
+    bmm = graph.call_function(torch.ops.aten.bmm.default, args=(x, w))
+    bmm.meta["val"] = torch.empty(
+        (x_shape[0], x_shape[1], w_shape[2]), dtype=dtype, device="spyre"
+    )
+    graph.output(bmm)
+    return graph
+
+
+def _overwrite_nodes(graph):
+    return [n for n in graph.nodes if n.target == torch.ops.spyre.overwrite.default]
+
 
 class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     torch.manual_seed(0xAFFE)
@@ -164,6 +198,51 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         assert "aten.mm.default" not in inductor_graph_str, (
             "aten.mm.default should be replaced by bmm after unflatten pass"
         )
+
+
+class TestInsertPadding(unittest.TestCase):
+    """Unit tests for the insert_padding post-grad FX pass."""
+
+    def test_mm_unaligned_reduction_dim_gets_padded(self):
+        # 200 is not a multiple of 64 (fp16 stick size), so both args need padding
+        graph = _make_mm_graph(x_shape=(67, 200), w_shape=(200, 128))
+        insert_padding(graph)
+        overwrites = _overwrite_nodes(graph)
+        self.assertEqual(len(overwrites), 2, "expected padding on both mm args")
+
+    def test_mm_aligned_reduction_dim_no_padding(self):
+        # 256 is a multiple of 64 — no padding needed on the reduction dim
+        graph = _make_mm_graph(x_shape=(67, 256), w_shape=(256, 128))
+        insert_padding(graph)
+        overwrites = _overwrite_nodes(graph)
+        self.assertEqual(
+            len(overwrites), 0, "expected no padding for aligned reduction dim"
+        )
+
+    def test_bmm_unaligned_reduction_dim_gets_padded(self):
+        # 200 is not a multiple of 64
+        graph = _make_bmm_graph(x_shape=(2, 67, 200), w_shape=(2, 200, 128))
+        insert_padding(graph)
+        overwrites = _overwrite_nodes(graph)
+        self.assertEqual(len(overwrites), 2, "expected padding on both bmm args")
+
+    def test_mm_reduction_dim_1_skipped(self):
+        # reduction dim == 1 is special-cased: lowering converts size-1 mm to mul
+        graph = _make_mm_graph(x_shape=(67, 1), w_shape=(1, 128))
+        insert_padding(graph)
+        overwrites = _overwrite_nodes(graph)
+        self.assertEqual(
+            len(overwrites), 0, "size-1 reduction dim should not be padded"
+        )
+
+    def test_mm_padded_arg_has_correct_shape(self):
+        # x is (67, 200): pad 200 → 256 along dim -1; w is (200, 128): pad 200 → 256 along dim -2
+        graph = _make_mm_graph(x_shape=(67, 200), w_shape=(200, 128))
+        insert_padding(graph)
+        overwrites = _overwrite_nodes(graph)
+        shapes = sorted([tuple(n.meta["val"].shape) for n in overwrites])
+        self.assertIn((67, 256), shapes)
+        self.assertIn((256, 128), shapes)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -20,9 +20,11 @@ logger = get_inductor_logger("padding")
 aten = torch.ops.aten
 
 """
-Pass to add padding where useful for correctness or performance.  Must be a pre-grad pass 
-if we want to leverage decomposition for constant_pad_nn.  If this pass must come later then
-pad will need to be inserted in its decomposed form.
+Pass to add padding where useful for correctness or performance.  Runs as the first pass
+in CustomPostPasses on the post-grad FX graph, so it matches ATen default overloads
+(aten.mm.default, aten.bmm.default).  Decompositions run before post-grad passes, so this
+pass inserts the decomposed form directly: spyre.full + aten.expand + aten.clone +
+spyre.overwrite (mirroring pad_decomp in decompositions.py).
 """
 
 
@@ -34,38 +36,56 @@ def compute_padding(cur_size: int, dtype: torch.dtype) -> int:
 
 def pad_arg(graph: torch.fx.Graph, node: torch.fx.Node, arg_i: int, dim: int) -> None:
     arg = node.args[arg_i]
-    example_value = arg.meta["example_value"]
-    shape = example_value.shape
+    val = arg.meta["val"]
+    shape = val.shape
     ndim = len(shape)
     dim = dim if dim >= 0 else ndim + dim  # convert neg to pos indices
 
-    pad = compute_padding(shape[dim], example_value.dtype)
+    pad = compute_padding(shape[dim], val.dtype)
     if pad > 0:
-        # We are paddding dimension 'dim'.  F.pad takes padding inner to outer (until no more)
-        # so put in zeros until dim is reached
-        pad_list = [0, 0] * (ndim - 1 - dim) + [0, pad]
+        output_shape = list(shape)
+        output_shape[dim] += pad
+        device = val.device
+        dtype = val.dtype
+        # Replicate the pad_decomp transformation from decompositions.py directly
+        # as FX nodes, since decompositions run before post-grad passes.
+        # Insert all new nodes immediately after the arg node.
         with graph.inserting_after(arg):
-            padded = graph.call_function(
-                aten.constant_pad_nd.default,
-                args=(arg, pad_list, 0.0),
+            scalar = graph.call_function(
+                torch.ops.spyre.full.default,
+                args=([1], 0.0, device, dtype),
             )
-            new_shape = list(shape)
-            new_shape[dim] += pad
-            padded.meta["example_value"] = example_value.new_empty(new_shape)
+            scalar.meta["val"] = torch.empty([1], dtype=dtype, device=device)
+        with graph.inserting_after(scalar):
+            expanded = graph.call_function(
+                aten.expand.default,
+                args=(scalar, output_shape),
+            )
+            expanded.meta["val"] = torch.empty(output_shape, dtype=dtype, device=device)
+        with graph.inserting_after(expanded):
+            output = graph.call_function(
+                aten.clone.default,
+                args=(expanded,),
+            )
+            output.meta["val"] = torch.empty(output_shape, dtype=dtype, device=device)
+        with graph.inserting_after(output):
+            padded = graph.call_function(
+                torch.ops.spyre.overwrite.default,
+                args=(arg, output, [dim], [0]),
+            )
+            padded.meta["val"] = torch.empty(output_shape, dtype=dtype, device=device)
         node.replace_input_with(arg, padded)
 
 
 def insert_padding(graph: torch.fx.Graph) -> None:
-    # This pass runs pre-grad, so we have to detect both call_function and call_method variants
-    # If we ever move it to run post-grad, we need to change this to use aten.bmm.default, etc.
-    matmul_ops = {torch.matmul, torch.mm, torch.bmm, "matmul", "mm", "bmm"}
+    matmul_ops = {aten.mm.default, aten.bmm.default}
     for node in list(graph.nodes):
-        if node.op in ("call_function", "call_method") and node.target in matmul_ops:
+        if node.op == "call_function" and node.target in matmul_ops:
             args = node.args
             if not all(isinstance(arg, torch.fx.Node) for arg in args):
                 continue
 
-            x_val = args[0].meta.get("example_value")
+            x_val = args[0].meta.get("val")
             if x_val is None or not isinstance(x_val, torch.Tensor):
                 continue
             # Skip if reduction dim size is 1 (special cased in in lowering, size 1 mm is converted to mul)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -89,7 +89,7 @@ class CustomPreGradPasses:
     pre-grad FX graph.
     """
 
-    passes: List[Callable[[torch.fx.graph.Graph], None]] = [insert_padding]
+    passes: List[Callable[[torch.fx.graph.Graph], None]] = []
 
     def __call__(self, graph: torch.fx.graph.Graph) -> None:
         for p in self.passes:
@@ -127,6 +127,7 @@ class CustomPostPasses(CustomGraphPass):
     The list of custom passes to run
     """
     passes: List[Callable[[torch.fx.graph.Graph], None]] = [
+        insert_padding,
         replace_scalar_with_tensor,
         mm_to_bmm_pass.apply,
         bmm_unflatten_pass.apply,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Move the FX graph-level padding insertion for matmul/bmm to a late post grad pass so that it will also apply to
matmuls introduced by decompositions. 

#### Which issue(s) this PR is related to:

Motivated by the discussion in #1107 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
