### PR TITLE
skill(add-spyre-operation): promote model-based verification to required first test step

### DIFF
--- a/.claude/skills/add-spyre-operation/SKILL.md
+++ b/.claude/skills/add-spyre-operation/SKILL.md
@@ -143,14 +143,19 @@ register it in `torch_spyre/fallbacks.py`.
 
 ## Test Requirements
 
-Every new op must have tests. See the `write-spyre-op-test` skill for details.
-At minimum:
+Every new op requires two levels of validation:
 
-- **Compiled-path test** in `tests/_inductor/test_inductor_ops.py` using
-  `compare_with_cpu()` or `compare()`
-- **Shape variety:** 1D through 4D, stick-aligned (multiples of 64) and
-  non-aligned sizes
-- **Default dtype:** `torch.float16`
+1. **Model-based verification** — run the op against parameters drawn from
+   real target models:
+   `pytest -c pytest_models.ini tests/models/test_model_ops.py -k <op_name>`
+
+2. **Unit tests** — add compiled-path and (if applicable) eager-path tests.
+   See the `write-spyre-op-test` skill for details. At minimum:
+   - **Compiled-path test** in `tests/_inductor/test_inductor_ops.py` using
+     `compare_with_cpu()` or `compare()`
+   - **Shape variety:** 1D through 4D, stick-aligned (multiples of 64) and
+     non-aligned sizes
+   - **Default dtype:** `torch.float16`
 
 ---
 

--- a/.claude/skills/add-spyre-operation/op-checklist.md
+++ b/.claude/skills/add-spyre-operation/op-checklist.md
@@ -45,7 +45,17 @@ Check off each item as you complete it.
 - [ ] Add op name constant to `torch_spyre/_inductor/constants.py`
   if used across files
 
-## 4. Write Tests
+## 4. Verify Against Target Model Parameters
+
+Run before writing unit tests: real model parameters often reveal issues
+that synthetic tests miss.
+
+- [ ] Run `pytest -c pytest_models.ini tests/models/test_model_ops.py -k <op_name>`
+  where `<op_name>` is the torch op name that is replaced `.` with `_`.
+  (e.g. `torch.add` -> `torch_add`)
+- [ ] All tests pass, or failures are in already-known unsupported features.
+
+## 5. Write Tests
 
 - [ ] Add compiled-path test in `tests/_inductor/test_inductor_ops.py`
   - [ ] Use `compare_with_cpu()` or `compare()` from `utils_inductor`
@@ -56,7 +66,7 @@ Check off each item as you complete it.
 - [ ] Add building-block test in `tests/_inductor/test_building_blocks.py`
   (if op is part of a larger module like LayerNorm)
 
-## 5. Final Checks
+## 6. Final Checks
 
 - [ ] Run `pre-commit run --all-files`
 - [ ] Run `python3 -m pytest tests/_inductor/test_inductor_ops.py` (at
@@ -65,7 +75,7 @@ Check off each item as you complete it.
 - [ ] Use `import regex` not `import re` in any new Python files
 - [ ] Sign off commit: `git commit -s`
 
-## 6. Fallback (if needed)
+## 7. Fallback (if needed)
 
 - [ ] Register CPU fallback in `torch_spyre/fallbacks.py` if the op
   cannot run on Spyre in some configurations


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

Promotes model-based testing to a required first step in the add-spyre-operation skill, before writing unit tests.                                                                                                                                                                                                                                                                                                                                         
   
The existing checklist jumped straight from implementation to unit tests. Unit tests with synthetic shapes can miss failures that only appear with parameter shapes, dtypes, and strides drawn from real target models. Running pytest_models.ini / test_model_ops.py first catches these issues earlier.                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Changes:                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - op-checklist.md: inserts a new step 4 ("Verify Against Target Model Parameters") between the implementation steps and the unit-test step; renumbers subsequent steps.                                                                                                                                                                                                                                                                                  
  - SKILL.md (Test Requirements): reframes requirements as two explicit levels — (1) model-based verification, (2) unit tests — with the same rationale.                                                                                                                                                                                                                                                                                                     


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#808

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
