### PR TITLE
Refactor overwrite lowering with Scatter IRNode

### DIFF
--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -314,14 +314,6 @@ def _create_sdsc_tensors(
             )
             offsets[dim] = 0
             dim_device_stride = math.prod(arg.device_size[-stride_idx - 1 :])
-            for key in list(overwrite_infos.keys()):
-                info = overwrite_infos[key]
-                if info["device_stride"] == dim_device_stride and not arg.is_input:
-                    backGap[dim] = info["gap"]
-                    offsets[dim] = info["device_offset"] * info["device_stride"]
-                    overwrite_infos.pop(key)
-                    use_adjusted_size = False
-                    break
 
             dev_dim_size = arg.device_size[-stride_idx - 2]
             it_dim_size = iteration_space[dim]
@@ -330,9 +322,7 @@ def _create_sdsc_tensors(
                 dev_dim_size *= stick_size
                 it_dim_size = ((it_dim_size - 1) // stick_size + 1) * stick_size
 
-            if dev_dim_size > it_dim_size and "overwrite_infos" not in op_spec.op_info:
-                # TODO: overwrite and view offsets cannot be used together until the
-                # overwrite operator is refactored to use coordinate expression offsets
+            if dev_dim_size > it_dim_size:
                 dim_coord = arg.device_coordinates[-stride_idx - 2]
                 dim_offset = int(dim_coord.as_coeff_Add()[0])
                 offsets[dim] = dim_offset * dim_device_stride
@@ -362,28 +352,6 @@ def _create_sdsc_tensors(
                 backGap=backGap,
             )
         )
-
-    # For each overwrite entry with a device dimension of size 1 (absent from
-    # the iteration space), inject a synthetic dimension.
-    for info in overwrite_infos.values():
-        missing_dim = Symbol(INPUT_DIM_LABELS[len(op_dim_order)])
-        iteration_space[missing_dim] = 1
-        for sdsc_arg, src_arg in zip(sdsc_args, op_spec.args):
-            dim_idx = len(sdsc_arg.scales)
-            sdsc_arg.scales[missing_dim] = 1
-            sdsc_arg.max_dim_sizes[missing_dim] = -1
-            sdsc_arg.strides[missing_dim] = _calculate_device_stride(
-                dim_idx, src_arg.device_size
-            )
-            if not src_arg.is_input:
-                sdsc_arg.backGap[missing_dim] = info["gap"]
-                sdsc_arg.offsets[missing_dim] = (
-                    info["device_offset"] * info["device_stride"]
-                )
-            if missing_dim not in layouts[sdsc_arg.layout]["dim_order"]:
-                layouts[sdsc_arg.layout]["dim_order"] = layouts[sdsc_arg.layout][
-                    "dim_order"
-                ] + [missing_dim]
 
     return sdsc_args, layouts, missing_dim
 

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -257,25 +257,7 @@ def _create_sdsc_tensors(
     use_op_dims = not _is_matmul(op_spec.op)
 
     missing_dim = None
-    overwrite_infos: dict = (
-        dict(op_spec.op_info.get("overwrite_infos", {})) if op_spec.op_info else {}
-    )
     adjusted_output_size = op_spec.args[-1].device_size.copy()
-    if overwrite_infos:
-        output = op_spec.args[-1]
-        dim_order, stick_dim = _get_device_dim_order(output, symbol_mapping)
-        for dim_idx, dim in enumerate(dim_order):
-            for info in overwrite_infos.values():
-                if info["device_stride"] == math.prod(
-                    output.device_size[-dim_idx - 1 :]
-                ):
-                    dim_size = iteration_space[dim]
-                    dev_dim_idx = len(output.device_size) - 2 - dim_idx
-                    adjusted_output_size[dev_dim_idx] = (
-                        dim_size // output.device_dtype.elems_per_stick()
-                        if dim == stick_dim
-                        else dim_size
-                    )
     sdsc_args: list[SDSCArgs] = []
     for arg in op_spec.args:
         addr = None if arg.arg_index < 0 else SEGMENT_OFFSETS[arg.arg_index]

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -22,6 +22,7 @@ from torch._inductor.ir import (
     IRNode,
     Reduction,
     ReductionHint,
+    Scatter,
     TensorBox,
 )
 from torch_spyre._C import SpyreTensorLayout

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -22,7 +22,6 @@ from torch._inductor.ir import (
     IRNode,
     Reduction,
     ReductionHint,
-    Scatter,
     TensorBox,
 )
 from torch_spyre._C import SpyreTensorLayout

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 
 import torch
 
-from torch._inductor.ir import ComputedBuffer, Reduction, Pointwise, StorageBox
+from torch._inductor.ir import ComputedBuffer, Reduction, Pointwise, Scatter, StorageBox
 import torch._inductor.lowering as lowering
 
 from typing import Any, Callable, Union
@@ -25,7 +25,7 @@ from typing import Any, Callable, Union
 from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 import torch_spyre._inductor.customops  # noqa: F401
 from torch_spyre.ops.fallbacks import fallback_ops
-from .ir import Scatter, SpyreReduction
+from .ir import SpyreReduction
 from torch._inductor.virtualized import V
 from .errors import Unsupported
 import threading

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Union
 from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
 import torch_spyre._inductor.customops  # noqa: F401
 from torch_spyre.ops.fallbacks import fallback_ops
-from .ir import SpyreReduction
+from .ir import Scatter, SpyreReduction
 from torch._inductor.virtualized import V
 from .errors import Unsupported
 import threading
@@ -512,22 +512,21 @@ def lower_spyre_from_d2d(src, dst):
 def lower_overwrite(input, output, dims, offsets):
     fn = lowering.ops_wrapper(torch.ops.spyre.overwrite.__name__)
 
-    strides = [int(output.get_layout().stride[d]) for d in dims]
-    gaps = [int(output.get_layout().size[d] - input.get_layout().size[d]) for d in dims]
-
     def inner_fn(index):
-        return fn(
-            input.make_loader()(index),
-            strides,
-            offsets,
-            gaps,
-        )
+        return fn(input.make_loader()(index))
 
-    inp = Pointwise(
+    def output_indexer(index):
+        out_index = [*index]
+        for dim, offset in zip(dims, offsets):
+            out_index[dim] += offset
+        return out_index
+
+    inp = Scatter(
         device=input.get_device(),
         dtype=input.get_dtype(),
         inner_fn=inner_fn,
         ranges=input.get_size(),
+        output_indexer=output_indexer,
     )
 
     output.realize()

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -15,7 +15,6 @@
 from dataclasses import dataclass, field
 from typing import Any, Callable, Self, Sequence, Tuple, Union
 from abc import ABC
-import math
 
 import torch
 import sympy

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -172,14 +172,8 @@ class SpyreOpFuncs:
         return PointwiseOp("neg", [a])
 
     @staticmethod
-    def overwrite(input, strides, offsets, gaps):
-        op_info = {
-            "overwrite_infos": {
-                i: {"stride": s, "offset": o, "gap": g}
-                for i, (s, o, g) in enumerate(zip(strides, offsets, gaps))
-            }
-        }
-        return PointwiseOp("overwrite", [input], op_info)
+    def overwrite(input):
+        return PointwiseOp("overwrite", [input])
 
     @staticmethod
     def reciprocal(x):
@@ -452,10 +446,6 @@ class SpyreKernel(Kernel[CSEVariable]):
                     raise Unsupported(f"unexpected argument {input} to {value.op}")
             args.append(self.create_tensor_arg(False, real_dst_name, dst))
             op_info.update(value.op_info)
-            if value.op == "overwrite":
-                convert_overwrite(
-                    value.op_info["overwrite_infos"], dst.layout.device_layout
-                )
             self.op_specs.append(self.create_op_spec(value.op, False, args, op_info))
         elif isinstance(value, TensorAccess):
             # Reshapes, transposes, and other dataops
@@ -635,19 +625,3 @@ def simplify_op_spec(op_spec):
     for arg, t in zip(op_spec.args, new_tensors):
         arg.device_size = t["size"]
         arg.device_coordinates = t["coordinates"]
-
-
-def convert_overwrite(overwrite_infos, stl):
-    for info in overwrite_infos.values():
-        stride = info["stride"]
-        gap = info["gap"]
-        offset = info["offset"]
-        span = gap * stride
-        device_dim = None
-        max_stride = 0
-        for i, st in enumerate(stl.stride_map):
-            if st > max_stride and span >= st and stl.device_size[i] > 1:
-                max_stride = st
-                device_dim = i
-        info["device_stride"] = math.prod(stl.device_size[device_dim + 1 :])
-        info["device_offset"] = offset * stride // max_stride


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This change refactors the lowering definition of overwrite to use Scatter IRNode to represent the offset in output tensor. 

#### Which issue(s) this PR is related to:

Issue #1549 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
