### PR TITLE
[TESTING] Add support for precision patching and specification of dtype precision

### DIFF
--- a/tests/spyre_test_base_common.py
+++ b/tests/spyre_test_base_common.py
@@ -1,21 +1,10 @@
 """
 Shared class and methods for all OOT PyTorch test overrides.
 
-Usage:
-    export PYTORCH_TESTING_DEVICE_ONLY_FOR="privateuse1"
-
-    # Clone pytorch
-    $DTI_PROJECT_ROOT/torch-spyre-docs/scripts/checkout-pytorch-src.sh
-
-    export TORCH_TEST_DEVICES="$DTI_PROJECT_ROOT/torch-spyre/tests/spyre_test_base_common.py"
-    export PYTORCH_TEST_CONFIG="$DTI_PROJECT_ROOT/torch-spyre/tests/test_suite_config.yaml"
-
-    cd $DTI_PROJECT_ROOT/pytorch/test/
-    python3 -m pytest test_binary_ufuncs.py -v
 """
 
 import os
-from typing import Dict, Optional, Set
+from typing import Dict, List, Optional, Set
 
 import pytest  # type: ignore
 import torch
@@ -47,9 +36,11 @@ from spyre_upstream_patcher import (
     _OOTOpListPatcher,
     _OOTModuleListPatcher,
     _OOTModuleDtypePatcher,
+    _OOTPrecisionOverridePatcher,
 )
 from spyre_test_config_models import (
     OOTTestConfig,
+    Precision,
     SupportedOpConfig,
     SupportedModuleConfig,
     TestEntry,
@@ -163,6 +154,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         str, "SupportedModuleConfig"
     ] = {}  # {module_name -> config}
     GLOBAL_SUPPORTED_DTYPES: Optional[Set[torch.dtype]] = None  # None = no filtering
+    GLOBAL_DTYPE_PRECISION: Dict[torch.dtype, "Precision"] = {}
 
     @classmethod
     def setUpClass(cls):
@@ -202,6 +194,9 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
             cls.SUPPORTED_MODULES_CONFIG = module_configs
 
         cls.GLOBAL_SUPPORTED_DTYPES = config.global_config.resolved_supported_dtypes()
+        cls.GLOBAL_DTYPE_PRECISION = (
+            config.global_config.resolved_supported_dtypes_precision()
+        )
 
         file_entry: FileEntry = resolve_current_file(config, path)
 
@@ -302,11 +297,24 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         # print tags to stderr
         entry = cls.TEST_ENTRIES.get(name)
         tags = entry.tags if entry is not None else []
-        if tags:
+        # Collect op-level tags from all OpsNamedItem entries in this TestEntry
+        # and union them with test-level tags so pytest -m works for both levels.
+        op_tags: List[str] = []
+        if entry is not None:
+            seen_op_tags: set = set()
+            for ops_item in entry.edits.ops.include:
+                for t in ops_item.tags:
+                    if t not in seen_op_tags:
+                        seen_op_tags.add(t)
+                        op_tags.append(t)
+
+        # Union: test-level tags + op-level tags (deduplicated)
+        all_tags = tags + [t for t in op_tags if t not in set(tags)]
+        if all_tags:
             os.write(
                 2,
                 f"[OOTDeviceTestBase] {generic_cls.__name__}::{name} "
-                f"tags: [{', '.join(tags)}]\n".encode(),
+                f"tags: [{', '.join(all_tags)}]\n".encode(),
             )
 
         # op list filtering
@@ -379,6 +387,16 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                 _OOTDtypePatcher(test, extra_dtypes).patch()
                 _OOTOpDtypeExpander(test, extra_dtypes).patch()
 
+        _OOTPrecisionOverridePatcher(
+            test,
+            global_dtype_precision=cls.GLOBAL_DTYPE_PRECISION,
+            include_dtype_precision=(
+                entry.edits.dtypes.resolved_include_precision()
+                if entry is not None
+                else {}
+            ),
+        ).patch()
+
         existing_methods = set(cls.__dict__.keys())
         super().instantiate_test(name, test, generic_cls=generic_cls)
         new_methods = set(cls.__dict__.keys()) - existing_methods
