### PR TITLE
Add HuggingFace Transformers adapters for Spyre

### DIFF
--- a/tests/adapters/test_adapter_cpu_accuracy.py
+++ b/tests/adapters/test_adapter_cpu_accuracy.py
@@ -1,0 +1,359 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CPU accuracy test: compare adapter forward passes against stock HF on CPU.
+
+Tests prefill (full sequence) and 4 autoregressive decode steps, comparing
+logits and greedy token selections at each step.
+
+Usage:
+    python tests/adapters/test_adapter_cpu_accuracy.py [granite|qwen3|granite4|smollm3]
+
+Requires: transformers, torch (2.x), sentencepiece
+"""
+
+import importlib
+import importlib.util
+import math
+import os
+import sys
+import traceback
+
+import torch
+import torch.nn.functional as F
+
+# ---------------------------------------------------------------------------
+# Import adapter modules without triggering torch_spyre.__init__
+# We load them as standalone modules via importlib.
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+ADAPTERS_DIR = os.path.join(REPO_ROOT, "torch_spyre", "adapters")
+
+
+def _load_adapter_module(filename):
+    """Load an adapter .py file as a module, bypassing torch_spyre.__init__."""
+    filepath = os.path.join(ADAPTERS_DIR, filename)
+    mod_name = f"_adapter_{filename.replace('.py', '')}"
+    spec = importlib.util.spec_from_file_location(mod_name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    return mod, spec
+
+
+# Step 1: load hf_common first so adapters can import from it
+_common_path = os.path.join(ADAPTERS_DIR, "hf_common.py")
+_common_spec = importlib.util.spec_from_file_location(
+    "torch_spyre.adapters.hf_common", _common_path
+)
+_common_mod = importlib.util.module_from_spec(_common_spec)
+# Patch DEVICE to cpu BEFORE executing the module
+sys.modules["torch_spyre.adapters.hf_common"] = _common_mod
+_common_spec.loader.exec_module(_common_mod)
+_common_mod.DEVICE = "cpu"
+
+# Also register torch_spyre.adapters so relative imports work
+sys.modules.setdefault("torch_spyre", type(sys)("torch_spyre"))
+sys.modules.setdefault("torch_spyre.adapters", type(sys)("torch_spyre.adapters"))
+
+
+def load_adapter(filename):
+    """Load an adapter module by filename."""
+    mod_name = f"torch_spyre.adapters.{filename.replace('.py', '')}"
+    filepath = os.path.join(ADAPTERS_DIR, filename)
+    spec = importlib.util.spec_from_file_location(mod_name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# HF reference: token-by-token greedy with DynamicCache
+# ---------------------------------------------------------------------------
+
+def hf_greedy_steps(model, input_ids, num_decode=4):
+    """Run stock HF model for prefill + N greedy decode steps.
+
+    Returns list of dicts with logits/token for each step.
+    Step 0 = prefill, steps 1..N = decode.
+    """
+    from transformers import DynamicCache
+
+    results = []
+    past = DynamicCache()
+    ids = input_ids.clone()
+    seq_len = ids.shape[1]
+
+    for step in range(num_decode + 1):
+        if step == 0:
+            position_ids = torch.arange(seq_len).unsqueeze(0)
+        else:
+            position_ids = torch.tensor([[seq_len + step - 1]])
+
+        with torch.no_grad():
+            out = model(
+                input_ids=ids,
+                position_ids=position_ids,
+                past_key_values=past,
+                use_cache=True,
+            )
+
+        logits = out.logits
+        last_logits = logits[0, -1, :].float()
+        token = last_logits.argmax().item()
+        results.append({"logits": last_logits, "token": token, "step": step})
+
+        past = out.past_key_values
+        ids = torch.tensor([[token]])
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Adapter: prefill + decode using adapter _run_forward with KV cache
+# ---------------------------------------------------------------------------
+
+def adapter_greedy_steps(run_forward_fn, model, input_ids, num_decode=4):
+    """Run adapter forward for prefill + N greedy decode steps on CPU."""
+    results = []
+    batch_size = input_ids.shape[0]
+    seq_len = input_ids.shape[1]
+
+    num_layers = model.config.num_hidden_layers
+    num_kv_heads = model.config.num_key_value_heads
+    head_dim = getattr(
+        model.config, "head_dim",
+        model.config.hidden_size // model.config.num_attention_heads,
+    )
+    vocab_size = model.config.vocab_size
+
+    # Empty KV caches
+    key_caches = [
+        torch.empty(batch_size, num_kv_heads, 0, head_dim, dtype=torch.float16)
+        for _ in range(num_layers)
+    ]
+    value_caches = [
+        torch.empty(batch_size, num_kv_heads, 0, head_dim, dtype=torch.float16)
+        for _ in range(num_layers)
+    ]
+
+    # --- Prefill ---
+    position_ids = torch.arange(seq_len).unsqueeze(0)
+    causal_mask = torch.zeros((1, 1, seq_len, seq_len), dtype=torch.float16)
+    for i in range(seq_len):
+        causal_mask[:, :, i, i + 1:] = -torch.inf
+
+    with torch.no_grad():
+        logits = run_forward_fn(
+            model, input_ids, position_ids, causal_mask,
+            key_caches, value_caches,
+            is_filling=False, token_index=0, cache_position=0,
+        )
+
+    last_logits = logits[0, -1, :].float()[:vocab_size]
+    token = last_logits.argmax().item()
+    results.append({"logits": last_logits, "token": token, "step": 0})
+
+    cache_len = seq_len
+
+    # --- Decode steps (expand mode) ---
+    for step in range(1, num_decode + 1):
+        next_ids = torch.tensor([[token]])
+        next_pos = torch.tensor([[seq_len + step - 1]])
+        total_len = cache_len + 1
+        decode_mask = torch.zeros((1, 1, 1, total_len), dtype=torch.float16)
+
+        with torch.no_grad():
+            logits = run_forward_fn(
+                model, next_ids, next_pos, decode_mask,
+                key_caches, value_caches,
+                is_filling=False, token_index=0, cache_position=0,
+            )
+
+        last_logits = logits[0, -1, :].float()[:vocab_size]
+        token = last_logits.argmax().item()
+        results.append({"logits": last_logits, "token": token, "step": step})
+        cache_len += 1
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Test driver
+# ---------------------------------------------------------------------------
+
+def run_model_test(model_name, model_path, adapter_filename, num_decode=4):
+    """Load model, run HF ref vs adapter, return comparison list."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    adapter_mod = load_adapter(adapter_filename)
+    run_forward_fn = adapter_mod._run_forward
+    prepare_fn = adapter_mod.prepare_for_spyre
+
+    print(f"\n{'='*70}")
+    print(f"  {model_name}: loading {model_path}")
+    print(f"{'='*70}")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path, torch_dtype=torch.float16, device_map="cpu",
+    )
+    model.eval()
+    model.requires_grad_(False)
+
+    prompt = "The capital of France is"
+    encoded = tokenizer(prompt, return_tensors="pt")
+    input_ids = encoded["input_ids"]
+    print(f"  Prompt: {prompt!r}  ({input_ids.shape[1]} tokens)")
+
+    # --- HF reference (BEFORE patching) ---
+    print("  Running HF reference ...")
+    hf_results = hf_greedy_steps(model, input_ids, num_decode=num_decode)
+
+    # --- Adapter ---
+    print("  Preparing adapter ...")
+    prepare_fn(model)
+
+    # Unwrap torch.compile for CPU (skip compilation overhead)
+    if hasattr(model, "_spyre_compiled_blocks"):
+        unwrapped = []
+        for cb in model._spyre_compiled_blocks:
+            orig = getattr(cb, "_orig_mod", None)
+            unwrapped.append(orig if orig is not None else cb)
+        model._spyre_compiled_blocks = unwrapped
+
+    print("  Running adapter ...")
+    adapter_results = adapter_greedy_steps(
+        run_forward_fn, model, input_ids, num_decode=num_decode,
+    )
+
+    # --- Compare ---
+    comparisons = []
+    for hf_r, ad_r in zip(hf_results, adapter_results):
+        step = hf_r["step"]
+        h_logits = hf_r["logits"]
+        a_logits = ad_r["logits"]
+
+        abs_diff = (h_logits - a_logits).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        h_top5 = h_logits.topk(5).indices.tolist()
+        a_top5 = a_logits.topk(5).indices.tolist()
+        top1_match = h_top5[0] == a_top5[0]
+        top5_overlap = len(set(h_top5) & set(a_top5))
+
+        step_label = "prefill" if step == 0 else f"decode-{step}"
+        hf_tok_str = tokenizer.decode([hf_r["token"]])
+        ad_tok_str = tokenizer.decode([ad_r["token"]])
+
+        comparisons.append({
+            "step": step_label,
+            "hf_token": hf_r["token"],
+            "hf_tok_str": hf_tok_str,
+            "adapter_token": ad_r["token"],
+            "adapter_tok_str": ad_tok_str,
+            "top1_match": top1_match,
+            "top5_overlap": top5_overlap,
+            "max_diff": max_diff,
+            "mean_diff": mean_diff,
+        })
+
+    return comparisons, tokenizer
+
+
+def print_results_table(model_name, comparisons):
+    """Print formatted results table. Returns True if all top-1 match."""
+    print(f"\n  {model_name} Results")
+    print(f"  {'Step':<12} {'HF Token':<20} {'Adapter Token':<20} "
+          f"{'Top1':<6} {'Top5':<5} {'MaxDiff':<10} {'MeanDiff':<10}")
+    print(f"  {'-'*12} {'-'*20} {'-'*20} "
+          f"{'-'*6} {'-'*5} {'-'*10} {'-'*10}")
+    all_match = True
+    for c in comparisons:
+        match_str = "OK" if c["top1_match"] else "FAIL"
+        if not c["top1_match"]:
+            all_match = False
+        hf_str = f"{c['hf_token']:>6} {c['hf_tok_str']!r:<12}"
+        ad_str = f"{c['adapter_token']:>6} {c['adapter_tok_str']!r:<12}"
+        print(f"  {c['step']:<12} {hf_str:<20} {ad_str:<20} "
+              f"{match_str:<6} {c['top5_overlap']}/5  "
+              f"{c['max_diff']:<10.4f} {c['mean_diff']:<10.6f}")
+    return all_match
+
+
+# ---------------------------------------------------------------------------
+# Model registry
+# ---------------------------------------------------------------------------
+
+MODELS = {
+    "qwen3": {
+        "name": "Qwen3 0.6B",
+        "path": "Qwen/Qwen3-0.6B",
+        "adapter": "hf_qwen3.py",
+    },
+    "granite": {
+        "name": "Granite 3.3 2B",
+        "path": "ibm-granite/granite-3.3-2b-instruct",
+        "adapter": "hf_granite.py",
+    },
+    "granite4": {
+        "name": "Granite 4.0 Tiny",
+        "path": "ibm-granite/granite-4.0-tiny-preview",
+        "adapter": "hf_granitemoehybrid.py",
+    },
+    "smollm3": {
+        "name": "SmolLM3 3B",
+        "path": "HuggingFaceTB/SmolLM3-3B-Base",
+        "adapter": "hf_smollm3.py",
+    },
+}
+
+
+if __name__ == "__main__":
+    which = sys.argv[1:] if len(sys.argv) > 1 else list(MODELS.keys())
+
+    all_results = {}
+    for key in which:
+        if key not in MODELS:
+            print(f"Unknown model: {key}. Options: {list(MODELS.keys())}")
+            continue
+        m = MODELS[key]
+        try:
+            comps, _ = run_model_test(
+                m["name"], m["path"], m["adapter"], num_decode=4,
+            )
+            ok = print_results_table(m["name"], comps)
+            all_results[key] = {"comparisons": comps, "all_match": ok}
+        except Exception as e:
+            print(f"\n!!! {m['name']} FAILED:")
+            traceback.print_exc()
+            all_results[key] = {"error": str(e)}
+
+    # Summary
+    print(f"\n{'='*70}")
+    print("  SUMMARY")
+    print(f"{'='*70}")
+    for key in which:
+        if key not in MODELS or key not in all_results:
+            continue
+        name = MODELS[key]["name"]
+        res = all_results[key]
+        if "error" in res:
+            print(f"  {name:<22} ERROR: {res['error']}")
+        else:
+            status = "PASS" if res["all_match"] else "FAIL"
+            print(f"  {name:<22} {status}")
+    print(f"{'='*70}")

