### PR TITLE
[TESTING] Apply pytest markers dynamically to each of op and dtype in class ops as it gets expanded in upstream @ops

### DIFF
--- a/tests/spyre_test_base_common.py
+++ b/tests/spyre_test_base_common.py
@@ -4,8 +4,9 @@ Shared class and methods for all OOT PyTorch test overrides.
 """
 
 import os
-import regex as re
 from typing import Dict, List, Optional, Set
+import warnings
+
 
 import pytest  # type: ignore
 import torch
@@ -37,6 +38,7 @@ from spyre_upstream_patcher import (
     _OOTOpListPatcher,
     _OOTModuleListPatcher,
     _OOTModuleDtypePatcher,
+    _OOTOpMarkerPatcher,
     _OOTPrecisionOverridePatcher,
 )
 from spyre_test_config_models import (
@@ -46,6 +48,8 @@ from spyre_test_config_models import (
     SupportedModuleConfig,
     TestEntry,
 )
+
+warnings.filterwarnings("ignore", category=pytest.PytestUnknownMarkWarning)
 
 
 # Resolve the actual backend name registered for privateuse1.
@@ -294,7 +298,6 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
     def instantiate_test(cls, name, test, *, generic_cls=None):
         _OOTOnlyOnPatcher(test, _SPYRE_DEVICE_TYPE).patch()
         cls._load_test_suite_config()
-
         # print tags to stderr
         entry = cls.TEST_ENTRIES.get(name)
         tags = entry.tags if entry is not None else []
@@ -398,6 +401,9 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
             ),
         ).patch()
 
+        # Dynamically adds pytest marker to each of ops and dtype passed to @ops
+        _OOTOpMarkerPatcher(test).patch()
+
         existing_methods = set(cls.__dict__.keys())
         super().instantiate_test(name, test, generic_cls=generic_cls)
         new_methods = set(cls.__dict__.keys()) - existing_methods
@@ -442,16 +448,6 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                     for tag in all_tags:
                         marked_fn = pytest.mark.__getattr__(tag)(marked_fn)
                     setattr(cls, method_name, marked_fn)
-
-            # apply the full method name as its own pytest marker
-            existing_fn = cls.__dict__.get(method_name)
-            if existing_fn is not None:
-                safe_marker = re.sub(r"[^a-zA-Z0-9_]", "_", method_name)
-                setattr(
-                    cls,
-                    method_name,
-                    pytest.mark.__getattr__(safe_marker)(existing_fn),
-                )
 
             # apply xfail if needed
             if is_xfail:

--- a/tests/spyre_test_base_common.py
+++ b/tests/spyre_test_base_common.py
@@ -33,6 +33,7 @@ from spyre_test_parsing import (
 
 from spyre_upstream_patcher import (
     _OOTDtypePatcher,
+    _OOTModuleMarkerPatcher,
     _OOTOnlyOnPatcher,
     _OOTOpDtypeExpander,
     _OOTOpListPatcher,
@@ -376,7 +377,10 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                 and isinstance(p.__self__, _modules_cls)
             ):
                 for mod_info in p.__self__.module_info_list:
-                    mod_cfg = cls.SUPPORTED_MODULES_CONFIG.get(mod_info.name)
+                    mod_cfg = cls.SUPPORTED_MODULES_CONFIG.get(
+                        mod_info.name
+                    ) or cls.SUPPORTED_MODULES_CONFIG.get(f"torch.{mod_info.name}")
+
                     if mod_cfg is not None:
                         resolved = mod_cfg.resolved_dtypes()
                         if resolved is not None:
@@ -403,6 +407,9 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
 
         # Dynamically adds pytest marker to each of ops and dtype passed to @ops
         _OOTOpMarkerPatcher(test).patch()
+
+        # Dynamically adds pytest marker to each of modules and dtype passed to @modules
+        _OOTModuleMarkerPatcher(test).patch()
 
         existing_methods = set(cls.__dict__.keys())
         super().instantiate_test(name, test, generic_cls=generic_cls)

--- a/tests/spyre_test_config_models.py
+++ b/tests/spyre_test_config_models.py
@@ -783,9 +783,15 @@ class SupportedModuleConfig(BaseModel):
 
     name: str
     force_xfail: bool = False
+    dtypes: List[SupportedOpDtypeConfig] = []
 
     def get_name(self) -> str:
         return self.name
+
+    def resolved_dtypes(self) -> Optional[Set[torch.dtype]]:
+        if not self.dtypes:
+            return None
+        return {d.resolved_dtype() for d in self.dtypes}
 
 
 class InputConfig(BaseModel):
@@ -799,7 +805,7 @@ class GlobalConfig(BaseModel):
 
     supported_dtypes: List[DtypeNamedItem] = []
     supported_ops: Optional[List[SupportedOpConfig]] = None
-    supported_modules: Optional[List[ModulesNamedItem]] = None
+    supported_modules: Optional[List[SupportedModuleConfig]] = None
     input_config: InputConfig = InputConfig()
 
     @field_validator("supported_dtypes", mode="before")

--- a/tests/spyre_upstream_patcher.py
+++ b/tests/spyre_upstream_patcher.py
@@ -334,10 +334,13 @@ class _OOTModuleListPatcher:
         if self._included_modules:
             existing_names = {m.name for m in self._modules_instance.module_info_list}
             for name in self._included_modules:
-                if name not in existing_names:
-                    mod_info = module_db_by_name.get(name)
-                    if mod_info is not None:
-                        self._modules_instance.module_info_list.append(mod_info)
+                # YAML may use "torch.nn.X" but module_db keys use "nn.X"
+                short_name = name.removeprefix("torch.")
+                mod_info = module_db_by_name.get(short_name) or module_db_by_name.get(
+                    name
+                )
+                if mod_info is not None and mod_info.name not in existing_names:
+                    self._modules_instance.module_info_list.append(mod_info)
 
         # filter to global.supported_modules
         # included_modules will exist even if not in supported_modules
@@ -345,7 +348,10 @@ class _OOTModuleListPatcher:
             filtered = [
                 m
                 for m in self._modules_instance.module_info_list
-                if m.name in self._supported_modules or m.name in self._included_modules
+                if m.name in self._supported_modules
+                or m.name in self._included_modules
+                or f"torch.{m.name}" in self._supported_modules
+                or f"torch.{m.name}" in self._included_modules
             ]
             if filtered:
                 self._modules_instance.module_info_list[:] = filtered
@@ -356,6 +362,7 @@ class _OOTModuleListPatcher:
                 m
                 for m in self._modules_instance.module_info_list
                 if m.name not in self._excluded_modules
+                and f"torch.{m.name}" not in self._excluded_modules  # ← add
             ]
             if filtered:
                 self._modules_instance.module_info_list[:] = filtered
@@ -488,11 +495,9 @@ class _OOTOpMarkerPatcher:
             return
 
         import pytest
-        import re
+        import regex as re
 
-        original_parametrize_fn = (
-            self._underlying_fn.parametrize_fn
-        )  # bound method on fn
+        original_parametrize_fn = self._underlying_fn.parametrize_fn
 
         def patched_parametrize_fn(test, generic_cls, device_cls):
             for (
@@ -508,7 +513,9 @@ class _OOTOpMarkerPatcher:
                     op_safe = re.sub(r"[^a-zA-Z0-9_]", "_", op.name).strip("_")
                     op_safe = re.sub(r"__\d+$", "", op_safe).strip("_")
                     if op_safe:
-                        test_wrapper = pytest.mark.__getattr__(op_safe)(test_wrapper)
+                        test_wrapper = pytest.mark.__getattr__(f"op__{op_safe}")(
+                            test_wrapper
+                        )
 
                 if dtype is not None:
                     dtype_safe = re.sub(
@@ -516,9 +523,89 @@ class _OOTOpMarkerPatcher:
                     ).strip("_")
                     dtype_safe = re.sub(r"__\d+$", "", dtype_safe).strip("_")
                     if dtype_safe:
-                        test_wrapper = pytest.mark.__getattr__(dtype_safe)(test_wrapper)
+                        test_wrapper = pytest.mark.__getattr__(f"dtype__{dtype_safe}")(
+                            test_wrapper
+                        )
 
                 yield test_wrapper, test_name, param_kwargs, decorator_fn
 
         # Replacing on the function object itself because this is what the upstream reads.
         self._underlying_fn.parametrize_fn = patched_parametrize_fn
+
+
+class _OOTModuleMarkerPatcher:
+    """Patches @modules.parametrize_fn to attach pytest markers directly on
+    each test_wrapper as it is yielded, before super().instantiate_test()
+    installs it as a class method.
+
+    Follows _OOTOpMarkerPatcher exactly but targets the @modules decorator.
+    Attaches module name and dtype as pytest markers so tests can be filtered
+    with -m "nn_Linear" or -m "float16".
+    """
+
+    def __init__(self, test: object) -> None:
+        from torch.testing._internal.common_modules import modules as _modules_cls
+
+        self._test = test  # store original test object
+        underlying_fn = test.__func__ if hasattr(test, "__func__") else test
+        p = getattr(underlying_fn, "parametrize_fn", None)
+        self._modules_instance = (
+            p.__self__
+            if p is not None
+            and hasattr(p, "__self__")
+            and isinstance(p.__self__, _modules_cls)
+            else None
+        )
+        self._underlying_fn = underlying_fn
+
+    def patch(self) -> None:
+        if self._modules_instance is None:
+            return
+
+        import pytest
+        import regex as re
+
+        original_parametrize_fn = self._underlying_fn.parametrize_fn
+
+        def patched_parametrize_fn(test, generic_cls, device_cls):
+            for (
+                test_wrapper,
+                test_name,
+                param_kwargs,
+                decorator_fn,
+            ) in original_parametrize_fn(test, generic_cls, device_cls):
+                module_info = param_kwargs.get("module_info")
+                dtype = param_kwargs.get("dtype")
+
+                if module_info is not None:
+                    module_safe = re.sub(r"[^a-zA-Z0-9_]", "_", module_info.name).strip(
+                        "_"
+                    )
+                    module_safe = re.sub(r"__\d+$", "", module_safe).strip("_")
+                    if module_safe:
+                        mark = pytest.mark.__getattr__(f"module__{module_safe}")
+                        # Set directly on pytestmark list so @wraps copies it
+                        if not hasattr(test_wrapper, "pytestmark"):
+                            test_wrapper.pytestmark = []
+                        test_wrapper.pytestmark = list(test_wrapper.pytestmark) + [mark]
+
+                if dtype is not None:
+                    dtype_safe = re.sub(
+                        r"[^a-zA-Z0-9_]", "_", str(dtype).replace("torch.", "")
+                    ).strip("_")
+                    dtype_safe = re.sub(r"__\d+$", "", dtype_safe).strip("_")
+                    if dtype_safe:
+                        mark = pytest.mark.__getattr__(f"dtype__{dtype_safe}")
+                        if not hasattr(test_wrapper, "pytestmark"):
+                            test_wrapper.pytestmark = []
+                        test_wrapper.pytestmark = list(test_wrapper.pytestmark) + [mark]
+
+                yield test_wrapper, test_name, param_kwargs, decorator_fn
+
+        self._underlying_fn.parametrize_fn = patched_parametrize_fn
+        # Also set directly on the test object in case getattr(test, ...)
+        # resolves differently from getattr(test.__func__, ...)
+        try:
+            self._test.parametrize_fn = patched_parametrize_fn  # type: ignore[attr-defined]
+        except AttributeError:
+            pass

--- a/tests/spyre_upstream_patcher.py
+++ b/tests/spyre_upstream_patcher.py
@@ -460,3 +460,65 @@ class _OOTPrecisionOverridePatcher:
                 # setdefault for global, direct assign for include (already merged above
                 # so just assign - include already won priority during merge)
                 self._underlying_fn.precision_overrides[dtype] = atol
+
+
+class _OOTOpMarkerPatcher:
+    """Patches @ops._parametrize_test to attach pytest markers directly on
+    each test_wrapper as it is yielded, before super().instantiate_test()
+    installs it as a class method.
+
+    """
+
+    def __init__(self, test: object) -> None:
+        from torch.testing._internal.common_device_type import ops as _ops_cls
+
+        underlying_fn = test.__func__ if hasattr(test, "__func__") else test
+        p = getattr(underlying_fn, "parametrize_fn", None)
+        self._ops_instance = (
+            p.__self__
+            if p is not None
+            and hasattr(p, "__self__")
+            and isinstance(p.__self__, _ops_cls)
+            else None
+        )
+        self._underlying_fn = underlying_fn
+
+    def patch(self) -> None:
+        if self._ops_instance is None:
+            return
+
+        import pytest
+        import re
+
+        original_parametrize_fn = (
+            self._underlying_fn.parametrize_fn
+        )  # bound method on fn
+
+        def patched_parametrize_fn(test, generic_cls, device_cls):
+            for (
+                test_wrapper,
+                test_name,
+                param_kwargs,
+                decorator_fn,
+            ) in original_parametrize_fn(test, generic_cls, device_cls):
+                op = param_kwargs.get("op")
+                dtype = param_kwargs.get("dtype")
+
+                if op is not None:
+                    op_safe = re.sub(r"[^a-zA-Z0-9_]", "_", op.name).strip("_")
+                    op_safe = re.sub(r"__\d+$", "", op_safe).strip("_")
+                    if op_safe:
+                        test_wrapper = pytest.mark.__getattr__(op_safe)(test_wrapper)
+
+                if dtype is not None:
+                    dtype_safe = re.sub(
+                        r"[^a-zA-Z0-9_]", "_", str(dtype).replace("torch.", "")
+                    ).strip("_")
+                    dtype_safe = re.sub(r"__\d+$", "", dtype_safe).strip("_")
+                    if dtype_safe:
+                        test_wrapper = pytest.mark.__getattr__(dtype_safe)(test_wrapper)
+
+                yield test_wrapper, test_name, param_kwargs, decorator_fn
+
+        # Replacing on the function object itself because this is what the upstream reads.
+        self._underlying_fn.parametrize_fn = patched_parametrize_fn


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- feature

#### What this PR does:

Currently there is no way to run tests for a specific op or dtype without modifying the YAML config. This PR adds automatic pytest markers derived from op.name and dtype for every test variant generated by @ops which lacks in upstream pytorch test framework.

- `spyre_upstream_patcher.py`: Added `_OOTOpMarkerPatcher` which wraps `parametrize_fn` on the underlying test function to intercept each test_wrapper as it is yielded by `_parametrize_test`, attaching op.name and dtype as pytest markers before upstream installs the method on the class.

- `spyre_test_base_common.py`:  Call `_OOTOpMarkerPatcher(test).patch()` after all other patchers and before super().instantiate_test(). Suppress PytestUnknownMarkWarning since markers are registered dynamically.

Please note that the framework auto-prefixes `op__` for ops marker, `dtype__` for dtype marker and `module__` for modules marker when expanding and patching the `@ops` and `@modules` upstream class.


#### Which issue(s) this PR is related to:


Fixes https://github.com/torch-spyre/torch-spyre/issues/1754
Epic: https://github.com/torch-spyre/torch-spyre/issues/1156

#### Special notes for your reviewer:

Run the following 
```bash
bash run_test.sh configs/gpt_oss_20b_spyre.yaml -v -m "op__torch_nn_functional_embedding" --collect-only
bash run_test.sh configs/example_test_config.yaml -v -m "module__nn_Linear" --collect-only
bash run_test.sh configs/example_test_config.yaml -v -m "dtype__float32" --collect-only
bash run_test.sh configs/example_test_config.yaml -v -m "module__nn_BatchNorm2d and dtype__float32" --collect-only
bash run_test.sh configs/gpt_oss_20b_spyre.yaml -v -m "op__torch_add" --collect-only
```

Outputs should look like this (easy to filter out based on op name irrespective of the upper level tags)
<img width="3456" height="772" alt="image" src="https://github.com/user-attachments/assets/3841f09e-cfd3-49e1-865f-aac227e967f1" />

<img width="3456" height="772" alt="image" src="https://github.com/user-attachments/assets/bceac285-caa1-495d-b2e3-51bf75113113" />

<img width="3456" height="814" alt="image" src="https://github.com/user-attachments/assets/aacec619-d1d3-49da-9fa8-68811d3c9d4f" />

<img width="3452" height="756" alt="image" src="https://github.com/user-attachments/assets/3488cfca-944b-421c-b8ff-045faf308e51" />

<img width="3456" height="1506" alt="image" src="https://github.com/user-attachments/assets/837ec15f-4305-4c4b-acd3-853079eb0dbc" />




#### Does this PR introduce a user-facing change? No