@@ -416,11 +434,11 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
             #     continue
 
             # apply pytest tags as marks
-            if tags:
+            if all_tags:
                 existing_fn = cls.__dict__.get(method_name)
                 if existing_fn is not None:
                     marked_fn = existing_fn
-                    for tag in tags:
+                    for tag in all_tags:
                         marked_fn = pytest.mark.__getattr__(tag)(marked_fn)
                     setattr(cls, method_name, marked_fn)
 

--- a/tests/spyre_test_config_models.py
+++ b/tests/spyre_test_config_models.py
@@ -54,6 +54,13 @@ _VALID_UNLISTED_MODES = {"skip", "xfail", "xfail_strict", "mandatory_success"}
 # ---------------------------------------------------------------------------
 # Models
 # ---------------------------------------------------------------------------
+class Precision(BaseModel):
+    """Precision sub-model for tolerance overrides."""
+
+    atol: Optional[float] = None
+    rtol: Optional[float] = None
+
+
 class NamedItem(BaseModel):
     """A named item in an include/exclude list."""
 
@@ -61,11 +68,12 @@ class NamedItem(BaseModel):
     description: Optional[str] = None
 
 
-class Precision(BaseModel):
-    """Precision sub-model for tolerance overrides"""
+class DtypeNamedItem(BaseModel):
+    """A dtype item with optional precision override."""
 
-    atol: Optional[float] = None
-    rtol: Optional[float] = None
+    name: str
+    description: Optional[str] = None
+    precision: Optional[Precision] = None
 
 
 class OpsEdits(BaseModel):
@@ -97,7 +105,7 @@ class ModulesEdits(BaseModel):
 class DtypesEdits(BaseModel):
     """Per-test dtype overrides."""
 
-    include: List[NamedItem] = []  # inject dtypes into @ops.allowed_dtypes
+    include: List[DtypeNamedItem] = []  # inject dtypes into @ops.allowed_dtypes
     exclude: List[NamedItem] = []  # remove dtype variants for this test
 
     @field_validator("include", "exclude", mode="before")
@@ -123,6 +131,14 @@ class DtypesEdits(BaseModel):
 
     def resolved_exclude(self) -> Set[torch.dtype]:
         return {parse_dtype(item.name) for item in self.exclude}
+
+    def resolved_include_precision(self) -> Dict[torch.dtype, Precision]:
+        """Return {dtype -> Precision} for included dtypes that have precision overrides."""
+        return {
+            parse_dtype(item.name): item.precision
+            for item in self.include
+            if item.precision is not None
+        }
 
 
 class TestEdits(BaseModel):
@@ -268,7 +284,7 @@ class SupportedModuleConfig(BaseModel):
 class GlobalConfig(BaseModel):
     """Model for global configs: supported_dtypes, supported_ops"""
 
-    supported_dtypes: List[NamedItem] = []
+    supported_dtypes: List[DtypeNamedItem] = []
     supported_ops: Optional[List[SupportedOpConfig]] = None
     supported_modules: Optional[List[SupportedModuleConfig]] = None
 
@@ -312,6 +328,16 @@ class GlobalConfig(BaseModel):
         if not self.supported_dtypes:
             return None
         return {parse_dtype(item.name) for item in self.supported_dtypes}
+
+    def resolved_supported_dtypes_precision(
+        self,
+    ) -> Dict[torch.dtype, Precision]:
+        """Return {dtype -> Precision} for dtypes that have precision overrides."""
+        return {
+            parse_dtype(item.name): item.precision
+            for item in self.supported_dtypes
+            if item.precision is not None
+        }
 
     def resolved_supported_ops(self) -> Optional[Set[str]]:
         if self.supported_ops is None:

--- a/tests/spyre_upstream_patcher.py
+++ b/tests/spyre_upstream_patcher.py
@@ -390,3 +390,73 @@ class _OOTModuleDtypePatcher:
             and self._modules_instance.allowed_dtypes is not None
         ):
             self._modules_instance.allowed_dtypes |= self._extra_dtypes