--- a/tests/adapters/test_block_cpu_vs_spyre.py
+++ b/tests/adapters/test_block_cpu_vs_spyre.py
@@ -1,0 +1,457 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Per-layer CPU vs Spyre compiled block comparison.
+
+Creates tiny random-weight models (3 layers each, no weight download needed),
+runs each decoder block on CPU (uncompiled) and Spyre (compiled), and compares
+the output hidden states numerically.
+
+Usage (on Spyre pod):
+    python3 test_block_cpu_vs_spyre.py [qwen3|granite|granite4|smollm3|all]
+
+Output: markdown tables with per-layer max/mean abs diff and NaN flags.
+"""
+
+import sys
+import traceback
+
+import torch
+import torch_spyre  # noqa: F401 — registers Spyre device
+
+DEVICE = "spyre"
+SEQ_LEN = 64  # prefill sequence length (one Spyre stick)
+
+
+# ---------------------------------------------------------------------------
+# Model registry: tiny configs for each model family (no weight download)
+# ---------------------------------------------------------------------------
+
+def _make_qwen3_config():
+    from transformers import AutoConfig
+    try:
+        cfg = AutoConfig.from_pretrained("Qwen/Qwen3-0.6B")
+    except Exception:
+        from transformers import Qwen3Config
+        cfg = Qwen3Config(
+            hidden_size=1024, num_attention_heads=16, num_key_value_heads=2,
+            intermediate_size=2560, num_hidden_layers=3, vocab_size=151936,
+            rms_norm_eps=1e-6, max_position_embeddings=4096,
+        )
+    cfg.num_hidden_layers = 3
+    cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_granite_config():
+    from transformers import AutoConfig
+    try:
+        # Use 8B config (head_dim=128, D/2=64 = one stick — compiles on Spyre).
+        # The 2B config has head_dim=64 (D/2=32) which triggers a stickify
+        # assertion with 32 attention heads.
+        cfg = AutoConfig.from_pretrained("ibm-granite/granite-3.3-8b-instruct")
+    except Exception:
+        from transformers import GraniteConfig
+        cfg = GraniteConfig(
+            hidden_size=4096, num_attention_heads=32, num_key_value_heads=8,
+            intermediate_size=10944, num_hidden_layers=3, vocab_size=49152,
+            rms_norm_eps=1e-5, max_position_embeddings=4096,
+            embedding_multiplier=12.0, residual_multiplier=0.22,
+            attention_multiplier=0.0625, logits_scaling=13.0,
+        )
+    cfg.num_hidden_layers = 3
+    cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_granite4_config():
+    from transformers import AutoConfig
+    try:
+        cfg = AutoConfig.from_pretrained("ibm-granite/granite-4.0-1b-base")
+    except Exception:
+        from transformers import GraniteMoeHybridConfig
+        cfg = GraniteMoeHybridConfig(
+            hidden_size=2048, num_attention_heads=16, num_key_value_heads=4,
+            shared_intermediate_size=5632, num_hidden_layers=3, vocab_size=49152,
+            rms_norm_eps=1e-5, max_position_embeddings=4096,
+            embedding_multiplier=12.0, residual_multiplier=0.22,
+            attention_multiplier=0.0625, logits_scaling=13.0,
+            num_local_experts=0,
+            layers_block_type=["attention"] * 3,
+        )
+    cfg.num_hidden_layers = 3
+    # Force all-attention (no Mamba)
+    if hasattr(cfg, "layers_block_type"):
+        cfg.layers_block_type = ["attention"] * cfg.num_hidden_layers
+    if hasattr(cfg, "num_local_experts"):
+        cfg.num_local_experts = 0
+    cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_smollm3_config():
+    from transformers import AutoConfig
+    try:
+        cfg = AutoConfig.from_pretrained("HuggingFaceTB/SmolLM3-3B-Base")
+    except Exception:
+        from transformers import SmolLM3Config
+        cfg = SmolLM3Config(
+            hidden_size=2048, num_attention_heads=16, num_key_value_heads=4,
+            intermediate_size=11008, num_hidden_layers=4, vocab_size=128256,
+            rms_norm_eps=1e-6, max_position_embeddings=4096,
+            no_rope_layer_interval=4,
+        )
+    cfg.num_hidden_layers = 4  # keep 4 so NoPE pattern (interval=4) is tested
+    cfg.pad_token_id = None
+    # Recompute no_rope_layers for the reduced layer count
+    interval = getattr(cfg, "no_rope_layer_interval", 4)
+    cfg.no_rope_layers = [
+        int((i + 1) % interval != 0) for i in range(cfg.num_hidden_layers)
+    ]
+    if hasattr(cfg, "layer_types"):
+        cfg.layer_types = ["full_attention"] * cfg.num_hidden_layers
+    cfg._attn_implementation = "eager"
+    return cfg
+
+
+MODEL_REGISTRY = {
+    "qwen3": {
+        "name": "Qwen3 0.6B",
+        "config_fn": _make_qwen3_config,
+        "adapter": "torch_spyre.adapters.hf_qwen3",
+    },
+    "granite": {
+        "name": "Granite 3.3 8B",
+        "config_fn": _make_granite_config,
+        "adapter": "torch_spyre.adapters.hf_granite",
+    },
+    "granite4": {
+        "name": "Granite 4.0",
+        "config_fn": _make_granite4_config,
+        "adapter": "torch_spyre.adapters.hf_granitemoehybrid",
+    },
+    "smollm3": {
+        "name": "SmolLM3",
+        "config_fn": _make_smollm3_config,
+        "adapter": "torch_spyre.adapters.hf_smollm3",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Input creation
+# ---------------------------------------------------------------------------
+
+def make_inputs(config, mode, seed, cache_len=64, device="cpu"):
+    """Create deterministic random inputs for a block_forward call.
+
+    Args:
+        config: HF model config
+        mode: "prefill" or "decode"
+        seed: random seed
+        cache_len: KV cache length for decode mode
+        device: target device ("cpu" or "spyre")
+
+    Returns: dict of tensors on the specified device (fp16)
+    """
+    torch.manual_seed(seed)
+    H = config.hidden_size
+    head_dim = getattr(
+        config, "head_dim", H // config.num_attention_heads
+    )
+    num_kv_heads = config.num_key_value_heads
+    half_dim = head_dim // 2
+
+    if mode == "prefill":
+        L = SEQ_LEN
+        # Create on CPU first, then move (zero-length tensors crash on Spyre
+        # .to(), so create empty KV caches directly on the target device)
+        hidden = torch.randn(1, L, H, dtype=torch.float16).to(device)
+        freqs = torch.randn(1, L, 2, 2, half_dim, dtype=torch.float16).to(
+            device
+        )
+        mask = torch.zeros(1, 1, L, L, dtype=torch.float16)
+        for i in range(L):
+            mask[:, :, i, i + 1:] = -torch.inf
+        mask = mask.to(device)
+        # Empty KV caches: create directly on target device (avoids segfault)
+        kc = torch.empty(
+            1, num_kv_heads, 0, head_dim, dtype=torch.float16, device=device
+        )
+        vc = torch.empty(
+            1, num_kv_heads, 0, head_dim, dtype=torch.float16, device=device
+        )
+        is_filling = False
+    else:
+        L = 1
+        total = cache_len + 1
+        hidden = torch.randn(1, L, H, dtype=torch.float16).to(device)
+        freqs = torch.randn(1, L, 2, 2, half_dim, dtype=torch.float16).to(
+            device
+        )
+        mask = torch.zeros(1, 1, L, total, dtype=torch.float16).to(device)
+        kc = torch.randn(
+            1, num_kv_heads, cache_len, head_dim, dtype=torch.float16
+        ).to(device)
+        vc = torch.randn(
+            1, num_kv_heads, cache_len, head_dim, dtype=torch.float16
+        ).to(device)
+        is_filling = False
+
+    return {
+        "hidden_states": hidden,
+        "selected_freqs": freqs,
+        "attn_mask": mask,
+        "key_cache": kc,
+        "value_cache": vc,
+        "is_filling": is_filling,
+        "token_index": 0,
+        "cache_position": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core comparison logic
+# ---------------------------------------------------------------------------
+
+def compare_block(uncompiled_fn, compiled_fn, inputs_cpu):
+    """Run block on CPU (uncompiled) and Spyre (compiled), compare outputs."""
+    # --- CPU ---
+    with torch.no_grad():
+        cpu_h, cpu_kc, cpu_vc = uncompiled_fn(
+            inputs_cpu["hidden_states"],
+            inputs_cpu["selected_freqs"],
+            inputs_cpu["attn_mask"],
+            inputs_cpu["key_cache"],
+            inputs_cpu["value_cache"],
+            inputs_cpu["is_filling"],
+            inputs_cpu["token_index"],
+            inputs_cpu["cache_position"],
+        )
+
+    # --- Spyre ---
+    spyre_inputs = {
+        k: v.to(DEVICE) if isinstance(v, torch.Tensor) else v
+        for k, v in inputs_cpu.items()
+    }
+    with torch.no_grad():
+        spyre_h, spyre_kc, spyre_vc = compiled_fn(
+            spyre_inputs["hidden_states"],
+            spyre_inputs["selected_freqs"],
+            spyre_inputs["attn_mask"],
+            spyre_inputs["key_cache"],
+            spyre_inputs["value_cache"],
+            spyre_inputs["is_filling"],
+            spyre_inputs["token_index"],
+            spyre_inputs["cache_position"],
+        )
+
+    spyre_h_cpu = spyre_h.to("cpu")
+
+    # --- Metrics ---
+    diff = (cpu_h - spyre_h_cpu).abs()
+    return {
+        "max_abs_diff": diff.max().item(),
+        "mean_abs_diff": diff.mean().item(),
+        "cpu_nan": cpu_h.isnan().any().item(),
+        "spyre_nan": spyre_h_cpu.isnan().any().item(),
+        "cpu_shape": list(cpu_h.shape),
+        "spyre_shape": list(spyre_h_cpu.shape),
+    }
+
+
+def test_model(model_key):
+    """Run per-layer comparison for one model. Returns list of result dicts."""
+    import importlib
+    from transformers import AutoModelForCausalLM
+
+    info = MODEL_REGISTRY[model_key]
+    print(f"\n{'='*70}")
+    print(f"  {info['name']}: creating tiny model with random weights")
+    print(f"{'='*70}")
+
+    config = info["config_fn"]()
+    print(f"  Config: {config.num_hidden_layers} layers, "
+          f"hidden={config.hidden_size}, "
+          f"heads={config.num_attention_heads}/{config.num_key_value_heads}")
+
+    # Create model with random weights
+    torch.manual_seed(42)
+    model = AutoModelForCausalLM.from_config(config).to(torch.float16)
+    model.eval()
+    model.requires_grad_(False)
+
+    # Prepare adapter (patches RMSNorm, creates compiled blocks, etc.)
+    adapter = importlib.import_module(info["adapter"])
+    print(f"  Preparing adapter ...")
+    adapter.prepare_for_spyre(model)
+
+    num_blocks = len(model._spyre_compiled_blocks)
+
+    # --- Phase A: CPU runs ---
+    print(f"  Phase A: running {num_blocks} blocks on CPU ...")
+    cpu_results = {}
+    for layer_idx in range(num_blocks):
+        compiled_block = model._spyre_compiled_blocks[layer_idx]
+        uncompiled = getattr(compiled_block, "_orig_mod", compiled_block)
+        for mode in ("prefill", "decode"):
+            seed = 42 + layer_idx * 100 + (0 if mode == "prefill" else 1)
+            inputs = make_inputs(config, mode, seed, device="cpu")
+            with torch.no_grad():
+                h, kc, vc = uncompiled(
+                    inputs["hidden_states"], inputs["selected_freqs"],
+                    inputs["attn_mask"], inputs["key_cache"],
+                    inputs["value_cache"], inputs["is_filling"],
+                    inputs["token_index"], inputs["cache_position"],
+                )
+            cpu_results[(layer_idx, mode)] = h.clone()
+
+    # --- Phase B: Move model to Spyre, run compiled blocks ---
+    print(f"  Moving model to Spyre ...")
+    model.to(DEVICE)
+    print(f"  Phase B: running {num_blocks} blocks on Spyre ...")
+
+    results = []
+    for layer_idx in range(num_blocks):
+        compiled_block = model._spyre_compiled_blocks[layer_idx]
+        for mode in ("prefill", "decode"):
+            seed = 42 + layer_idx * 100 + (0 if mode == "prefill" else 1)
+            spyre_inputs = make_inputs(
+                config, mode, seed, device=DEVICE,
+            )
+
+            try:
+                print(f"    Layer {layer_idx} {mode} ...", end=" ", flush=True)
+                with torch.no_grad():
+                    spyre_h, _, _ = compiled_block(
+                        spyre_inputs["hidden_states"],
+                        spyre_inputs["selected_freqs"],
+                        spyre_inputs["attn_mask"],
+                        spyre_inputs["key_cache"],
+                        spyre_inputs["value_cache"],
+                        spyre_inputs["is_filling"],
+                        spyre_inputs["token_index"],
+                        spyre_inputs["cache_position"],
+                    )
+                spyre_h_cpu = spyre_h.to("cpu")
+                cpu_h = cpu_results[(layer_idx, mode)]
+
+                diff = (cpu_h - spyre_h_cpu).abs()
+                r = {
+                    "model": info["name"],
+                    "layer": layer_idx,
+                    "mode": mode,
+                    "shape": (
+                        f"[1,{SEQ_LEN if mode == 'prefill' else 1}"
+                        f",{config.hidden_size}]"
+                    ),
+                    "max_abs_diff": diff.max().item(),
+                    "mean_abs_diff": diff.mean().item(),
+                    "cpu_nan": cpu_h.isnan().any().item(),
+                    "spyre_nan": spyre_h_cpu.isnan().any().item(),
+                    "error": None,
+                }
+                print(f"max_diff={r['max_abs_diff']:.4f}")
+            except Exception as e:
+                r = {
+                    "model": info["name"],
+                    "layer": layer_idx,
+                    "mode": mode,
+                    "shape": (
+                        f"[1,{SEQ_LEN if mode == 'prefill' else 1}"
+                        f",{config.hidden_size}]"
+                    ),
+                    "max_abs_diff": None,
+                    "mean_abs_diff": None,
+                    "cpu_nan": None,
+                    "spyre_nan": None,
+                    "error": str(e)[:80],
+                }
+                print(f"ERROR: {r['error']}")
+
+            results.append(r)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def print_table(all_results):
+    """Print markdown table of all results."""
+    print(f"\n## Per-Layer CPU vs Spyre Block Comparison\n")
+    print(f"| Model | Layer | Mode | Shape | Max Diff | Mean Diff "
+          f"| CPU NaN | Spyre NaN | Error |")
+    print(f"|-------|-------|------|-------|----------|----------- "
+          f"|---------|-----------|-------|")
+    for r in all_results:
+        if r["error"]:
+            print(f"| {r['model']} | {r['layer']} | {r['mode']} "
+                  f"| {r['shape']} | — | — | — | — | {r['error']} |")
+        else:
+            nan_c = "Yes" if r["cpu_nan"] else "No"
+            nan_s = "Yes" if r["spyre_nan"] else "No"
+            print(f"| {r['model']} | {r['layer']} | {r['mode']} "
+                  f"| {r['shape']} "
+                  f"| {r['max_abs_diff']:.4f} | {r['mean_abs_diff']:.6f} "
+                  f"| {nan_c} | {nan_s} | — |")
+
+
+def print_summary(all_results):
+    """Print pass/fail summary per model."""
+    from collections import defaultdict
+    by_model = defaultdict(list)
+    for r in all_results:
+        by_model[r["model"]].append(r)
+
+    print(f"\n## Summary\n")
+    print(f"| Model | Layers Tested | Errors | Max Diff (worst) | Any NaN |")
+    print(f"|-------|--------------|--------|------------------|---------|")
+    for model, rows in by_model.items():
+        n_layers = len(set(r["layer"] for r in rows))
+        n_errors = sum(1 for r in rows if r["error"])
+        valid = [r for r in rows if r["error"] is None]
+        worst = max((r["max_abs_diff"] for r in valid), default=0.0)
+        any_nan = any(r.get("spyre_nan") for r in valid)
+        print(f"| {model} | {n_layers} | {n_errors} "
+              f"| {worst:.4f} | {'Yes' if any_nan else 'No'} |")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    which = sys.argv[1:] if len(sys.argv) > 1 else ["all"]
+    if "all" in which:
+        which = list(MODEL_REGISTRY.keys())
+
+    all_results = []
+    for key in which:
+        if key not in MODEL_REGISTRY:
+            print(f"Unknown model: {key}. "
+                  f"Options: {list(MODEL_REGISTRY.keys())} or 'all'")
+            continue
+        try:
+            results = test_model(key)
+            all_results.extend(results)
+        except Exception:
+            print(f"\n!!! {MODEL_REGISTRY[key]['name']} FAILED:")
+            traceback.print_exc()
+
+    if all_results:
+        print_table(all_results)
+        print_summary(all_results)

--- a/tests/adapters/test_e2e_smoke_spyre.py
+++ b/tests/adapters/test_e2e_smoke_spyre.py
@@ -1,0 +1,154 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+E2E smoke test: load HF model on Spyre, generate tokens, verify non-trivial.
+
+Usage (on Spyre pod):
+    python3 test_e2e_smoke_spyre.py [qwen3|granite|granite4|smollm3]
+
+Verifies:
+  - Model loads and moves to Spyre without error
+  - generate() produces non-empty output
+  - Generated tokens are not all-zero or all-same
+"""
+
+import sys
+import time
+import traceback
+
+import torch
+import torch_spyre  # noqa: F401 — registers Spyre device
+
+MODEL_REGISTRY = {
+    "qwen3": {
+        "name": "Qwen3 0.6B",
+        "path": "Qwen/Qwen3-0.6B",
+        "adapter": "torch_spyre.adapters.hf_qwen3",
+    },
+    "granite": {
+        "name": "Granite 3.3 2B",
+        "path": "ibm-granite/granite-3.3-2b-instruct",
+        "adapter": "torch_spyre.adapters.hf_granite",
+    },
+    "granite4": {
+        "name": "Granite 4.0 1B",
+        "path": "ibm-granite/granite-4.0-1b-base",
+        "adapter": "torch_spyre.adapters.hf_granitemoehybrid",
+    },
+    "smollm3": {
+        "name": "SmolLM3 3B",
+        "path": "HuggingFaceTB/SmolLM3-3B-Base",
+        "adapter": "torch_spyre.adapters.hf_smollm3",
+    },
+}
+
+
+def run_smoke(model_key):
+    """Load model, generate 5 tokens, validate output."""
+    import importlib
+
+    from transformers import AutoTokenizer
+
+    info = MODEL_REGISTRY[model_key]
+    adapter = importlib.import_module(info["adapter"])
+
+    print(f"\n{'='*70}")
+    print(f"  {info['name']}: loading from {info['path']}")
+    print(f"{'='*70}")
+
+    # Load model (downloads weights, prepares, moves to Spyre)
+    t0 = time.time()
+    model = adapter.load_model(info["path"])
+    load_time = time.time() - t0
+    print(f"  Load time: {load_time:.1f}s")
+
+    tokenizer = AutoTokenizer.from_pretrained(info["path"])
+    prompt = "The capital of France is"
+    print(f"  Prompt: {prompt!r}")
+
+    # Generate
+    t0 = time.time()
+    outputs = adapter.generate(
+        model, tokenizer, [prompt],
+        max_new_tokens=5, do_sample=False, timing=True,
+    )
+    gen_time = time.time() - t0
+
+    output_text = outputs[0] if outputs else ""
+    print(f"  Output: {output_text!r}")
+    print(f"  Generate time: {gen_time:.1f}s")
+
+    # Validate
+    checks = {
+        "non_empty": len(output_text.strip()) > 0,
+        "not_all_spaces": output_text.strip() != "",
+    }
+
+    # Encode output to check token diversity
+    if output_text:
+        gen_ids = tokenizer.encode(output_text, add_special_tokens=False)
+        checks["has_tokens"] = len(gen_ids) > 0
+        checks["not_all_zero"] = not all(t == 0 for t in gen_ids)
+        checks["not_all_same"] = len(set(gen_ids)) > 1 or len(gen_ids) <= 1
+        checks["token_ids"] = gen_ids
+    else:
+        checks["has_tokens"] = False
+        checks["not_all_zero"] = False
+        checks["not_all_same"] = False
+        checks["token_ids"] = []
+
+    passed = all(v for k, v in checks.items() if k != "token_ids")
+
+    return {
+        "model": info["name"],
+        "status": "PASS" if passed else "FAIL",
+        "tokens": len(checks.get("token_ids", [])),
+        "text": output_text[:50],
+        "load_s": load_time,
+        "gen_s": gen_time,
+        "checks": checks,
+    }
+
+
+if __name__ == "__main__":
+    which = sys.argv[1:] if len(sys.argv) > 1 else ["qwen3"]
+
+    results = []
+    for key in which:
+        if key not in MODEL_REGISTRY:
+            print(f"Unknown: {key}. Options: {list(MODEL_REGISTRY.keys())}")
+            continue
+        try:
+            r = run_smoke(key)
+            results.append(r)
+        except Exception:
+            print(f"\n!!! {MODEL_REGISTRY[key]['name']} FAILED:")
+            traceback.print_exc()
+            results.append({
+                "model": MODEL_REGISTRY[key]["name"],
+                "status": "ERROR",
+                "tokens": 0,
+                "text": "",
+                "load_s": 0,
+                "gen_s": 0,
+            })
+
+    # Summary table
+    print(f"\n## E2E Smoke Test Results\n")
+    print(f"| Model | Status | Tokens | Generated Text | Load (s) | Gen (s) |")
+    print(f"|-------|--------|--------|----------------|----------|---------|")
+    for r in results:
+        print(f"| {r['model']} | {r['status']} | {r['tokens']} "
+              f"| {r['text']!r} | {r['load_s']:.1f} | {r['gen_s']:.1f} |")

