### PR TITLE
Add an initial size-1 dimension support for tensor slicing

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1647,6 +1647,17 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "3d2s2": (2, 2, cached_randn((9, 15, 384), dtype=torch.float16)),
             },
         },
+        ("test_slice", "test_slice_cpu"): {
+            "ops_dict": {
+                "slice3": lambda dim, index, x: x.exp(),
+            },
+            "param_sets": {
+                # TODO: Add more tests by generalizing size-1 dim support. See #1548
+                "3d1s0": (1, 0, cached_randn((5, 3, 192), dtype=torch.float16)),
+                "3d1s1": (1, 1, cached_randn((5, 3, 192), dtype=torch.float16)),
+                "3d1s2": (1, 2, cached_randn((5, 3, 192), dtype=torch.float16)),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -2220,6 +2231,19 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     def test_split_cpu(self, op, dim, index, x):
         def fn(x):
             return op(dim, index, x)
+
+        compare_with_cpu(fn, x, run_eager=False)
+
+    def test_slice_cpu(self, op, dim, index, x):
+        def fn(x):
+            start = index * (x.size()[0] // 3)
+            end = (index + 1) * (x.size()[0] // 3)
+            if dim == 0:
+                return op(dim, index, x[start:end])
+            elif dim == 1:
+                return op(dim, index, x[:, start:end])
+            elif dim == 2:
+                return op(dim, index, x[:, :, start:end])
 
         compare_with_cpu(fn, x, run_eager=False, cpu_compile=False)
 

--- a/tests/tensor/test_coordinates.py
+++ b/tests/tensor/test_coordinates.py
@@ -107,7 +107,7 @@ class TestCoordinates(TestCase):
         )
         self.assertEqual(cx, [p0, p1, p2 + 128])
 
-        # offset spanning dimentions
+        # offset spanning dimensions
         cx = compute_coordinates(
             [10, 20, 30],
             [600, 30, 1],
@@ -163,7 +163,7 @@ class TestCoordinates(TestCase):
         )
         self.assertEqual(cx, [p1, p2 // 64 + 2, p0, p2 % 64])
 
-        # non-contiguous strides wit offset
+        # non-contiguous strides with offset
         cx = compute_coordinates(
             [256, 64, 2, 64],
             [4096, 64, 1048576, 1],
@@ -173,7 +173,7 @@ class TestCoordinates(TestCase):
         # offset 200 = 0*1048576 + 0*4096 + 3*64 + 8*1
         self.assertEqual(cx, [p2, 2 * p1 + p3 // 64 + 3, p0, p3 % 64 + 8])
 
-        # spliting the stick dimention
+        # splitting the stick dimension
         cx = compute_coordinates(
             [15, 6, 9, 64],
             [384, 64, 5760, 1],

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -577,3 +577,9 @@ def lower_restickify(x):
 
     pw.realize()
     return pw
+
+
+@register_spyre_lowering(torch.ops.aten.slice.Tensor, type_promotion_kind=None)
+def lower_slice(x, dim=0, start=None, end=None, step=1):
+    result = lowering.slice_(x, dim=dim, start=start, end=end, step=step)
+    return clone(result, memory_format=torch.contiguous_format)

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -136,7 +136,7 @@ class Term:
     """
     A term num*(var%mod)//den + offset in a coordinate expression.
     Includes the size of the dimension the expression is intended for.
-    Zero is represented as Term(None, None, None, None, dim_size, 0).
+    Constant including zero is represented as Term(None, None, None, None, dim_size, offset).
     """
 
     num: sympy.Expr | None  # numerator
@@ -174,9 +174,7 @@ def normalize_coordinates(
         vars = expr.free_symbols
         offset = expr.xreplace({var: sympy.S.Zero for var in vars})
         if len(vars) == 0:
-            # TODO: Support size-1 dimensions with non-zero offset
-            assert offset == 0
-            terms.append(Term(None, None, None, None, dim_size))
+            terms.append(Term(None, None, None, None, dim_size, offset))
             continue
         dim_terms = []  # terms for current dimension
         for var in vars:
@@ -249,10 +247,10 @@ def normalize_coordinates(
             fused_term.dim_size *= term.dim_size
             fused_term.offset += term.offset
         else:
-            if fused_term.dim_size > 1:
+            if fused_term.dim_size > 1 or fused_term.var is not None:
                 fused_terms.append(fused_term)
             fused_term = term
-    if fused_term.dim_size > 1:
+    if fused_term.dim_size > 1 or fused_term.var is not None:
         fused_terms.append(fused_term)
     # add term for stick dimension
     fused_terms.append(terms[-1])
@@ -262,7 +260,7 @@ def normalize_coordinates(
 
 def align_tensors(
     iteration_space: Dict[sympy.Symbol, Tuple[sympy.Expr, int]],
-    tensors: Sequence[Dict[str, Sequence[sympy.Expr]]],
+    tensors: list[Dict[str, list[sympy.Expr]]],
 ) -> tuple[
     (dict[sympy.Symbol, tuple[sympy.Expr, int]], list[dict[str, list[sympy.Expr]]])
 ]:
@@ -282,6 +280,35 @@ def align_tensors(
     all_terms = []  # terms for each tensor
     stick_dim = []  # stick var for each tensor
     stick_size = []  # stick size for each tensor
+
+    n = 0  # next symbol number
+
+    # TODO: Current support of size-1 dimensions are limited. We will generalize this
+    # in follow-up PRs. See #1548
+    is_pointwise_op = len(set([len(tensor["size"]) for tensor in tensors])) == 1
+    if is_pointwise_op:
+        rank = len(tensors[0]["size"])
+        vars = var_ranges.keys()
+        for i in range(rank):
+            coords = [tensor["coordinates"][i] for tensor in tensors]
+            if all(c == 0 for c in coords):
+                continue
+            if not any(c == 0 for c in coords):
+                continue
+            if not any(c.is_number and c > 0 for c in coords):
+                continue
+
+            new_var = sympy.symbols(f"z{n}")
+            n += 1
+            var_ranges[new_var] = 1
+            splits[new_var] = set()
+
+            for tensor in tensors:
+                coord = tensor["coordinates"][i]
+                if coord == 0:
+                    tensor["coordinates"][i] = new_var
+                else:
+                    tensor["coordinates"][i] = new_var + coord
 
     for tensor in tensors:
         terms = normalize_coordinates(var_ranges, tensor["size"], tensor["coordinates"])
@@ -304,7 +331,6 @@ def align_tensors(
     # with one var per segment (split[i], split[i+1])
     new_var_ranges = {}
     new_op_it_space_splits = {}
-    n = 0  # next symbol number
     remap = {}  # map old var to new vars in splits order
     for var, split in splits.items():
         div = op_it_space_splits[var] if var in op_it_space_splits else 1
@@ -351,7 +377,11 @@ def align_tensors(
                 and den not in splits[var]
                 else splits[var].index(den)
             )  # replace split[var].index(stick_size) with 0 for stick dim
-            for i in reversed(range(low, splits[var].index(mod))):
+            high = splits[var].index(mod)
+            if low == high:
+                size.append(dim_size)
+                coordinates.append(var + offset)
+            for i in reversed(range(low, high)):
                 if i == splits[var].index(mod) - 1:
                     # upper bound of iteration range is dim_size * den
                     size.append(dim_size * den // splits[var][i])

--- a/torch_spyre/ops/fallbacks.py
+++ b/torch_spyre/ops/fallbacks.py
@@ -272,8 +272,3 @@ def spyre__tril(input, diagonal=0, **kwargs):
 @register_fallback([aten.triu.default, aten.triu.out])
 def spyre__triu(input, diagonal=0, **kwargs):
     return torch.triu(input, diagonal, **kwargs)
-
-
-@register_fallback([aten.slice.Tensor])
-def spyre__slice(self, dim=0, start=None, end=None, step=1):
-    return torch.ops.aten.slice(self, dim, start, end, step)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR add changes to support size-1 dimensions when splitting tensors using views.

Current support is limited. It only works when the operation following the slice is pointwise; reduction and overwrite ops    are not supported.

Follow-up PRs will address these limitations.

#### Which issue(s) this PR is related to:

- #1548

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