+
+
+class _OOTPrecisionOverridePatcher:
+    """Injects dtype-level precision overrides into fn.precision_overrides and
+    fn.tolerance_overrides before super().instantiate_test() runs.
+
+    Uses two upstream mechanisms that instantiate_test reads automatically:
+      - fn.precision_overrides: {dtype -> atol}          (@precisionOverride)
+      - fn.tolerance_overrides: {dtype -> tol(atol,rtol)} (@toleranceOverride)
+
+    When only atol is specified, precision_overrides is used.
+    When rtol is specified (with or without atol), tolerance_overrides is used
+    since it is the only upstream mechanism that carries rtol.
+
+    """
+
+    def __init__(
+        self,
+        test: object,
+        global_dtype_precision: dict,  # {torch.dtype -> Precision}
+        include_dtype_precision: dict,  # {torch.dtype -> Precision}
+    ) -> None:
+        self._underlying_fn = test.__func__ if hasattr(test, "__func__") else test
+        self._global_dtype_precision = global_dtype_precision
+        self._include_dtype_precision = include_dtype_precision
+
+    def patch(self) -> None:
+        if not self._global_dtype_precision and not self._include_dtype_precision:
+            return
+
+        # Merge: global first (lower priority), include overrides
+        merged: dict = {}
+        for dtype, prec in self._global_dtype_precision.items():
+            if prec is not None:
+                merged[dtype] = prec
+        for dtype, prec in self._include_dtype_precision.items():
+            if prec is not None:
+                merged[dtype] = prec
+
+        if not merged:
+            return
+
+        try:
+            from torch.testing._internal.common_device_type import tol as _tol
+
+            has_tol = True
+        except ImportError:
+            has_tol = False
+
+        for dtype, prec in merged.items():
+            atol = prec.atol
+            rtol = prec.rtol
+
+            if rtol is not None and has_tol:
+                # rtol specified - use tolerance_overrides (carries both atol+rtol)
+                # tolerance_overrides takes precedence over precision_overrides
+                # in upstream instantiate_test.
+                if not hasattr(self._underlying_fn, "tolerance_overrides"):
+                    self._underlying_fn.tolerance_overrides = {}
+                self._underlying_fn.tolerance_overrides[dtype] = _tol(
+                    atol=atol if atol is not None else 0.0,
+                    rtol=rtol,
+                )
+            elif atol is not None:
+                # atol only - use precision_overrides (simpler, matches @precisionOverride)
+                if not hasattr(self._underlying_fn, "precision_overrides"):
+                    self._underlying_fn.precision_overrides = {}
+                # setdefault for global, direct assign for include (already merged above
+                # so just assign - include already won priority during merge)
+                self._underlying_fn.precision_overrides[dtype] = atol


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- feature

#### What this PR does:

This PR adds support for precision patching and specification of dtype precision
```yaml
global:
    supported_dtypes:
      - name: float16
        precision:
            atol: 1e-3
            rtol: 1e-3
```

`_OOTPrecisionOverridePatcher` extends the OOT framework's patcher pattern to support per-dtype tolerance configuration driven entirely from the YAML config. It injects precision overrides into the test function before `super().instantiate_test()` runs, using the same two upstream mechanisms that PyTorch's `@precisionOverride` and `@toleranceOverride` decorators use — fn.precision_overrides for atol-only overrides and fn.tolerance_overrides for overrides that include rtol, using the upstream tol namedtuple. This means the upstream instantiate_test machinery picks up and applies the overrides automatically per dtype variant, setting self.precision and self.rel_tol on the test instance at run time without any additional wiring. Precision can be specified at two levels: globally under global.supported_dtypes (applying to all tests for that dtype) or per-test under edits.dtypes.include (which takes priority over the global value). The merge happens in the patcher itself — global entries are loaded first and include entries overwrite them, so the priority is always respected. When only atol is specified, precision_overrides is used; when rtol is specified (with or without atol), tolerance_overrides is used instead since it is the only upstream mechanism that carries rtol. This keeps the behavior consistent with how upstream test authors use @toleranceOverride, where it takes precedence over @precisionOverride.

#### Which issue(s) this PR is related to:


Fixes https://github.com/torch-spyre/torch-spyre/issues/1715

#### Does this PR introduce a user-facing change? No 