--- a/tests/adapters/test_e2e_token_compare_spyre.py
+++ b/tests/adapters/test_e2e_token_compare_spyre.py
@@ -1,0 +1,321 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+E2E token-level comparison: HF stock forward (CPU) vs adapter forward (Spyre).
+
+For each model, runs prefill + 4 greedy decode steps on both CPU (stock HF)
+and Spyre (adapter), comparing logits and greedy tokens at each step.
+
+NOTE: Spyre currently has known correctness issues. This test is expected
+to show mismatches now but will pass once hardware fixes land (~1 week).
+
+Usage (on Spyre pod):
+    python3 test_e2e_token_compare_spyre.py [qwen3|granite]
+"""
+
+import importlib
+import math
+import sys
+import traceback
+
+import torch
+import torch.nn.functional as F
+import torch_spyre  # noqa: F401 — registers Spyre device
+
+from torch_spyre.adapters.hf_common import BLOCK_SIZE
+
+DEVICE = "spyre"
+
+MODEL_REGISTRY = {
+    "qwen3": {
+        "name": "Qwen3 0.6B",
+        "path": "Qwen/Qwen3-0.6B",
+        "adapter": "torch_spyre.adapters.hf_qwen3",
+    },
+    "granite": {
+        "name": "Granite 3.3 2B",
+        "path": "ibm-granite/granite-3.3-2b-instruct",
+        "adapter": "torch_spyre.adapters.hf_granite",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# HF reference: stock forward on CPU with DynamicCache
+# ---------------------------------------------------------------------------
+
+def hf_greedy_steps(model, input_ids, num_decode=4):
+    """Run stock HF model for prefill + N decode steps on CPU."""
+    from transformers import DynamicCache
+
+    results = []
+    past = DynamicCache()
+    ids = input_ids.clone()
+    seq_len = ids.shape[1]
+
+    for step in range(num_decode + 1):
+        if step == 0:
+            position_ids = torch.arange(seq_len).unsqueeze(0)
+        else:
+            position_ids = torch.tensor([[seq_len + step - 1]])
+
+        with torch.no_grad():
+            out = model(
+                input_ids=ids, position_ids=position_ids,
+                past_key_values=past, use_cache=True,
+            )
+
+        logits = out.logits[0, -1, :].float()
+        token = logits.argmax().item()
+        results.append({"logits": logits, "token": token, "step": step})
+        past = out.past_key_values
+        ids = torch.tensor([[token]])
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Adapter forward on Spyre
+# ---------------------------------------------------------------------------
+
+def adapter_greedy_steps(run_forward_fn, model, input_ids, num_decode=4):
+    """Run adapter forward on Spyre for prefill + N decode steps."""
+    batch_size = input_ids.shape[0]
+    seq_len = input_ids.shape[1]
+
+    num_layers = model.config.num_hidden_layers
+    num_kv_heads = model.config.num_key_value_heads
+    head_dim = getattr(
+        model.config, "head_dim",
+        model.config.hidden_size // model.config.num_attention_heads,
+    )
+    vocab_size = model.config.vocab_size
+
+    # Pad to BLOCK_SIZE
+    padded_len = math.ceil(seq_len / BLOCK_SIZE) * BLOCK_SIZE
+    prompt_offset = padded_len - seq_len
+    if prompt_offset > 0:
+        pad = input_ids.new_zeros((batch_size, prompt_offset))
+        padded_ids = torch.cat([pad, input_ids], dim=1)
+    else:
+        padded_ids = input_ids
+
+    position_ids = torch.zeros((batch_size, padded_len), dtype=torch.long)
+    position_ids[:, prompt_offset:] = torch.arange(seq_len)
+
+    key_caches = [
+        torch.empty(batch_size, num_kv_heads, 0, head_dim,
+                     dtype=torch.float16, device=DEVICE)
+        for _ in range(num_layers)
+    ]
+    value_caches = [
+        torch.empty(batch_size, num_kv_heads, 0, head_dim,
+                     dtype=torch.float16, device=DEVICE)
+        for _ in range(num_layers)
+    ]
+
+    results = []
+
+    # --- Prefill ---
+    from torch_spyre.adapters.hf_common import build_prefill_mask
+
+    prefill_mask = build_prefill_mask(batch_size, padded_len, prompt_offset)
+
+    with torch.no_grad():
+        logits = run_forward_fn(
+            model, padded_ids.to(DEVICE), position_ids.to(DEVICE),
+            prefill_mask.to(DEVICE), key_caches, value_caches,
+            is_filling=False, token_index=0, cache_position=0,
+        )
+    logits_cpu = logits.to("cpu")[0, -1, :].float()[:vocab_size]
+    token = logits_cpu.argmax().item()
+    results.append({"logits": logits_cpu, "token": token, "step": 0})
+
+    # --- Decode steps (expansion mode for simplicity) ---
+    cache_len = padded_len
+    # Build decode position tracking
+    decode_pos = torch.zeros((batch_size, BLOCK_SIZE), dtype=torch.long)
+    for j in range(BLOCK_SIZE):
+        decode_pos[:, j] = seq_len + j - BLOCK_SIZE
+
+    # We generate one token at a time using expansion blocks
+    result_buf = padded_ids.clone()
+    result_buf = F.pad(result_buf, (0, BLOCK_SIZE))
+    result_buf[:, padded_len] = token
+
+    tokens_in_block = 1
+
+    for step in range(1, num_decode + 1):
+        # Always use expansion mode (simpler for the comparison test)
+        cache_len += BLOCK_SIZE
+        decode_pos = decode_pos + BLOCK_SIZE
+
+        from torch_spyre.adapters.hf_common import build_expansion_mask
+        exp_mask = build_expansion_mask(
+            batch_size, BLOCK_SIZE, cache_len, prompt_offset,
+        )
+
+        next_input = result_buf[:, -BLOCK_SIZE:]
+
+        with torch.no_grad():
+            logits = run_forward_fn(
+                model, next_input.to(DEVICE), decode_pos.to(DEVICE),
+                exp_mask.to(DEVICE), key_caches, value_caches,
+                is_filling=False, token_index=0, cache_position=0,
+            )
+
+        logits_cpu = logits.to("cpu")
+        # The relevant logit is at the first position of the block
+        # (previous token was placed at result_buf[:, padded_len + ...])
+        last_logits = logits_cpu[0, -BLOCK_SIZE, :].float()[:vocab_size]
+        token = last_logits.argmax().item()
+        results.append({"logits": last_logits, "token": token, "step": step})
+
+        # Place token and prepare next block
+        result_buf = F.pad(result_buf, (0, BLOCK_SIZE))
+        result_buf[:, -BLOCK_SIZE] = token
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+def compare_results(hf_results, adapter_results, tokenizer, model_name):
+    """Compare HF vs adapter results, return comparison rows."""
+    rows = []
+    for hf_r, ad_r in zip(hf_results, adapter_results):
+        step = hf_r["step"]
+        h_logits = hf_r["logits"]
+        a_logits = ad_r["logits"]
+
+        # Trim to common vocab
+        min_vocab = min(h_logits.shape[0], a_logits.shape[0])
+        h = h_logits[:min_vocab]
+        a = a_logits[:min_vocab]
+
+        diff = (h - a).abs()
+        max_diff = diff.max().item()
+        mean_diff = diff.mean().item()
+
+        h_top1 = h.argmax().item()
+        a_top1 = a.argmax().item()
+        match = h_top1 == a_top1
+
+        step_label = "prefill" if step == 0 else f"decode-{step}"
+        h_str = tokenizer.decode([hf_r["token"]])
+        a_str = tokenizer.decode([ad_r["token"]])
+
+        rows.append({
+            "model": model_name,
+            "step": step_label,
+            "hf_token": hf_r["token"],
+            "hf_str": h_str,
+            "spyre_token": ad_r["token"],
+            "spyre_str": a_str,
+            "top1_match": match,
+            "max_diff": max_diff,
+            "mean_diff": mean_diff,
+            "hf_nan": h_logits.isnan().any().item(),
+            "spyre_nan": a_logits.isnan().any().item(),
+        })
+    return rows
+
+
+def run_model_test(model_key, num_decode=4):
+    """Full comparison for one model."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    info = MODEL_REGISTRY[model_key]
+    adapter = importlib.import_module(info["adapter"])
+
+    print(f"\n{'='*70}")
+    print(f"  {info['name']}: {info['path']}")
+    print(f"{'='*70}")
+
+    tokenizer = AutoTokenizer.from_pretrained(info["path"])
+    model = AutoModelForCausalLM.from_pretrained(
+        info["path"], torch_dtype=torch.float16, device_map="cpu",
+    )
+    model.eval()
+    model.requires_grad_(False)
+
+    prompt = "The capital of France is"
+    encoded = tokenizer(prompt, return_tensors="pt")
+    input_ids = encoded["input_ids"]
+    print(f"  Prompt: {prompt!r} ({input_ids.shape[1]} tokens)")
+
+    # --- HF reference on CPU (BEFORE patching) ---
+    print("  Running HF reference on CPU ...")
+    hf_results = hf_greedy_steps(model, input_ids, num_decode=num_decode)
+
+    # --- Adapter on Spyre ---
+    print("  Preparing adapter ...")
+    adapter.prepare_for_spyre(model)
+    print("  Moving model to Spyre ...")
+    model.to(DEVICE)
+    print("  Running adapter on Spyre ...")
+    adapter_results = adapter_greedy_steps(
+        adapter._run_forward, model, input_ids, num_decode=num_decode,
+    )
+
+    rows = compare_results(hf_results, adapter_results, tokenizer, info["name"])
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def print_table(all_rows):
+    """Print markdown comparison table."""
+    print(f"\n## E2E Token Comparison: HF (CPU) vs Adapter (Spyre)\n")
+    print(f"| Model | Step | HF Token | Spyre Token | Match "
+          f"| Max Diff | Mean Diff | HF NaN | Spyre NaN |")
+    print(f"|-------|------|----------|-------------|-------"
+          f"|----------|-----------|--------|-----------|")
+    for r in all_rows:
+        match = "OK" if r["top1_match"] else "FAIL"
+        hf_col = f"{r['hf_token']:>5} {r['hf_str']!r}"
+        sp_col = f"{r['spyre_token']:>5} {r['spyre_str']!r}"
+        hn = "Yes" if r["hf_nan"] else "No"
+        sn = "Yes" if r["spyre_nan"] else "No"
+        print(f"| {r['model']} | {r['step']} | {hf_col} | {sp_col} "
+              f"| {match} | {r['max_diff']:.4f} | {r['mean_diff']:.6f} "
+              f"| {hn} | {sn} |")
+
+
+if __name__ == "__main__":
+    which = sys.argv[1:] if len(sys.argv) > 1 else ["qwen3"]
+
+    all_rows = []
+    for key in which:
+        if key not in MODEL_REGISTRY:
+            print(f"Unknown: {key}. Options: {list(MODEL_REGISTRY.keys())}")
+            continue
+        try:
+            rows = run_model_test(key)
+            all_rows.extend(rows)
+        except Exception:
+            print(f"\n!!! {MODEL_REGISTRY[key]['name']} FAILED:")
+            traceback.print_exc()
+
+    if all_rows:
+        print_table(all_rows)
+        n_match = sum(1 for r in all_rows if r["top1_match"])
+        print(f"\nTop-1 agreement: {n_match}/{len(all_rows)} steps")
+        if n_match < len(all_rows):
+            print("NOTE: Spyre has known correctness issues being fixed.")

--- a/torch_spyre/adapters/SPYRE_ADAPTER_STATUS.md
+++ b/torch_spyre/adapters/SPYRE_ADAPTER_STATUS.md
@@ -1,0 +1,425 @@
+# HF Adapter Spyre Status
+
+Status of HuggingFace Transformers adapters on Spyre hardware.
+Last updated: 2026-04-21.
+
+## Model Compatibility Matrix
+
+| Model | model\_type | head\_dim | D/2 | Stick Aligned | CPU Accurate | Spyre Compiles | Spyre Runs |
+|-------|-----------|---------|-----|--------------|-------------|---------------|-----------|
+| Qwen3 0.6B | qwen3 | 128 | 64 | Yes | Yes | Yes | Yes |
+| Granite 3.3 8B | granite | 128 | 64 | Yes | Yes | Yes | Yes |
+| Granite 3.3 2B | granite | 64 | 32 | **No** | Yes | **No** | — |
+| Granite 4.0 1B | granitemoehybrid | 128 | 64 | Yes | Yes | Yes | Yes |
+| SmolLM3 3B | smollm3 | 128 | 64 | Yes | Yes | Yes | Yes |
+
+**CPU Accurate** = adapter produces identical greedy tokens to stock HF on CPU.
+**Spyre Compiles** = `torch.compile(block_forward)` succeeds on Spyre.
+**Spyre Runs** = block produces output (no crash/NaN). Numerical accuracy is
+limited by known Spyre hardware correctness issues being fixed.
+
+## Stick Alignment Requirement
+
+The RoPE matmul implementation reshapes Q/K to `[B, L, H, 2, D/2]` where
+`D = head_dim`. When `D/2 < 64` (sub-stick), the stickify compiler pass
+generates a compound dimension expression (`H*d3 + d4`) that it cannot
+decompose, causing an `AssertionError`:
+
+```
+AssertionError: Could not find a host dimension matching stick expr d4
+in [0, d0, 64*d1 + 32*d3 + d4]
+```
+
+**Rule: a model works on Spyre if `head_dim >= 128` (i.e. `D/2 >= 64`).**
+
+All models tested with `head_dim=128` compile and run. Granite 3.3 2B
+(`head_dim=64`) is the only failure.
+
+Note that `head_dim` is not always `hidden_size // num_attention_heads`.
+Some models (e.g. Qwen3) explicitly set `head_dim` in config independent
+of `hidden_size` and `num_attention_heads`.
+
+### Checking a new model
+
+```python
+from transformers import AutoConfig
+config = AutoConfig.from_pretrained("org/model-name")
+head_dim = getattr(config, "head_dim",
+                   config.hidden_size // config.num_attention_heads)
+will_compile = (head_dim // 2) >= 64  # D/2 must fill at least one stick
+```
+
+## How the Adapters Work
+
+### Architecture
+
+Each adapter follows the FMS `eager_spyre` compilation pattern: compiled
+block functions with raw tensor KV caches, precomputed RoPE rotation
+matrices, fp16 RMSNorm, and padded 64-block decode generation loop.
+
+```
+torch_spyre/adapters/
+├── hf_common.py          — shared utilities (~430 lines)
+│   PrecomputedRotaryEmbedding, apply_rope_matmul,
+│   patch_rmsnorm, pad_lm_head, kv_cache_update,
+│   build_prefill_mask, build_expansion_mask,
+│   load_model_common, generate
+├── hf_granite.py          — Granite 3.3 adapter (~130 lines)
+├── hf_qwen3.py            — Qwen3 adapter (~140 lines)
+├── hf_granitemoehybrid.py — Granite 4.0 dense adapter (~170 lines)
+├── hf_smollm3.py          — SmolLM3 adapter (~140 lines)
+├── hf_phi3.py             — Phi-4 mini adapter (blocked, see Known Issues)
+└── __init__.py
+```
+
+```
+┌─────────────────────────────────────────────────────┐
+│  generate() — Python loop (hf_common.py, ~190 lines)│
+│  ┌───────────────────────────────────────────────┐  │
+│  │  _run_forward() — per-model, calls blocks     │  │
+│  │  ┌─────────────────────────────────────────┐  │  │
+│  │  │  compiled block_forward()               │  │  │
+│  │  │  • RMSNorm (fp16, patched)              │  │  │
+│  │  │  • QKV projections                      │  │  │
+│  │  │  • RoPE (matmul, no slicing)            │  │  │
+│  │  │  • KV cache update (cat or overwrite)   │  │  │
+│  │  │  • SDPA (enable_gqa=True)               │  │  │
+│  │  │  • Output projection                    │  │  │
+│  │  │  • MLP (SwiGLU)                         │  │  │
+│  │  └─────────────────────────────────────────┘  │  │
+│  │  × N layers                                   │  │
+│  │  Final RMSNorm + LM head                      │  │
+│  └───────────────────────────────────────────────┘  │
+│  Token selection (CPU) + result buffer management   │
+└─────────────────────────────────────────────────────┘
+```
+
+### Deviations from Stock HuggingFace Transformers
+
+#### 1. RoPE: Precomputed Rotation Matrices
+
+| | HF Transformers | Adapter (`hf_common.py`) |
+|---|---|---|
+| **Where** | `*RotaryEmbedding.forward()` | `PrecomputedRotaryEmbedding` |
+| **sin/cos** | Computed every forward call on-device | Precomputed once on CPU, cached as `[S, 2, 2, D/2]` rotation matrices |
+| **Application** | `rotate_half()` + slices with `x[..., :half]` (`aten.slice`) | `apply_rope_matmul()` — reshape to `[B, L, H, 2, D/2]`, broadcast multiply by rotation matrix, sum. No slicing. |
+| **Output** | `(cos, sin)` tuple | `selected_freqs` tensor `[B, L, 2, 2, D/2]` |
+
+**Why:** Spyre has no `sin`/`cos` hardware ops and `aten.slice.Tensor` falls
+back to CPU with stride mismatches inside compiled graphs.
+
+#### 2. RMSNorm: Class-Level Patch
+
+| | HF Transformers | Adapter (`hf_common.py`) |
+|---|---|---|
+| **Mechanism** | Each model has its own RMSNorm class | `patch_rmsnorm(cls)` patches any RMSNorm class in-place |
+| **Precision** | Casts to `float32` for variance, back to input dtype | Spyre: stays in `float16` throughout. CPU: `float32` (matches HF). |
+| **Variance** | `hidden_states.pow(2).mean()` | Spyre: `(hidden_states * hidden_states).mean()`. CPU: same as HF. |
+| **Epsilon** | Python float scalar | Spyre: `torch.ops.spyre.full((1,), eps, device, dtype)` tensor. CPU: Python float. |
+
+**Why:** Spyre does not support dtype conversion on-device. The `pow(2)`
+op is also not well supported; element-wise multiply is native.
+
+#### 3. LM Head Weight: Padded
+
+| | HF Transformers | Adapter (`hf_common.py`) |
+|---|---|---|
+| **Vocab dim** | As-is from model config | Padded to `ceil(vocab/64)*64 + 64` via `pad_lm_head()` |
+
+**Why:** Spyre requires tensor dimensions aligned to 64-element sticks
+(128 bytes at fp16) for efficient matmul work division. The extra +64 avoids
+prime-number multiples that cause poor work distribution across Spyre cores.
+
+#### 4. Decoder Layers: Custom Compiled Blocks
+
+| | HF Transformers | Adapter (per-model `_make_compiled_block()`) |
+|---|---|---|
+| **Layer forward** | `*DecoderLayer.forward()` | `block_forward()` — plain function closure wrapping the same weights |
+| **KV cache** | `DynamicCache` Python object with `.update()` method | Raw tensor lists `key_caches[i]`, `value_caches[i]` passed as function args |
+| **Cache update** | `torch.cat` inside `DynamicCache.update()` | `torch.cat` (expand mode) or `torch.ops.spyre.overwrite` (fill mode) via `kv_cache_update()` in `hf_common.py` |
+| **Compilation** | Not compiled by default | `torch.compile(block_forward, dynamic=False)` |
+
+**Why:** `DynamicCache` is a Python object with side effects that causes graph
+breaks in `torch.compile`. Raw tensor args trace cleanly.
+`torch.ops.spyre.overwrite` must execute inside the compiled graph to produce
+Spyre device code (returns `None` in eager mode).
+
+#### 5. Generation Loop: Custom Implementation
+
+| | HF Transformers | Adapter (`hf_common.generate()`) |
+|---|---|---|
+| **Entry point** | `GenerationMixin.generate()` (~2000 lines) | `generate()` (~190 lines) |
+| **Decode protocol** | Token-by-token with dynamic cache growth | 64-block padded decode: prefill → expand → fill (×63) → expand cycle |
+| **Prompt handling** | Right-padded or unpadded | Left-padded to multiple of 64 |
+| **KV cache growth** | Grows by 1 per token (`torch.cat`) | Grows by 64 per expansion, then 63 single-slot overwrites |
+| **Extras** | Full sampling, beam search, etc. | Greedy + top-k sampling, per-token timing |
+
+**Why:** Spyre requires fixed-size block decode with `spyre.overwrite` for KV
+cache updates. HF's generate has dynamic shapes, CPU-only causal mask creation,
+and DynamicCache that are all incompatible with Spyre's static-shape compilation
+model.
+
+#### 6. Attention Mask: Built Externally
+
+| | HF Transformers | Adapter (`hf_common.py`) |
+|---|---|---|
+| **Creation** | `create_causal_mask()` using `torch.tril` inside model forward | `build_prefill_mask()` / `build_expansion_mask()` on CPU |
+| **Dtype** | Model dtype (may be float32) | Always `float16` |
+| **Transfer** | On-device | Built on CPU, moved to Spyre |
+
+**Why:** `torch.tril` is not supported on Spyre. Masks must be `float16`
+(Spyre's native dtype).
+
+#### 7. Embedding: No Change Required
+
+HF's `nn.Embedding` automatically falls back to CPU via torch-spyre's fallback
+mechanism. The result is transparently transferred to the Spyre device. No
+adapter code needed.
+
+### What Works As-Is (No Patching)
+
+These HF Transformer components run natively on Spyre without modification:
+
+| Component | HF Class/Function | Spyre Support |
+|---|---|---|
+| Linear projections (Q, K, V, O, gate, up, down) | `nn.Linear` | Native matmul |
+| MLP activation | `nn.SiLU` (SwiGLU) | Native `silu` |
+| Embedding multiplier | `inputs_embeds * config.embedding_multiplier` | Native scalar-tensor mul |
+| Residual multiplier | `hidden_states * config.residual_multiplier` | Native scalar-tensor mul |
+| Logits scaling | `logits / config.logits_scaling` | Native tensor-scalar div |
+| Scaled dot-product attention | `F.scaled_dot_product_attention` | Decomposed by torch-spyre |
+| GQA head expansion | `enable_gqa=True` in SDPA | Handled internally by SDPA decomposition |
+| Embedding lookup | `nn.Embedding` | CPU fallback (automatic) |
+
+### Model-Specific Differences
+
+| Feature | Granite 3.3 | Qwen3 | Granite 4.0 | SmolLM3 |
+|---------|------------|-------|-------------|---------|
+| Embedding multiplier | Yes | No | Yes | No |
+| Residual multiplier | Yes | No | Yes | No |
+| Logits scaling | Yes | No | Yes | No |
+| Q/K RMSNorm | No | Yes (per-head) | No | No |
+| Fused MLP weights | No | No | Yes (split at prepare time) | No |
+| NoPE layers | No | No | No | Yes (conditional RoPE per layer) |
+| Attention scaling | `config.attention_multiplier` | `head_dim**-0.5` | `config.attention_multiplier` | `head_dim**-0.5` |
+
+## Per-Layer CPU vs Spyre Numerical Comparison
+
+Tested with tiny random-weight models (3-4 layers), `batch=1`, `seq_len=64`.
+Diffs are expected due to known Spyre numerical accuracy issues.
+
+### Qwen3 0.6B (hidden=1024, heads=16/8, head\_dim=128)
+
+| Layer | Mode | Shape | Max Diff | Mean Diff |
+|-------|------|-------|----------|-----------|
+| 0 | prefill | [1,64,1024] | 1.79 | 0.29 |
+| 0 | decode | [1,1,1024] | 0.87 | 0.19 |
+| 1 | prefill | [1,64,1024] | 2.02 | 0.29 |
+| 1 | decode | [1,1,1024] | 5.06 | 2.04 |
+| 2 | prefill | [1,64,1024] | 1.93 | 0.29 |
+| 2 | decode | [1,1,1024] | 5.51 | 2.00 |
+
+### Granite 3.3 8B (hidden=4096, heads=32/8, head\_dim=128)
+
+| Layer | Mode | Shape | Max Diff | Mean Diff |
+|-------|------|-------|----------|-----------|
+| 0 | prefill | [1,64,4096] | 7.75 | 1.25 |
+| 0 | decode | [1,1,4096] | 0.17 | 0.04 |
+| 1 | prefill | [1,64,4096] | 8.25 | 1.25 |
+| 1 | decode | [1,1,4096] | 0.17 | 0.04 |
+| 2 | prefill | [1,64,4096] | 6.89 | 1.25 |
+| 2 | decode | [1,1,4096] | 5.99 | 2.03 |
+
+### Granite 4.0 1B (hidden=2048, heads=16/4, head\_dim=128)
+
+| Layer | Mode | Shape | Max Diff | Mean Diff |
+|-------|------|-------|----------|-----------|
+| 0 | prefill | [1,64,2048] | 127.13 | 22.38 |
+| 0 | decode | [1,1,2048] | 68.06 | 16.31 |
+| 1 | prefill | [1,64,2048] | 133.00 | 22.78 |
+| 1 | decode | [1,1,2048] | 77.06 | 17.06 |
+| 2 | prefill | [1,64,2048] | 133.25 | 22.77 |
+| 2 | decode | [1,1,2048] | 278.00 | 62.22 |
+
+Large diffs from `residual_multiplier` / `embedding_multiplier` amplifying
+fp16 errors through the residual stream.
+
+### SmolLM3 3B (hidden=2048, heads=16/4, head\_dim=128)
+
+| Layer | Mode | Shape | Max Diff | Mean Diff | Notes |
+|-------|------|-------|----------|-----------|-------|
+| 0 | prefill | [1,64,2048] | 3.26 | 0.46 | RoPE layer |
+| 0 | decode | [1,1,2048] | 19.38 | 4.55 | RoPE layer |
+| 1 | prefill | [1,64,2048] | 3.23 | 0.46 | RoPE layer |
+| 1 | decode | [1,1,2048] | 7.09 | 2.12 | RoPE layer |
+| 2 | prefill | [1,64,2048] | 3.07 | 0.46 | RoPE layer |
+| 2 | decode | [1,1,2048] | 4.35 | 0.98 | RoPE layer |
+| 3 | prefill | [1,64,2048] | **0.04** | 0.006 | NoPE layer |
+| 3 | decode | [1,1,2048] | **0.90** | 0.20 | NoPE layer |
+
+NoPE layers (no RoPE) have ~100x lower error, confirming the RoPE matmul
+path is the primary source of Spyre numerical error.
+
+## E2E Token Generation (Qwen3 0.6B, Real Weights)
+
+| Test | Result | Notes |
+|------|--------|-------|
+| Smoke: generates tokens | **PASS** | Produces 5 non-trivial tokens |
+| Token match vs HF CPU | **FAIL** (0/5) | Expected; known Spyre accuracy issues |
+
+Generated text: `" reefstanding nightlyOnce nightly"` (garbage, but not
+NaN/zeros — the pipeline runs end-to-end).
+
+## CPU Accuracy (All Models, Real Weights)
+
+All adapters produce **identical greedy tokens** to stock HF transformers
+on CPU, verified for prefill + 4 decode steps:
+
+| Model | Prefill Token | Decode-1 | Decode-2 | Decode-3 | Decode-4 | Max Logit Diff |
+|-------|--------------|----------|----------|----------|----------|---------------|
+| Qwen3 0.6B | Paris | . | The | capital | of | 0.033 |
+| Granite 3.3 2B | Par | is | . | \\n | \\n | 0.031 |
+| Granite 4.0 1B | Paris | . | The | capital | of | 0.001 |
+| SmolLM3 (tiny) | 555 | 526 | 179 | 197 | 197 | exact |
+
+Granite 4.0 tested in float32 (fp16 overflows on CPU due to multipliers).
+SmolLM3 tested with tiny random model (3B too large to download locally).
+
+## Bug Fixed: SmolLM3 no\_rope\_layers Inversion
+
+**File:** `hf_smollm3.py:129`
+
+The `no_rope_layers` config flag was inverted. HF uses `1` = use RoPE,
+`0` = skip, but the adapter had `use_rope = not no_rope[idx]` which
+flipped the meaning. Fixed to `use_rope = bool(no_rope[idx])`.
+
+## Adding a New Model
+
+### Checklist
+
+1. Check `head_dim >= 128` (see Stick Alignment above)
+2. Check for fused weights that need splitting (like Granite 4.0's
+   `input_linear`)
+3. Check for partial RoPE (`partial_rotary_factor < 1.0`) — requires
+   splitting Q/K into rotated/non-rotated portions, which hits stickify
+   non-zero offset assertions (see Phi-4 blocker in Known Issues)
+4. Check for model-specific multipliers (embedding, residual, attention,
+   logits) — must be preserved in the block function
+5. Check for per-layer variations (NoPE layers, sliding window, MoE routing)
+6. Verify CPU accuracy before testing on Spyre
+
+### Comparison with FMS `eager_spyre` Approach
+
+| Aspect | FMS `eager_spyre` | HF Adapter |
+|---|---|---|
+| Model source | FMS (custom codebase) | HuggingFace Transformers (standard) |
+| RoPE | Matmul with `selected_freqs` (restructured code) | Same approach, applied via monkey-patch |
+| RMSNorm | `torch.nn.RMSNorm` (replaced FMS's custom LayerNormParameterized) | `patch_rmsnorm(cls)` patches HF's RMSNorm class in-place |
+| KV cache | Tuple of tensors `(key, value)` passed through FMS attention | List of tensors passed to compiled block function |
+| GQA | Manual `unsqueeze(2).expand().flatten(1,2)` | `F.scaled_dot_product_attention(enable_gqa=True)` |
+| Compilation | `block.compile(dynamic=False)` on FMS GraniteBlock | `torch.compile(block_forward, dynamic=False)` on extracted function |
+| Generation | Custom `generate()` in `fms.utils.generation` | Custom `generate()` in `hf_common.py` |
+| Weight loading | FMS serialization (CPU → dtype → device) | HF `from_pretrained(dtype=fp16, device_map="cpu")` then `.to("spyre")` |
+| Maintenance | Requires FMS fork (`eager_spyre` branch) | No fork; runtime monkey-patches on stock HF |
+
+## Known Issues
+
+### Spyre Limitations
+
+| Limitation | Impact | Workaround |
+|-----------|--------|------------|
+| No `sin`/`cos` ops | RoPE must be precomputed | `PrecomputedRotaryEmbedding` |
+| No dtype conversion | RMSNorm must stay fp16 | Patched forward with device check |
+| No `aten.slice` in compiled graphs | KV cache indexing falls back to CPU | `spyre.overwrite` for fill mode |
+| `head_dim/2 < 64` (sub-stick) | Stickify assertion on RoPE matmul | Only use models with `head_dim >= 128` |
+| `partial_rotary_factor < 1.0` | Non-zero offset assertion in stickify | Split Q/K weights (not yet implemented; blocks Phi-4) |
+| Zero-length tensors crash `copy_host_to_device` | Segfault on `.to("spyre")` | Create empty tensors directly on device |
+| fp16 overflow on CPU for large multipliers | NaN logits on CPU | Test in float32; runs fine on Spyre hardware |
+
+### Performance Issues
+
+These affect speed but not correctness:
+
+**Compilation overhead (first run):** The first invocation compiles graphs per
+layer per mode (expand + fill). This takes several minutes. Subsequent runs
+with the same shapes reuse cached compiled graphs.
+
+**`aten.slice` fallback in fill mode:** The KV cache fill operation
+`k[:, :, token_index:token_index+1, :]` inside `spyre.overwrite` triggers an
+`aten.slice.Tensor` CPU fallback per layer per fill step. FMS has the same
+slice pattern but benefits from tighter integration with the Spyre compiler.
+
+**Recompilation per `token_index`:** Each unique `token_index` value in fill
+mode triggers a new graph specialization (because `torch.compile` specializes
+on Python int arguments). Over 63 fill steps, this causes 63 recompilations
+on first use.
+
+### Open Work
+
+1. **Fix `token_index` recompilation** — pass as tensor to avoid specialization
+2. **Fix `aten.slice` fallback in fill** — restructure overwrite call
+3. **Multi-iteration benchmarking** — run 5+ iterations to measure steady-state
+   latency (after compilation cache is warm)
+4. ~~Validate output correctness~~ — **Done.** CPU accuracy verified for all 4 models.
+5. ~~Support more models~~ — **Done.** Qwen3, Granite 4.0, SmolLM3 added.
+6. **Phi-4 mini** — blocked by `partial_rotary_factor=0.75` (stickify non-zero
+   offset assertion). Fix: split Q/K weights so rotated dims are separate linears.
+7. **Stick alignment for small head\_dim** — Granite 3.3 2B (`head_dim=64`)
+   fails stickify. Needs compiler fix or alternative RoPE implementation.
+
+## Test Scripts
+
+| Script | Purpose | Requires Spyre |
+|--------|---------|---------------|
+| `tests/adapters/test_adapter_cpu_accuracy.py` | CPU: adapter vs HF logit comparison | No |
+| `tests/adapters/test_block_cpu_vs_spyre.py` | Per-layer CPU vs Spyre block comparison | Yes |
+| `tests/adapters/test_e2e_smoke_spyre.py` | E2E: load model, generate tokens | Yes |
+| `tests/adapters/test_e2e_token_compare_spyre.py` | E2E: HF CPU vs adapter Spyre tokens | Yes |
+
+### Running on the Spyre pod
+
+```bash
+# Copy and run
+kubectl cp tests/adapters/test_block_cpu_vs_spyre.py \
+  a5-deepview/rganti-spyre-dev-pf:/home/rganti/test_block_cpu_vs_spyre.py
+kubectl exec -n a5-deepview rganti-spyre-dev-pf -- \
+  bash -lc "python3 /home/rganti/test_block_cpu_vs_spyre.py all"
+```
+
+## Public API
+
+```python
+# Granite 3.3
+from torch_spyre.adapters.hf_granite import load_model, generate
+model = load_model("/path/to/granite-3.3-8b-instruct")
+
+# Qwen3
+from torch_spyre.adapters.hf_qwen3 import load_model, generate
+model = load_model("Qwen/Qwen3-0.6B")
+
+# Granite 4.0 (dense variants only — no Mamba layers)
+from torch_spyre.adapters.hf_granitemoehybrid import load_model, generate
+model = load_model("ibm-granite/granite-4.0-1b-base")
+
+# SmolLM3
+from torch_spyre.adapters.hf_smollm3 import load_model, generate
+model = load_model("HuggingFaceTB/SmolLM3-3B-Base")
+
+# Generate (same for all models)
+from transformers import AutoTokenizer
+tokenizer = AutoTokenizer.from_pretrained("/path/to/model")
+outputs = generate(model, tokenizer, ["What is 2+2?"], max_new_tokens=128)
+```
+
+Each adapter also exposes `prepare_for_spyre(model)` for manual control:
+
+```python
+from transformers import AutoModelForCausalLM
+from torch_spyre.adapters.hf_granite import prepare_for_spyre, generate
+
+model = AutoModelForCausalLM.from_pretrained(path, dtype=torch.float16,
+                                              device_map="cpu")
+prepare_for_spyre(model)
+model.to("spyre")
+outputs = generate(model, tokenizer, ["Hello!"], max_new_tokens=32)
+```

--- a/torch_spyre/adapters/SPYRE_ADAPTER_STATUS.md
+++ b/torch_spyre/adapters/SPYRE_ADAPTER_STATUS.md
@@ -1,7 +1,6 @@
 # HF Adapter Spyre Status
 
 Status of HuggingFace Transformers adapters on Spyre hardware.
-Last updated: 2026-04-21.
 
 ## Model Compatibility Matrix
 
@@ -13,378 +12,12 @@ Last updated: 2026-04-21.
 | Granite 4.0 1B | granitemoehybrid | 128 | 64 | Yes | Yes | Yes | Yes |
 | SmolLM3 3B | smollm3 | 128 | 64 | Yes | Yes | Yes | Yes |
 
-**CPU Accurate** = adapter produces identical greedy tokens to stock HF on CPU.
+**CPU Accurate** = adapter produces identical greedy tokens to stock
+HF on CPU.
 **Spyre Compiles** = `torch.compile(block_forward)` succeeds on Spyre.
-**Spyre Runs** = block produces output (no crash/NaN). Numerical accuracy is
-limited by known Spyre hardware correctness issues being fixed.
-
-## Stick Alignment Requirement
-
-The RoPE matmul implementation reshapes Q/K to `[B, L, H, 2, D/2]` where
-`D = head_dim`. When `D/2 < 64` (sub-stick), the stickify compiler pass
-generates a compound dimension expression (`H*d3 + d4`) that it cannot
-decompose, causing an `AssertionError`:
-
-```
-AssertionError: Could not find a host dimension matching stick expr d4
-in [0, d0, 64*d1 + 32*d3 + d4]
-```
-
-**Rule: a model works on Spyre if `head_dim >= 128` (i.e. `D/2 >= 64`).**
-
-All models tested with `head_dim=128` compile and run. Granite 3.3 2B
-(`head_dim=64`) is the only failure.
-
-Note that `head_dim` is not always `hidden_size // num_attention_heads`.
-Some models (e.g. Qwen3) explicitly set `head_dim` in config independent
-of `hidden_size` and `num_attention_heads`.
-
-### Checking a new model
-
-```python
-from transformers import AutoConfig
-config = AutoConfig.from_pretrained("org/model-name")
-head_dim = getattr(config, "head_dim",
-                   config.hidden_size // config.num_attention_heads)
-will_compile = (head_dim // 2) >= 64  # D/2 must fill at least one stick
-```
-
-## How the Adapters Work
-
-### Architecture
-
-Each adapter follows the FMS `eager_spyre` compilation pattern: compiled
-block functions with raw tensor KV caches, precomputed RoPE rotation
-matrices, fp16 RMSNorm, and padded 64-block decode generation loop.
-
-```
-torch_spyre/adapters/
-├── hf_common.py          — shared utilities (~430 lines)
-│   PrecomputedRotaryEmbedding, apply_rope_matmul,
-│   patch_rmsnorm, pad_lm_head, kv_cache_update,
-│   build_prefill_mask, build_expansion_mask,
-│   load_model_common, generate
-├── hf_granite.py          — Granite 3.3 adapter (~130 lines)
-├── hf_qwen3.py            — Qwen3 adapter (~140 lines)
-├── hf_granitemoehybrid.py — Granite 4.0 dense adapter (~170 lines)
-├── hf_smollm3.py          — SmolLM3 adapter (~140 lines)
-├── hf_phi3.py             — Phi-4 mini adapter (blocked, see Known Issues)
-└── __init__.py
-```
-
-```
-┌─────────────────────────────────────────────────────┐
-│  generate() — Python loop (hf_common.py, ~190 lines)│
-│  ┌───────────────────────────────────────────────┐  │
-│  │  _run_forward() — per-model, calls blocks     │  │
-│  │  ┌─────────────────────────────────────────┐  │  │
-│  │  │  compiled block_forward()               │  │  │
-│  │  │  • RMSNorm (fp16, patched)              │  │  │
-│  │  │  • QKV projections                      │  │  │
-│  │  │  • RoPE (matmul, no slicing)            │  │  │
-│  │  │  • KV cache update (cat or overwrite)   │  │  │
-│  │  │  • SDPA (enable_gqa=True)               │  │  │
-│  │  │  • Output projection                    │  │  │
-│  │  │  • MLP (SwiGLU)                         │  │  │
-│  │  └─────────────────────────────────────────┘  │  │
-│  │  × N layers                                   │  │
-│  │  Final RMSNorm + LM head                      │  │
-│  └───────────────────────────────────────────────┘  │
-│  Token selection (CPU) + result buffer management   │
-└─────────────────────────────────────────────────────┘
-```
-
-### Deviations from Stock HuggingFace Transformers
-
-#### 1. RoPE: Precomputed Rotation Matrices
-
-| | HF Transformers | Adapter (`hf_common.py`) |
-|---|---|---|
-| **Where** | `*RotaryEmbedding.forward()` | `PrecomputedRotaryEmbedding` |
-| **sin/cos** | Computed every forward call on-device | Precomputed once on CPU, cached as `[S, 2, 2, D/2]` rotation matrices |
-| **Application** | `rotate_half()` + slices with `x[..., :half]` (`aten.slice`) | `apply_rope_matmul()` — reshape to `[B, L, H, 2, D/2]`, broadcast multiply by rotation matrix, sum. No slicing. |
-| **Output** | `(cos, sin)` tuple | `selected_freqs` tensor `[B, L, 2, 2, D/2]` |
-
-**Why:** Spyre has no `sin`/`cos` hardware ops and `aten.slice.Tensor` falls
-back to CPU with stride mismatches inside compiled graphs.
-
-#### 2. RMSNorm: Class-Level Patch
-
-| | HF Transformers | Adapter (`hf_common.py`) |
-|---|---|---|
-| **Mechanism** | Each model has its own RMSNorm class | `patch_rmsnorm(cls)` patches any RMSNorm class in-place |
-| **Precision** | Casts to `float32` for variance, back to input dtype | Spyre: stays in `float16` throughout. CPU: `float32` (matches HF). |
-| **Variance** | `hidden_states.pow(2).mean()` | Spyre: `(hidden_states * hidden_states).mean()`. CPU: same as HF. |
-| **Epsilon** | Python float scalar | Spyre: `torch.ops.spyre.full((1,), eps, device, dtype)` tensor. CPU: Python float. |
-
-**Why:** Spyre does not support dtype conversion on-device. The `pow(2)`
-op is also not well supported; element-wise multiply is native.
-
-#### 3. LM Head Weight: Padded
-
-| | HF Transformers | Adapter (`hf_common.py`) |
-|---|---|---|
-| **Vocab dim** | As-is from model config | Padded to `ceil(vocab/64)*64 + 64` via `pad_lm_head()` |
-
-**Why:** Spyre requires tensor dimensions aligned to 64-element sticks
-(128 bytes at fp16) for efficient matmul work division. The extra +64 avoids
-prime-number multiples that cause poor work distribution across Spyre cores.
-
-#### 4. Decoder Layers: Custom Compiled Blocks
-
-| | HF Transformers | Adapter (per-model `_make_compiled_block()`) |
-|---|---|---|
-| **Layer forward** | `*DecoderLayer.forward()` | `block_forward()` — plain function closure wrapping the same weights |
-| **KV cache** | `DynamicCache` Python object with `.update()` method | Raw tensor lists `key_caches[i]`, `value_caches[i]` passed as function args |
-| **Cache update** | `torch.cat` inside `DynamicCache.update()` | `torch.cat` (expand mode) or `torch.ops.spyre.overwrite` (fill mode) via `kv_cache_update()` in `hf_common.py` |
-| **Compilation** | Not compiled by default | `torch.compile(block_forward, dynamic=False)` |
-
-**Why:** `DynamicCache` is a Python object with side effects that causes graph
-breaks in `torch.compile`. Raw tensor args trace cleanly.
-`torch.ops.spyre.overwrite` must execute inside the compiled graph to produce
-Spyre device code (returns `None` in eager mode).
-
-#### 5. Generation Loop: Custom Implementation
-
-| | HF Transformers | Adapter (`hf_common.generate()`) |
-|---|---|---|
-| **Entry point** | `GenerationMixin.generate()` (~2000 lines) | `generate()` (~190 lines) |
-| **Decode protocol** | Token-by-token with dynamic cache growth | 64-block padded decode: prefill → expand → fill (×63) → expand cycle |
-| **Prompt handling** | Right-padded or unpadded | Left-padded to multiple of 64 |
-| **KV cache growth** | Grows by 1 per token (`torch.cat`) | Grows by 64 per expansion, then 63 single-slot overwrites |
-| **Extras** | Full sampling, beam search, etc. | Greedy + top-k sampling, per-token timing |
-
-**Why:** Spyre requires fixed-size block decode with `spyre.overwrite` for KV
-cache updates. HF's generate has dynamic shapes, CPU-only causal mask creation,
-and DynamicCache that are all incompatible with Spyre's static-shape compilation
-model.
-
-#### 6. Attention Mask: Built Externally
-
-| | HF Transformers | Adapter (`hf_common.py`) |
-|---|---|---|
-| **Creation** | `create_causal_mask()` using `torch.tril` inside model forward | `build_prefill_mask()` / `build_expansion_mask()` on CPU |
-| **Dtype** | Model dtype (may be float32) | Always `float16` |
-| **Transfer** | On-device | Built on CPU, moved to Spyre |
-
-**Why:** `torch.tril` is not supported on Spyre. Masks must be `float16`
-(Spyre's native dtype).
-
-#### 7. Embedding: No Change Required
-
-HF's `nn.Embedding` automatically falls back to CPU via torch-spyre's fallback
-mechanism. The result is transparently transferred to the Spyre device. No
-adapter code needed.
-
-### What Works As-Is (No Patching)
-
-These HF Transformer components run natively on Spyre without modification:
-
-| Component | HF Class/Function | Spyre Support |
-|---|---|---|
-| Linear projections (Q, K, V, O, gate, up, down) | `nn.Linear` | Native matmul |
-| MLP activation | `nn.SiLU` (SwiGLU) | Native `silu` |
-| Embedding multiplier | `inputs_embeds * config.embedding_multiplier` | Native scalar-tensor mul |
-| Residual multiplier | `hidden_states * config.residual_multiplier` | Native scalar-tensor mul |
-| Logits scaling | `logits / config.logits_scaling` | Native tensor-scalar div |
-| Scaled dot-product attention | `F.scaled_dot_product_attention` | Decomposed by torch-spyre |
-| GQA head expansion | `enable_gqa=True` in SDPA | Handled internally by SDPA decomposition |
-| Embedding lookup | `nn.Embedding` | CPU fallback (automatic) |
-
-### Model-Specific Differences
-
-| Feature | Granite 3.3 | Qwen3 | Granite 4.0 | SmolLM3 |
-|---------|------------|-------|-------------|---------|
-| Embedding multiplier | Yes | No | Yes | No |
-| Residual multiplier | Yes | No | Yes | No |
-| Logits scaling | Yes | No | Yes | No |
-| Q/K RMSNorm | No | Yes (per-head) | No | No |
-| Fused MLP weights | No | No | Yes (split at prepare time) | No |
-| NoPE layers | No | No | No | Yes (conditional RoPE per layer) |
-| Attention scaling | `config.attention_multiplier` | `head_dim**-0.5` | `config.attention_multiplier` | `head_dim**-0.5` |
-
-## Per-Layer CPU vs Spyre Numerical Comparison
-
-Tested with tiny random-weight models (3-4 layers), `batch=1`, `seq_len=64`.
-Diffs are expected due to known Spyre numerical accuracy issues.
-
-### Qwen3 0.6B (hidden=1024, heads=16/8, head\_dim=128)
-
-| Layer | Mode | Shape | Max Diff | Mean Diff |
-|-------|------|-------|----------|-----------|
-| 0 | prefill | [1,64,1024] | 1.79 | 0.29 |
-| 0 | decode | [1,1,1024] | 0.87 | 0.19 |
-| 1 | prefill | [1,64,1024] | 2.02 | 0.29 |
-| 1 | decode | [1,1,1024] | 5.06 | 2.04 |
-| 2 | prefill | [1,64,1024] | 1.93 | 0.29 |
-| 2 | decode | [1,1,1024] | 5.51 | 2.00 |
-
-### Granite 3.3 8B (hidden=4096, heads=32/8, head\_dim=128)
-
-| Layer | Mode | Shape | Max Diff | Mean Diff |
-|-------|------|-------|----------|-----------|
-| 0 | prefill | [1,64,4096] | 7.75 | 1.25 |
-| 0 | decode | [1,1,4096] | 0.17 | 0.04 |
-| 1 | prefill | [1,64,4096] | 8.25 | 1.25 |
-| 1 | decode | [1,1,4096] | 0.17 | 0.04 |
-| 2 | prefill | [1,64,4096] | 6.89 | 1.25 |
-| 2 | decode | [1,1,4096] | 5.99 | 2.03 |
-
-### Granite 4.0 1B (hidden=2048, heads=16/4, head\_dim=128)
-
-| Layer | Mode | Shape | Max Diff | Mean Diff |
-|-------|------|-------|----------|-----------|
-| 0 | prefill | [1,64,2048] | 127.13 | 22.38 |
-| 0 | decode | [1,1,2048] | 68.06 | 16.31 |
-| 1 | prefill | [1,64,2048] | 133.00 | 22.78 |
-| 1 | decode | [1,1,2048] | 77.06 | 17.06 |
-| 2 | prefill | [1,64,2048] | 133.25 | 22.77 |
-| 2 | decode | [1,1,2048] | 278.00 | 62.22 |
-
-Large diffs from `residual_multiplier` / `embedding_multiplier` amplifying
-fp16 errors through the residual stream.
-
-### SmolLM3 3B (hidden=2048, heads=16/4, head\_dim=128)
-
-| Layer | Mode | Shape | Max Diff | Mean Diff | Notes |
-|-------|------|-------|----------|-----------|-------|
-| 0 | prefill | [1,64,2048] | 3.26 | 0.46 | RoPE layer |
-| 0 | decode | [1,1,2048] | 19.38 | 4.55 | RoPE layer |
-| 1 | prefill | [1,64,2048] | 3.23 | 0.46 | RoPE layer |
-| 1 | decode | [1,1,2048] | 7.09 | 2.12 | RoPE layer |
-| 2 | prefill | [1,64,2048] | 3.07 | 0.46 | RoPE layer |
-| 2 | decode | [1,1,2048] | 4.35 | 0.98 | RoPE layer |
-| 3 | prefill | [1,64,2048] | **0.04** | 0.006 | NoPE layer |
-| 3 | decode | [1,1,2048] | **0.90** | 0.20 | NoPE layer |
-
-NoPE layers (no RoPE) have ~100x lower error, confirming the RoPE matmul
-path is the primary source of Spyre numerical error.
-
-## E2E Token Generation (Qwen3 0.6B, Real Weights)
-
-| Test | Result | Notes |
-|------|--------|-------|
-| Smoke: generates tokens | **PASS** | Produces 5 non-trivial tokens |
-| Token match vs HF CPU | **FAIL** (0/5) | Expected; known Spyre accuracy issues |
-
-Generated text: `" reefstanding nightlyOnce nightly"` (garbage, but not
-NaN/zeros — the pipeline runs end-to-end).
-
-## CPU Accuracy (All Models, Real Weights)
-
-All adapters produce **identical greedy tokens** to stock HF transformers
-on CPU, verified for prefill + 4 decode steps:
-
-| Model | Prefill Token | Decode-1 | Decode-2 | Decode-3 | Decode-4 | Max Logit Diff |
-|-------|--------------|----------|----------|----------|----------|---------------|
-| Qwen3 0.6B | Paris | . | The | capital | of | 0.033 |
-| Granite 3.3 2B | Par | is | . | \\n | \\n | 0.031 |
-| Granite 4.0 1B | Paris | . | The | capital | of | 0.001 |
-| SmolLM3 (tiny) | 555 | 526 | 179 | 197 | 197 | exact |
-
-Granite 4.0 tested in float32 (fp16 overflows on CPU due to multipliers).
-SmolLM3 tested with tiny random model (3B too large to download locally).
-
-## Bug Fixed: SmolLM3 no\_rope\_layers Inversion
-
-**File:** `hf_smollm3.py:129`
-
-The `no_rope_layers` config flag was inverted. HF uses `1` = use RoPE,
-`0` = skip, but the adapter had `use_rope = not no_rope[idx]` which
-flipped the meaning. Fixed to `use_rope = bool(no_rope[idx])`.
-
-## Adding a New Model
-
-### Checklist
-
-1. Check `head_dim >= 128` (see Stick Alignment above)
-2. Check for fused weights that need splitting (like Granite 4.0's
-   `input_linear`)
-3. Check for partial RoPE (`partial_rotary_factor < 1.0`) — requires
-   splitting Q/K into rotated/non-rotated portions, which hits stickify
-   non-zero offset assertions (see Phi-4 blocker in Known Issues)
-4. Check for model-specific multipliers (embedding, residual, attention,
-   logits) — must be preserved in the block function
-5. Check for per-layer variations (NoPE layers, sliding window, MoE routing)
-6. Verify CPU accuracy before testing on Spyre
-
-### Comparison with FMS `eager_spyre` Approach
-
-| Aspect | FMS `eager_spyre` | HF Adapter |
-|---|---|---|
-| Model source | FMS (custom codebase) | HuggingFace Transformers (standard) |
-| RoPE | Matmul with `selected_freqs` (restructured code) | Same approach, applied via monkey-patch |
-| RMSNorm | `torch.nn.RMSNorm` (replaced FMS's custom LayerNormParameterized) | `patch_rmsnorm(cls)` patches HF's RMSNorm class in-place |
-| KV cache | Tuple of tensors `(key, value)` passed through FMS attention | List of tensors passed to compiled block function |
-| GQA | Manual `unsqueeze(2).expand().flatten(1,2)` | `F.scaled_dot_product_attention(enable_gqa=True)` |
-| Compilation | `block.compile(dynamic=False)` on FMS GraniteBlock | `torch.compile(block_forward, dynamic=False)` on extracted function |
-| Generation | Custom `generate()` in `fms.utils.generation` | Custom `generate()` in `hf_common.py` |
-| Weight loading | FMS serialization (CPU → dtype → device) | HF `from_pretrained(dtype=fp16, device_map="cpu")` then `.to("spyre")` |
-| Maintenance | Requires FMS fork (`eager_spyre` branch) | No fork; runtime monkey-patches on stock HF |
-
-## Known Issues
-
-### Spyre Limitations
-
-| Limitation | Impact | Workaround |
-|-----------|--------|------------|
-| No `sin`/`cos` ops | RoPE must be precomputed | `PrecomputedRotaryEmbedding` |
-| No dtype conversion | RMSNorm must stay fp16 | Patched forward with device check |
-| No `aten.slice` in compiled graphs | KV cache indexing falls back to CPU | `spyre.overwrite` for fill mode |
-| `head_dim/2 < 64` (sub-stick) | Stickify assertion on RoPE matmul | Only use models with `head_dim >= 128` |
-| `partial_rotary_factor < 1.0` | Non-zero offset assertion in stickify | Split Q/K weights (not yet implemented; blocks Phi-4) |
-| Zero-length tensors crash `copy_host_to_device` | Segfault on `.to("spyre")` | Create empty tensors directly on device |
-| fp16 overflow on CPU for large multipliers | NaN logits on CPU | Test in float32; runs fine on Spyre hardware |
-
-### Performance Issues
-
-These affect speed but not correctness:
-
-**Compilation overhead (first run):** The first invocation compiles graphs per
-layer per mode (expand + fill). This takes several minutes. Subsequent runs
-with the same shapes reuse cached compiled graphs.
-
-**`aten.slice` fallback in fill mode:** The KV cache fill operation
-`k[:, :, token_index:token_index+1, :]` inside `spyre.overwrite` triggers an
-`aten.slice.Tensor` CPU fallback per layer per fill step. FMS has the same
-slice pattern but benefits from tighter integration with the Spyre compiler.
-
-**Recompilation per `token_index`:** Each unique `token_index` value in fill
-mode triggers a new graph specialization (because `torch.compile` specializes
-on Python int arguments). Over 63 fill steps, this causes 63 recompilations
-on first use.
-
-### Open Work
-
-1. **Fix `token_index` recompilation** — pass as tensor to avoid specialization
-2. **Fix `aten.slice` fallback in fill** — restructure overwrite call
-3. **Multi-iteration benchmarking** — run 5+ iterations to measure steady-state
-   latency (after compilation cache is warm)
-4. ~~Validate output correctness~~ — **Done.** CPU accuracy verified for all 4 models.
-5. ~~Support more models~~ — **Done.** Qwen3, Granite 4.0, SmolLM3 added.
-6. **Phi-4 mini** — blocked by `partial_rotary_factor=0.75` (stickify non-zero
-   offset assertion). Fix: split Q/K weights so rotated dims are separate linears.
-7. **Stick alignment for small head\_dim** — Granite 3.3 2B (`head_dim=64`)
-   fails stickify. Needs compiler fix or alternative RoPE implementation.
-
-## Test Scripts
-
-| Script | Purpose | Requires Spyre |
-|--------|---------|---------------|
-| `tests/adapters/test_adapter_cpu_accuracy.py` | CPU: adapter vs HF logit comparison | No |
-| `tests/adapters/test_block_cpu_vs_spyre.py` | Per-layer CPU vs Spyre block comparison | Yes |
-| `tests/adapters/test_e2e_smoke_spyre.py` | E2E: load model, generate tokens | Yes |
-| `tests/adapters/test_e2e_token_compare_spyre.py` | E2E: HF CPU vs adapter Spyre tokens | Yes |
-
-### Running on the Spyre pod
-
-```bash
-# Copy and run
-kubectl cp tests/adapters/test_block_cpu_vs_spyre.py \
-  a5-deepview/rganti-spyre-dev-pf:/home/rganti/test_block_cpu_vs_spyre.py
-kubectl exec -n a5-deepview rganti-spyre-dev-pf -- \
-  bash -lc "python3 /home/rganti/test_block_cpu_vs_spyre.py all"
-```
+**Spyre Runs** = block produces output (no crash/NaN). Numerical
+accuracy is limited by known Spyre hardware correctness issues being
+fixed.
 
 ## Public API
 
@@ -408,18 +41,307 @@ model = load_model("HuggingFaceTB/SmolLM3-3B-Base")
 # Generate (same for all models)
 from transformers import AutoTokenizer
 tokenizer = AutoTokenizer.from_pretrained("/path/to/model")
-outputs = generate(model, tokenizer, ["What is 2+2?"], max_new_tokens=128)
+outputs = generate(
+    model, tokenizer, ["What is 2+2?"], max_new_tokens=128,
+)
 ```
 
-Each adapter also exposes `prepare_for_spyre(model)` for manual control:
+Each adapter also exposes `prepare_for_spyre(model)` for manual
+control:
 
 ```python
 from transformers import AutoModelForCausalLM
-from torch_spyre.adapters.hf_granite import prepare_for_spyre, generate
+from torch_spyre.adapters.hf_granite import (
+    prepare_for_spyre, generate,
+)
 
-model = AutoModelForCausalLM.from_pretrained(path, dtype=torch.float16,
-                                              device_map="cpu")
+model = AutoModelForCausalLM.from_pretrained(
+    path, dtype=torch.float16, device_map="cpu",
+)
 prepare_for_spyre(model)
 model.to("spyre")
-outputs = generate(model, tokenizer, ["Hello!"], max_new_tokens=32)
+outputs = generate(
+    model, tokenizer, ["Hello!"], max_new_tokens=32,
+)
 ```
+
+## How the Adapters Work
+
+### Architecture
+
+Each adapter follows the FMS `eager_spyre` compilation pattern:
+compiled block functions with raw tensor KV caches, precomputed
+RoPE rotation matrices, fp16 RMSNorm, and padded 64-block decode
+generation loop.
+
+```
+torch_spyre/adapters/
+├── hf_common.py          — shared utilities
+│   PrecomputedRotaryEmbedding, apply_rope_matmul,
+│   patch_rmsnorm, pad_lm_head, kv_cache_update,
+│   build_prefill_mask, build_expansion_mask,
+│   load_model_common, generate
+├── hf_granite.py          — Granite 3.3 adapter
+├── hf_qwen3.py            — Qwen3 adapter
+├── hf_granitemoehybrid.py — Granite 4.0 dense adapter
+├── hf_smollm3.py          — SmolLM3 adapter
+├── hf_phi3.py             — Phi-4 mini adapter (blocked)
+└── __init__.py
+```
+
+```
+┌───────────────────────────────────────────────┐
+│  generate() — Python loop (hf_common.py)      │
+│  ┌─────────────────────────────────────────┐  │
+│  │  _run_forward() — per-model             │  │
+│  │  ┌───────────────────────────────────┐  │  │
+│  │  │  compiled block_forward()         │  │  │
+│  │  │  • RMSNorm (fp16, patched)        │  │  │
+│  │  │  • QKV projections                │  │  │
+│  │  │  • RoPE (matmul, no slicing)      │  │  │
+│  │  │  • KV cache update                │  │  │
+│  │  │  • SDPA (enable_gqa=True)         │  │  │
+│  │  │  • Output projection              │  │  │
+│  │  │  • MLP (SwiGLU)                   │  │  │
+│  │  └───────────────────────────────────┘  │  │
+│  │  x N layers                             │  │
+│  │  Final RMSNorm + LM head                │  │
+│  └─────────────────────────────────────────┘  │
+│  Token selection (CPU) + buffer management    │
+└───────────────────────────────────────────────┘
+```
+
+### Deviations from Stock HuggingFace Transformers
+
+#### 1. RoPE: Precomputed Rotation Matrices
+
+| | HF Transformers | Adapter |
+|---|---|---|
+| **Where** | `*RotaryEmbedding.forward()` | `PrecomputedRotaryEmbedding` |
+| **sin/cos** | Computed every forward call | Precomputed once on CPU, cached as `[S, 2, 2, D/2]` rotation matrices |
+| **Application** | `rotate_half()` + slices | `apply_rope_matmul()` — reshape to `[B, L, H, 2, D/2]`, broadcast multiply, sum. No slicing. |
+| **Output** | `(cos, sin)` tuple | `selected_freqs` tensor `[B, L, 2, 2, D/2]` |
+
+**Why:** Spyre has no `sin`/`cos` hardware ops and
+`aten.slice.Tensor` falls back to CPU with stride mismatches
+inside compiled graphs.
+
+#### 2. RMSNorm: Class-Level Patch
+
+| | HF Transformers | Adapter |
+|---|---|---|
+| **Mechanism** | Each model has its own RMSNorm class | `patch_rmsnorm(cls)` patches any RMSNorm class in-place |
+| **Precision** | Casts to float32 for variance | Spyre: stays fp16. CPU: float32 (matches HF). |
+| **Variance** | `hidden_states.pow(2).mean()` | Spyre: `(hidden_states * hidden_states).mean()`. CPU: same as HF. |
+| **Epsilon** | Python float scalar | Spyre: `torch.ops.spyre.full((1,), eps, ...)` tensor. CPU: Python float. |
+
+**Why:** Spyre does not support dtype conversion on-device. The
+`pow(2)` op is also not well supported; element-wise multiply is
+native.
+
+#### 3. LM Head Weight: Padded
+
+| | HF Transformers | Adapter |
+|---|---|---|
+| **Vocab dim** | As-is from model config | Padded to `ceil(vocab/64)*64 + 64` via `pad_lm_head()` |
+
+**Why:** Spyre requires tensor dimensions aligned to 64-element
+sticks (128 bytes at fp16) for efficient matmul work division.
+The extra +64 avoids prime-number multiples that cause poor work
+distribution across Spyre cores.
+
+#### 4. Decoder Layers: Custom Compiled Blocks
+
+| | HF Transformers | Adapter |
+|---|---|---|
+| **Layer forward** | `*DecoderLayer.forward()` | `block_forward()` — plain function closure wrapping the same weights |
+| **KV cache** | `DynamicCache` Python object | Raw tensor lists passed as function args |
+| **Cache update** | `torch.cat` inside `DynamicCache.update()` | `torch.cat` (expand) or `spyre.overwrite` (fill) |
+| **Compilation** | Not compiled by default | `torch.compile(block_forward, dynamic=False)` |
+
+**Why:** `DynamicCache` is a Python object with side effects that
+causes graph breaks in `torch.compile`. Raw tensor args trace
+cleanly. `torch.ops.spyre.overwrite` must execute inside the
+compiled graph to produce Spyre device code.
+
+#### 5. Generation Loop: Custom Implementation
+
+| | HF Transformers | Adapter |
+|---|---|---|
+| **Entry point** | `GenerationMixin.generate()` | `generate()` in `hf_common.py` |
+| **Decode protocol** | Token-by-token with dynamic cache growth | 64-block padded decode: prefill, expand, fill (x63), expand cycle |
+| **Prompt handling** | Right-padded or unpadded | Left-padded to multiple of 64 |
+| **KV cache growth** | Grows by 1 per token | Grows by 64 per expansion, then 63 single-slot overwrites |
+| **Extras** | Full sampling, beam search, etc. | Greedy + top-k sampling, per-token timing |
+
+**Why:** Spyre requires fixed-size block decode with
+`spyre.overwrite` for KV cache updates. HF's generate has dynamic
+shapes, CPU-only causal mask creation, and DynamicCache that are
+all incompatible with Spyre's static-shape compilation model.
+
+#### 6. Attention Mask: Built Externally
+
+| | HF Transformers | Adapter |
+|---|---|---|
+| **Creation** | `create_causal_mask()` using `torch.tril` | `build_prefill_mask()` / `build_expansion_mask()` on CPU |
+| **Dtype** | Model dtype (may be float32) | Always `float16` |
+| **Transfer** | On-device | Built on CPU, moved to Spyre |
+
+**Why:** `torch.tril` is not supported on Spyre. Masks must be
+`float16` (Spyre's native dtype).
+
+#### 7. Embedding: No Change Required
+
+HF's `nn.Embedding` automatically falls back to CPU via
+torch-spyre's fallback mechanism. The result is transparently
+transferred to the Spyre device. No adapter code needed.
+
+### What Works As-Is (No Patching)
+
+These HF Transformer components run natively on Spyre without
+modification:
+
+| Component | HF Class/Function | Spyre Support |
+|---|---|---|
+| Linear projections | `nn.Linear` | Native matmul |
+| MLP activation | `nn.SiLU` (SwiGLU) | Native `silu` |
+| Embedding multiplier | scalar-tensor mul | Native |
+| Residual multiplier | scalar-tensor mul | Native |
+| Logits scaling | tensor-scalar div | Native |
+| SDPA | `F.scaled_dot_product_attention` | Decomposed by torch-spyre |
+| GQA head expansion | `enable_gqa=True` | SDPA decomposition |
+| Embedding lookup | `nn.Embedding` | CPU fallback (automatic) |
+
+### Model-Specific Differences
+
+| Feature | Granite 3.3 | Qwen3 | Granite 4.0 | SmolLM3 |
+|---------|------------|-------|-------------|---------|
+| Embedding multiplier | Yes | No | Yes | No |
+| Residual multiplier | Yes | No | Yes | No |
+| Logits scaling | Yes | No | Yes | No |
+| Q/K RMSNorm | No | Yes (per-head) | No | No |
+| Fused MLP weights | No | No | Yes (split at prepare time) | No |
+| NoPE layers | No | No | No | Yes (conditional RoPE) |
+| Attention scaling | `config.attention_multiplier` | `head_dim**-0.5` | `config.attention_multiplier` | `head_dim**-0.5` |
+
+## Adding a New Model
+
+### Checklist
+
+1. Check `head_dim >= 128` (see Stick Alignment below)
+2. Check for fused weights that need splitting (like Granite 4.0's
+   `input_linear`)
+3. Check for partial RoPE (`partial_rotary_factor < 1.0`) — requires
+   splitting Q/K into rotated/non-rotated portions, which hits
+   stickify non-zero offset assertions (see Known Issues)
+4. Check for model-specific multipliers (embedding, residual,
+   attention, logits) — must be preserved in the block function
+5. Check for per-layer variations (NoPE layers, sliding window,
+   MoE routing)
+6. Verify CPU accuracy before testing on Spyre
+
+### Comparison with FMS `eager_spyre` Approach
+
+| Aspect | FMS `eager_spyre` | HF Adapter |
+|---|---|---|
+| Model source | FMS (custom codebase) | HuggingFace Transformers (standard) |
+| RoPE | Matmul with `selected_freqs` | Same approach, applied via monkey-patch |
+| RMSNorm | `torch.nn.RMSNorm` | `patch_rmsnorm(cls)` patches HF's RMSNorm in-place |
+| KV cache | Tuple of tensors through FMS attention | List of tensors passed to compiled block function |
+| GQA | Manual expand/flatten | `F.scaled_dot_product_attention(enable_gqa=True)` |
+| Compilation | `block.compile(dynamic=False)` | `torch.compile(block_forward, dynamic=False)` |
+| Generation | `fms.utils.generation` | `hf_common.generate()` |
+| Weight loading | FMS serialization | HF `from_pretrained` then `.to("spyre")` |
+| Maintenance | Requires FMS fork | No fork; runtime monkey-patches on stock HF |
+
+## Stick Alignment Requirement
+
+The RoPE matmul implementation reshapes Q/K to `[B, L, H, 2, D/2]`
+where `D = head_dim`. When `D/2 < 64` (sub-stick), the stickify
+compiler pass generates a compound dimension expression that it
+cannot decompose, causing an `AssertionError`:
+
+```
+AssertionError: Could not find a host dimension matching stick
+expr d4 in [0, d0, 64*d1 + 32*d3 + d4]
+```
+
+**Rule: a model works on Spyre if `head_dim >= 128`
+(i.e. `D/2 >= 64`).**
+
+All models tested with `head_dim=128` compile and run. Granite 3.3
+2B (`head_dim=64`) is the only failure.
+
+Note that `head_dim` is not always
+`hidden_size // num_attention_heads`. Some models (e.g. Qwen3)
+explicitly set `head_dim` in config independent of `hidden_size`
+and `num_attention_heads`.
+
+### Checking a new model
+
+```python
+from transformers import AutoConfig
+config = AutoConfig.from_pretrained("org/model-name")
+head_dim = getattr(
+    config, "head_dim",
+    config.hidden_size // config.num_attention_heads,
+)
+will_compile = (head_dim // 2) >= 64
+```
+
+## Known Issues
+
+### Spyre Limitations
+
+| Limitation | Impact | Workaround |
+|-----------|--------|------------|
+| No `sin`/`cos` ops | RoPE must be precomputed | `PrecomputedRotaryEmbedding` |
+| No dtype conversion | RMSNorm must stay fp16 | Patched forward with device check |
+| No `aten.slice` in compiled graphs | KV cache indexing falls back to CPU | `spyre.overwrite` for fill mode |
+| `head_dim/2 < 64` (sub-stick) | Stickify assertion on RoPE matmul | Only use models with `head_dim >= 128` |
+| `partial_rotary_factor < 1.0` | Non-zero offset assertion in stickify | Split Q/K weights (not yet implemented; blocks Phi-4) |
+| Zero-length tensors crash `copy_host_to_device` | Segfault on `.to("spyre")` | Create empty tensors directly on device |
+| fp16 overflow on CPU for large multipliers | NaN logits on CPU | Test in float32; runs fine on Spyre hardware |
+
+### Performance Issues
+
+These affect speed but not correctness:
+
+**Compilation overhead (first run):** The first invocation compiles
+graphs per layer per mode (expand + fill). This takes several
+minutes. Subsequent runs with the same shapes reuse cached compiled
+graphs.
+
+**`aten.slice` fallback in fill mode:** The KV cache fill operation
+`k[:, :, token_index:token_index+1, :]` inside `spyre.overwrite`
+triggers an `aten.slice.Tensor` CPU fallback per layer per fill
+step.
+
+**Recompilation per `token_index`:** Each unique `token_index`
+value in fill mode triggers a new graph specialization (because
+`torch.compile` specializes on Python int arguments). Over 63 fill
+steps, this causes 63 recompilations on first use.
+
+### Open Work
+
+1. **Fix `token_index` recompilation** — pass as tensor to avoid
+   specialization
+2. **Fix `aten.slice` fallback in fill** — restructure overwrite
+   call
+3. **Multi-iteration benchmarking** — run 5+ iterations to measure
+   steady-state latency (after compilation cache is warm)
+4. **Phi-4 mini** — blocked by `partial_rotary_factor=0.75`
+   (stickify non-zero offset assertion). Fix: split Q/K weights so
+   rotated dims are separate linears.
+5. **Stick alignment for small head\_dim** — Granite 3.3 2B
+   (`head_dim=64`) fails stickify. Needs compiler fix or
+   alternative RoPE implementation.
+
+## Test Scripts
+
+| Script | Purpose | Requires Spyre |
+|--------|---------|---------------|
+| `tests/adapters/test_adapter_cpu_accuracy.py` | CPU: adapter vs HF logit comparison | No |
+| `tests/adapters/test_block_cpu_vs_spyre.py` | Per-layer CPU vs Spyre block comparison | Yes |
+| `tests/adapters/test_e2e_smoke_spyre.py` | E2E: load model, generate tokens | Yes |
+| `tests/adapters/test_e2e_token_compare_spyre.py` | E2E: HF CPU vs adapter Spyre tokens | Yes |

--- a/torch_spyre/adapters/__init__.py
+++ b/torch_spyre/adapters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/torch_spyre/adapters/hf_common.py
+++ b/torch_spyre/adapters/hf_common.py
@@ -1,0 +1,422 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Shared utilities for HuggingFace Transformers adapters on Spyre.
+
+Provides RoPE precomputation, RMSNorm patching, LM head padding, mask
+construction, KV cache update helpers, and a model-agnostic generate loop.
+Per-model adapters import from this module and provide only model-specific
+compiled block functions.
+"""
+
+import math
+import time
+from typing import Callable, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+DEVICE = "spyre"
+BLOCK_SIZE = 64  # Spyre stick size at fp16 (128 bytes / 2 bytes per element)
+
+
+# ---------------------------------------------------------------------------
+# RoPE: precompute rotation matrices on CPU (FMS approach)
+# ---------------------------------------------------------------------------
+
+
+class PrecomputedRotaryEmbedding(nn.Module):
+    """Builds [S, 2, 2, D/2] rotation matrix cache on CPU.
+
+    Returns ``selected_freqs`` [B, L, 2, 2, D/2] on Spyre, indexed by
+    position_ids.  The companion ``apply_rope_matmul`` applies the rotation
+    without any tensor slicing.
+    """
+
+    def __init__(self, original_rope: nn.Module):
+        super().__init__()
+        self.original = original_rope
+        self._freq_cache: Optional[torch.Tensor] = None
+        self._cached_len = 0
+
+    def _extend_cache(self, max_len: int):
+        if max_len <= self._cached_len:
+            return
+        target_len = max(max_len, self._cached_len * 2, 2048)
+        inv_freq = self.original.inv_freq.to("cpu").float()
+        t = torch.arange(target_len, dtype=inv_freq.dtype)
+        freqs = torch.outer(t, inv_freq).float()  # [S, D/2]
+        scaling = getattr(self.original, "attention_scaling", 1.0)
+        self._freq_cache = torch.stack(
+            [
+                torch.cos(freqs) * scaling,
+                -torch.sin(freqs) * scaling,
+                torch.sin(freqs) * scaling,
+                torch.cos(freqs) * scaling,
+            ],
+            dim=1,
+        ).view(target_len, 2, 2, freqs.shape[1]).contiguous().to(torch.float16)
+        self._cached_len = target_len
+
+    def forward(self, hidden_states, position_ids):
+        pos_cpu = position_ids.to("cpu")
+        max_pos = int(pos_cpu.max().item()) + 1
+        self._extend_cache(max_pos)
+        selected = self._freq_cache[pos_cpu]  # [B, L, 2, 2, D/2]
+        return selected.to(DEVICE)
+
+
+def apply_rope_matmul(x, selected_freqs):
+    """Apply RoPE via matmul with [2,2,D/2] rotation matrix. No slicing.
+
+    Args:
+        x: [B, H, L, D] — query or key tensor
+        selected_freqs: [B, L, 2, 2, D/2] — rotation matrices
+
+    Returns: [B, H, L, D]
+    """
+    B, H, L, D = x.shape
+    half = D // 2
+    x_ = x.transpose(1, 2).reshape(B, L, H, 2, half)
+    sf = selected_freqs[:, :, None, :, :, :]
+    out = sf.mul(x_.unsqueeze(-3)).sum(4, keepdim=True).flatten(3)
+    return out.transpose(1, 2)
+
+
+# ---------------------------------------------------------------------------
+# KV cache update (inside compiled graph)
+# ---------------------------------------------------------------------------
+
+
+def kv_cache_update(k, v, key_cache, value_cache,
+                    is_filling, token_index, cache_position):
+    """Update KV cache: cat for expansion, spyre.overwrite for fill.
+
+    All args are tensors; is_filling/token_index/cache_position are Python
+    scalars that torch.compile specializes on.
+    """
+    if is_filling:
+        k_slice = k[:, :, token_index:token_index + 1, :]
+        v_slice = v[:, :, token_index:token_index + 1, :]
+        if key_cache.device.type == "spyre":
+            key_cache = torch.ops.spyre.overwrite(
+                input=k_slice,
+                output=key_cache, dims=[2], offsets=[cache_position],
+            )
+            value_cache = torch.ops.spyre.overwrite(
+                input=v_slice,
+                output=value_cache, dims=[2], offsets=[cache_position],
+            )
+        else:
+            # CPU fallback: direct index assignment
+            key_cache = key_cache.clone()
+            key_cache[:, :, cache_position:cache_position + 1, :] = k_slice
+            value_cache = value_cache.clone()
+            value_cache[:, :, cache_position:cache_position + 1, :] = v_slice
+    else:
+        key_cache = torch.cat((key_cache, k), dim=2)
+        value_cache = torch.cat((value_cache, v), dim=2)
+    return key_cache, value_cache
+
+
+# ---------------------------------------------------------------------------
+# Patches
+# ---------------------------------------------------------------------------
+
+
+def patch_rmsnorm(rmsnorm_cls):
+    """Patch any RMSNorm class to stay in fp16 (Spyre has no dtype conversion).
+
+    Args:
+        rmsnorm_cls: The RMSNorm class to patch (e.g. GraniteRMSNorm, Qwen3RMSNorm).
+    """
+    def _forward_fp16(self, hidden_states):
+        if hidden_states.device.type == "spyre":
+            # Spyre path: no dtype conversion, stay in fp16
+            variance = (hidden_states * hidden_states).mean(-1, keepdim=True)
+            eps = torch.ops.spyre.full(
+                (1,), self.variance_epsilon,
+                hidden_states.device, torch.float16,
+            )
+            return self.weight * (hidden_states * torch.rsqrt(variance + eps))
+        else:
+            # CPU path: use float32 for numerical stability (matches stock HF)
+            xf = hidden_states.float()
+            variance = (xf * xf).mean(-1, keepdim=True)
+            xf = xf * torch.rsqrt(variance + self.variance_epsilon)
+            return self.weight * xf.to(hidden_states.dtype)
+
+    rmsnorm_cls.forward = _forward_fp16
+
+
+def pad_lm_head(model):
+    """Pad LM head vocab dim to stick-aligned size (+64 for work division)."""
+    w = model.lm_head.weight
+    vocab = w.shape[0]
+    padded = ((vocab + BLOCK_SIZE - 1) // BLOCK_SIZE * BLOCK_SIZE) + BLOCK_SIZE
+    if padded != vocab:
+        model.lm_head.weight = nn.Parameter(
+            F.pad(w, (0, 0, 0, padded - vocab)), requires_grad=False
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mask builders
+# ---------------------------------------------------------------------------
+
+
+def build_prefill_mask(batch_size, padded_len, prompt_offset):
+    """Causal mask for prefill, masking left-padding columns."""
+    mask = torch.zeros((batch_size, 1, padded_len, padded_len), dtype=torch.float16)
+    mask[:, :, :, :prompt_offset] = -torch.inf
+    for i in range(padded_len):
+        mask[:, :, i, i + 1:] = -torch.inf
+    return mask
+
+
+def build_expansion_mask(batch_size, block_size, total_cache_len, prompt_offset):
+    """Causal mask for an expansion decode step."""
+    mask = torch.zeros(
+        (batch_size, 1, block_size, total_cache_len), dtype=torch.float16
+    )
+    mask[:, :, :, :prompt_offset] = -torch.inf
+    for j in range(block_size):
+        attend_up_to = total_cache_len - block_size + j + 1
+        mask[:, :, j, attend_up_to:] = -torch.inf
+    return mask
+
+
+# ---------------------------------------------------------------------------
+# Model-agnostic load + generate
+# ---------------------------------------------------------------------------
+
+
+def load_model_common(model_path, prepare_fn, dtype=torch.float16):
+    """Load an HF model, apply Spyre adaptations, move to device.
+
+    Args:
+        model_path: HF model path or local directory.
+        prepare_fn: Model-specific ``prepare_for_spyre(model)`` callable.
+        dtype: Weight dtype (default fp16).
+    """
+    from transformers import AutoModelForCausalLM
+
+    print(f"Loading model from {model_path} ...")
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path, dtype=dtype, device_map="cpu",
+    )
+    model.eval()
+    model.requires_grad_(False)
+    prepare_fn(model)
+    print("Moving model to Spyre ...")
+    model.to(DEVICE)
+    print("Model ready.")
+    return model
+
+
+def generate(run_forward_fn: Callable, model, tokenizer, prompts,
+             max_new_tokens=128, do_sample=False, temperature=1.0,
+             top_k=50, timing=False):
+    """Model-agnostic generation with padded 64-block decode.
+
+    Args:
+        run_forward_fn: ``fn(model, input_ids, position_ids, attn_mask,
+            key_caches, value_caches, is_filling, token_index,
+            cache_position) -> logits``
+        model: Prepared HF model on Spyre.
+        tokenizer: HF tokenizer.
+        prompts: List of prompt strings.
+        max_new_tokens: Max tokens to generate.
+        do_sample: Sampling vs greedy.
+        temperature: Sampling temperature.
+        top_k: Top-k filtering.
+        timing: Print per-token latency.
+    """
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    encoded = tokenizer(
+        prompts, return_tensors="pt", padding=True, return_attention_mask=True,
+    )
+    input_ids = encoded["input_ids"]
+    batch_size = input_ids.shape[0]
+    prompt_length = input_ids.shape[1]
+
+    # Left-pad to BLOCK_SIZE multiple
+    padded_len = math.ceil(prompt_length / BLOCK_SIZE) * BLOCK_SIZE
+    prompt_offset = padded_len - prompt_length
+    if prompt_offset > 0:
+        pad = input_ids.new_zeros((batch_size, prompt_offset))
+        input_ids = torch.cat([pad, input_ids], dim=1)
+
+    position_ids = torch.zeros((batch_size, padded_len), dtype=torch.long)
+    position_ids[:, prompt_offset:] = torch.arange(prompt_length)
+
+    # Initialize empty KV caches
+    num_layers = model.config.num_hidden_layers
+    num_kv_heads = model.config.num_key_value_heads
+    head_dim = getattr(
+        model.config, "head_dim",
+        model.config.hidden_size // model.config.num_attention_heads,
+    )
+    key_caches = [
+        torch.empty(batch_size, num_kv_heads, 0, head_dim,
+                     dtype=torch.float16, device=DEVICE)
+        for _ in range(num_layers)
+    ]
+    value_caches = [
+        torch.empty(batch_size, num_kv_heads, 0, head_dim,
+                     dtype=torch.float16, device=DEVICE)
+        for _ in range(num_layers)
+    ]
+
+    # Decode state
+    result = input_ids.clone()
+    current_cache_len = padded_len
+    tokens_in_block = BLOCK_SIZE - 1
+    decode_pos = None
+    fill_mask_device = None
+
+    times_list = []
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    num_generated = 0
+
+    for i in range(max_new_tokens):
+        t0 = time.time()
+
+        if i == 0:
+            # --- PREFILL ---
+            prefill_mask = build_prefill_mask(
+                batch_size, padded_len, prompt_offset
+            )
+            logits = run_forward_fn(
+                model, input_ids.to(DEVICE), position_ids.to(DEVICE),
+                prefill_mask.to(DEVICE), key_caches, value_caches,
+                is_filling=False, token_index=0, cache_position=0,
+            )
+            logits_cpu = logits.to("cpu")
+            next_logits = logits_cpu[0, -1, :]
+            current_cache_len = padded_len
+            # Initialize decode_pos so that after the first +BLOCK_SIZE
+            # increment (which happens BEFORE the first expansion forward
+            # call), position 0 of the block gets position_id =
+            # prompt_length.  Since the expansion code does
+            #   decode_pos = decode_pos + BLOCK_SIZE
+            # we need: initial[j] + BLOCK_SIZE = prompt_length + j
+            # i.e.  initial[j] = prompt_length + j - BLOCK_SIZE
+            decode_pos = torch.zeros(
+                (batch_size, BLOCK_SIZE), dtype=torch.long
+            )
+            for j in range(BLOCK_SIZE):
+                decode_pos[:, j] = prompt_length + j - BLOCK_SIZE
+
+        else:
+            is_filling = tokens_in_block > 0
+            next_input = result[:, -BLOCK_SIZE:].to(DEVICE)
+
+            if is_filling:
+                fill_pos = (
+                    current_cache_len - BLOCK_SIZE + tokens_in_block
+                )
+                logits = run_forward_fn(
+                    model, next_input, decode_pos.to(DEVICE),
+                    fill_mask_device, key_caches, value_caches,
+                    is_filling=True,
+                    token_index=tokens_in_block,
+                    cache_position=fill_pos,
+                )
+                logits_cpu = logits.to("cpu")
+                grab_idx = BLOCK_SIZE - tokens_in_block
+                next_logits = logits_cpu[0, -grab_idx, :]
+
+            else:
+                current_cache_len += BLOCK_SIZE
+                decode_pos = decode_pos + BLOCK_SIZE
+                exp_mask = build_expansion_mask(
+                    batch_size, BLOCK_SIZE, current_cache_len, prompt_offset
+                )
+                logits = run_forward_fn(
+                    model, next_input, decode_pos.to(DEVICE),
+                    exp_mask.to(DEVICE), key_caches, value_caches,
+                    is_filling=False, token_index=0, cache_position=0,
+                )
+                logits_cpu = logits.to("cpu")
+                next_logits = logits_cpu[0, -BLOCK_SIZE, :]
+                fill_mask_device = exp_mask.to(DEVICE)
+
+        # Token selection (CPU)
+        if do_sample:
+            scaled = next_logits / temperature
+            if top_k > 0:
+                v, _ = torch.topk(scaled, min(top_k, scaled.size(-1)))
+                scaled[scaled < v[-1]] = -torch.inf
+            probs = F.softmax(scaled, dim=-1)
+            next_val = torch.multinomial(probs.unsqueeze(0), num_samples=1)
+        else:
+            next_val = torch.argmax(next_logits).unsqueeze(0).unsqueeze(0)
+
+        if timing:
+            times_list.append(time.time() - t0)
+
+        # Place token in result (FMS logic)
+        if tokens_in_block == BLOCK_SIZE - 1:
+            result = F.pad(result, (0, BLOCK_SIZE))
+        tokens_in_block = (tokens_in_block + 1) % BLOCK_SIZE
+        grab_idx = (
+            (BLOCK_SIZE - tokens_in_block) if tokens_in_block > 0 else BLOCK_SIZE
+        )
+        result[:, -grab_idx] = next_val.squeeze()
+        num_generated += 1
+
+        if eos_token_id is not None and next_val.item() == eos_token_id:
+            break
+
+    # Timing
+    if timing and times_list:
+        print(f"\nFirst-token latency: {times_list[0]*1000:.3f} ms")
+        if len(times_list) > 1:
+            avg = sum(times_list[1:]) / len(times_list[1:])
+            print(f"Avg next-token latency: {avg*1000:.3f} ms")
+        print(
+            "Per-token: "
+            + ", ".join(f"{t*1000:.1f}" for t in times_list)
+            + " ms"
+        )
+
+    # Decode text — use num_generated to extract exactly the tokens we placed,
+    # avoiding the old nonzero heuristic which fails when token_id 0 is valid.
+    # Generated tokens are scattered across blocks in the result buffer.
+    # Collect them by walking the block structure.
+    all_gen_ids = []
+    block_start = padded_len
+    remaining = num_generated
+    while remaining > 0:
+        # First token in a block is at block_start, then block_start+1, etc.
+        take = min(remaining, BLOCK_SIZE)
+        for j in range(take):
+            all_gen_ids.append(result[0, block_start + j].item())
+        remaining -= take
+        block_start += BLOCK_SIZE
+
+    results = []
+    for b in range(batch_size):
+        gen_ids = torch.tensor(all_gen_ids)
+        if eos_token_id is not None:
+            eos_pos = (gen_ids == eos_token_id).nonzero(as_tuple=True)[0]
+            if len(eos_pos) > 0:
+                gen_ids = gen_ids[: eos_pos[0].item()]
+        results.append(tokenizer.decode(gen_ids, skip_special_tokens=True))
+
+    return results

--- a/torch_spyre/adapters/hf_granite.py
+++ b/torch_spyre/adapters/hf_granite.py
@@ -1,0 +1,129 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+HuggingFace Transformers adapter for Granite 3.3 models on Spyre.
+
+Usage::
+
+    from torch_spyre.adapters.hf_granite import load_model, generate
+    from transformers import AutoTokenizer
+
+    model = load_model("/path/to/granite-3.3-8b-instruct")
+    tokenizer = AutoTokenizer.from_pretrained("/path/to/granite-3.3-8b-instruct")
+    outputs = generate(model, tokenizer, ["Hello!"], max_new_tokens=32)
+"""
+
+import torch
+import torch.nn.functional as F
+
+from torch_spyre.adapters.hf_common import (
+    PrecomputedRotaryEmbedding,
+    apply_rope_matmul,
+    generate as _generate,
+    kv_cache_update,
+    load_model_common,
+    pad_lm_head,
+    patch_rmsnorm,
+)
+
+
+def _make_compiled_block(layer):
+    """Compiled block for Granite 3.3: separate QKV, residual multiplier."""
+    attn = layer.self_attn
+    mlp = layer.mlp
+    input_ln = layer.input_layernorm
+    post_attn_ln = layer.post_attention_layernorm
+    res_mult = layer.residual_multiplier
+
+    def block_forward(hidden_states, selected_freqs, attn_mask,
+                      key_cache, value_cache,
+                      is_filling, token_index, cache_position):
+        residual = hidden_states
+        h = input_ln(hidden_states)
+
+        bsz, seq_len, _ = h.shape
+        q = attn.q_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        k = attn.k_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        v = attn.v_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+
+        q = apply_rope_matmul(q, selected_freqs)
+        k = apply_rope_matmul(k, selected_freqs)
+
+        key_cache, value_cache = kv_cache_update(
+            k, v, key_cache, value_cache,
+            is_filling, token_index, cache_position,
+        )
+
+        attn_out = F.scaled_dot_product_attention(
+            q, key_cache, value_cache,
+            attn_mask=attn_mask, dropout_p=0.0, scale=attn.scaling, enable_gqa=True,
+        )
+        attn_out = attn_out.transpose(1, 2).reshape(bsz, seq_len, -1)
+        attn_out = attn.o_proj(attn_out)
+
+        h = residual + attn_out * res_mult
+
+        residual = h
+        h = post_attn_ln(h)
+        h = mlp(h)
+        h = residual + h * res_mult
+
+        return h, key_cache, value_cache
+
+    return torch.compile(block_forward, dynamic=False)
+
+
+def _run_forward(model, input_ids, position_ids, attn_mask,
+                 key_caches, value_caches,
+                 is_filling, token_index, cache_position):
+    """Granite 3.3 forward: embedding * multiplier, blocks, norm, head / scaling."""
+    h = model.model.embed_tokens(input_ids)
+    h = h * model.model.embedding_multiplier
+
+    selected_freqs = model._spyre_rope(h, position_ids)
+
+    for i, compiled_block in enumerate(model._spyre_compiled_blocks):
+        h, key_caches[i], value_caches[i] = compiled_block(
+            h, selected_freqs, attn_mask,
+            key_caches[i], value_caches[i],
+            is_filling, token_index, cache_position,
+        )
+
+    h = model.model.norm(h)
+    logits = model.lm_head(h)
+    logits = logits / model.config.logits_scaling
+    return logits
+
+
+def prepare_for_spyre(model):
+    """Apply Spyre adaptations to Granite 3.3 model in-place."""
+    from transformers.models.granite.modeling_granite import GraniteRMSNorm
+
+    model._spyre_rope = PrecomputedRotaryEmbedding(model.model.rotary_emb)
+    patch_rmsnorm(GraniteRMSNorm)
+    pad_lm_head(model)
+    model._spyre_compiled_blocks = [
+        _make_compiled_block(layer) for layer in model.model.layers
+    ]
+
+
+def load_model(model_path, dtype=torch.float16):
+    """Load Granite 3.3 model for Spyre."""
+    return load_model_common(model_path, prepare_for_spyre, dtype)
+
+
+def generate(model, tokenizer, prompts, **kwargs):
+    """Generate text with Granite 3.3 on Spyre."""
+    return _generate(_run_forward, model, tokenizer, prompts, **kwargs)

--- a/torch_spyre/adapters/hf_granitemoehybrid.py
+++ b/torch_spyre/adapters/hf_granitemoehybrid.py
@@ -1,0 +1,173 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+HuggingFace Transformers adapter for Granite 4.0 dense models on Spyre.
+
+Granite 4.0 uses the ``granitemoehybrid`` model_type. Dense variants
+(1B, Micro) have ``num_local_experts=1`` and no Mamba layers — they are
+pure transformers that happen to use the MoE codebase.
+
+Differences from Granite 3.3:
+- Fused input_linear (gate+up) and output_linear MLP
+- ``shared_intermediate_size`` config field
+- Same multipliers (embedding, residual, attention, logits)
+
+Usage::
+
+    from torch_spyre.adapters.hf_granitemoehybrid import load_model, generate
+    from transformers import AutoTokenizer
+
+    model = load_model("ibm-granite/granite-4.0-1b-base")
+    tokenizer = AutoTokenizer.from_pretrained("ibm-granite/granite-4.0-1b-base")
+    outputs = generate(model, tokenizer, ["Hello!"], max_new_tokens=32)
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torch_spyre.adapters.hf_common import (
+    PrecomputedRotaryEmbedding,
+    apply_rope_matmul,
+    generate as _generate,
+    kv_cache_update,
+    load_model_common,
+    pad_lm_head,
+    patch_rmsnorm,
+)
+
+
+def _split_fused_mlp(mlp):
+    """Split a fused input_linear into separate gate_proj and up_proj.
+
+    Spyre's stickify pass cannot handle non-zero offsets from fused weight
+    splits. We replace the fused linear with two separate linears.
+    """
+    w = mlp.input_linear.weight  # [2*intermediate, hidden]
+    half = w.shape[0] // 2
+    gate_proj = nn.Linear(w.shape[1], half, bias=False)
+    up_proj = nn.Linear(w.shape[1], half, bias=False)
+    gate_proj.weight = nn.Parameter(w[:half].clone(), requires_grad=False)
+    up_proj.weight = nn.Parameter(w[half:].clone(), requires_grad=False)
+    return gate_proj, up_proj
+
+
+def _make_compiled_block(layer, res_mult, gate_proj, up_proj):
+    """Compiled block for Granite 4.0 dense: split MLP, multipliers."""
+    attn = layer.self_attn
+    input_ln = layer.input_layernorm
+    post_attn_ln = layer.post_attention_layernorm
+    down_proj = layer.shared_mlp.output_linear
+    act_fn = layer.shared_mlp.activation
+
+    def block_forward(hidden_states, selected_freqs, attn_mask,
+                      key_cache, value_cache,
+                      is_filling, token_index, cache_position):
+        residual = hidden_states
+        h = input_ln(hidden_states)
+
+        bsz, seq_len, _ = h.shape
+        q = attn.q_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        k = attn.k_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        v = attn.v_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+
+        q = apply_rope_matmul(q, selected_freqs)
+        k = apply_rope_matmul(k, selected_freqs)
+
+        key_cache, value_cache = kv_cache_update(
+            k, v, key_cache, value_cache,
+            is_filling, token_index, cache_position,
+        )
+
+        attn_out = F.scaled_dot_product_attention(
+            q, key_cache, value_cache,
+            attn_mask=attn_mask, dropout_p=0.0, scale=attn.scaling, enable_gqa=True,
+        )
+        attn_out = attn_out.transpose(1, 2).reshape(bsz, seq_len, -1)
+        attn_out = attn.o_proj(attn_out)
+
+        h = residual + attn_out * res_mult
+
+        # MLP: separate gate/up projections (split at prepare time)
+        residual = h
+        h = post_attn_ln(h)
+        h = down_proj(act_fn(gate_proj(h)) * up_proj(h))
+        h = residual + h * res_mult
+
+        return h, key_cache, value_cache
+
+    return torch.compile(block_forward, dynamic=False)
+
+
+def _run_forward(model, input_ids, position_ids, attn_mask,
+                 key_caches, value_caches,
+                 is_filling, token_index, cache_position):
+    """Granite 4.0 forward: embedding * multiplier, blocks, norm, head / scaling."""
+    h = model.model.embed_tokens(input_ids)
+    h = h * model.config.embedding_multiplier
+
+    selected_freqs = model._spyre_rope(h, position_ids)
+
+    for i, compiled_block in enumerate(model._spyre_compiled_blocks):
+        h, key_caches[i], value_caches[i] = compiled_block(
+            h, selected_freqs, attn_mask,
+            key_caches[i], value_caches[i],
+            is_filling, token_index, cache_position,
+        )
+
+    h = model.model.norm(h)
+    logits = model.lm_head(h)
+    logits = logits / model.config.logits_scaling
+    return logits
+
+
+def prepare_for_spyre(model):
+    """Apply Spyre adaptations to Granite 4.0 dense model in-place."""
+    from transformers.models.granitemoehybrid.modeling_granitemoehybrid import (
+        GraniteMoeHybridRMSNorm,
+    )
+
+    model._spyre_rope = PrecomputedRotaryEmbedding(model.model.rotary_emb)
+    patch_rmsnorm(GraniteMoeHybridRMSNorm)
+    pad_lm_head(model)
+
+    res_mult = model.config.residual_multiplier
+
+    # Split fused MLP weights and register as submodules so .to() moves them
+    model._spyre_gate_projs = nn.ModuleList()
+    model._spyre_up_projs = nn.ModuleList()
+    for layer in model.model.layers:
+        gate_proj, up_proj = _split_fused_mlp(layer.shared_mlp)
+        model._spyre_gate_projs.append(gate_proj)
+        model._spyre_up_projs.append(up_proj)
+
+    model._spyre_compiled_blocks = [
+        _make_compiled_block(layer, res_mult, gate, up)
+        for layer, gate, up in zip(
+            model.model.layers,
+            model._spyre_gate_projs,
+            model._spyre_up_projs,
+        )
+    ]
+
+
+def load_model(model_path, dtype=torch.float16):
+    """Load Granite 4.0 dense model for Spyre."""
+    return load_model_common(model_path, prepare_for_spyre, dtype)
+
+
+def generate(model, tokenizer, prompts, **kwargs):
+    """Generate text with Granite 4.0 on Spyre."""
+    return _generate(_run_forward, model, tokenizer, prompts, **kwargs)

--- a/torch_spyre/adapters/hf_phi3.py
+++ b/torch_spyre/adapters/hf_phi3.py
@@ -1,0 +1,322 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+HuggingFace Transformers adapter for Phi-3/Phi-4 models on Spyre.
+
+Phi-3 differences from Granite:
+- Combined QKV projection (split at prepare time)
+- Combined gate+up MLP (split at prepare time)
+- Partial RoPE: only ``partial_rotary_factor`` of head_dim is rotated.
+  Handled by padding the rotation matrix with identity entries so that
+  ``apply_rope_matmul`` on full head_dim passes through non-rotated dims.
+- No embedding/residual/logits multipliers
+
+Usage::
+
+    from torch_spyre.adapters.hf_phi3 import load_model, generate
+    from transformers import AutoTokenizer
+
+    model = load_model("microsoft/Phi-4-mini-instruct")
+    tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-4-mini-instruct")
+    outputs = generate(model, tokenizer, ["Hello!"], max_new_tokens=32)
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torch_spyre.adapters.hf_common import (
+    apply_rope_matmul,
+    generate as _generate,
+    kv_cache_update,
+    load_model_common,
+    pad_lm_head,
+    patch_rmsnorm,
+    DEVICE,
+)
+
+
+# ---------------------------------------------------------------------------
+# RoPE with identity padding for partial rotary
+# ---------------------------------------------------------------------------
+
+
+class PartialPrecomputedRotaryEmbedding(nn.Module):
+    """Like PrecomputedRotaryEmbedding, but pads with identity for non-rotated dims.
+
+    For partial_rotary_factor < 1.0, the inv_freq covers only ``rope_dim/2``
+    frequencies. We pad the ``[S, 2, 2, rope_dim/2]`` rotation matrix to
+    ``[S, 2, 2, head_dim/2]`` using identity entries ``[[1,0],[0,1]]`` so that
+    ``apply_rope_matmul`` on the full head_dim passes through non-rotated dims.
+    """
+
+    def __init__(self, original_rope, head_dim):
+        super().__init__()
+        self.original = original_rope
+        self.head_dim = head_dim
+        self._freq_cache = None
+        self._cached_len = 0
+
+    def _extend_cache(self, max_len):
+        if max_len <= self._cached_len:
+            return
+        target_len = max(max_len, self._cached_len * 2, 2048)
+        inv_freq = self.original.inv_freq.to("cpu").float()
+        rope_half = inv_freq.shape[0]  # rope_dim / 2
+        full_half = self.head_dim // 2  # head_dim / 2
+        pad_half = full_half - rope_half
+
+        t = torch.arange(target_len, dtype=inv_freq.dtype)
+        freqs = torch.outer(t, inv_freq).float()  # [S, rope_half]
+        scaling = getattr(self.original, "attention_scaling", 1.0)
+
+        # Build rotation matrix [S, 2, 2, rope_half]
+        rot = torch.stack([
+            torch.cos(freqs) * scaling,
+            -torch.sin(freqs) * scaling,
+            torch.sin(freqs) * scaling,
+            torch.cos(freqs) * scaling,
+        ], dim=1).view(target_len, 2, 2, rope_half)
+
+        if pad_half > 0:
+            # Identity matrix [[1,0],[0,1]] for non-rotated dims
+            ident = torch.zeros(target_len, 2, 2, pad_half)
+            ident[:, 0, 0, :] = 1.0  # cos = 1
+            ident[:, 1, 1, :] = 1.0  # cos = 1
+            # -sin = 0, sin = 0 already
+            rot = torch.cat([rot, ident], dim=-1)  # [S, 2, 2, full_half]
+
+        self._freq_cache = rot.contiguous().to(torch.float16)
+        self._cached_len = target_len
+
+    def forward(self, hidden_states, position_ids):
+        pos_cpu = position_ids.to("cpu")
+        max_pos = int(pos_cpu.max().item()) + 1
+        self._extend_cache(max_pos)
+        selected = self._freq_cache[pos_cpu]
+        return selected.to(DEVICE)
+
+
+# ---------------------------------------------------------------------------
+# Weight splitting
+# ---------------------------------------------------------------------------
+
+
+def _chunk_lm_head(model, num_chunks=8):
+    """Split LM head weight into N chunks along vocab dim.
+
+    Large vocab (200K+) exceeds Spyre's per-core 256 MB EAR limit.
+    We replace the single lm_head with N smaller nn.Linear modules.
+    Each chunk processes vocab_size/N output dims.
+    """
+    w = model.lm_head.weight  # [vocab, hidden]
+    vocab, hidden = w.shape
+    chunk_size = (vocab + num_chunks - 1) // num_chunks
+
+    STICK = 64
+    chunks = nn.ModuleList()
+    for i in range(num_chunks):
+        start = i * chunk_size
+        end = min(start + chunk_size, vocab)
+        w_chunk = w[start:end].clone()
+        # Pad to stick-aligned size
+        sz = w_chunk.shape[0]
+        padded_sz = ((sz + STICK - 1) // STICK) * STICK
+        if padded_sz != sz:
+            w_chunk = F.pad(w_chunk, (0, 0, 0, padded_sz - sz))
+        chunk = nn.Linear(hidden, padded_sz, bias=False)
+        chunk.weight = nn.Parameter(w_chunk, requires_grad=False)
+        chunks.append(chunk)
+
+    model._spyre_lm_head_chunks = chunks
+
+
+def _split_fused_qkv(attn, num_q, num_kv, head_dim):
+    """Split fused qkv_proj into separate q/k/v projections."""
+    w = attn.qkv_proj.weight
+    q_dim = num_q * head_dim
+    k_dim = num_kv * head_dim
+    hidden = w.shape[1]
+
+    def _mk(w_data, out_dim):
+        p = nn.Linear(hidden, out_dim, bias=False)
+        p.weight = nn.Parameter(w_data.clone(), requires_grad=False)
+        return p
+
+    return (
+        _mk(w[:q_dim], q_dim),
+        _mk(w[q_dim:q_dim + k_dim], k_dim),
+        _mk(w[q_dim + k_dim:], k_dim),
+    )
+
+
+def _split_fused_mlp(mlp):
+    """Split fused gate_up_proj into separate gate/up projections."""
+    w = mlp.gate_up_proj.weight
+    half = w.shape[0] // 2
+    hidden = w.shape[1]
+
+    def _mk(w_data, out_dim):
+        p = nn.Linear(hidden, out_dim, bias=False)
+        p.weight = nn.Parameter(w_data.clone(), requires_grad=False)
+        return p
+
+    return _mk(w[:half], half), _mk(w[half:], half)
+
+
+# ---------------------------------------------------------------------------
+# Compiled block
+# ---------------------------------------------------------------------------
+
+
+def _make_compiled_block(layer, q_proj, k_proj, v_proj, gate_proj, up_proj,
+                         head_dim):
+    """Compiled block for Phi-3. Full head_dim RoPE via identity-padded freqs."""
+    input_ln = layer.input_layernorm
+    post_attn_ln = layer.post_attention_layernorm
+    down_proj = layer.mlp.down_proj
+    act_fn = layer.mlp.activation_fn
+    o_proj = layer.self_attn.o_proj
+    scaling = layer.self_attn.scaling
+
+    def block_forward(hidden_states, selected_freqs, attn_mask,
+                      key_cache, value_cache,
+                      is_filling, token_index, cache_position):
+        residual = hidden_states
+        h = input_ln(hidden_states)
+        bsz, seq_len, _ = h.shape
+
+        # Separate Q/K/V projections (split at prepare time)
+        q = q_proj(h).view(bsz, seq_len, -1, head_dim).transpose(1, 2)
+        k = k_proj(h).view(bsz, seq_len, -1, head_dim).transpose(1, 2)
+        v = v_proj(h).view(bsz, seq_len, -1, head_dim).transpose(1, 2)
+
+        # RoPE on full head_dim — identity-padded freqs pass through
+        # non-rotated dims unchanged
+        q = apply_rope_matmul(q, selected_freqs)
+        k = apply_rope_matmul(k, selected_freqs)
+
+        key_cache, value_cache = kv_cache_update(
+            k, v, key_cache, value_cache,
+            is_filling, token_index, cache_position,
+        )
+
+        attn_out = F.scaled_dot_product_attention(
+            q, key_cache, value_cache,
+            attn_mask=attn_mask, dropout_p=0.0, scale=scaling, enable_gqa=True,
+        )
+        attn_out = attn_out.transpose(1, 2).reshape(bsz, seq_len, -1)
+        attn_out = o_proj(attn_out)
+
+        h = residual + attn_out
+
+        # MLP with pre-split gate/up
+        residual = h
+        h = post_attn_ln(h)
+        h = down_proj(act_fn(gate_proj(h)) * up_proj(h))
+        h = residual + h
+
+        return h, key_cache, value_cache
+
+    return torch.compile(block_forward, dynamic=False)
+
+
+# ---------------------------------------------------------------------------
+# Forward / prepare / load / generate
+# ---------------------------------------------------------------------------
+
+
+def _run_forward(model, input_ids, position_ids, attn_mask,
+                 key_caches, value_caches,
+                 is_filling, token_index, cache_position):
+    h = model.model.embed_tokens(input_ids)
+    selected_freqs = model._spyre_rope(h, position_ids)
+
+    for i, compiled_block in enumerate(model._spyre_compiled_blocks):
+        h, key_caches[i], value_caches[i] = compiled_block(
+            h, selected_freqs, attn_mask,
+            key_caches[i], value_caches[i],
+            is_filling, token_index, cache_position,
+        )
+
+    h = model.model.norm(h)
+
+    # Chunked LM head: large vocab (200K+) exceeds Spyre's per-core EAR limit.
+    # Split into N chunks, run each on Spyre, cat on CPU.
+    logits_parts = []
+    for lm_chunk in model._spyre_lm_head_chunks:
+        logits_parts.append(lm_chunk(h).to("cpu"))
+    logits = torch.cat(logits_parts, dim=-1)
+    return logits
+
+
+def prepare_for_spyre(model):
+    """Apply Spyre adaptations to Phi-3 model in-place."""
+    from transformers.models.phi3.modeling_phi3 import Phi3RMSNorm
+
+    cfg = model.config
+    hd = cfg.hidden_size // cfg.num_attention_heads
+
+    # RoPE with identity padding for partial rotary
+    model._spyre_rope = PartialPrecomputedRotaryEmbedding(
+        model.model.rotary_emb, hd
+    )
+    patch_rmsnorm(Phi3RMSNorm)
+
+    # Chunk LM head for large vocab models (200K+ vocab exceeds EAR limit)
+    # Each chunk is stick-padded internally. Don't call pad_lm_head.
+    _chunk_lm_head(model, num_chunks=8)
+
+    num_q = cfg.num_attention_heads
+    num_kv = cfg.num_key_value_heads
+
+    # Split fused weights, register as submodules
+    model._spyre_q_projs = nn.ModuleList()
+    model._spyre_k_projs = nn.ModuleList()
+    model._spyre_v_projs = nn.ModuleList()
+    model._spyre_gate_projs = nn.ModuleList()
+    model._spyre_up_projs = nn.ModuleList()
+
+    for layer in model.model.layers:
+        q, k, v = _split_fused_qkv(layer.self_attn, num_q, num_kv, hd)
+        model._spyre_q_projs.append(q)
+        model._spyre_k_projs.append(k)
+        model._spyre_v_projs.append(v)
+
+        gate, up = _split_fused_mlp(layer.mlp)
+        model._spyre_gate_projs.append(gate)
+        model._spyre_up_projs.append(up)
+
+    model._spyre_compiled_blocks = [
+        _make_compiled_block(layer, qp, kp, vp, gp, up, hd)
+        for layer, qp, kp, vp, gp, up in zip(
+            model.model.layers,
+            model._spyre_q_projs,
+            model._spyre_k_projs,
+            model._spyre_v_projs,
+            model._spyre_gate_projs,
+            model._spyre_up_projs,
+        )
+    ]
+
+
+def load_model(model_path, dtype=torch.float16):
+    """Load Phi-3/Phi-4 model for Spyre."""
+    return load_model_common(model_path, prepare_for_spyre, dtype)
+
+
+def generate(model, tokenizer, prompts, **kwargs):
+    """Generate text with Phi-3/Phi-4 on Spyre."""
+    return _generate(_run_forward, model, tokenizer, prompts, **kwargs)

--- a/torch_spyre/adapters/hf_qwen3.py
+++ b/torch_spyre/adapters/hf_qwen3.py
@@ -1,0 +1,139 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+HuggingFace Transformers adapter for Qwen3 models on Spyre.
+
+Qwen3 differences from Granite:
+- Q/K RMSNorm applied before RoPE
+- No embedding/residual/logits multipliers
+- Standard head_dim**-0.5 scaling
+
+Usage::
+
+    from torch_spyre.adapters.hf_qwen3 import load_model, generate
+    from transformers import AutoTokenizer
+
+    model = load_model("Qwen/Qwen3-0.6B")
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    outputs = generate(model, tokenizer, ["Hello!"], max_new_tokens=32)
+"""
+
+import torch
+import torch.nn.functional as F
+
+from torch_spyre.adapters.hf_common import (
+    PrecomputedRotaryEmbedding,
+    apply_rope_matmul,
+    generate as _generate,
+    kv_cache_update,
+    load_model_common,
+    pad_lm_head,
+    patch_rmsnorm,
+)
+
+
+def _make_compiled_block(layer):
+    """Compiled block for Qwen3: Q/K norm before RoPE, no multipliers."""
+    attn = layer.self_attn
+    mlp = layer.mlp
+    input_ln = layer.input_layernorm
+    post_attn_ln = layer.post_attention_layernorm
+
+    # Qwen3 has per-head RMSNorm on Q and K
+    q_norm = attn.q_norm
+    k_norm = attn.k_norm
+
+    def block_forward(hidden_states, selected_freqs, attn_mask,
+                      key_cache, value_cache,
+                      is_filling, token_index, cache_position):
+        residual = hidden_states
+        h = input_ln(hidden_states)
+
+        bsz, seq_len, _ = h.shape
+        q = attn.q_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        k = attn.k_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        v = attn.v_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+
+        # Qwen3-specific: RMSNorm on Q and K before RoPE
+        q = q_norm(q)
+        k = k_norm(k)
+
+        q = apply_rope_matmul(q, selected_freqs)
+        k = apply_rope_matmul(k, selected_freqs)
+
+        key_cache, value_cache = kv_cache_update(
+            k, v, key_cache, value_cache,
+            is_filling, token_index, cache_position,
+        )
+
+        attn_out = F.scaled_dot_product_attention(
+            q, key_cache, value_cache,
+            attn_mask=attn_mask, dropout_p=0.0, scale=attn.scaling, enable_gqa=True,
+        )
+        attn_out = attn_out.transpose(1, 2).reshape(bsz, seq_len, -1)
+        attn_out = attn.o_proj(attn_out)
+
+        h = residual + attn_out
+
+        residual = h
+        h = post_attn_ln(h)
+        h = mlp(h)
+        h = residual + h
+
+        return h, key_cache, value_cache
+
+    return torch.compile(block_forward, dynamic=False)
+
+
+def _run_forward(model, input_ids, position_ids, attn_mask,
+                 key_caches, value_caches,
+                 is_filling, token_index, cache_position):
+    """Qwen3 forward: no embedding multiplier, no logits scaling."""
+    h = model.model.embed_tokens(input_ids)
+
+    selected_freqs = model._spyre_rope(h, position_ids)
+
+    for i, compiled_block in enumerate(model._spyre_compiled_blocks):
+        h, key_caches[i], value_caches[i] = compiled_block(
+            h, selected_freqs, attn_mask,
+            key_caches[i], value_caches[i],
+            is_filling, token_index, cache_position,
+        )
+
+    h = model.model.norm(h)
+    logits = model.lm_head(h)
+    return logits
+
+
+def prepare_for_spyre(model):
+    """Apply Spyre adaptations to Qwen3 model in-place."""
+    from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm
+
+    model._spyre_rope = PrecomputedRotaryEmbedding(model.model.rotary_emb)
+    patch_rmsnorm(Qwen3RMSNorm)
+    pad_lm_head(model)
+    model._spyre_compiled_blocks = [
+        _make_compiled_block(layer) for layer in model.model.layers
+    ]
+
+
+def load_model(model_path, dtype=torch.float16):
+    """Load Qwen3 model for Spyre."""
+    return load_model_common(model_path, prepare_for_spyre, dtype)
+
+
+def generate(model, tokenizer, prompts, **kwargs):
+    """Generate text with Qwen3 on Spyre."""
+    return _generate(_run_forward, model, tokenizer, prompts, **kwargs)

--- a/torch_spyre/adapters/hf_smollm3.py
+++ b/torch_spyre/adapters/hf_smollm3.py
@@ -1,0 +1,142 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+HuggingFace Transformers adapter for SmolLM3 models on Spyre.
+
+SmolLM3 differences from Granite:
+- NoPE layers: some layers skip RoPE entirely (controlled by config.no_rope_layers)
+- No embedding/residual/logits multipliers
+
+Usage::
+
+    from torch_spyre.adapters.hf_smollm3 import load_model, generate
+    from transformers import AutoTokenizer
+
+    model = load_model("HuggingFaceTB/SmolLM3-3B-Base")
+    tokenizer = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM3-3B-Base")
+    outputs = generate(model, tokenizer, ["Hello!"], max_new_tokens=32)
+"""
+
+import torch
+import torch.nn.functional as F
+
+from torch_spyre.adapters.hf_common import (
+    PrecomputedRotaryEmbedding,
+    apply_rope_matmul,
+    generate as _generate,
+    kv_cache_update,
+    load_model_common,
+    pad_lm_head,
+    patch_rmsnorm,
+)
+
+
+def _make_compiled_block(layer, use_rope):
+    """Compiled block for SmolLM3: conditional RoPE per layer."""
+    attn = layer.self_attn
+    mlp = layer.mlp
+    input_ln = layer.input_layernorm
+    post_attn_ln = layer.post_attention_layernorm
+
+    def block_forward(hidden_states, selected_freqs, attn_mask,
+                      key_cache, value_cache,
+                      is_filling, token_index, cache_position):
+        residual = hidden_states
+        h = input_ln(hidden_states)
+
+        bsz, seq_len, _ = h.shape
+        q = attn.q_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        k = attn.k_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+        v = attn.v_proj(h).view(bsz, seq_len, -1, attn.head_dim).transpose(1, 2)
+
+        # SmolLM3: RoPE is conditional per layer (NoPE layers skip it)
+        if use_rope:
+            q = apply_rope_matmul(q, selected_freqs)
+            k = apply_rope_matmul(k, selected_freqs)
+
+        key_cache, value_cache = kv_cache_update(
+            k, v, key_cache, value_cache,
+            is_filling, token_index, cache_position,
+        )
+
+        attn_out = F.scaled_dot_product_attention(
+            q, key_cache, value_cache,
+            attn_mask=attn_mask, dropout_p=0.0, scale=attn.scaling, enable_gqa=True,
+        )
+        attn_out = attn_out.transpose(1, 2).reshape(bsz, seq_len, -1)
+        attn_out = attn.o_proj(attn_out)
+
+        h = residual + attn_out
+
+        residual = h
+        h = post_attn_ln(h)
+        h = mlp(h)
+        h = residual + h
+
+        return h, key_cache, value_cache
+
+    return torch.compile(block_forward, dynamic=False)
+
+
+def _run_forward(model, input_ids, position_ids, attn_mask,
+                 key_caches, value_caches,
+                 is_filling, token_index, cache_position):
+    """SmolLM3 forward: no multipliers."""
+    h = model.model.embed_tokens(input_ids)
+
+    selected_freqs = model._spyre_rope(h, position_ids)
+
+    for i, compiled_block in enumerate(model._spyre_compiled_blocks):
+        h, key_caches[i], value_caches[i] = compiled_block(
+            h, selected_freqs, attn_mask,
+            key_caches[i], value_caches[i],
+            is_filling, token_index, cache_position,
+        )
+
+    h = model.model.norm(h)
+    logits = model.lm_head(h)
+    return logits
+
+
+def prepare_for_spyre(model):
+    """Apply Spyre adaptations to SmolLM3 model in-place."""
+    from transformers.models.smollm3.modeling_smollm3 import SmolLM3RMSNorm
+
+    model._spyre_rope = PrecomputedRotaryEmbedding(model.model.rotary_emb)
+    patch_rmsnorm(SmolLM3RMSNorm)
+    pad_lm_head(model)
+
+    # Determine which layers use RoPE vs NoPE
+    # SmolLM3 config has no_rope_layers: list of bools (True = skip RoPE)
+    no_rope = getattr(model.config, "no_rope_layers", None)
+
+    model._spyre_compiled_blocks = []
+    for idx, layer in enumerate(model.model.layers):
+        use_rope = True
+        if no_rope is not None and idx < len(no_rope):
+            use_rope = bool(no_rope[idx])
+        model._spyre_compiled_blocks.append(
+            _make_compiled_block(layer, use_rope)
+        )
+
+
+def load_model(model_path, dtype=torch.float16):
+    """Load SmolLM3 model for Spyre."""
+    return load_model_common(model_path, prepare_for_spyre, dtype)
+
+
+def generate(model, tokenizer, prompts, **kwargs):
+    """Generate text with SmolLM3 on Spyre."""
+    return _generate(_run_forward, model, tokenizer, prompts, **kwargs)


### PR DESCRIPTION
## Summary

- Adds a model-agnostic adapter framework (`torch_spyre/adapters/`) that enables stock HuggingFace Transformer models to run on Spyre via `torch.compile`
- Includes adapters for **Granite 3.3**, **Qwen3**, **Granite 4.0**, **SmolLM3**, and **Phi-4** (blocked by partial RoPE stickify issue)
- Shared utilities in `hf_common.py`: RoPE precomputation, RMSNorm fp16 patching, LM head padding, KV cache update, mask builders, and padded 64-block decode generation loop
- All adapters produce identical greedy tokens to stock HF on CPU
- Test suite: CPU accuracy comparison, per-layer CPU vs Spyre block comparison, E2E smoke tests, E2E token comparison

### Key design choices

- **No HF fork required** — runtime monkey-patches on stock HuggingFace Transformers
- **Follows FMS `eager_spyre` compilation pattern** — compiled block functions with raw tensor KV caches
- **`enable_gqa=True`** via SDPA (depends on #1551, already merged)
- **Stick alignment rule**: models require `head_dim >= 128` (D/2 >= 64)

### Files

| Path | Purpose |
|------|---------|
| `torch_spyre/adapters/hf_common.py` | Shared utilities (~420 lines) |
| `torch_spyre/adapters/hf_granite.py` | Granite 3.3 adapter |
| `torch_spyre/adapters/hf_qwen3.py` | Qwen3 adapter |
| `torch_spyre/adapters/hf_granitemoehybrid.py` | Granite 4.0 dense adapter |
| `torch_spyre/adapters/hf_smollm3.py` | SmolLM3 adapter |
| `torch_spyre/adapters/hf_phi3.py` | Phi-4 adapter (blocked) |
| `torch_spyre/adapters/SPYRE_ADAPTER_STATUS.md` | Detailed status & design doc |
| `tests/adapters/test_adapter_cpu_accuracy.py` | CPU accuracy test |
| `tests/adapters/test_block_cpu_vs_spyre.py` | Per-layer CPU vs Spyre comparison |
| `tests/adapters/test_e2e_smoke_spyre.py` | E2E smoke test (Spyre) |
| `tests/adapters/test_e2e_token_compare_spyre.py` | E2E token comparison (Spyre) |

Based on work by @raghukiran1224.

## Test plan

- [ ] Verify CPU accuracy tests pass: `python tests/adapters/test_adapter_cpu_accuracy.py`
- [ ] Run per-layer comparison on Spyre pod: `python tests/adapters/test_block_cpu_vs_spyre.py all`
- [ ] Run E2E smoke test on Spyre: `python tests/adapters/test_e2e_smoke_spyre.py qwen3`
- [ ] Verify pre-commit checks pass: `pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)