### PR TITLE
add SpyreCode to JobPlan translation

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -121,6 +121,8 @@ jobs:
             config: torch_spyre_tests/test_spyre_lazy_silent_config.yaml
           - name: Test Stream
             config: torch_spyre_tests/test_stream_config.yaml
+          - name: Test Prepare Kernel
+            config: torch_spyre_tests/test_prepare_kernel_config.yaml
           # Inductor tests
           - name: Inductor Building Blocks
             config: torch_spyre_tests/inductor/test_building_blocks_config.yaml

--- a/tests/configs/torch_spyre_tests/test_prepare_kernel_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_prepare_kernel_config.yaml
@@ -1,0 +1,4 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/test_prepare_kernel.py
+      unlisted_test_mode: mandatory_success

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -43,7 +43,7 @@ class TestPrepareKernel:
         Returns:
             Path to the SpyreCode directory
         """
-        spyrecode_dir = os.path.join(tmpdir, "mock_spyrecode")
+        spyrecode_dir = os.path.join(tmpdir, "spyreCodeDir")
         os.makedirs(spyrecode_dir, exist_ok=True)
 
         # Create a minimal spyrecode.json
@@ -53,7 +53,7 @@ class TestPrepareKernel:
                 {
                     "command": "InitTransfer",
                     "properties": {
-                        "file_path": os.path.join(spyrecode_dir, "init.bin"),
+                        "file_path": tmpdir,
                         "dev_ptr": "120259084288",
                         "size": "1024",
                     },

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -114,7 +114,7 @@ class TestPrepareKernel:
             job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
 
             # First step should be ComputeSpecialize
-            assert job_plan.get_step_type(0) == "ComputeSpecialize"
+            assert job_plan.get_step_type(0) == "Compute"
 
     def test_prepare_kernel_invalid_directory(self):
         """Test PrepareKernel with invalid directory."""

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -36,62 +36,55 @@ class TestPrepareKernel:
 
     def create_mock_spyrecode(self, tmpdir):
         """Create a mock SpyreCode directory structure for testing.
-        
+
         Args:
             tmpdir: Temporary directory path
-            
+
         Returns:
             Path to the SpyreCode directory
         """
         spyrecode_dir = os.path.join(tmpdir, "mock_spyrecode")
         os.makedirs(spyrecode_dir, exist_ok=True)
-        
+
         # Create a minimal spyrecode.json
         spyrecode_json = {
             "JobPreparationPlan": [
-                {
-                    "command": "Allocate",
-                    "properties": {
-                        "size": "1024"
-                    }
-                },
+                {"command": "Allocate", "properties": {"size": "1024"}},
                 {
                     "command": "InitTransfer",
                     "properties": {
                         "file_path": os.path.join(spyrecode_dir, "init.bin"),
                         "dev_ptr": "120259084288",
-                        "size": "1024"
-                    }
-                }
+                        "size": "1024",
+                    },
+                },
             ],
             "JobExecPlan": [
                 {
                     "command": "ComputeOnDevice",
-                    "properties": {
-                        "job_bin_ptr": "120259084288"
-                    }
+                    "properties": {"job_bin_ptr": "120259084288"},
                 }
-            ]
+            ],
         }
-        
+
         # Write spyrecode.json
         with open(os.path.join(spyrecode_dir, "spyrecode.json"), "w") as f:
             json.dump(spyrecode_json, f, indent=2)
-        
+
         # Create a dummy binary file
         with open(os.path.join(spyrecode_dir, "init.bin"), "wb") as f:
             f.write(b"\x00" * 1024)
-        
+
         return spyrecode_dir
 
     def test_prepare_kernel_basic(self):
         """Test basic PrepareKernel functionality."""
         with tempfile.TemporaryDirectory() as tmpdir:
             spyrecode_dir = self.create_mock_spyrecode(tmpdir)
-            
+
             # Call prepare_kernel
             job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
-            
+
             # Verify JobPlan was created
             assert job_plan is not None
             assert isinstance(job_plan, torch_spyre._C.JobPlan)
@@ -101,7 +94,7 @@ class TestPrepareKernel:
         with tempfile.TemporaryDirectory() as tmpdir:
             spyrecode_dir = self.create_mock_spyrecode(tmpdir)
             job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
-            
+
             # Should have 1 step (ComputeOnDevice)
             assert job_plan.num_steps() == 1
 
@@ -110,7 +103,7 @@ class TestPrepareKernel:
         with tempfile.TemporaryDirectory() as tmpdir:
             spyrecode_dir = self.create_mock_spyrecode(tmpdir)
             job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
-            
+
             # Should match the allocated size (1024 bytes)
             assert job_plan.job_allocation_size() == 1024
 
@@ -119,7 +112,7 @@ class TestPrepareKernel:
         with tempfile.TemporaryDirectory() as tmpdir:
             spyrecode_dir = self.create_mock_spyrecode(tmpdir)
             job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
-            
+
             # First step should be ComputeSpecialize
             assert job_plan.get_step_type(0) == "ComputeSpecialize"
 
@@ -140,12 +133,11 @@ class TestPrepareKernel:
         with tempfile.TemporaryDirectory() as tmpdir:
             spyrecode_dir = self.create_mock_spyrecode(tmpdir)
             job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
-            
+
             # Should raise error for out-of-range index
             with pytest.raises(RuntimeError, match="Step index out of range"):
                 job_plan.get_step_type(999)
 
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-
-# Made with Bob

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PrepareKernel Python bindings and JobPlan verification."""
+
+import os
+import tempfile
+import json
+import pytest
+import torch
+import torch_spyre
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initialize_runtime():
+    """Initialize Spyre runtime before running tests."""
+    # Initialize torch with spyre device to start runtime
+    torch.zeros(1, device="spyre")
+    yield
+    # Runtime cleanup happens automatically
+
+
+class TestPrepareKernel:
+    """Test suite for PrepareKernel and JobPlan bindings."""
+
+    def create_mock_spyrecode(self, tmpdir):
+        """Create a mock SpyreCode directory structure for testing.
+        
+        Args:
+            tmpdir: Temporary directory path
+            
+        Returns:
+            Path to the SpyreCode directory
+        """
+        spyrecode_dir = os.path.join(tmpdir, "mock_spyrecode")
+        os.makedirs(spyrecode_dir, exist_ok=True)
+        
+        # Create a minimal spyrecode.json
+        spyrecode_json = {
+            "JobPreparationPlan": [
+                {
+                    "command": "Allocate",
+                    "properties": {
+                        "size": "1024"
+                    }
+                },
+                {
+                    "command": "InitTransfer",
+                    "properties": {
+                        "file_path": os.path.join(spyrecode_dir, "init.bin"),
+                        "dev_ptr": "120259084288",
+                        "size": "1024"
+                    }
+                }
+            ],
+            "JobExecPlan": [
+                {
+                    "command": "ComputeOnDevice",
+                    "properties": {
+                        "job_bin_ptr": "120259084288"
+                    }
+                }
+            ]
+        }
+        
+        # Write spyrecode.json
+        with open(os.path.join(spyrecode_dir, "spyrecode.json"), "w") as f:
+            json.dump(spyrecode_json, f, indent=2)
+        
+        # Create a dummy binary file
+        with open(os.path.join(spyrecode_dir, "init.bin"), "wb") as f:
+            f.write(b"\x00" * 1024)
+        
+        return spyrecode_dir
+
+    def test_prepare_kernel_basic(self):
+        """Test basic PrepareKernel functionality."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spyrecode_dir = self.create_mock_spyrecode(tmpdir)
+            
+            # Call prepare_kernel
+            job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
+            
+            # Verify JobPlan was created
+            assert job_plan is not None
+            assert isinstance(job_plan, torch_spyre._C.JobPlan)
+
+    def test_job_plan_num_steps(self):
+        """Test JobPlan.num_steps() method."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spyrecode_dir = self.create_mock_spyrecode(tmpdir)
+            job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
+            
+            # Should have 1 step (ComputeOnDevice)
+            assert job_plan.num_steps() == 1
+
+    def test_job_plan_allocation_size(self):
+        """Test JobPlan.job_allocation_size() method."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spyrecode_dir = self.create_mock_spyrecode(tmpdir)
+            job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
+            
+            # Should match the allocated size (1024 bytes)
+            assert job_plan.job_allocation_size() == 1024
+
+    def test_job_plan_step_type(self):
+        """Test JobPlan.get_step_type() method."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spyrecode_dir = self.create_mock_spyrecode(tmpdir)
+            job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
+            
+            # First step should be ComputeSpecialize
+            assert job_plan.get_step_type(0) == "ComputeSpecialize"
+
+    def test_prepare_kernel_invalid_directory(self):
+        """Test PrepareKernel with invalid directory."""
+        with pytest.raises(RuntimeError, match="SpyreCode directory does not exist"):
+            torch_spyre._C.prepare_kernel("/nonexistent/directory")
+
+    def test_prepare_kernel_missing_json(self):
+        """Test PrepareKernel with missing spyrecode.json."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create directory but no spyrecode.json
+            with pytest.raises(RuntimeError, match="spyrecode.json not found"):
+                torch_spyre._C.prepare_kernel(tmpdir)
+
+    def test_job_plan_step_index_out_of_range(self):
+        """Test JobPlan methods with out-of-range index."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            spyrecode_dir = self.create_mock_spyrecode(tmpdir)
+            job_plan = torch_spyre._C.prepare_kernel(spyrecode_dir)
+            
+            # Should raise error for out-of-range index
+            with pytest.raises(RuntimeError, match="Step index out of range"):
+                job_plan.get_step_type(999)
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+
+# Made with Bob

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -53,7 +53,7 @@ class TestPrepareKernel:
                 {
                     "command": "InitTransfer",
                     "properties": {
-                        "file_path": tmpdir,
+                        "file_path": os.path.join(spyrecode_dir, "init.bin"),
                         "dev_ptr": "120259084288",
                         "size": "1024",
                     },

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -53,7 +53,7 @@ class TestPrepareKernel:
                 {
                     "command": "InitTransfer",
                     "properties": {
-                        "file_path": os.path.join(spyrecode_dir, "init.bin"),
+                        "init_bin_file": "init_binary.bin",
                         "dev_ptr": "120259084288",
                         "size": "1024",
                     },

--- a/tests/test_prepare_kernel.py
+++ b/tests/test_prepare_kernel.py
@@ -72,7 +72,7 @@ class TestPrepareKernel:
             json.dump(spyrecode_json, f, indent=2)
 
         # Create a dummy binary file
-        with open(os.path.join(spyrecode_dir, "init.bin"), "wb") as f:
+        with open(os.path.join(spyrecode_dir, "init_binary.bin"), "wb") as f:
             f.write(b"\x00" * 1024)
 
         return spyrecode_dir

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -42,7 +42,22 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepD2H::construct(
 }
 
 std::unique_ptr<flex::RuntimeOperation> JobPlanStepCompute::construct(
-    LaunchContext&) const {
+    LaunchContext& ctx) const {
+  if (specialize_addresses_) {
+    std::vector<const flex::CompositeAddress*> inp;
+    for (auto& tensor : ctx.inputs_outputs) {
+      flex::CompositeAddress* address =
+          &(static_cast<SharedOwnerCtx*>(
+                tensor.storage().data_ptr().get_context())
+                ->composite_addr);
+      inp.push_back((address));
+    }
+
+    auto op =
+        std::make_unique<flex::RuntimeOperationCompute>(&binary_address_, inp);
+    op->setPipelineBarrier(pipeline_barrier_);
+    return op;
+  }
   auto op = std::make_unique<flex::RuntimeOperationCompute>(&binary_address_);
   op->setPipelineBarrier(pipeline_barrier_);
   return op;
@@ -81,22 +96,6 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepHostCompute::construct(
   auto op = std::make_unique<flex::RuntimeOperationHostCallback>(
       pipeline_barrier_, std::move(callback), nullptr);
 
-  return op;
-}
-
-std::unique_ptr<flex::RuntimeOperation> JobPlanStepComputeSpecialize::construct(
-    LaunchContext& ctx) const {
-  std::vector<const flex::CompositeAddress*> inp;
-  for (auto& tensor : ctx.inputs_outputs) {
-    flex::CompositeAddress* address = &(
-        static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context())
-            ->composite_addr);
-    inp.push_back((address));
-  }
-
-  auto op =
-      std::make_unique<flex::RuntimeOperationCompute>(&binary_address_, inp);
-  op->setPipelineBarrier(pipeline_barrier_);
   return op;
 }
 

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepHostCompute::construct(
 
 std::unique_ptr<flex::RuntimeOperation> JobPlanStepComputeSpecialize::construct(
     LaunchContext& ctx) const {
-  std::vector<flex::CompositeAddress*> inp;
+  std::vector<const flex::CompositeAddress*> inp;
   for (auto& tensor : ctx.inputs_outputs) {
     flex::CompositeAddress* address = &(
         static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context())
@@ -94,11 +94,8 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepComputeSpecialize::construct(
     inp.push_back((address));
   }
 
-  TORCH_CHECK(false, "not yet implemented - waiting for flex PR merge");
-  // TODO(jni): update once flex PR merged
-  // auto op =
-  //    std::make_unique<flex::RuntimeOperationCompute>(&binary_address_, inp);
-  auto op = std::make_unique<flex::RuntimeOperationCompute>(&binary_address_);
+  auto op =
+      std::make_unique<flex::RuntimeOperationCompute>(&binary_address_, inp);
   op->setPipelineBarrier(pipeline_barrier_);
   return op;
 }

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -21,8 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "flex/allocator/alloc_address.hpp"
-#include "flex/runtime_stream/runtime_operation.hpp"
 #include "spyre_allocator.h"
 
 namespace spyre {

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -84,21 +84,23 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepHostCompute::construct(
   return op;
 }
 
-// TODO(jni): to be added once flex PR merged
-// std::unique_ptr<flex::RuntimeOperation>
-// JobPlanStepComputeSpecialize::construct(
-//     LaunchContext& ctx) const {
-//   std::vector<flex::CompositeAddress*> inp;
-//   for (auto& tensor : ctx.inputs_outputs) {
-//     flex::CompositeAddress* address = &(
-//         static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context())
-//             ->composite_addr);
-//     inp.push_back((address));
-//   }
-//   auto op =
-//   std::make_unique<flex::RuntimeOperationComputeSpecializeResident>(
-//       &binary_address_, inp);
-//   return op;
-// }
+std::unique_ptr<flex::RuntimeOperation> JobPlanStepComputeSpecialize::construct(
+    LaunchContext& ctx) const {
+  std::vector<flex::CompositeAddress*> inp;
+  for (auto& tensor : ctx.inputs_outputs) {
+    flex::CompositeAddress* address = &(
+        static_cast<SharedOwnerCtx*>(tensor.storage().data_ptr().get_context())
+            ->composite_addr);
+    inp.push_back((address));
+  }
+
+  TORCH_CHECK(false, "not yet implemented - waiting for flex PR merge");
+  // TODO(jni): update once flex PR merged
+  // auto op =
+  //    std::make_unique<flex::RuntimeOperationCompute>(&binary_address_, inp);
+  auto op = std::make_unique<flex::RuntimeOperationCompute>(&binary_address_);
+  op->setPipelineBarrier(pipeline_barrier_);
+  return op;
+}
 
 }  // namespace spyre

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepD2H::construct(
 
 std::unique_ptr<flex::RuntimeOperation> JobPlanStepCompute::construct(
     LaunchContext& ctx) const {
-  if (specialize_addresses_) {
+  if (bind_io_addresses_) {
     std::vector<const flex::CompositeAddress*> inp;
     for (auto& tensor : ctx.inputs_outputs) {
       flex::CompositeAddress* address =

--- a/torch_spyre/csrc/job_plan.cpp
+++ b/torch_spyre/csrc/job_plan.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepCompute::construct(
           &(static_cast<SharedOwnerCtx*>(
                 tensor.storage().data_ptr().get_context())
                 ->composite_addr);
-      inp.push_back((address));
+      inp.push_back(address);
     }
 
     auto op =
@@ -63,8 +63,6 @@ std::unique_ptr<flex::RuntimeOperation> JobPlanStepCompute::construct(
   return op;
 }
 
-// constexpr int64_t SegmentSize = 16LL * 1024 * 1024 * 1024;
-
 // convert CompositeAddress to address that host compute function expects
 int64_t convert_address(flex::CompositeAddress& composite_address) {
   size_t num_chunks = composite_address.chunks().size();
@@ -72,7 +70,7 @@ int64_t convert_address(flex::CompositeAddress& composite_address) {
 
   // TODO(jni): update once resolved on flex support
   // const auto& addr = composite_address.chunks().at(0).addr;
-  // int64_t address = addr.segment_id * SegmentSize + addr.offset;
+  // int64_t address = addr.segment_id * flex::SEGMENT_SIZE + addr.offset;
 
   TORCH_CHECK(false,
               "convert_address not yet implemented - waiting for flex support");

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -199,14 +199,17 @@ class JobPlanStepCompute final : public JobPlanStep {
    *
    * @param binary_address Address of the program binary on device
    */
-  explicit JobPlanStepCompute(flex::CompositeAddress binary_address)
-      : binary_address_(std::move(binary_address)) {}
+  explicit JobPlanStepCompute(flex::CompositeAddress binary_address,
+                              bool specialize_addresses)
+      : binary_address_(std::move(binary_address)),
+        specialize_addresses_(specialize_addresses) {}
 
   std::unique_ptr<flex::RuntimeOperation> construct(
       LaunchContext& ctx) const override;
 
  private:
   flex::CompositeAddress binary_address_;
+  bool specialize_addresses_;
 };
 
 /**
@@ -254,30 +257,6 @@ class JobPlanStepHostCompute final : public JobPlanStep {
   HostComputeFunction function_;
   std::unique_ptr<HostComputeMetadata> metadata_;
   void* output_buffer_;  // Non-owning pointer (JobPlan owns the buffer)
-};
-
-/**
- * @brief Specializes a resident kernel using composite addresses
- *
- * Binary address resolved during PrepareKernel; tensor input/output addresses
- * extracted from ctx.composite_addresses during construct(). Produces a
- * RuntimeOperationComputeSpecializeResident.
- */
-class JobPlanStepComputeSpecialize final : public JobPlanStep {
- public:
-  /**
-   * @brief Construct compute specialize step
-   *
-   * @param binary_address Address of the resident program binary on device
-   */
-  explicit JobPlanStepComputeSpecialize(flex::CompositeAddress binary_address)
-      : binary_address_(std::move(binary_address)) {}
-
-  std::unique_ptr<flex::RuntimeOperation> construct(
-      LaunchContext& ctx) const override;
-
- private:
-  flex::CompositeAddress binary_address_;
 };
 
 /**

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -19,7 +19,7 @@
 #include <torch/types.h>
 
 #include <cstdint>
-#include <flex/allocator/alloc_address.hpp>
+#include <flex/flex.hpp>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -319,14 +319,6 @@ struct JobPlan {
   std::vector<std::unique_ptr<JobPlanStep>> steps;
 
   /**
-   * @brief Compiled tile dimensions from SpyreCode
-   *
-   * One entry per kernel input tensor. Used by SpyreStream for tiling
-   * detection. Empty for pure DMA JobPlans (e.g., tensor .to(device)).
-   */
-  std::vector<std::vector<int64_t>> expected_input_shapes;
-
-  /**
    * @brief Owning CompositeAddress of the program binary, and conditionally
    * program correction data and spillover tensor data
    *
@@ -338,6 +330,14 @@ struct JobPlan {
    * operations.
    */
   flex::CompositeAddress job_allocation;
+
+  /**
+   * @brief Compiled tile dimensions from SpyreCode
+   *
+   * One entry per kernel input tensor. Used by SpyreStream for tiling
+   * detection. Empty for pure DMA JobPlans (e.g., tensor .to(device)).
+   */
+  std::vector<std::vector<int64_t>> expected_input_shapes;
 
   /**
    * @brief Pinned host buffers owned by this JobPlan

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -198,20 +198,20 @@ class JobPlanStepCompute final : public JobPlanStep {
    * @brief Construct compute step
    *
    * @param binary_address Address of the program binary on device
-   * @param specialize_addresses Whether to specialize the compute operation
-   * with inputs and outputs addresses from the launch context
+   * @param bind_io_addresses Whether to bind the compute operation
+   * with inputs and outputs addresses
    */
   explicit JobPlanStepCompute(flex::CompositeAddress binary_address,
-                              bool specialize_addresses)
+                              bool bind_io_addresses)
       : binary_address_(std::move(binary_address)),
-        specialize_addresses_(specialize_addresses) {}
+        bind_io_addresses_(bind_io_addresses) {}
 
   std::unique_ptr<flex::RuntimeOperation> construct(
       LaunchContext& ctx) const override;
 
  private:
   flex::CompositeAddress binary_address_;
-  bool specialize_addresses_;
+  bool bind_io_addresses_;
 };
 
 /**

--- a/torch_spyre/csrc/job_plan.h
+++ b/torch_spyre/csrc/job_plan.h
@@ -189,7 +189,7 @@ class JobPlanStepD2H final : public JobPlanStep {
 /**
  * @brief Device compute launch step
  *
- * Binary address resolved during PrepareKernel. construct() produces a
+ * All fields resolved during PrepareKernel. construct() produces a
  * RuntimeOperationCompute.
  */
 class JobPlanStepCompute final : public JobPlanStep {
@@ -198,6 +198,8 @@ class JobPlanStepCompute final : public JobPlanStep {
    * @brief Construct compute step
    *
    * @param binary_address Address of the program binary on device
+   * @param specialize_addresses Whether to specialize the compute operation
+   * with inputs and outputs addresses from the launch context
    */
   explicit JobPlanStepCompute(flex::CompositeAddress binary_address,
                               bool specialize_addresses)

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -31,7 +31,9 @@
 #include <string>
 #include <vector>
 
+#include "job_plan.h"
 #include "logging.h"
+#include "prepare_kernel.h"
 #include "spyre_allocator.h"
 #include "spyre_device_enum.h"
 #include "spyre_guard.h"
@@ -310,4 +312,53 @@ PYBIND11_MODULE(_C, m) {
         .index();
   });
   m.def("device_count", &spyre::device_count);
+
+  // PrepareKernel and JobPlan bindings
+  m.def("prepare_kernel", &spyre::PrepareKernel, py::arg("spyrecode_dir"),
+        "Prepare a kernel from a SpyreCode directory and return a JobPlan");
+
+  py::class_<spyre::JobPlan>(m, "JobPlan")
+      .def(
+          "num_steps",
+          [](const spyre::JobPlan &plan) { return plan.steps.size(); },
+          "Get the number of steps in the JobPlan")
+      .def(
+          "job_allocation_size",
+          [](const spyre::JobPlan &plan) {
+            return plan.job_allocation.total_size();
+          },
+          "Get the size of the job allocation")
+      .def(
+          "get_step_type",
+          [](const spyre::JobPlan &plan, size_t idx) {
+            TORCH_CHECK(idx < plan.steps.size(), "Step index out of range");
+            const auto &step = plan.steps[idx];
+            if (dynamic_cast<const spyre::JobPlanStepH2D *>(step.get())) {
+              return "H2D";
+            } else if (dynamic_cast<const spyre::JobPlanStepD2H *>(
+                           step.get())) {
+              return "D2H";
+            } else if (dynamic_cast<const spyre::JobPlanStepCompute *>(
+                           step.get())) {
+              return "Compute";
+            } else if (dynamic_cast<const spyre::JobPlanStepHostCompute *>(
+                           step.get())) {
+              return "HostCompute";
+            } else if (dynamic_cast<const spyre::JobPlanStepComputeSpecialize
+                                        *>(step.get())) {
+              return "ComputeSpecialize";
+            } else {
+              return "Unknown";
+            }
+          },
+          py::arg("idx"), "Get the type of step at the given index")
+      .def("__repr__", [](const spyre::JobPlan &plan) {
+        return "<JobPlan steps=" + std::to_string(plan.steps.size()) +
+               " job_allocation_size=" +
+               std::to_string(plan.job_allocation.total_size()) +
+               " expected_inputs=" +
+               std::to_string(plan.expected_input_shapes.size()) +
+               " pinned_buffers=" + std::to_string(plan.pinned_buffers.size()) +
+               ">";
+      });
 }

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -62,10 +62,10 @@ void set_downcast_warn_enabled(bool enabled) {
 
 // Optional: initialize from env at module init
 static void init_from_env() {
-  if (const char *v = std::getenv(SPYRE_DOWNCAST_ENV)) {
+  if (const char* v = std::getenv(SPYRE_DOWNCAST_ENV)) {
     // Accept 0/1, true/false, on/off
     std::string s(v);
-    for (auto &c : s) c = std::tolower(c);
+    for (auto& c : s) c = std::tolower(c);
     bool enable = !(s == "0" || s == "false" || s == "off");
     g_downcast_warn_enabled.store(enable, std::memory_order_relaxed);
   }
@@ -81,7 +81,7 @@ void _startRuntime() {
   int tls_idx = static_cast<int>(SpyreGuardImpl::tls_idx);
   if (tls_idx != 0) {
     logical_device_id = tls_idx;
-  } else if (const char *lr = std::getenv("LOCAL_RANK")) {
+  } else if (const char* lr = std::getenv("LOCAL_RANK")) {
     logical_device_id = std::atoi(lr);
   }
 
@@ -166,9 +166,9 @@ PYBIND11_MODULE(_C, m) {
       .def_readonly("stride_map", &spyre::SpyreTensorLayout::stride_map)
       .def_readonly("device_dtype", &spyre::SpyreTensorLayout::device_dtype)
       .def("__str__",
-           [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
+           [](const spyre::SpyreTensorLayout& c) { return c.toString(); })
       .def("__repr__",
-           [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
+           [](const spyre::SpyreTensorLayout& c) { return c.toString(); })
       .def("elems_per_stick", &spyre::SpyreTensorLayout::elems_per_stick)
       .def(py::self == py::self)
       .def("__hash__",
@@ -185,7 +185,7 @@ PYBIND11_MODULE(_C, m) {
            py::arg("device_size"), py::arg("stride_map"),
            py::arg("device_dtype"))
       .def(py::pickle(
-          [](const spyre::SpyreTensorLayout &p) {  // __getstate__
+          [](const spyre::SpyreTensorLayout& p) {  // __getstate__
             // Return a tuple that fully encodes the state of the object
             // If the pickle format changes, then update
             // kSpyreTensorLayoutPickleVersion but keep the tuple as the
@@ -250,7 +250,7 @@ PYBIND11_MODULE(_C, m) {
       .value("BFLOAT16", DataFormats::BFLOAT16)
       .value("SEN18F_FP24", DataFormats::SEN18F_FP24)
       .def("elems_per_stick",
-           [](const DataFormats &df) { return spyre::elems_per_stick(df); });
+           [](const DataFormats& df) { return spyre::elems_per_stick(df); });
 
   m.def("get_spyre_tensor_layout", &spyre::get_spyre_tensor_layout);
   m.def("set_spyre_tensor_layout", &spyre::set_spyre_tensor_layout);
@@ -293,7 +293,7 @@ PYBIND11_MODULE(_C, m) {
            "Get the device associated with this stream")
       .def("id", &spyre::SpyreStream::id, "Get the stream ID")
       .def("priority", &spyre::SpyreStream::priority, "Get the stream priority")
-      .def("__repr__", [](const spyre::SpyreStream &stream) {
+      .def("__repr__", [](const spyre::SpyreStream& stream) {
         return "<torch_spyre.Stream device=" +
                std::to_string(stream.device().index()) +
                " id=" + std::to_string(stream.id()) + ">";
@@ -314,34 +314,44 @@ PYBIND11_MODULE(_C, m) {
   m.def("device_count", &spyre::device_count);
 
   // PrepareKernel and JobPlan bindings
-  m.def("prepare_kernel", &spyre::PrepareKernel, py::arg("spyrecode_dir"),
-        "Prepare a kernel from a SpyreCode directory and return a JobPlan");
+  m.def(
+      "prepare_kernel",
+      [](const std::string& spyrecode_dir,
+         const spyre::SpyreStream* stream) -> std::unique_ptr<spyre::JobPlan> {
+        return spyre::PrepareKernel(spyrecode_dir, stream);
+      },
+      py::arg("spyrecode_dir"), py::arg("stream") = nullptr,
+      "Prepare a kernel from a SpyreCode directory and return a JobPlan.\n\n"
+      "Args:\n"
+      "    spyrecode_dir (str): Path to the SpyreCode directory\n"
+      "    stream (SpyreStream, optional): Stream to use for initialization "
+      "transfers.\n"
+      "        If None, uses the current stream. Defaults to None.");
 
   py::class_<spyre::JobPlan>(m, "JobPlan")
       .def(
           "num_steps",
-          [](const spyre::JobPlan &plan) { return plan.steps.size(); },
+          [](const spyre::JobPlan& plan) { return plan.steps.size(); },
           "Get the number of steps in the JobPlan")
       .def(
           "job_allocation_size",
-          [](const spyre::JobPlan &plan) {
+          [](const spyre::JobPlan& plan) {
             return plan.job_allocation.total_size();
           },
           "Get the size of the job allocation")
       .def(
           "get_step_type",
-          [](const spyre::JobPlan &plan, size_t idx) {
+          [](const spyre::JobPlan& plan, size_t idx) {
             TORCH_CHECK(idx < plan.steps.size(), "Step index out of range");
-            const auto &step = plan.steps[idx];
-            if (dynamic_cast<const spyre::JobPlanStepH2D *>(step.get())) {
+            const auto& step = plan.steps[idx];
+            if (dynamic_cast<const spyre::JobPlanStepH2D*>(step.get())) {
               return "H2D";
-            } else if (dynamic_cast<const spyre::JobPlanStepD2H *>(
-                           step.get())) {
+            } else if (dynamic_cast<const spyre::JobPlanStepD2H*>(step.get())) {
               return "D2H";
-            } else if (dynamic_cast<const spyre::JobPlanStepCompute *>(
+            } else if (dynamic_cast<const spyre::JobPlanStepCompute*>(
                            step.get())) {
               return "Compute";
-            } else if (dynamic_cast<const spyre::JobPlanStepHostCompute *>(
+            } else if (dynamic_cast<const spyre::JobPlanStepHostCompute*>(
                            step.get())) {
               return "HostCompute";
             } else {
@@ -349,7 +359,7 @@ PYBIND11_MODULE(_C, m) {
             }
           },
           py::arg("idx"), "Get the type of step at the given index")
-      .def("__repr__", [](const spyre::JobPlan &plan) {
+      .def("__repr__", [](const spyre::JobPlan& plan) {
         return "<JobPlan steps=" + std::to_string(plan.steps.size()) +
                " job_allocation_size=" +
                std::to_string(plan.job_allocation.total_size()) +

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -62,10 +62,10 @@ void set_downcast_warn_enabled(bool enabled) {
 
 // Optional: initialize from env at module init
 static void init_from_env() {
-  if (const char* v = std::getenv(SPYRE_DOWNCAST_ENV)) {
+  if (const char *v = std::getenv(SPYRE_DOWNCAST_ENV)) {
     // Accept 0/1, true/false, on/off
     std::string s(v);
-    for (auto& c : s) c = std::tolower(c);
+    for (auto &c : s) c = std::tolower(c);
     bool enable = !(s == "0" || s == "false" || s == "off");
     g_downcast_warn_enabled.store(enable, std::memory_order_relaxed);
   }
@@ -81,7 +81,7 @@ void _startRuntime() {
   int tls_idx = static_cast<int>(SpyreGuardImpl::tls_idx);
   if (tls_idx != 0) {
     logical_device_id = tls_idx;
-  } else if (const char* lr = std::getenv("LOCAL_RANK")) {
+  } else if (const char *lr = std::getenv("LOCAL_RANK")) {
     logical_device_id = std::atoi(lr);
   }
 
@@ -166,9 +166,9 @@ PYBIND11_MODULE(_C, m) {
       .def_readonly("stride_map", &spyre::SpyreTensorLayout::stride_map)
       .def_readonly("device_dtype", &spyre::SpyreTensorLayout::device_dtype)
       .def("__str__",
-           [](const spyre::SpyreTensorLayout& c) { return c.toString(); })
+           [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
       .def("__repr__",
-           [](const spyre::SpyreTensorLayout& c) { return c.toString(); })
+           [](const spyre::SpyreTensorLayout &c) { return c.toString(); })
       .def("elems_per_stick", &spyre::SpyreTensorLayout::elems_per_stick)
       .def(py::self == py::self)
       .def("__hash__",
@@ -185,7 +185,7 @@ PYBIND11_MODULE(_C, m) {
            py::arg("device_size"), py::arg("stride_map"),
            py::arg("device_dtype"))
       .def(py::pickle(
-          [](const spyre::SpyreTensorLayout& p) {  // __getstate__
+          [](const spyre::SpyreTensorLayout &p) {  // __getstate__
             // Return a tuple that fully encodes the state of the object
             // If the pickle format changes, then update
             // kSpyreTensorLayoutPickleVersion but keep the tuple as the
@@ -250,7 +250,7 @@ PYBIND11_MODULE(_C, m) {
       .value("BFLOAT16", DataFormats::BFLOAT16)
       .value("SEN18F_FP24", DataFormats::SEN18F_FP24)
       .def("elems_per_stick",
-           [](const DataFormats& df) { return spyre::elems_per_stick(df); });
+           [](const DataFormats &df) { return spyre::elems_per_stick(df); });
 
   m.def("get_spyre_tensor_layout", &spyre::get_spyre_tensor_layout);
   m.def("set_spyre_tensor_layout", &spyre::set_spyre_tensor_layout);
@@ -293,7 +293,7 @@ PYBIND11_MODULE(_C, m) {
            "Get the device associated with this stream")
       .def("id", &spyre::SpyreStream::id, "Get the stream ID")
       .def("priority", &spyre::SpyreStream::priority, "Get the stream priority")
-      .def("__repr__", [](const spyre::SpyreStream& stream) {
+      .def("__repr__", [](const spyre::SpyreStream &stream) {
         return "<torch_spyre.Stream device=" +
                std::to_string(stream.device().index()) +
                " id=" + std::to_string(stream.id()) + ">";

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -318,7 +318,7 @@ PYBIND11_MODULE(_C, m) {
       "prepare_kernel",
       [](const std::string& spyrecode_dir,
          const spyre::SpyreStream* stream) -> std::unique_ptr<spyre::JobPlan> {
-        return spyre::PrepareKernel(spyrecode_dir, stream);
+        return spyre::prepareKernel(spyrecode_dir, stream);
       },
       py::arg("spyrecode_dir"), py::arg("stream") = nullptr,
       "Prepare a kernel from a SpyreCode directory and return a JobPlan.\n\n"

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -344,9 +344,6 @@ PYBIND11_MODULE(_C, m) {
             } else if (dynamic_cast<const spyre::JobPlanStepHostCompute *>(
                            step.get())) {
               return "HostCompute";
-            } else if (dynamic_cast<const spyre::JobPlanStepComputeSpecialize
-                                        *>(step.get())) {
-              return "ComputeSpecialize";
             } else {
               return "Unknown";
             }

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -29,32 +29,14 @@
 #include "common/json.hpp"
 #include "flex/allocator/alloc_address.hpp"
 #include "flex/allocator/flex_allocator.hpp"
-#include "flex/runtime_stream/runtime_operation.hpp"
-#include "flex/runtime_stream/runtime_stream.hpp"
 #include "host_compute_step.h"
 #include "job_plan_step.h"
+#include "module.h"
 #include "spyre_allocator.h"
-
-// Forward declarations
-namespace flex {
-class RuntimeStream;
-class RuntimeEntry {
- public:
-  RuntimeStream* getDefaultStream(int device_id) const;
-};
-}  // namespace flex
 
 namespace spyre {
 
-// External linkage to GlobalRuntime accessor from module.cpp.
-std::shared_ptr<flex::RuntimeEntry>& getGlobalRuntimeInstance();
-
 namespace detail {
-
-// Helper to get the global runtime
-static std::shared_ptr<flex::RuntimeEntry> getGlobalRuntime() {
-  return getGlobalRuntimeInstance();
-}
 
 static uint64_t prog_dev_ptr = 0;
 
@@ -318,7 +300,8 @@ c10::DataPtr ExecuteJobPreparationPlan(
           program_address);
 
       // Get the default stream and launch the operation
-      auto runtime = getGlobalRuntime();
+      // TODO(jni): launch through SpyreStream
+      auto runtime = GlobalRuntime::get();
       if (!runtime) {
         throw std::runtime_error("GlobalRuntime not initialized");
       }

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -143,7 +143,7 @@ std::string ReadFileToString(const std::filesystem::path& path) {
  */
 static std::unique_ptr<JobPlanStep> ParseComputeOnDevice(
     const nlohmann::json& properties,
-    const flex::CompositeAddress& job_allocation) {
+    const flex::CompositeAddress& job_allocation, bool specialize_addresses) {
   TORCH_CHECK(properties.contains("job_bin_ptr"),
               "ComputeOnDevice command missing 'job_bin_ptr' property");
 
@@ -152,8 +152,8 @@ static std::unique_ptr<JobPlanStep> ParseComputeOnDevice(
 
   auto job_bin_addr = ComputeOffsetAddress(job_allocation, job_bin_ptr);
   // Create RuntimeOperationCompute with the allocated program address
-  return std::make_unique<JobPlanStepComputeSpecialize>(
-      std::move(job_bin_addr));
+  return std::make_unique<JobPlanStepCompute>(std::move(job_bin_addr),
+                                              specialize_addresses);
 }
 
 /**
@@ -267,8 +267,8 @@ static std::unique_ptr<JobPlanStep> ParseDataTransfer(
  * @param job_allocation The composite address allocated for the job_allocation
  */
 std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
-    const nlohmann::json& command,
-    const flex::CompositeAddress& job_allocation) {
+    const nlohmann::json& command, const flex::CompositeAddress& job_allocation,
+    bool specialize_addresses) {
   TORCH_CHECK(command.contains("command") && command["command"].is_string(),
               "SpyreCode command missing 'command' field");
 
@@ -279,7 +279,8 @@ std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
 
   switch (command_type) {
     case SpyreCodeCommandType::ComputeOnDevice:
-      return ParseComputeOnDevice(properties, job_allocation);
+      return ParseComputeOnDevice(properties, job_allocation,
+                                  specialize_addresses);
 
     case SpyreCodeCommandType::ComputeOnHost:
       return ParseComputeOnHost(properties, job_allocation);
@@ -391,11 +392,17 @@ std::unique_ptr<JobPlan> TranslateJobExecPlan(
     flex::CompositeAddress job_allocation) {
   TORCH_CHECK(job_exec_plan.is_array(), "JobExecPlan must be an array");
 
+  bool specialize_addresses = true;
+  if (job_exec_plan.size() > 1) {
+    specialize_addresses = false;
+  }
+
   // Parse each command in the JobExecPlan and create JobPlanSteps
   std::vector<std::unique_ptr<JobPlanStep>> steps;
   for (const auto& command : job_exec_plan) {
     try {
-      steps.push_back(ParseSpyreCodeCommand(command, job_allocation));
+      steps.push_back(
+          ParseSpyreCodeCommand(command, job_allocation, specialize_addresses));
     }
     catch (const std::exception& e) {
       TORCH_CHECK(false, "Failed to parse SpyreCode command: ", e.what());

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -203,10 +203,25 @@ JobPlanStep ParseSpyreCodeCommand(
       return JobPlanStep(h2d_op);
 
     } else if (direction == 1) {
-      // TODO(jni): check if this is required
       // Device-to-Host transfer
-      throw std::runtime_error("Invalid DataTransfer direction: " +
-                               std::to_string(direction));
+      // Extract host and device addresses
+      if (!properties.contains("dev_ptr")) {
+        throw std::runtime_error("DataTransfer D2H missing 'dev_ptr' property");
+      }
+
+      std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
+
+      // TODO(jni): indicate which HostCompute the output goes to
+      void* host_addr = nullptr;
+      uint64_t device_addr = std::stoull(dev_ptr_str);
+
+      // Compute CompositeAddress with offset from device_addr
+      flex::CompositeAddress comp_addr =
+          ComputeOffsetAddress(program_address, device_addr);
+
+      auto d2h_op =
+          std::make_shared<flex::RuntimeOperationD2H>(comp_addr, host_addr);
+      return JobPlanStep(d2h_op);
 
     } else {
       throw std::runtime_error("Invalid DataTransfer direction: " +

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -29,6 +29,7 @@
 #include "job_plan.h"
 #include "module.h"
 #include "spyre_allocator.h"
+#include "spyre_stream.h"
 
 namespace spyre {
 
@@ -272,16 +273,10 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
 
   auto device_addr = ComputeOffsetAddress(job_allocation, dev_ptr, init_size);
 
-  // Create RuntimeOperationH2D to transfer binary to device
-  auto h2d_op = flex::RuntimeOperationH2D(
+  auto stream = getCurrentStream();
+  stream.copyProgramAsync(
       const_cast<void*>(static_cast<const void*>(binary_data.data())),
       &device_addr);
-
-  // Get the default stream and launch the operation
-  // TODO(jni): launch through SpyreStream
-  auto runtime = GlobalRuntime::get();
-  flex::RuntimeStream* stream = runtime->getDefaultStream();
-  stream->launchOperation(h2d_op);
 
   return job_allocation;
 }

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "prepare_kernel.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+
+#include "common/json.hpp"
+#include "flex/allocator/alloc_address.hpp"
+#include "flex/allocator/flex_allocator.hpp"
+#include "flex/runtime_stream/runtime_operation.hpp"
+#include "flex/runtime_stream/runtime_stream.hpp"
+#include "host_compute_step.h"
+#include "job_plan_step.h"
+#include "spyre_allocator.h"
+
+// Forward declarations
+namespace flex {
+class RuntimeStream;
+class RuntimeEntry {
+ public:
+  RuntimeStream* getDefaultStream(int device_id) const;
+};
+}  // namespace flex
+
+namespace spyre {
+
+// External linkage to GlobalRuntime accessor from module.cpp.
+std::shared_ptr<flex::RuntimeEntry>& getGlobalRuntimeInstance();
+
+namespace detail {
+
+// Helper to get the global runtime
+static std::shared_ptr<flex::RuntimeEntry> getGlobalRuntime() {
+  return getGlobalRuntimeInstance();
+}
+
+// TODO: check CompositeAddress updates and verify
+// Helper to extract CompositeAddress from c10::DataPtr
+static flex::CompositeAddress ExtractCompositeAddress(const c10::DataPtr& data_ptr) {
+  auto* ctx = static_cast<SharedOwnerCtx*>(data_ptr.get_context());
+  if (!ctx || !ctx->owner) {
+    throw std::runtime_error("Failed to get allocation context from DataPtr");
+  }
+  
+  uint64_t dmpa = ctx->owner->DmpaAsBytes();
+  size_t alloc_size = ctx->owner->SizeAsBytes();
+  
+  // Create CompositeAddress from the DMPA
+  // region_id=0 for now, domain_id=0 for single-domain allocation
+  flex::LogicalAddress logical_addr(0, dmpa);
+  flex::Chunk chunk(logical_addr, alloc_size, 0);
+  return flex::CompositeAddress(chunk);
+}
+
+// TODO: check CompositeAddress updates and verify
+// Helper to compute CompositeAddress with offset from device_addr for program
+static flex::CompositeAddress ComputeOffsetAddress(
+    const flex::CompositeAddress& program_address,
+    uint64_t device_addr) {
+  // Calculate offset: device_addr is relative to 112GB base
+  constexpr uint64_t BASE_ADDR = 112ULL * 1024 * 1024 * 1024;
+  uint64_t offset = device_addr - BASE_ADDR;
+  
+  // Create CompositeAddress using program_address with offset
+  if (program_address.chunks().empty()) {
+    throw std::runtime_error("program_address has no chunks");
+  }
+  
+  // Get the first chunk and add offset to its address
+  const auto& base_chunk = program_address.chunks()[0];
+  flex::LogicalAddress offset_addr(
+      base_chunk.addr.region_id,
+      base_chunk.addr.offset + offset);
+  flex::Chunk offset_chunk(offset_addr, 0, base_chunk.domain_id);
+  return flex::CompositeAddress(offset_chunk);
+}
+
+// Helper to check if a file exists
+bool FileExists(const std::filesystem::path& path) {
+  return std::filesystem::exists(path) &&
+         std::filesystem::is_regular_file(path);
+}
+
+// Helper to read entire file into string
+std::string ReadFileToString(const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    throw std::runtime_error("Failed to open file: " + path.string());
+  }
+
+  std::ostringstream ss;
+  ss << file.rdbuf();
+  return ss.str();
+}
+
+// Helper to parse metadata JSON if present
+std::vector<std::vector<int64_t>> ParseExpectedInputShapes(
+    const std::filesystem::path& metadata_path) {
+  std::vector<std::vector<int64_t>> shapes;
+
+  if (!FileExists(metadata_path)) {
+    return shapes;  // Return empty if no metadata
+  }
+
+  try {
+    std::string json_str = ReadFileToString(metadata_path);
+    nlohmann::json metadata = nlohmann::json::parse(json_str);
+
+    if (metadata.contains("expected_input_shapes") &&
+        metadata["expected_input_shapes"].is_array()) {
+      for (const auto& shape_array : metadata["expected_input_shapes"]) {
+        std::vector<int64_t> shape;
+        for (const auto& dim : shape_array) {
+          shape.push_back(dim.get<int64_t>());
+        }
+        shapes.push_back(std::move(shape));
+      }
+    }
+  }
+  catch (const std::exception& e) {
+    // Log warning but don't fail - metadata is optional
+    // In production, you might want to use a proper logging framework
+  }
+
+  return shapes;
+}
+
+// Helper to parse a SpyreCode JSON command and create a JobPlanStep
+JobPlanStep ParseSpyreCodeCommand(
+    const nlohmann::json& command,
+    const flex::CompositeAddress& program_address) {
+  if (!command.contains("command") || !command["command"].is_string()) {
+    throw std::runtime_error("SpyreCode command missing 'command' field");
+  }
+
+  std::string command_type = command["command"].get<std::string>();
+  const auto& properties =
+      command.contains("properties") ? command["properties"] : nlohmann::json();
+
+  if (command_type == "ComputeOnDevice") {
+    // Create RuntimeOperationCompute with the allocated program address
+    auto compute_op =
+        std::make_shared<flex::RuntimeOperationCompute>(program_address);
+
+    return JobPlanStep(compute_op);
+
+  } else if (command_type == "ComputeOnHost") {
+    // Create a host compute step
+    // For now, create an empty HostComputeStep as placeholder
+    // metadata to be defined by deeptools
+    HostComputeStep host_step;
+    return JobPlanStep(std::move(host_step));
+
+  } else if (command_type == "DataTransfer") {
+    // Extract direction: 0 = H2D, 1 = D2H
+    if (!properties.contains("direction")) {
+      throw std::runtime_error(
+          "DataTransfer command missing 'direction' property");
+    }
+
+    int direction = properties["direction"].get<int>();
+
+    if (direction == 0) {
+      // Host-to-Device transfer
+      // Extract host and device addresses
+      if (!properties.contains("dev_ptr")) {
+        throw std::runtime_error(
+            "DataTransfer H2D missing 'dev_ptr' property");
+      }
+
+      std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
+
+      // TODO: indicate which HostCompute the input is from
+      void* host_addr = nullptr;
+      uint64_t device_addr = std::stoull(dev_ptr_str);
+
+      // Compute CompositeAddress with offset from device_addr
+      flex::CompositeAddress comp_addr = ComputeOffsetAddress(program_address, device_addr);
+
+      auto h2d_op =
+          std::make_shared<flex::RuntimeOperationH2D>(host_addr, comp_addr);
+      return JobPlanStep(h2d_op);
+
+    } else if (direction == 1) {
+      // TODO: check if this is required
+      // Device-to-Host transfer
+      throw std::runtime_error("Invalid DataTransfer direction: " +
+                               std::to_string(direction));
+
+    } else {
+      throw std::runtime_error("Invalid DataTransfer direction: " +
+                               std::to_string(direction));
+    }
+
+  } else {
+    throw std::runtime_error("Unknown SpyreCode command type: " + command_type);
+  }
+}
+
+// Helper to execute Job Preparation Plan
+c10::DataPtr ExecuteJobPreparationPlan(
+    const nlohmann::json& job_prep_plan,
+    const std::filesystem::path& spyrecode_dir) {
+  if (!job_prep_plan.is_array()) {
+    throw std::runtime_error("JobPreparationPlan must be an array");
+  }
+
+  c10::DataPtr allocated_ptr;
+  bool found_allocate = false;
+  bool found_init_transfer = false;
+
+  for (const auto& command : job_prep_plan) {
+    if (!command.contains("command") || !command["command"].is_string()) {
+      throw std::runtime_error(
+          "JobPreparationPlan command missing 'command' field");
+    }
+
+    std::string command_type = command["command"].get<std::string>();
+    const auto& properties = command.contains("properties")
+                                 ? command["properties"]
+                                 : nlohmann::json();
+
+    if (command_type == "Allocate") {
+      if (found_allocate) {
+        throw std::runtime_error(
+            "Multiple Allocate commands found in JobPreparationPlan");
+      }
+
+      // Extract size from properties
+      if (!properties.contains("size")) {
+        throw std::runtime_error("Allocate command missing 'size' property");
+      }
+
+      // Parse size (stored as string in JSON)
+      std::string size_str = properties["size"].get<std::string>();
+      size_t size = std::stoull(size_str);
+
+      // Call SpyreAllocator to allocate memory
+      auto& allocator = SpyreAllocator::instance();
+      allocated_ptr = allocator.allocate(size);
+
+      found_allocate = true;
+
+    } else if (command_type == "InitTransfer") {
+      if (found_init_transfer) {
+        throw std::runtime_error(
+            "Multiple InitTransfer commands found in JobPreparationPlan");
+      }
+
+      if (!found_allocate) {
+        throw std::runtime_error(
+            "InitTransfer command must come after Allocate command");
+      }
+
+      // Extract binary file path from properties
+      if (!properties.contains("file_path")) {
+        throw std::runtime_error(
+            "InitTransfer command missing 'binary_file' property");
+      }
+
+      std::string binary_file = properties["file_path"].get<std::string>();
+      std::filesystem::path binary_path(binary_file);
+
+      // Load binary from file
+      if (!FileExists(binary_path)) {
+        throw std::runtime_error("Binary file not found: " +
+                                 binary_path.string());
+      }
+
+      std::string binary_data = ReadFileToString(binary_path);
+
+      // Extract device address from properties
+      if (!properties.contains("dev_ptr")) {
+        throw std::runtime_error(
+            "InitTransfer command missing 'dev_ptr' property");
+      }
+
+      std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
+      uint64_t device_addr = std::stoull(dev_ptr_str);
+
+      // Extract CompositeAddress from allocated_ptr and compute offset
+      flex::CompositeAddress program_address = ExtractCompositeAddress(allocated_ptr);
+      flex::CompositeAddress comp_addr = ComputeOffsetAddress(program_address, device_addr);
+
+      // TODO: update RuntimeOperationH2D
+      // TODO: extend lifetime?
+      // Create RuntimeOperationH2D to transfer binary to device
+      auto h2d_op = std::make_shared<flex::RuntimeOperationH2D>(
+          const_cast<void*>(static_cast<const void*>(binary_data.data())),
+          comp_addr);
+
+      // Get the default stream and launch the operation
+      auto runtime = getGlobalRuntime();
+      if (!runtime) {
+        throw std::runtime_error("GlobalRuntime not initialized");
+      }
+      flex::RuntimeStream* stream = runtime->getDefaultStream(0);
+      stream->launchOperation(*h2d_op);
+
+      // Synchronize to ensure transfer completes before returning
+      stream->synchronize();
+
+      found_init_transfer = true;
+
+    } else {
+      throw std::runtime_error("Unknown JobPreparationPlan command type: " +
+                               command_type);
+    }
+  }
+
+  if (!allocated_ptr) {
+    throw std::runtime_error(
+        "JobPreparationPlan did not allocate program memory");
+  }
+
+  return allocated_ptr;
+}
+
+// Helper to translate Job Execution Plan to JobPlan
+std::unique_ptr<JobPlan> TranslateJobExecPlan(
+    const nlohmann::json& job_exec_plan,
+    const flex::CompositeAddress& program_address) {
+  if (!job_exec_plan.is_array()) {
+    throw std::runtime_error("JobExecPlan must be an array");
+  }
+
+  // Parse each command in the JobExecPlan and create JobPlanSteps
+  std::vector<JobPlanStep> steps;
+  for (const auto& command : job_exec_plan) {
+    try {
+      steps.push_back(ParseSpyreCodeCommand(command, program_address));
+    }
+    catch (const std::exception& e) {
+      throw std::runtime_error("Failed to parse SpyreCode command: " +
+                               std::string(e.what()));
+    }
+  }
+
+  // Create and return the JobPlan
+  return std::make_unique<JobPlan>(std::move(steps));
+}
+
+}  // namespace detail
+
+std::unique_ptr<JobPlan> PrepareKernel(
+    const std::filesystem::path& spyrecode_dir_path) {
+  if (!std::filesystem::exists(spyrecode_dir_path)) {
+    throw std::runtime_error("SpyreCode directory does not exist: " +
+                             spyrecode_dir_path.string());
+  }
+
+  if (!std::filesystem::is_directory(spyrecode_dir_path)) {
+    throw std::runtime_error("Path is not a directory: " +
+                             spyrecode_dir_path.string());
+  }
+
+  auto spyrecode_json_path = spyrecode_dir_path / "spyrecode.json";
+  if (!detail::FileExists(spyrecode_json_path)) {
+    throw std::runtime_error(
+        "Required file spyrecode.json not found in directory: " +
+        spyrecode_dir_path.string());
+  }
+
+  std::string json_str = detail::ReadFileToString(spyrecode_json_path);
+  nlohmann::json spyrecode_json;
+
+  try {
+    spyrecode_json = nlohmann::json::parse(json_str);
+  }
+  catch (const std::exception& e) {
+    throw std::runtime_error("Failed to parse spyrecode.json: " +
+                             std::string(e.what()));
+  }
+
+  if (!spyrecode_json.contains("JobPreparationPlan") ||
+      !spyrecode_json["JobPreparationPlan"].is_array()) {
+    throw std::runtime_error(
+        "SpyreCode JSON missing 'JobPreparationPlan' array");
+  }
+
+  c10::DataPtr allocated_memory = detail::ExecuteJobPreparationPlan(
+      spyrecode_json["JobPreparationPlan"], spyrecode_dir_path);
+
+  // Extract the CompositeAddress from the allocated DataPtr
+  flex::CompositeAddress program_address = detail::ExtractCompositeAddress(allocated_memory);
+
+  if (!spyrecode_json.contains("JobExecPlan") ||
+      !spyrecode_json["JobExecPlan"].is_array()) {
+    throw std::runtime_error("SpyreCode JSON missing 'JobExecPlan' array");
+  }
+
+  auto job_plan = detail::TranslateJobExecPlan(spyrecode_json["JobExecPlan"],
+                                               program_address);
+
+  // Store the program memory in JobPlan to keep it alive for the lifetime
+  // of the plan. This prevents premature deallocation of the device memory
+  // that contains the compiled program.
+  job_plan->setProgramMemory(std::move(allocated_memory));
+
+  auto metadata_path = spyrecode_dir_path / "metadata.json";
+  auto expected_shapes = detail::ParseExpectedInputShapes(metadata_path);
+
+  if (!expected_shapes.empty()) {
+    job_plan->setExpectedInputShapes(std::move(expected_shapes));
+  }
+
+  return job_plan;
+}
+
+bool ValidateSpyreCodeDir(const std::filesystem::path& spyrecode_dir_path,
+                          bool strict) {
+  // Check if directory exists
+  if (!std::filesystem::exists(spyrecode_dir_path)) {
+    return false;
+  }
+
+  if (!std::filesystem::is_directory(spyrecode_dir_path)) {
+    return false;
+  }
+
+  // Check for required spyrecode.json file
+  auto spyrecode_json_path = spyrecode_dir_path / "spyrecode.json";
+  if (!detail::FileExists(spyrecode_json_path)) {
+    return false;
+  }
+
+  // If strict validation is enabled, check file size
+  if (strict) {
+    auto file_size = std::filesystem::file_size(spyrecode_json_path);
+    if (file_size == 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace spyre

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -369,7 +369,7 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
               "InitTransfer command missing 'size' property");
 
   std::string init_size_str = allocate_props["size"].get<std::string>();
-  size_t init_size = std::stoull(size_str);
+  size_t init_size = std::stoull(init_size_str);
 
   auto device_addr = ComputeOffsetAddress(job_allocation, dev_ptr, init_size);
 

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -22,6 +22,9 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/json.hpp"
 #include "flex/allocator/alloc_address.hpp"
@@ -53,17 +56,18 @@ static std::shared_ptr<flex::RuntimeEntry> getGlobalRuntime() {
   return getGlobalRuntimeInstance();
 }
 
-// TODO: check CompositeAddress updates and verify
+// TODO(jni): check CompositeAddress updates and verify
 // Helper to extract CompositeAddress from c10::DataPtr
-static flex::CompositeAddress ExtractCompositeAddress(const c10::DataPtr& data_ptr) {
+static flex::CompositeAddress ExtractCompositeAddress(
+    const c10::DataPtr& data_ptr) {
   auto* ctx = static_cast<SharedOwnerCtx*>(data_ptr.get_context());
   if (!ctx || !ctx->owner) {
     throw std::runtime_error("Failed to get allocation context from DataPtr");
   }
-  
+
   uint64_t dmpa = ctx->owner->DmpaAsBytes();
   size_t alloc_size = ctx->owner->SizeAsBytes();
-  
+
   // Create CompositeAddress from the DMPA
   // region_id=0 for now, domain_id=0 for single-domain allocation
   flex::LogicalAddress logical_addr(0, dmpa);
@@ -71,25 +75,23 @@ static flex::CompositeAddress ExtractCompositeAddress(const c10::DataPtr& data_p
   return flex::CompositeAddress(chunk);
 }
 
-// TODO: check CompositeAddress updates and verify
+// TODO(jni): check CompositeAddress updates and verify
 // Helper to compute CompositeAddress with offset from device_addr for program
 static flex::CompositeAddress ComputeOffsetAddress(
-    const flex::CompositeAddress& program_address,
-    uint64_t device_addr) {
+    const flex::CompositeAddress& program_address, uint64_t device_addr) {
   // Calculate offset: device_addr is relative to 112GB base
   constexpr uint64_t BASE_ADDR = 112ULL * 1024 * 1024 * 1024;
   uint64_t offset = device_addr - BASE_ADDR;
-  
+
   // Create CompositeAddress using program_address with offset
   if (program_address.chunks().empty()) {
     throw std::runtime_error("program_address has no chunks");
   }
-  
+
   // Get the first chunk and add offset to its address
   const auto& base_chunk = program_address.chunks()[0];
-  flex::LogicalAddress offset_addr(
-      base_chunk.addr.region_id,
-      base_chunk.addr.offset + offset);
+  flex::LogicalAddress offset_addr(base_chunk.addr.region_id,
+                                   base_chunk.addr.offset + offset);
   flex::Chunk offset_chunk(offset_addr, 0, base_chunk.domain_id);
   return flex::CompositeAddress(offset_chunk);
 }
@@ -183,25 +185,25 @@ JobPlanStep ParseSpyreCodeCommand(
       // Host-to-Device transfer
       // Extract host and device addresses
       if (!properties.contains("dev_ptr")) {
-        throw std::runtime_error(
-            "DataTransfer H2D missing 'dev_ptr' property");
+        throw std::runtime_error("DataTransfer H2D missing 'dev_ptr' property");
       }
 
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
 
-      // TODO: indicate which HostCompute the input is from
+      // TODO(jni): indicate which HostCompute the input is from
       void* host_addr = nullptr;
       uint64_t device_addr = std::stoull(dev_ptr_str);
 
       // Compute CompositeAddress with offset from device_addr
-      flex::CompositeAddress comp_addr = ComputeOffsetAddress(program_address, device_addr);
+      flex::CompositeAddress comp_addr =
+          ComputeOffsetAddress(program_address, device_addr);
 
       auto h2d_op =
           std::make_shared<flex::RuntimeOperationH2D>(host_addr, comp_addr);
       return JobPlanStep(h2d_op);
 
     } else if (direction == 1) {
-      // TODO: check if this is required
+      // TODO(jni): check if this is required
       // Device-to-Host transfer
       throw std::runtime_error("Invalid DataTransfer direction: " +
                                std::to_string(direction));
@@ -298,11 +300,13 @@ c10::DataPtr ExecuteJobPreparationPlan(
       uint64_t device_addr = std::stoull(dev_ptr_str);
 
       // Extract CompositeAddress from allocated_ptr and compute offset
-      flex::CompositeAddress program_address = ExtractCompositeAddress(allocated_ptr);
-      flex::CompositeAddress comp_addr = ComputeOffsetAddress(program_address, device_addr);
+      flex::CompositeAddress program_address =
+          ExtractCompositeAddress(allocated_ptr);
+      flex::CompositeAddress comp_addr =
+          ComputeOffsetAddress(program_address, device_addr);
 
-      // TODO: update RuntimeOperationH2D
-      // TODO: extend lifetime?
+      // TODO(jni): update RuntimeOperationH2D
+      // TODO(jni): extend lifetime?
       // Create RuntimeOperationH2D to transfer binary to device
       auto h2d_op = std::make_shared<flex::RuntimeOperationH2D>(
           const_cast<void*>(static_cast<const void*>(binary_data.data())),
@@ -401,7 +405,8 @@ std::unique_ptr<JobPlan> PrepareKernel(
       spyrecode_json["JobPreparationPlan"], spyrecode_dir_path);
 
   // Extract the CompositeAddress from the allocated DataPtr
-  flex::CompositeAddress program_address = detail::ExtractCompositeAddress(allocated_memory);
+  flex::CompositeAddress program_address =
+      detail::ExtractCompositeAddress(allocated_memory);
 
   if (!spyrecode_json.contains("JobExecPlan") ||
       !spyrecode_json["JobExecPlan"].is_array()) {

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -16,21 +16,17 @@
 
 #include "prepare_kernel.h"
 
-#include <algorithm>
 #include <cstdint>
+#include <filesystem>  // NOLINT
 #include <fstream>
 #include <memory>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "common/json.hpp"
-#include "flex/allocator/alloc_address.hpp"
-#include "flex/allocator/flex_allocator.hpp"
-#include "host_compute_step.h"
-#include "job_plan_step.h"
+#include "job_plan.h"
 #include "module.h"
 #include "spyre_allocator.h"
 
@@ -38,339 +34,306 @@ namespace spyre {
 
 namespace detail {
 
-static uint64_t prog_dev_ptr = 0;
+static uint64_t job_allocation_ptr_start = 120259084288;
 
-// Helper to compute CompositeAddress with offset from device_addr for program
+/**
+ * @brief Helper to compute CompositeAddress with offset from device_addr for
+ * program
+ */
 static flex::CompositeAddress ComputeOffsetAddress(
-    const flex::CompositeAddress& program_address, uint64_t device_ptr,
-    size_t size) {
-  // Calculate offset
-  uint64_t offset = device_ptr - prog_dev_ptr;
-
+    const flex::CompositeAddress& job_allocation, uint64_t dev_ptr,
+    size_t size = 0) {
   // Create CompositeAddress using program_address with offset
-  if (program_address.chunks().empty()) {
-    throw std::runtime_error("program_address has no chunks");
+  TORCH_CHECK(job_allocation.chunks().size() == 1,
+              "job_allocation must have 1 chunk");
+
+  // Calculate offset
+  uint64_t offset = dev_ptr - job_allocation_ptr_start;
+  if (size == 0) {
+    size = job_allocation.total_size() - offset;
   }
 
   // Get the first chunk and add offset to its address
-  const auto& base_chunk = program_address.chunks()[0];
+  const auto& base_chunk = job_allocation.chunks()[0];
   flex::LogicalAddress offset_addr(base_chunk.addr.region_id,
                                    base_chunk.addr.offset + offset);
   flex::Chunk offset_chunk(offset_addr, size, base_chunk.domain_id);
   return flex::CompositeAddress(offset_chunk);
 }
 
-// Helper to check if a file exists
+/**
+ * @brief Helper to check if a file exists
+ */
 bool FileExists(const std::filesystem::path& path) {
   return std::filesystem::exists(path) &&
          std::filesystem::is_regular_file(path);
 }
 
-// Helper to read entire file into string
+/**
+ * @brief Helper to read entire file into string
+ */
 std::string ReadFileToString(const std::filesystem::path& path) {
   std::ifstream file(path, std::ios::binary);
-  if (!file) {
-    throw std::runtime_error("Failed to open file: " + path.string());
-  }
+  TORCH_CHECK(file, "Failed to open file: ", path.string());
 
   std::ostringstream ss;
   ss << file.rdbuf();
   return ss.str();
 }
 
-// Helper to parse metadata JSON if present
-std::vector<std::vector<int64_t>> ParseExpectedInputShapes(
-    const std::filesystem::path& metadata_path) {
-  std::vector<std::vector<int64_t>> shapes;
-
-  if (!FileExists(metadata_path)) {
-    return shapes;  // Return empty if no metadata
-  }
-
-  try {
-    std::string json_str = ReadFileToString(metadata_path);
-    nlohmann::json metadata = nlohmann::json::parse(json_str);
-
-    if (metadata.contains("expected_input_shapes") &&
-        metadata["expected_input_shapes"].is_array()) {
-      for (const auto& shape_array : metadata["expected_input_shapes"]) {
-        std::vector<int64_t> shape;
-        for (const auto& dim : shape_array) {
-          shape.push_back(dim.get<int64_t>());
-        }
-        shapes.push_back(std::move(shape));
-      }
-    }
-  }
-  catch (const std::exception& e) {
-    // Log warning but don't fail - metadata is optional
-    // In production, you might want to use a proper logging framework
-  }
-
-  return shapes;
-}
-
-// Helper to parse a SpyreCode JSON command and create a JobPlanStep
-JobPlanStep ParseSpyreCodeCommand(
+/**
+ * @brief Helper to parse a SpyreCode JSON command and create a JobPlanStep
+ * @param command The JSON command to parse
+ * @param program_address The composite address allocated for the job_allocation
+ */
+std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
     const nlohmann::json& command,
-    const flex::CompositeAddress& program_address) {
-  if (!command.contains("command") || !command["command"].is_string()) {
-    throw std::runtime_error("SpyreCode command missing 'command' field");
-  }
+    const flex::CompositeAddress& job_allocation) {
+  TORCH_CHECK(command.contains("command") && command["command"].is_string(),
+              "SpyreCode command missing 'command' field");
 
   std::string command_type = command["command"].get<std::string>();
   const auto& properties =
       command.contains("properties") ? command["properties"] : nlohmann::json();
 
   if (command_type == "ComputeOnDevice") {
+    TORCH_CHECK(properties.contains("job_bin_ptr"),
+                command_type + " command missing 'job_bin_ptr' property");
+
+    std::string job_bin_ptr_str = properties["dev_ptr"].get<std::string>();
+    uint64_t job_bin_ptr = std::stoull(job_bin_ptr_str);
+
+    auto job_bin_addr = ComputeOffsetAddress(job_allocation, job_bin_ptr);
     // Create RuntimeOperationCompute with the allocated program address
     auto compute_op =
-        std::make_shared<flex::RuntimeOperationCompute>(&program_address);
+        std::make_unique<JobPlanStepComputeSpecialize>(std::move(job_bin_addr));
 
-    return JobPlanStep(compute_op);
+    return compute_op;
 
   } else if (command_type == "ComputeOnHost") {
-    // Create a host compute step
-    // For now, create an empty HostComputeStep as placeholder
-    // metadata to be defined by deeptools
-    HostComputeStep host_step;
-    return JobPlanStep(std::move(host_step));
-
+    // TODO(jni): create JobPlanStepHostCompute
+    TORCH_CHECK(
+        false,
+        "ComputeOnHost not yet implemented - waiting for deeptools PR to "
+        "be merged");
   } else if (command_type == "DataTransfer") {
+    // TODO(jni): create JobPlanStepH2D or JobPlanStepD2H
+    TORCH_CHECK(
+        false,
+        "ComputeOnHost not yet implemented - waiting for deeptools PR to "
+        "be merged");
+
     // Extract direction: 0 = H2D, 1 = D2H
-    if (!properties.contains("direction")) {
-      throw std::runtime_error(
-          "DataTransfer command missing 'direction' property");
-    }
+    TORCH_CHECK(properties.contains("dirn"),
+                "DataTransfer command missing 'dirn' property");
 
-    int direction = properties["direction"].get<int>();
+    std::string dirn_str = properties["dirn"].get<std::string>();
 
-    if (direction == 0) {
+    if (dirn_str == "false") {
       // Host-to-Device transfer
       // Extract host and device addresses
-      if (!properties.contains("dev_ptr")) {
-        throw std::runtime_error("DataTransfer H2D missing 'dev_ptr' property");
-      }
+      TORCH_CHECK(properties.contains("dev_ptr"),
+                  "DataTransfer H2D missing 'dev_ptr' property");
 
-      if (!properties.contains("size")) {
-        throw std::runtime_error("DataTransfer H2D missing 'size' property");
-      }
+      TORCH_CHECK(properties.contains("size"),
+                  "DataTransfer H2D missing 'size' property");
 
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
       std::string size_str = properties["size"].get<std::string>();
 
-      // TODO(jni): indicate which HostCompute the input is from
+      // TODO(jni): host_handle should contain info about the host buffer to be
+      // copied, figure out how and connect host_addr
+      TORCH_CHECK(properties.contains("host_handle"),
+                  "DataTransfer H2D missing 'host_handle' property");
+      std::string host_handle_str =
+          properties["host_handle"].get<std::string>();
       void* host_addr = nullptr;
       uint64_t device_ptr = std::stoull(dev_ptr_str);
       size_t transfer_size = std::stoull(size_str);
 
       // Compute CompositeAddress with offset
       flex::CompositeAddress comp_addr =
-          ComputeOffsetAddress(program_address, device_ptr, transfer_size);
+          ComputeOffsetAddress(job_allocation, device_ptr, transfer_size);
 
       auto h2d_op =
-          std::make_shared<flex::RuntimeOperationH2D>(host_addr, &comp_addr);
-      return JobPlanStep(h2d_op);
+          std::make_unique<JobPlanStepH2D>(host_addr, std::move(comp_addr));
+      return h2d_op;
 
-    } else if (direction == 1) {
+    } else if (dirn_str == "true") {
       // Device-to-Host transfer
       // Extract host and device addresses
-      if (!properties.contains("dev_ptr")) {
-        throw std::runtime_error("DataTransfer D2H missing 'dev_ptr' property");
-      }
+      TORCH_CHECK(properties.contains("dev_ptr"),
+                  "DataTransfer D2H missing 'dev_ptr' property");
 
-      if (!properties.contains("size")) {
-        throw std::runtime_error("DataTransfer D2H missing 'size' property");
-      }
+      TORCH_CHECK(properties.contains("size"),
+                  "DataTransfer D2H missing 'size' property");
 
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
       std::string size_str = properties["size"].get<std::string>();
 
-      // TODO(jni): indicate which HostCompute the output goes to
+      // TODO(jni): host_handle should contain info about the host buffer to be
+      // copied to, figure out how and connect host_addr
+      TORCH_CHECK(properties.contains("host_handle"),
+                  "DataTransfer H2D missing 'host_handle' property");
+      std::string host_handle_str =
+          properties["host_handle"].get<std::string>();
       void* host_addr = nullptr;
       uint64_t device_ptr = std::stoull(dev_ptr_str);
       size_t transfer_size = std::stoull(size_str);
 
       // Compute CompositeAddress with offset from device_addr
       flex::CompositeAddress comp_addr =
-          ComputeOffsetAddress(program_address, device_ptr, transfer_size);
+          ComputeOffsetAddress(job_allocation, device_ptr, transfer_size);
 
       auto d2h_op =
-          std::make_shared<flex::RuntimeOperationD2H>(&comp_addr, host_addr);
-      return JobPlanStep(d2h_op);
+          std::make_unique<JobPlanStepD2H>(std::move(comp_addr), host_addr);
+      return d2h_op;
 
     } else {
-      throw std::runtime_error("Invalid DataTransfer direction: " +
-                               std::to_string(direction));
+      TORCH_CHECK(false, "Invalid DataTransfer direction: ", dirn_str);
     }
 
   } else {
-    throw std::runtime_error("Unknown SpyreCode command type: " + command_type);
+    TORCH_CHECK(false, "Unknown SpyreCode command type: ", command_type);
   }
 }
 
-// Helper to execute Job Preparation Plan
-c10::DataPtr ExecuteJobPreparationPlan(
+/**
+ * @brief Helper to execute Job Preparation Plan
+ * @return CompositeAddress allocated for the job_allocation during preparation
+ */
+flex::CompositeAddress ExecuteJobPreparationPlan(
     const nlohmann::json& job_prep_plan,
     const std::filesystem::path& spyrecode_dir) {
-  if (!job_prep_plan.is_array()) {
-    throw std::runtime_error("JobPreparationPlan must be an array");
-  }
+  TORCH_CHECK(job_prep_plan.is_array() && job_prep_plan.size() == 2,
+              "JobPreparationPlan must be an array with exactly 2 commands "
+              "(Allocate and InitTransfer)");
 
-  c10::DataPtr allocated_ptr;
-  bool found_allocate = false;
-  bool found_init_transfer = false;
+  // Process Allocate command (first item)
+  const auto& allocate_cmd = job_prep_plan[0];
+  TORCH_CHECK(
+      allocate_cmd.contains("command") && allocate_cmd["command"].is_string(),
+      "JobPreparationPlan command missing 'command' field");
 
-  for (const auto& command : job_prep_plan) {
-    if (!command.contains("command") || !command["command"].is_string()) {
-      throw std::runtime_error(
-          "JobPreparationPlan command missing 'command' field");
-    }
+  std::string allocate_type = allocate_cmd["command"].get<std::string>();
+  TORCH_CHECK(allocate_type == "Allocate",
+              "First command must be 'Allocate', got: " + allocate_type);
 
-    std::string command_type = command["command"].get<std::string>();
-    const auto& properties = command.contains("properties")
-                                 ? command["properties"]
-                                 : nlohmann::json();
+  const auto& allocate_props = allocate_cmd.contains("properties")
+                                   ? allocate_cmd["properties"]
+                                   : nlohmann::json();
 
-    if (command_type == "Allocate") {
-      if (found_allocate) {
-        throw std::runtime_error(
-            "Multiple Allocate commands found in JobPreparationPlan");
-      }
+  TORCH_CHECK(allocate_props.contains("size"),
+              "Allocate command missing 'size' property");
 
-      // Extract size from properties
-      if (!properties.contains("size")) {
-        throw std::runtime_error("Allocate command missing 'size' property");
-      }
+  std::string size_str = allocate_props["size"].get<std::string>();
+  size_t size = std::stoull(size_str);
 
-      // Parse size (stored as string in JSON)
-      std::string size_str = properties["size"].get<std::string>();
-      size_t size = std::stoull(size_str);
+  auto& allocator = SpyreAllocator::instance();
+  c10::DataPtr allocated_ptr = allocator.allocate(size);
 
-      // Call SpyreAllocator to allocate memory
-      auto& allocator = SpyreAllocator::instance();
-      allocated_ptr = allocator.allocate(size);
+  flex::CompositeAddress job_allocation =
+      std::move(static_cast<SharedOwnerCtx*>(allocated_ptr.get_context())
+                    ->composite_addr);
 
-      found_allocate = true;
+  // Process InitTransfer command (second item)
+  const auto& init_cmd = job_prep_plan[1];
+  TORCH_CHECK(init_cmd.contains("command") && init_cmd["command"].is_string(),
+              "JobPreparationPlan command missing 'command' field");
 
-    } else if (command_type == "InitTransfer") {
-      if (found_init_transfer) {
-        throw std::runtime_error(
-            "Multiple InitTransfer commands found in JobPreparationPlan");
-      }
+  std::string init_type = init_cmd["command"].get<std::string>();
+  TORCH_CHECK(init_type == "InitTransfer",
+              "Second command must be 'InitTransfer', got: " + init_type);
 
-      if (!found_allocate) {
-        throw std::runtime_error(
-            "InitTransfer command must come after Allocate command");
-      }
+  const auto& init_props = init_cmd.contains("properties")
+                               ? init_cmd["properties"]
+                               : nlohmann::json();
 
-      // Extract binary file path from properties
-      if (!properties.contains("file_path")) {
-        throw std::runtime_error(
-            "InitTransfer command missing 'binary_file' property");
-      }
+  TORCH_CHECK(init_props.contains("file_path"),
+              "InitTransfer command missing 'file_path' property");
 
-      std::string binary_file = properties["file_path"].get<std::string>();
-      std::filesystem::path binary_path(binary_file);
+  std::string binary_file = init_props["file_path"].get<std::string>();
+  std::filesystem::path binary_path(binary_file);
 
-      // Load binary from file
-      if (!FileExists(binary_path)) {
-        throw std::runtime_error("Binary file not found: " +
-                                 binary_path.string());
-      }
+  std::string binary_data = ReadFileToString(binary_path);
 
-      std::string binary_data = ReadFileToString(binary_path);
+  TORCH_CHECK(init_props.contains("dev_ptr"),
+              "InitTransfer command missing 'dev_ptr' property");
 
-      // Extract device address from properties
-      if (!properties.contains("dev_ptr")) {
-        throw std::runtime_error(
-            "InitTransfer command missing 'dev_ptr' property");
-      }
+  std::string dev_ptr_str = init_props["dev_ptr"].get<std::string>();
+  uint64_t dev_ptr = std::stoull(dev_ptr_str);
 
-      std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
-      prog_dev_ptr = std::stoull(dev_ptr_str);
+  TORCH_CHECK(allocate_props.contains("size"),
+              "InitTransfer command missing 'size' property");
 
-      auto* program_address =
-          &(static_cast<SharedOwnerCtx*>(allocated_ptr.get_context())
-                ->composite_addr);
+  std::string init_size_str = allocate_props["size"].get<std::string>();
+  size_t init_size = std::stoull(size_str);
 
-      // Create RuntimeOperationH2D to transfer binary to device
-      auto h2d_op = std::make_shared<flex::RuntimeOperationH2D>(
-          const_cast<void*>(static_cast<const void*>(binary_data.data())),
-          program_address);
+  auto device_addr = ComputeOffsetAddress(job_allocation, dev_ptr, init_size);
 
-      // Get the default stream and launch the operation
-      // TODO(jni): launch through SpyreStream
-      auto runtime = GlobalRuntime::get();
-      if (!runtime) {
-        throw std::runtime_error("GlobalRuntime not initialized");
-      }
-      flex::RuntimeStream* stream = runtime->getDefaultStream(0);
-      stream->launchOperation(*h2d_op);
+  // Create RuntimeOperationH2D to transfer binary to device
+  auto h2d_op = flex::RuntimeOperationH2D(
+      const_cast<void*>(static_cast<const void*>(binary_data.data())),
+      &device_addr);
 
-      // Synchronize to ensure transfer completes before returning
-      stream->synchronize();
+  // Get the default stream and launch the operation
+  // TODO(jni): launch through SpyreStream
+  auto runtime = GlobalRuntime::get();
+  flex::RuntimeStream* stream = runtime->getDefaultStream();
+  stream->launchOperation(h2d_op);
 
-      found_init_transfer = true;
-
-    } else {
-      throw std::runtime_error("Unknown JobPreparationPlan command type: " +
-                               command_type);
-    }
-  }
-
-  if (!allocated_ptr) {
-    throw std::runtime_error(
-        "JobPreparationPlan did not allocate program memory");
-  }
-
-  return allocated_ptr;
+  return job_allocation;
 }
 
-// Helper to translate Job Execution Plan to JobPlan
+/**
+ * @brief Helper to translate Job Execution Plan to JobPlan
+ * @param job_exec_plan The JSON job execution plan
+ * @param job_allocation The composite address allocated for the job_allocation
+ * during preparation (moved into JobPlan)
+ */
 std::unique_ptr<JobPlan> TranslateJobExecPlan(
     const nlohmann::json& job_exec_plan,
-    const flex::CompositeAddress& program_address) {
-  if (!job_exec_plan.is_array()) {
-    throw std::runtime_error("JobExecPlan must be an array");
-  }
+    flex::CompositeAddress job_allocation) {
+  TORCH_CHECK(job_exec_plan.is_array(), "JobExecPlan must be an array");
 
   // Parse each command in the JobExecPlan and create JobPlanSteps
-  std::vector<JobPlanStep> steps;
+  std::vector<std::unique_ptr<JobPlanStep>> steps;
   for (const auto& command : job_exec_plan) {
     try {
-      steps.push_back(ParseSpyreCodeCommand(command, program_address));
+      steps.push_back(ParseSpyreCodeCommand(command, job_allocation));
     }
     catch (const std::exception& e) {
-      throw std::runtime_error("Failed to parse SpyreCode command: " +
-                               std::string(e.what()));
+      TORCH_CHECK(false, "Failed to parse SpyreCode command: ", e.what());
     }
   }
 
-  // Create and return the JobPlan
-  return std::make_unique<JobPlan>(std::move(steps));
+  // TODO(jni): expected_input_shapes to be added once provided in SpyreCode
+  // TODO(jni): pinned buffer to be added as std::map once HostCompute provided
+  // in SpyreCode Create and return the JobPlan Use brace initialization to
+  // construct JobPlan with moved members
+  return std::make_unique<JobPlan>(JobPlan{
+      std::move(steps),           // steps
+      std::move(job_allocation),  // job_allocation
+      {},                         // expected_input_shapes
+      {}                          // pinned_buffers
+  });
 }
 
 }  // namespace detail
 
-std::unique_ptr<JobPlan> PrepareKernel(
-    const std::filesystem::path& spyrecode_dir_path) {
-  if (!std::filesystem::exists(spyrecode_dir_path)) {
-    throw std::runtime_error("SpyreCode directory does not exist: " +
-                             spyrecode_dir_path.string());
-  }
+std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir) {
+  std::filesystem::path spyrecode_dir_path(spyrecode_dir);
 
-  if (!std::filesystem::is_directory(spyrecode_dir_path)) {
-    throw std::runtime_error("Path is not a directory: " +
-                             spyrecode_dir_path.string());
-  }
+  TORCH_CHECK(std::filesystem::exists(spyrecode_dir_path),
+              "SpyreCode directory does not exist: ", spyrecode_dir_path);
+
+  TORCH_CHECK(std::filesystem::is_directory(spyrecode_dir_path),
+              "Path is not a directory: ", spyrecode_dir_path);
 
   auto spyrecode_json_path = spyrecode_dir_path / "spyrecode.json";
-  if (!detail::FileExists(spyrecode_json_path)) {
-    throw std::runtime_error(
-        "Required file spyrecode.json not found in directory: " +
-        spyrecode_dir_path.string());
-  }
+  TORCH_CHECK(detail::FileExists(spyrecode_json_path),
+              "Required file spyrecode.json not found in directory: ",
+              spyrecode_dir_path);
 
   std::string json_str = detail::ReadFileToString(spyrecode_json_path);
   nlohmann::json spyrecode_json;
@@ -379,73 +342,24 @@ std::unique_ptr<JobPlan> PrepareKernel(
     spyrecode_json = nlohmann::json::parse(json_str);
   }
   catch (const std::exception& e) {
-    throw std::runtime_error("Failed to parse spyrecode.json: " +
-                             std::string(e.what()));
+    TORCH_CHECK(false, "Failed to parse spyrecode.json: ", e.what());
   }
 
-  if (!spyrecode_json.contains("JobPreparationPlan") ||
-      !spyrecode_json["JobPreparationPlan"].is_array()) {
-    throw std::runtime_error(
-        "SpyreCode JSON missing 'JobPreparationPlan' array");
-  }
+  TORCH_CHECK(spyrecode_json.contains("JobPreparationPlan") &&
+                  spyrecode_json["JobPreparationPlan"].is_array(),
+              "SpyreCode JSON missing 'JobPreparationPlan' array");
 
-  c10::DataPtr allocated_memory = detail::ExecuteJobPreparationPlan(
+  flex::CompositeAddress job_allocation = detail::ExecuteJobPreparationPlan(
       spyrecode_json["JobPreparationPlan"], spyrecode_dir_path);
 
-  // Extract the CompositeAddress from the allocated DataPtr
-  auto program_address =
-      std::move(static_cast<SharedOwnerCtx*>(allocated_memory.get_context())
-                    ->composite_addr);
-
-  if (!spyrecode_json.contains("JobExecPlan") ||
-      !spyrecode_json["JobExecPlan"].is_array()) {
-    throw std::runtime_error("SpyreCode JSON missing 'JobExecPlan' array");
-  }
+  TORCH_CHECK(spyrecode_json.contains("JobExecPlan") &&
+                  spyrecode_json["JobExecPlan"].is_array(),
+              "SpyreCode JSON missing 'JobExecPlan' array");
 
   auto job_plan = detail::TranslateJobExecPlan(spyrecode_json["JobExecPlan"],
-                                               program_address);
-
-  // Store the program memory in JobPlan to keep it alive for the lifetime
-  // of the plan. This prevents premature deallocation of the device memory
-  // that contains the compiled program.
-  job_plan->setProgramMemory(std::move(allocated_memory));
-
-  auto metadata_path = spyrecode_dir_path / "metadata.json";
-  auto expected_shapes = detail::ParseExpectedInputShapes(metadata_path);
-
-  if (!expected_shapes.empty()) {
-    job_plan->setExpectedInputShapes(std::move(expected_shapes));
-  }
+                                               std::move(job_allocation));
 
   return job_plan;
-}
-
-bool ValidateSpyreCodeDir(const std::filesystem::path& spyrecode_dir_path,
-                          bool strict) {
-  // Check if directory exists
-  if (!std::filesystem::exists(spyrecode_dir_path)) {
-    return false;
-  }
-
-  if (!std::filesystem::is_directory(spyrecode_dir_path)) {
-    return false;
-  }
-
-  // Check for required spyrecode.json file
-  auto spyrecode_json_path = spyrecode_dir_path / "spyrecode.json";
-  if (!detail::FileExists(spyrecode_json_path)) {
-    return false;
-  }
-
-  // If strict validation is enabled, check file size
-  if (strict) {
-    auto file_size = std::filesystem::file_size(spyrecode_json_path);
-    if (file_size == 0) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
 }  // namespace spyre

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -56,32 +56,14 @@ static std::shared_ptr<flex::RuntimeEntry> getGlobalRuntime() {
   return getGlobalRuntimeInstance();
 }
 
-// TODO(jni): check CompositeAddress updates and verify
-// Helper to extract CompositeAddress from c10::DataPtr
-static flex::CompositeAddress ExtractCompositeAddress(
-    const c10::DataPtr& data_ptr) {
-  auto* ctx = static_cast<SharedOwnerCtx*>(data_ptr.get_context());
-  if (!ctx || !ctx->owner) {
-    throw std::runtime_error("Failed to get allocation context from DataPtr");
-  }
+static uint64_t prog_dev_ptr = 0;
 
-  uint64_t dmpa = ctx->owner->DmpaAsBytes();
-  size_t alloc_size = ctx->owner->SizeAsBytes();
-
-  // Create CompositeAddress from the DMPA
-  // region_id=0 for now, domain_id=0 for single-domain allocation
-  flex::LogicalAddress logical_addr(0, dmpa);
-  flex::Chunk chunk(logical_addr, alloc_size, 0);
-  return flex::CompositeAddress(chunk);
-}
-
-// TODO(jni): check CompositeAddress updates and verify
 // Helper to compute CompositeAddress with offset from device_addr for program
 static flex::CompositeAddress ComputeOffsetAddress(
-    const flex::CompositeAddress& program_address, uint64_t device_addr) {
-  // Calculate offset: device_addr is relative to 112GB base
-  constexpr uint64_t BASE_ADDR = 112ULL * 1024 * 1024 * 1024;
-  uint64_t offset = device_addr - BASE_ADDR;
+    const flex::CompositeAddress& program_address, uint64_t device_ptr,
+    size_t size) {
+  // Calculate offset
+  uint64_t offset = device_ptr - prog_dev_ptr;
 
   // Create CompositeAddress using program_address with offset
   if (program_address.chunks().empty()) {
@@ -92,7 +74,7 @@ static flex::CompositeAddress ComputeOffsetAddress(
   const auto& base_chunk = program_address.chunks()[0];
   flex::LogicalAddress offset_addr(base_chunk.addr.region_id,
                                    base_chunk.addr.offset + offset);
-  flex::Chunk offset_chunk(offset_addr, 0, base_chunk.domain_id);
+  flex::Chunk offset_chunk(offset_addr, size, base_chunk.domain_id);
   return flex::CompositeAddress(offset_chunk);
 }
 
@@ -161,7 +143,7 @@ JobPlanStep ParseSpyreCodeCommand(
   if (command_type == "ComputeOnDevice") {
     // Create RuntimeOperationCompute with the allocated program address
     auto compute_op =
-        std::make_shared<flex::RuntimeOperationCompute>(program_address);
+        std::make_shared<flex::RuntimeOperationCompute>(&program_address);
 
     return JobPlanStep(compute_op);
 
@@ -188,18 +170,24 @@ JobPlanStep ParseSpyreCodeCommand(
         throw std::runtime_error("DataTransfer H2D missing 'dev_ptr' property");
       }
 
+      if (!properties.contains("size")) {
+        throw std::runtime_error("DataTransfer H2D missing 'size' property");
+      }
+
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
+      std::string size_str = properties["size"].get<std::string>();
 
       // TODO(jni): indicate which HostCompute the input is from
       void* host_addr = nullptr;
-      uint64_t device_addr = std::stoull(dev_ptr_str);
+      uint64_t device_ptr = std::stoull(dev_ptr_str);
+      size_t transfer_size = std::stoull(size_str);
 
-      // Compute CompositeAddress with offset from device_addr
+      // Compute CompositeAddress with offset
       flex::CompositeAddress comp_addr =
-          ComputeOffsetAddress(program_address, device_addr);
+          ComputeOffsetAddress(program_address, device_ptr, transfer_size);
 
       auto h2d_op =
-          std::make_shared<flex::RuntimeOperationH2D>(host_addr, comp_addr);
+          std::make_shared<flex::RuntimeOperationH2D>(host_addr, &comp_addr);
       return JobPlanStep(h2d_op);
 
     } else if (direction == 1) {
@@ -209,18 +197,24 @@ JobPlanStep ParseSpyreCodeCommand(
         throw std::runtime_error("DataTransfer D2H missing 'dev_ptr' property");
       }
 
+      if (!properties.contains("size")) {
+        throw std::runtime_error("DataTransfer D2H missing 'size' property");
+      }
+
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
+      std::string size_str = properties["size"].get<std::string>();
 
       // TODO(jni): indicate which HostCompute the output goes to
       void* host_addr = nullptr;
-      uint64_t device_addr = std::stoull(dev_ptr_str);
+      uint64_t device_ptr = std::stoull(dev_ptr_str);
+      size_t transfer_size = std::stoull(size_str);
 
       // Compute CompositeAddress with offset from device_addr
       flex::CompositeAddress comp_addr =
-          ComputeOffsetAddress(program_address, device_addr);
+          ComputeOffsetAddress(program_address, device_ptr, transfer_size);
 
       auto d2h_op =
-          std::make_shared<flex::RuntimeOperationD2H>(comp_addr, host_addr);
+          std::make_shared<flex::RuntimeOperationD2H>(&comp_addr, host_addr);
       return JobPlanStep(d2h_op);
 
     } else {
@@ -312,20 +306,16 @@ c10::DataPtr ExecuteJobPreparationPlan(
       }
 
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
-      uint64_t device_addr = std::stoull(dev_ptr_str);
+      prog_dev_ptr = std::stoull(dev_ptr_str);
 
-      // Extract CompositeAddress from allocated_ptr and compute offset
-      flex::CompositeAddress program_address =
-          ExtractCompositeAddress(allocated_ptr);
-      flex::CompositeAddress comp_addr =
-          ComputeOffsetAddress(program_address, device_addr);
+      auto* program_address =
+          &(static_cast<SharedOwnerCtx*>(allocated_ptr.get_context())
+                ->composite_addr);
 
-      // TODO(jni): update RuntimeOperationH2D
-      // TODO(jni): extend lifetime?
       // Create RuntimeOperationH2D to transfer binary to device
       auto h2d_op = std::make_shared<flex::RuntimeOperationH2D>(
           const_cast<void*>(static_cast<const void*>(binary_data.data())),
-          comp_addr);
+          program_address);
 
       // Get the default stream and launch the operation
       auto runtime = getGlobalRuntime();
@@ -420,8 +410,9 @@ std::unique_ptr<JobPlan> PrepareKernel(
       spyrecode_json["JobPreparationPlan"], spyrecode_dir_path);
 
   // Extract the CompositeAddress from the allocated DataPtr
-  flex::CompositeAddress program_address =
-      detail::ExtractCompositeAddress(allocated_memory);
+  auto program_address =
+      std::move(static_cast<SharedOwnerCtx*>(allocated_memory.get_context())
+                    ->composite_addr);
 
   if (!spyrecode_json.contains("JobExecPlan") ||
       !spyrecode_json["JobExecPlan"].is_array()) {

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -254,6 +254,7 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
 
   std::string binary_file = init_props["file_path"].get<std::string>();
   std::filesystem::path binary_path(binary_file);
+  binary_path += "/spyreCodeDir/init.bin";
 
   std::string binary_data = ReadFileToString(binary_path);
 

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -298,26 +298,20 @@ std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
 }
 
 /**
- * @brief Helper to execute Job Preparation Plan
- * @return CompositeAddress allocated for the job_allocation during preparation
+ * @brief Execute Allocate command from Job Preparation Plan
+ * @param allocate_cmd The JSON allocate command
+ * @return CompositeAddress allocated for the job_allocation
  */
-flex::CompositeAddress ExecuteJobPreparationPlan(
-    const nlohmann::json& job_prep_plan,
-    const std::filesystem::path& spyrecode_dir) {
-  TORCH_CHECK(job_prep_plan.is_array() && job_prep_plan.size() == 2,
-              "JobPreparationPlan must be an array with exactly 2 commands "
-              "(Allocate and InitTransfer)");
-
-  // Process Allocate command (first item)
-  const auto& allocate_cmd = job_prep_plan[0];
+static flex::CompositeAddress ExecuteAllocate(
+    const nlohmann::json& allocate_cmd) {
   TORCH_CHECK(
       allocate_cmd.contains("command") && allocate_cmd["command"].is_string(),
-      "JobPreparationPlan command missing 'command' field");
+      "Allocate command missing 'command' field");
 
   std::string allocate_type_str = allocate_cmd["command"].get<std::string>();
   SpyreCodeCommandType allocate_type = ParseCommandType(allocate_type_str);
   TORCH_CHECK(allocate_type == SpyreCodeCommandType::Allocate,
-              "First command must be 'Allocate', got: " + allocate_type_str);
+              "Expected 'Allocate' command, got: " + allocate_type_str);
 
   const auto& allocate_props = allocate_cmd.contains("properties")
                                    ? allocate_cmd["properties"]
@@ -332,19 +326,25 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
   auto& allocator = SpyreAllocator::instance();
   c10::DataPtr allocated_ptr = allocator.allocate(size);
 
-  flex::CompositeAddress job_allocation =
-      std::move(static_cast<SharedOwnerCtx*>(allocated_ptr.get_context())
-                    ->composite_addr);
+  return std::move(static_cast<SharedOwnerCtx*>(allocated_ptr.get_context())
+                       ->composite_addr);
+}
 
-  // Process InitTransfer command (second item)
-  const auto& init_cmd = job_prep_plan[1];
+/**
+ * @brief Execute InitTransfer command from Job Preparation Plan
+ * @param init_cmd The JSON init transfer command
+ * @param job_allocation The composite address allocated for the job_allocation
+ */
+static void ExecuteInitTransfer(const nlohmann::json& init_cmd,
+                                const flex::CompositeAddress& job_allocation,
+                                const SpyreStream& stream) {
   TORCH_CHECK(init_cmd.contains("command") && init_cmd["command"].is_string(),
-              "JobPreparationPlan command missing 'command' field");
+              "InitTransfer command missing 'command' field");
 
   std::string init_type_str = init_cmd["command"].get<std::string>();
   SpyreCodeCommandType init_type = ParseCommandType(init_type_str);
   TORCH_CHECK(init_type == SpyreCodeCommandType::InitTransfer,
-              "Second command must be 'InitTransfer', got: " + init_type_str);
+              "Expected 'InitTransfer' command, got: " + init_type_str);
 
   const auto& init_props = init_cmd.contains("properties")
                                ? init_cmd["properties"]
@@ -355,7 +355,6 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
 
   std::string binary_file = init_props["file_path"].get<std::string>();
   std::filesystem::path binary_path(binary_file);
-  binary_path += "/spyreCodeDir/init.bin";
 
   std::string binary_data = ReadFileToString(binary_path);
 
@@ -365,18 +364,37 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
   std::string dev_ptr_str = init_props["dev_ptr"].get<std::string>();
   uint64_t dev_ptr = std::stoull(dev_ptr_str);
 
-  TORCH_CHECK(allocate_props.contains("size"),
+  TORCH_CHECK(init_props.contains("size"),
               "InitTransfer command missing 'size' property");
 
-  std::string init_size_str = allocate_props["size"].get<std::string>();
+  std::string init_size_str = init_props["size"].get<std::string>();
   size_t init_size = std::stoull(init_size_str);
 
   auto device_addr = ComputeOffsetAddress(job_allocation, dev_ptr, init_size);
 
-  auto stream = getCurrentStream();
   stream.copyProgramAsync(
       const_cast<void*>(static_cast<const void*>(binary_data.data())),
       &device_addr);
+}
+
+/**
+ * @brief Helper to execute Job Preparation Plan
+ * @return CompositeAddress allocated for the job_allocation during preparation
+ */
+flex::CompositeAddress ExecuteJobPreparationPlan(
+    const nlohmann::json& job_prep_plan) {
+  TORCH_CHECK(job_prep_plan.is_array() && job_prep_plan.size() >= 2,
+              "JobPreparationPlan must be an array with at least 2 commands "
+              "(1 Allocate and 1+ InitTransfer)");
+
+  // Execute Allocate command (first item)
+  flex::CompositeAddress job_allocation = ExecuteAllocate(job_prep_plan[0]);
+
+  // Execute InitTransfer commands (remaining items)
+  auto stream = getCurrentStream();
+  for (size_t i = 1; i < job_prep_plan.size(); ++i) {
+    ExecuteInitTransfer(job_prep_plan[i], job_allocation, stream);
+  }
 
   return job_allocation;
 }
@@ -451,8 +469,8 @@ std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir) {
                   spyrecode_json["JobPreparationPlan"].is_array(),
               "SpyreCode JSON missing 'JobPreparationPlan' array");
 
-  flex::CompositeAddress job_allocation = detail::ExecuteJobPreparationPlan(
-      spyrecode_json["JobPreparationPlan"], spyrecode_dir_path);
+  flex::CompositeAddress job_allocation =
+      detail::ExecuteJobPreparationPlan(spyrecode_json["JobPreparationPlan"]);
 
   TORCH_CHECK(spyrecode_json.contains("JobExecPlan") &&
                   spyrecode_json["JobExecPlan"].is_array(),

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -23,6 +23,7 @@
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -34,6 +35,58 @@
 namespace spyre {
 
 namespace detail {
+
+/**
+ * @brief Enum for SpyreCode command types
+ */
+enum class SpyreCodeCommandType {
+  ComputeOnDevice,
+  ComputeOnHost,
+  DataTransfer,
+  Allocate,
+  InitTransfer,
+  Unknown
+};
+
+/**
+ * @brief Enum for DataTransfer direction
+ */
+enum class TransferDirection {
+  HostToDevice,  // H2D
+  DeviceToHost,  // D2H
+  Unknown
+};
+
+/**
+ * @brief Parse command type string to enum
+ * @param command_str The command string from JSON
+ * @return Corresponding SpyreCodeCommandType enum value
+ */
+static SpyreCodeCommandType ParseCommandType(const std::string& command_str) {
+  static const std::unordered_map<std::string, SpyreCodeCommandType> mapping = {
+      {"ComputeOnDevice", SpyreCodeCommandType::ComputeOnDevice},
+      {"ComputeOnHost", SpyreCodeCommandType::ComputeOnHost},
+      {"DataTransfer", SpyreCodeCommandType::DataTransfer},
+      {"Allocate", SpyreCodeCommandType::Allocate},
+      {"InitTransfer", SpyreCodeCommandType::InitTransfer}};
+
+  auto it = mapping.find(command_str);
+  return it != mapping.end() ? it->second : SpyreCodeCommandType::Unknown;
+}
+
+/**
+ * @brief Parse transfer direction string to enum
+ * @param dirn_str The direction string from JSON ("false" = H2D, "true" = D2H)
+ * @return Corresponding TransferDirection enum value
+ */
+static TransferDirection ParseTransferDirection(const std::string& dirn_str) {
+  if (dirn_str == "false") {
+    return TransferDirection::HostToDevice;
+  } else if (dirn_str == "true") {
+    return TransferDirection::DeviceToHost;
+  }
+  return TransferDirection::Unknown;
+}
 
 static uint64_t job_allocation_ptr_start = 120259084288;
 
@@ -83,54 +136,65 @@ std::string ReadFileToString(const std::filesystem::path& path) {
 }
 
 /**
- * @brief Helper to parse a SpyreCode JSON command and create a JobPlanStep
- * @param command The JSON command to parse
- * @param program_address The composite address allocated for the job_allocation
+ * @brief Parse ComputeOnDevice command and create JobPlanStep
+ * @param properties The properties JSON object from the command
+ * @param job_allocation The composite address allocated for the job_allocation
+ * @return JobPlanStepComputeSpecialize for device compute
  */
-std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
-    const nlohmann::json& command,
+static std::unique_ptr<JobPlanStep> ParseComputeOnDevice(
+    const nlohmann::json& properties,
     const flex::CompositeAddress& job_allocation) {
-  TORCH_CHECK(command.contains("command") && command["command"].is_string(),
-              "SpyreCode command missing 'command' field");
+  TORCH_CHECK(properties.contains("job_bin_ptr"),
+              "ComputeOnDevice command missing 'job_bin_ptr' property");
 
-  std::string command_type = command["command"].get<std::string>();
-  const auto& properties =
-      command.contains("properties") ? command["properties"] : nlohmann::json();
+  std::string job_bin_ptr_str = properties["job_bin_ptr"].get<std::string>();
+  uint64_t job_bin_ptr = std::stoull(job_bin_ptr_str);
 
-  if (command_type == "ComputeOnDevice") {
-    TORCH_CHECK(properties.contains("job_bin_ptr"),
-                command_type + " command missing 'job_bin_ptr' property");
+  auto job_bin_addr = ComputeOffsetAddress(job_allocation, job_bin_ptr);
+  // Create RuntimeOperationCompute with the allocated program address
+  return std::make_unique<JobPlanStepComputeSpecialize>(
+      std::move(job_bin_addr));
+}
 
-    std::string job_bin_ptr_str = properties["job_bin_ptr"].get<std::string>();
-    uint64_t job_bin_ptr = std::stoull(job_bin_ptr_str);
+/**
+ * @brief Parse ComputeOnHost command and create JobPlanStep
+ * @param properties The properties JSON object from the command
+ * @param job_allocation The composite address allocated for the job_allocation
+ * @return JobPlanStepHostCompute for host-side computation
+ */
+static std::unique_ptr<JobPlanStep> ParseComputeOnHost(
+    const nlohmann::json& properties,
+    const flex::CompositeAddress& job_allocation) {
+  // TODO(jni): create JobPlanStepHostCompute
+  TORCH_CHECK(false,
+              "ComputeOnHost not yet implemented - waiting for deeptools PR to "
+              "be merged");
+  return nullptr;
+}
 
-    auto job_bin_addr = ComputeOffsetAddress(job_allocation, job_bin_ptr);
-    // Create RuntimeOperationCompute with the allocated program address
-    auto compute_op =
-        std::make_unique<JobPlanStepComputeSpecialize>(std::move(job_bin_addr));
+/**
+ * @brief Parse DataTransfer command and create JobPlanStep
+ * @param properties The properties JSON object from the command
+ * @param job_allocation The composite address allocated for the job_allocation
+ * @return JobPlanStepH2D or JobPlanStepD2H depending on transfer direction
+ */
+static std::unique_ptr<JobPlanStep> ParseDataTransfer(
+    const nlohmann::json& properties,
+    const flex::CompositeAddress& job_allocation) {
+  // TODO(jni): create JobPlanStepH2D or JobPlanStepD2H
+  TORCH_CHECK(false,
+              "DataTransfer not yet implemented - waiting for deeptools PR to "
+              "be merged");
 
-    return compute_op;
+  // Extract direction: 0 = H2D, 1 = D2H
+  TORCH_CHECK(properties.contains("dirn"),
+              "DataTransfer command missing 'dirn' property");
 
-  } else if (command_type == "ComputeOnHost") {
-    // TODO(jni): create JobPlanStepHostCompute
-    TORCH_CHECK(
-        false,
-        "ComputeOnHost not yet implemented - waiting for deeptools PR to "
-        "be merged");
-  } else if (command_type == "DataTransfer") {
-    // TODO(jni): create JobPlanStepH2D or JobPlanStepD2H
-    TORCH_CHECK(
-        false,
-        "ComputeOnHost not yet implemented - waiting for deeptools PR to "
-        "be merged");
+  std::string dirn_str = properties["dirn"].get<std::string>();
+  TransferDirection direction = ParseTransferDirection(dirn_str);
 
-    // Extract direction: 0 = H2D, 1 = D2H
-    TORCH_CHECK(properties.contains("dirn"),
-                "DataTransfer command missing 'dirn' property");
-
-    std::string dirn_str = properties["dirn"].get<std::string>();
-
-    if (dirn_str == "false") {
+  switch (direction) {
+    case TransferDirection::HostToDevice: {
       // Host-to-Device transfer
       // Extract host and device addresses
       TORCH_CHECK(properties.contains("dev_ptr"),
@@ -142,8 +206,8 @@ std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
       std::string size_str = properties["size"].get<std::string>();
 
-      // TODO(jni): host_handle should contain info about the host buffer to be
-      // copied, figure out how and connect host_addr
+      // TODO(jni): host_handle should contain info about the host buffer
+      // to be copied, figure out how and connect host_addr
       TORCH_CHECK(properties.contains("host_handle"),
                   "DataTransfer H2D missing 'host_handle' property");
       std::string host_handle_str =
@@ -156,11 +220,10 @@ std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
       flex::CompositeAddress comp_addr =
           ComputeOffsetAddress(job_allocation, device_ptr, transfer_size);
 
-      auto h2d_op =
-          std::make_unique<JobPlanStepH2D>(host_addr, std::move(comp_addr));
-      return h2d_op;
+      return std::make_unique<JobPlanStepH2D>(host_addr, std::move(comp_addr));
+    }
 
-    } else if (dirn_str == "true") {
+    case TransferDirection::DeviceToHost: {
       // Device-to-Host transfer
       // Extract host and device addresses
       TORCH_CHECK(properties.contains("dev_ptr"),
@@ -172,10 +235,10 @@ std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
       std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
       std::string size_str = properties["size"].get<std::string>();
 
-      // TODO(jni): host_handle should contain info about the host buffer to be
-      // copied to, figure out how and connect host_addr
+      // TODO(jni): host_handle should contain info about the host buffer
+      // to be copied to, figure out how and connect host_addr
       TORCH_CHECK(properties.contains("host_handle"),
-                  "DataTransfer H2D missing 'host_handle' property");
+                  "DataTransfer D2H missing 'host_handle' property");
       std::string host_handle_str =
           properties["host_handle"].get<std::string>();
       void* host_addr = nullptr;
@@ -186,17 +249,51 @@ std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
       flex::CompositeAddress comp_addr =
           ComputeOffsetAddress(job_allocation, device_ptr, transfer_size);
 
-      auto d2h_op =
-          std::make_unique<JobPlanStepD2H>(std::move(comp_addr), host_addr);
-      return d2h_op;
-
-    } else {
-      TORCH_CHECK(false, "Invalid DataTransfer direction: ", dirn_str);
+      return std::make_unique<JobPlanStepD2H>(std::move(comp_addr), host_addr);
     }
 
-  } else {
-    TORCH_CHECK(false, "Unknown SpyreCode command type: ", command_type);
+    case TransferDirection::Unknown:
+    default:
+      TORCH_CHECK(false, "Invalid DataTransfer direction: ", dirn_str);
   }
+
+  // Unreachable, but needed to suppress compiler warning
+  return nullptr;
+}
+
+/**
+ * @brief Helper to parse a SpyreCode JSON command and create a JobPlanStep
+ * @param command The JSON command to parse
+ * @param job_allocation The composite address allocated for the job_allocation
+ */
+std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
+    const nlohmann::json& command,
+    const flex::CompositeAddress& job_allocation) {
+  TORCH_CHECK(command.contains("command") && command["command"].is_string(),
+              "SpyreCode command missing 'command' field");
+
+  std::string command_type_str = command["command"].get<std::string>();
+  SpyreCodeCommandType command_type = ParseCommandType(command_type_str);
+  const auto& properties =
+      command.contains("properties") ? command["properties"] : nlohmann::json();
+
+  switch (command_type) {
+    case SpyreCodeCommandType::ComputeOnDevice:
+      return ParseComputeOnDevice(properties, job_allocation);
+
+    case SpyreCodeCommandType::ComputeOnHost:
+      return ParseComputeOnHost(properties, job_allocation);
+
+    case SpyreCodeCommandType::DataTransfer:
+      return ParseDataTransfer(properties, job_allocation);
+
+    case SpyreCodeCommandType::Unknown:
+    default:
+      TORCH_CHECK(false, "Unknown SpyreCode command type: ", command_type_str);
+  }
+
+  // Unreachable, but needed to suppress compiler warning
+  return nullptr;
 }
 
 /**
@@ -216,9 +313,10 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
       allocate_cmd.contains("command") && allocate_cmd["command"].is_string(),
       "JobPreparationPlan command missing 'command' field");
 
-  std::string allocate_type = allocate_cmd["command"].get<std::string>();
-  TORCH_CHECK(allocate_type == "Allocate",
-              "First command must be 'Allocate', got: " + allocate_type);
+  std::string allocate_type_str = allocate_cmd["command"].get<std::string>();
+  SpyreCodeCommandType allocate_type = ParseCommandType(allocate_type_str);
+  TORCH_CHECK(allocate_type == SpyreCodeCommandType::Allocate,
+              "First command must be 'Allocate', got: " + allocate_type_str);
 
   const auto& allocate_props = allocate_cmd.contains("properties")
                                    ? allocate_cmd["properties"]
@@ -242,9 +340,10 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
   TORCH_CHECK(init_cmd.contains("command") && init_cmd["command"].is_string(),
               "JobPreparationPlan command missing 'command' field");
 
-  std::string init_type = init_cmd["command"].get<std::string>();
-  TORCH_CHECK(init_type == "InitTransfer",
-              "Second command must be 'InitTransfer', got: " + init_type);
+  std::string init_type_str = init_cmd["command"].get<std::string>();
+  SpyreCodeCommandType init_type = ParseCommandType(init_type_str);
+  TORCH_CHECK(init_type == SpyreCodeCommandType::InitTransfer,
+              "Second command must be 'InitTransfer', got: " + init_type_str);
 
   const auto& init_props = init_cmd.contains("properties")
                                ? init_cmd["properties"]

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
     TORCH_CHECK(properties.contains("job_bin_ptr"),
                 command_type + " command missing 'job_bin_ptr' property");
 
-    std::string job_bin_ptr_str = properties["dev_ptr"].get<std::string>();
+    std::string job_bin_ptr_str = properties["job_bin_ptr"].get<std::string>();
     uint64_t job_bin_ptr = std::stoull(job_bin_ptr_str);
 
     auto job_bin_addr = ComputeOffsetAddress(job_allocation, job_bin_ptr);

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -20,12 +20,12 @@
 #include <filesystem>  // NOLINT
 #include <fstream>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "common/json.hpp"
 #include "job_plan.h"
 #include "module.h"
 #include "spyre_allocator.h"

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -384,7 +384,7 @@ static void ExecuteInitTransfer(const nlohmann::json& init_cmd,
  * @return CompositeAddress allocated for the job_allocation during preparation
  */
 flex::CompositeAddress ExecuteJobPreparationPlan(
-    const nlohmann::json& job_prep_plan) {
+    const nlohmann::json& job_prep_plan, const SpyreStream& stream) {
   TORCH_CHECK(job_prep_plan.is_array() && job_prep_plan.size() >= 2,
               "JobPreparationPlan must be an array with at least 2 commands "
               "(1 Allocate and 1+ InitTransfer)");
@@ -393,7 +393,6 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
   flex::CompositeAddress job_allocation = ExecuteAllocate(job_prep_plan[0]);
 
   // Execute InitTransfer commands (remaining items)
-  auto stream = getCurrentStream();
   for (size_t i = 1; i < job_prep_plan.size(); ++i) {
     ExecuteInitTransfer(job_prep_plan[i], job_allocation, stream);
   }
@@ -443,7 +442,8 @@ std::unique_ptr<JobPlan> TranslateJobExecPlan(
 
 }  // namespace detail
 
-std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir) {
+std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,
+                                       const SpyreStream* stream) {
   std::filesystem::path spyrecode_dir_path(spyrecode_dir);
 
   TORCH_CHECK(std::filesystem::exists(spyrecode_dir_path),
@@ -471,8 +471,11 @@ std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir) {
                   spyrecode_json["JobPreparationPlan"].is_array(),
               "SpyreCode JSON missing 'JobPreparationPlan' array");
 
-  flex::CompositeAddress job_allocation =
-      detail::ExecuteJobPreparationPlan(spyrecode_json["JobPreparationPlan"]);
+  // Use provided stream or get current stream
+  SpyreStream stream_to_use = stream ? *stream : getCurrentStream();
+
+  flex::CompositeAddress job_allocation = detail::ExecuteJobPreparationPlan(
+      spyrecode_json["JobPreparationPlan"], stream_to_use);
 
   TORCH_CHECK(spyrecode_json.contains("JobExecPlan") &&
                   spyrecode_json["JobExecPlan"].is_array(),

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -396,6 +396,7 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
   for (size_t i = 1; i < job_prep_plan.size(); ++i) {
     ExecuteInitTransfer(job_prep_plan[i], job_allocation, stream);
   }
+  stream.synchronize();
 
   return job_allocation;
 }

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -127,6 +127,8 @@ bool FileExists(const std::filesystem::path& path) {
  * @brief Helper to read entire file into string
  */
 std::string ReadFileToString(const std::filesystem::path& path) {
+  TORCH_CHECK(FileExists(path),
+              "Path does not exist, or not a regular file: ", path.string());
   std::ifstream file(path, std::ios::binary);
   TORCH_CHECK(file, "Failed to open file: ", path.string());
 

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -27,6 +27,8 @@
 #include <utility>
 #include <vector>
 
+#include "flex/include/flex/util/defines.hpp"
+#include "flex/util/defines.hpp"
 #include "job_plan.h"
 #include "module.h"
 #include "spyre_allocator.h"
@@ -88,8 +90,6 @@ static TransferDirection ParseTransferDirection(const std::string& dirn_str) {
   return TransferDirection::Unknown;
 }
 
-static uint64_t job_allocation_ptr_start = 120259084288;
-
 /**
  * @brief Helper to compute CompositeAddress with offset from device_addr for
  * program
@@ -102,7 +102,7 @@ static flex::CompositeAddress ComputeOffsetAddress(
               "job_allocation must have 1 chunk");
 
   // Calculate offset
-  uint64_t offset = dev_ptr - job_allocation_ptr_start;
+  uint64_t offset = dev_ptr - flex::PROG_OFFSET_NOSHIFT;
   if (size == 0) {
     size = job_allocation.total_size() - offset;
   }

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -268,7 +268,7 @@ std::unique_ptr<JobPlanStep> JobPlanBuilder::translateComputeOnDevice(
       compute_offset_address(job_allocation_.value(), job_bin_ptr);
   // Create RuntimeOperationCompute with the allocated program address
   return std::make_unique<JobPlanStepCompute>(std::move(job_bin_addr),
-                                              specialize_addresses_);
+                                              bind_io_addresses_);
 }
 
 std::unique_ptr<JobPlanStep> JobPlanBuilder::translateComputeOnHost(
@@ -395,9 +395,9 @@ std::unique_ptr<JobPlan> JobPlanBuilder::translateJobExecPlan() {
 
   // TODO(jni): check on the condition to specialize addresses
   if (job_exec_plan.size() > 1) {
-    specialize_addresses_ = false;
+    bind_io_addresses_ = false;
   } else {
-    specialize_addresses_ = true;
+    bind_io_addresses_ = true;
   }
 
   // Parse each command in the JobExecPlan and create JobPlanSteps

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -27,8 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include "flex/include/flex/util/defines.hpp"
-#include "flex/util/defines.hpp"
 #include "job_plan.h"
 #include "module.h"
 #include "spyre_allocator.h"
@@ -90,6 +88,11 @@ static TransferDirection ParseTransferDirection(const std::string& dirn_str) {
   return TransferDirection::Unknown;
 }
 
+// Program segment boundaries for validation
+static const uint64_t prog_offset_base = flex::PROG_OFFSET_BASE;
+static const uint64_t prog_offset_limit =
+    flex::PROG_OFFSET_BASE + flex::SEGMENT_SIZE;
+
 /**
  * @brief Helper to compute CompositeAddress with offset from device_addr for
  * program
@@ -101,8 +104,14 @@ static flex::CompositeAddress ComputeOffsetAddress(
   TORCH_CHECK(job_allocation.chunks().size() == 1,
               "job_allocation must have 1 chunk");
 
+  // Validate device pointer is within program segment bounds
+  TORCH_CHECK(dev_ptr >= prog_offset_base && dev_ptr < prog_offset_limit,
+              "Device pointer 0x", std::hex, dev_ptr,
+              " is out of program segment bounds [0x", prog_offset_base, ", 0x",
+              prog_offset_limit, ")");
+
   // Calculate offset
-  uint64_t offset = dev_ptr - flex::PROG_OFFSET_NOSHIFT;
+  uint64_t offset = dev_ptr - prog_offset_base;
   if (size == 0) {
     size = job_allocation.total_size() - offset;
   }
@@ -141,7 +150,7 @@ std::string ReadFileToString(const std::filesystem::path& path) {
  * @brief Parse ComputeOnDevice command and create JobPlanStep
  * @param properties The properties JSON object from the command
  * @param job_allocation The composite address allocated for the job_allocation
- * @return JobPlanStepComputeSpecialize for device compute
+ * @return JobPlanStepCompute for device compute
  */
 static std::unique_ptr<JobPlanStep> ParseComputeOnDevice(
     const nlohmann::json& properties,
@@ -339,6 +348,7 @@ static flex::CompositeAddress ExecuteAllocate(
  */
 static void ExecuteInitTransfer(const nlohmann::json& init_cmd,
                                 const flex::CompositeAddress& job_allocation,
+                                const std::filesystem::path& spyrecode_dir,
                                 const SpyreStream& stream) {
   TORCH_CHECK(init_cmd.contains("command") && init_cmd["command"].is_string(),
               "InitTransfer command missing 'command' field");
@@ -352,11 +362,11 @@ static void ExecuteInitTransfer(const nlohmann::json& init_cmd,
                                ? init_cmd["properties"]
                                : nlohmann::json();
 
-  TORCH_CHECK(init_props.contains("file_path"),
-              "InitTransfer command missing 'file_path' property");
+  TORCH_CHECK(init_props.contains("init_bin_file"),
+              "InitTransfer command missing 'init_bin_file' property");
 
-  std::string binary_file = init_props["file_path"].get<std::string>();
-  std::filesystem::path binary_path(binary_file);
+  std::string binary_file = init_props["init_bin_file"].get<std::string>();
+  std::filesystem::path binary_path = spyrecode_dir / binary_file;
 
   std::string binary_data = ReadFileToString(binary_path);
 
@@ -384,7 +394,8 @@ static void ExecuteInitTransfer(const nlohmann::json& init_cmd,
  * @return CompositeAddress allocated for the job_allocation during preparation
  */
 flex::CompositeAddress ExecuteJobPreparationPlan(
-    const nlohmann::json& job_prep_plan, const SpyreStream& stream) {
+    const nlohmann::json& job_prep_plan,
+    const std::filesystem::path& spyrecode_dir, const SpyreStream& stream) {
   TORCH_CHECK(job_prep_plan.is_array() && job_prep_plan.size() >= 2,
               "JobPreparationPlan must be an array with at least 2 commands "
               "(1 Allocate and 1+ InitTransfer)");
@@ -394,7 +405,8 @@ flex::CompositeAddress ExecuteJobPreparationPlan(
 
   // Execute InitTransfer commands (remaining items)
   for (size_t i = 1; i < job_prep_plan.size(); ++i) {
-    ExecuteInitTransfer(job_prep_plan[i], job_allocation, stream);
+    ExecuteInitTransfer(job_prep_plan[i], job_allocation, spyrecode_dir,
+                        stream);
   }
   stream.synchronize();
 
@@ -412,6 +424,7 @@ std::unique_ptr<JobPlan> TranslateJobExecPlan(
     flex::CompositeAddress job_allocation) {
   TORCH_CHECK(job_exec_plan.is_array(), "JobExecPlan must be an array");
 
+  // TODO(jni): check on the condition to specialize addresses
   bool specialize_addresses = true;
   if (job_exec_plan.size() > 1) {
     specialize_addresses = false;
@@ -476,7 +489,7 @@ std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,
   SpyreStream stream_to_use = stream ? *stream : getCurrentStream();
 
   flex::CompositeAddress job_allocation = detail::ExecuteJobPreparationPlan(
-      spyrecode_json["JobPreparationPlan"], stream_to_use);
+      spyrecode_json["JobPreparationPlan"], spyrecode_dir_path, stream_to_use);
 
   TORCH_CHECK(spyrecode_json.contains("JobExecPlan") &&
                   spyrecode_json["JobExecPlan"].is_array(),

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -17,10 +17,8 @@
 #include "prepare_kernel.h"
 
 #include <cstdint>
-#include <filesystem>  // NOLINT
 #include <fstream>
 #include <memory>
-#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -28,13 +26,9 @@
 #include <vector>
 
 #include "job_plan.h"
-#include "module.h"
 #include "spyre_allocator.h"
-#include "spyre_stream.h"
 
 namespace spyre {
-
-namespace detail {
 
 /**
  * @brief Enum for SpyreCode command types
@@ -146,187 +140,51 @@ std::string ReadFileToString(const std::filesystem::path& path) {
   return ss.str();
 }
 
-/**
- * @brief Parse ComputeOnDevice command and create JobPlanStep
- * @param properties The properties JSON object from the command
- * @param job_allocation The composite address allocated for the job_allocation
- * @return JobPlanStepCompute for device compute
- */
-static std::unique_ptr<JobPlanStep> ParseComputeOnDevice(
-    const nlohmann::json& properties,
-    const flex::CompositeAddress& job_allocation, bool specialize_addresses) {
-  TORCH_CHECK(properties.contains("job_bin_ptr"),
-              "ComputeOnDevice command missing 'job_bin_ptr' property");
+JobPlanBuilder::JobPlanBuilder(const std::string& spyrecode_dir,
+                               const SpyreStream* stream)
+    : spyrecode_dir_(spyrecode_dir),
+      stream_(stream ? *stream : getCurrentStream()) {
+  // Validate directory exists
+  TORCH_CHECK(std::filesystem::exists(spyrecode_dir_),
+              "SpyreCode directory does not exist: ", spyrecode_dir_.string());
 
-  std::string job_bin_ptr_str = properties["job_bin_ptr"].get<std::string>();
-  uint64_t job_bin_ptr = std::stoull(job_bin_ptr_str);
+  TORCH_CHECK(std::filesystem::is_directory(spyrecode_dir_),
+              "Path is not a directory: ", spyrecode_dir_.string());
 
-  auto job_bin_addr = ComputeOffsetAddress(job_allocation, job_bin_ptr);
-  // Create RuntimeOperationCompute with the allocated program address
-  return std::make_unique<JobPlanStepCompute>(std::move(job_bin_addr),
-                                              specialize_addresses);
-}
+  // Load and parse spyrecode.json
+  auto spyrecode_json_path = spyrecode_dir_ / "spyrecode.json";
+  TORCH_CHECK(FileExists(spyrecode_json_path),
+              "Required file spyrecode.json not found in directory: ",
+              spyrecode_dir_.string());
 
-/**
- * @brief Parse ComputeOnHost command and create JobPlanStep
- * @param properties The properties JSON object from the command
- * @param job_allocation The composite address allocated for the job_allocation
- * @return JobPlanStepHostCompute for host-side computation
- */
-static std::unique_ptr<JobPlanStep> ParseComputeOnHost(
-    const nlohmann::json& properties,
-    const flex::CompositeAddress& job_allocation) {
-  // TODO(jni): create JobPlanStepHostCompute
-  TORCH_CHECK(false,
-              "ComputeOnHost not yet implemented - waiting for deeptools PR to "
-              "be merged");
-  return nullptr;
-}
+  std::string json_str = ReadFileToString(spyrecode_json_path);
 
-/**
- * @brief Parse DataTransfer command and create JobPlanStep
- * @param properties The properties JSON object from the command
- * @param job_allocation The composite address allocated for the job_allocation
- * @return JobPlanStepH2D or JobPlanStepD2H depending on transfer direction
- */
-static std::unique_ptr<JobPlanStep> ParseDataTransfer(
-    const nlohmann::json& properties,
-    const flex::CompositeAddress& job_allocation) {
-  // TODO(jni): create JobPlanStepH2D or JobPlanStepD2H
-  TORCH_CHECK(false,
-              "DataTransfer not yet implemented - waiting for deeptools PR to "
-              "be merged");
-
-  // Extract direction: 0 = H2D, 1 = D2H
-  TORCH_CHECK(properties.contains("dirn"),
-              "DataTransfer command missing 'dirn' property");
-
-  std::string dirn_str = properties["dirn"].get<std::string>();
-  TransferDirection direction = ParseTransferDirection(dirn_str);
-
-  switch (direction) {
-    case TransferDirection::HostToDevice: {
-      // Host-to-Device transfer
-      // Extract host and device addresses
-      TORCH_CHECK(properties.contains("dev_ptr"),
-                  "DataTransfer H2D missing 'dev_ptr' property");
-
-      TORCH_CHECK(properties.contains("size"),
-                  "DataTransfer H2D missing 'size' property");
-
-      std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
-      std::string size_str = properties["size"].get<std::string>();
-
-      // TODO(jni): host_handle should contain info about the host buffer
-      // to be copied, figure out how and connect host_addr
-      TORCH_CHECK(properties.contains("host_handle"),
-                  "DataTransfer H2D missing 'host_handle' property");
-      std::string host_handle_str =
-          properties["host_handle"].get<std::string>();
-      void* host_addr = nullptr;
-      uint64_t device_ptr = std::stoull(dev_ptr_str);
-      size_t transfer_size = std::stoull(size_str);
-
-      // Compute CompositeAddress with offset
-      flex::CompositeAddress comp_addr =
-          ComputeOffsetAddress(job_allocation, device_ptr, transfer_size);
-
-      return std::make_unique<JobPlanStepH2D>(host_addr, std::move(comp_addr));
-    }
-
-    case TransferDirection::DeviceToHost: {
-      // Device-to-Host transfer
-      // Extract host and device addresses
-      TORCH_CHECK(properties.contains("dev_ptr"),
-                  "DataTransfer D2H missing 'dev_ptr' property");
-
-      TORCH_CHECK(properties.contains("size"),
-                  "DataTransfer D2H missing 'size' property");
-
-      std::string dev_ptr_str = properties["dev_ptr"].get<std::string>();
-      std::string size_str = properties["size"].get<std::string>();
-
-      // TODO(jni): host_handle should contain info about the host buffer
-      // to be copied to, figure out how and connect host_addr
-      TORCH_CHECK(properties.contains("host_handle"),
-                  "DataTransfer D2H missing 'host_handle' property");
-      std::string host_handle_str =
-          properties["host_handle"].get<std::string>();
-      void* host_addr = nullptr;
-      uint64_t device_ptr = std::stoull(dev_ptr_str);
-      size_t transfer_size = std::stoull(size_str);
-
-      // Compute CompositeAddress with offset from device_addr
-      flex::CompositeAddress comp_addr =
-          ComputeOffsetAddress(job_allocation, device_ptr, transfer_size);
-
-      return std::make_unique<JobPlanStepD2H>(std::move(comp_addr), host_addr);
-    }
-
-    case TransferDirection::Unknown:
-    default:
-      TORCH_CHECK(false, "Invalid DataTransfer direction: ", dirn_str);
+  try {
+    spyrecode_json_ = nlohmann::json::parse(json_str);
+  }
+  catch (const std::exception& e) {
+    TORCH_CHECK(false, "Failed to parse spyrecode.json: ", e.what());
   }
 
-  // Unreachable, but needed to suppress compiler warning
-  return nullptr;
+  // Validate required fields
+  TORCH_CHECK(spyrecode_json_.contains("JobPreparationPlan"),
+              "SpyreCode JSON missing 'JobPreparationPlan' array");
+
+  TORCH_CHECK(spyrecode_json_.contains("JobExecPlan"),
+              "SpyreCode JSON missing 'JobExecPlan' array");
 }
 
-/**
- * @brief Helper to parse a SpyreCode JSON command and create a JobPlanStep
- * @param command The JSON command to parse
- * @param job_allocation The composite address allocated for the job_allocation
- */
-std::unique_ptr<JobPlanStep> ParseSpyreCodeCommand(
-    const nlohmann::json& command, const flex::CompositeAddress& job_allocation,
-    bool specialize_addresses) {
-  TORCH_CHECK(command.contains("command") && command["command"].is_string(),
-              "SpyreCode command missing 'command' field");
+void JobPlanBuilder::executeAllocate(const nlohmann::json& cmd) {
+  TORCH_CHECK(cmd.contains("command") && cmd["command"].is_string(),
+              "Allocate command missing 'command' field");
 
-  std::string command_type_str = command["command"].get<std::string>();
-  SpyreCodeCommandType command_type = ParseCommandType(command_type_str);
-  const auto& properties =
-      command.contains("properties") ? command["properties"] : nlohmann::json();
-
-  switch (command_type) {
-    case SpyreCodeCommandType::ComputeOnDevice:
-      return ParseComputeOnDevice(properties, job_allocation,
-                                  specialize_addresses);
-
-    case SpyreCodeCommandType::ComputeOnHost:
-      return ParseComputeOnHost(properties, job_allocation);
-
-    case SpyreCodeCommandType::DataTransfer:
-      return ParseDataTransfer(properties, job_allocation);
-
-    case SpyreCodeCommandType::Unknown:
-    default:
-      TORCH_CHECK(false, "Unknown SpyreCode command type: ", command_type_str);
-  }
-
-  // Unreachable, but needed to suppress compiler warning
-  return nullptr;
-}
-
-/**
- * @brief Execute Allocate command from Job Preparation Plan
- * @param allocate_cmd The JSON allocate command
- * @return CompositeAddress allocated for the job_allocation
- */
-static flex::CompositeAddress ExecuteAllocate(
-    const nlohmann::json& allocate_cmd) {
-  TORCH_CHECK(
-      allocate_cmd.contains("command") && allocate_cmd["command"].is_string(),
-      "Allocate command missing 'command' field");
-
-  std::string allocate_type_str = allocate_cmd["command"].get<std::string>();
+  std::string allocate_type_str = cmd["command"].get<std::string>();
   SpyreCodeCommandType allocate_type = ParseCommandType(allocate_type_str);
   TORCH_CHECK(allocate_type == SpyreCodeCommandType::Allocate,
               "Expected 'Allocate' command, got: " + allocate_type_str);
 
-  const auto& allocate_props = allocate_cmd.contains("properties")
-                                   ? allocate_cmd["properties"]
-                                   : nlohmann::json();
+  const auto& allocate_props =
+      cmd.contains("properties") ? cmd["properties"] : nlohmann::json();
 
   TORCH_CHECK(allocate_props.contains("size"),
               "Allocate command missing 'size' property");
@@ -337,36 +195,28 @@ static flex::CompositeAddress ExecuteAllocate(
   auto& allocator = SpyreAllocator::instance();
   c10::DataPtr allocated_ptr = allocator.allocate(size);
 
-  return std::move(static_cast<SharedOwnerCtx*>(allocated_ptr.get_context())
-                       ->composite_addr);
+  job_allocation_ =
+      std::move(static_cast<SharedOwnerCtx*>(allocated_ptr.get_context())
+                    ->composite_addr);
 }
 
-/**
- * @brief Execute InitTransfer command from Job Preparation Plan
- * @param init_cmd The JSON init transfer command
- * @param job_allocation The composite address allocated for the job_allocation
- */
-static void ExecuteInitTransfer(const nlohmann::json& init_cmd,
-                                const flex::CompositeAddress& job_allocation,
-                                const std::filesystem::path& spyrecode_dir,
-                                const SpyreStream& stream) {
-  TORCH_CHECK(init_cmd.contains("command") && init_cmd["command"].is_string(),
+void JobPlanBuilder::executeInitTransfer(const nlohmann::json& cmd) {
+  TORCH_CHECK(cmd.contains("command") && cmd["command"].is_string(),
               "InitTransfer command missing 'command' field");
 
-  std::string init_type_str = init_cmd["command"].get<std::string>();
+  std::string init_type_str = cmd["command"].get<std::string>();
   SpyreCodeCommandType init_type = ParseCommandType(init_type_str);
   TORCH_CHECK(init_type == SpyreCodeCommandType::InitTransfer,
               "Expected 'InitTransfer' command, got: " + init_type_str);
 
-  const auto& init_props = init_cmd.contains("properties")
-                               ? init_cmd["properties"]
-                               : nlohmann::json();
+  const auto& init_props =
+      cmd.contains("properties") ? cmd["properties"] : nlohmann::json();
 
   TORCH_CHECK(init_props.contains("init_bin_file"),
               "InitTransfer command missing 'init_bin_file' property");
 
   std::string binary_file = init_props["init_bin_file"].get<std::string>();
-  std::filesystem::path binary_path = spyrecode_dir / binary_file;
+  std::filesystem::path binary_path = spyrecode_dir_ / binary_file;
 
   std::string binary_data = ReadFileToString(binary_path);
 
@@ -382,60 +232,179 @@ static void ExecuteInitTransfer(const nlohmann::json& init_cmd,
   std::string init_size_str = init_props["size"].get<std::string>();
   size_t init_size = std::stoull(init_size_str);
 
-  auto device_addr = ComputeOffsetAddress(job_allocation, dev_ptr, init_size);
+  auto device_addr =
+      ComputeOffsetAddress(job_allocation_.value(), dev_ptr, init_size);
 
-  stream.copyProgramAsync(
+  stream_.copyProgramAsync(
       const_cast<void*>(static_cast<const void*>(binary_data.data())),
       &device_addr);
 }
 
-/**
- * @brief Helper to execute Job Preparation Plan
- * @return CompositeAddress allocated for the job_allocation during preparation
- */
-flex::CompositeAddress ExecuteJobPreparationPlan(
-    const nlohmann::json& job_prep_plan,
-    const std::filesystem::path& spyrecode_dir, const SpyreStream& stream) {
+void JobPlanBuilder::executeJobPreparationPlan() {
+  auto job_prep_plan = spyrecode_json_["JobPreparationPlan"];
   TORCH_CHECK(job_prep_plan.is_array() && job_prep_plan.size() >= 2,
-              "JobPreparationPlan must be an array with at least 2 commands "
-              "(1 Allocate and 1+ InitTransfer)");
+              "JobPreparationPlan must be an array with at least 2 commands (1 "
+              "Allocate and 1+ InitTransfer)");
 
   // Execute Allocate command (first item)
-  flex::CompositeAddress job_allocation = ExecuteAllocate(job_prep_plan[0]);
+  executeAllocate(job_prep_plan[0]);
 
   // Execute InitTransfer commands (remaining items)
   for (size_t i = 1; i < job_prep_plan.size(); ++i) {
-    ExecuteInitTransfer(job_prep_plan[i], job_allocation, spyrecode_dir,
-                        stream);
+    executeInitTransfer(job_prep_plan[i]);
   }
-  stream.synchronize();
-
-  return job_allocation;
+  stream_.synchronize();
 }
 
-/**
- * @brief Helper to translate Job Execution Plan to JobPlan
- * @param job_exec_plan The JSON job execution plan
- * @param job_allocation The composite address allocated for the job_allocation
- * during preparation (moved into JobPlan)
- */
-std::unique_ptr<JobPlan> TranslateJobExecPlan(
-    const nlohmann::json& job_exec_plan,
-    flex::CompositeAddress job_allocation) {
+std::unique_ptr<JobPlanStep> JobPlanBuilder::translateComputeOnDevice(
+    const nlohmann::json& cmd) {
+  TORCH_CHECK(cmd.contains("job_bin_ptr"),
+              "ComputeOnDevice command missing 'job_bin_ptr' property");
+
+  std::string job_bin_ptr_str = cmd["job_bin_ptr"].get<std::string>();
+  uint64_t job_bin_ptr = std::stoull(job_bin_ptr_str);
+
+  auto job_bin_addr =
+      ComputeOffsetAddress(job_allocation_.value(), job_bin_ptr);
+  // Create RuntimeOperationCompute with the allocated program address
+  return std::make_unique<JobPlanStepCompute>(std::move(job_bin_addr),
+                                              specialize_addresses_);
+}
+
+std::unique_ptr<JobPlanStep> JobPlanBuilder::translateComputeOnHost(
+    const nlohmann::json& cmd) {
+  // TODO(jni): create JobPlanStepHostCompute
+  TORCH_CHECK(false,
+              "ComputeOnHost not yet implemented - waiting for deeptools PR to "
+              "be merged");
+  return nullptr;
+}
+
+std::unique_ptr<JobPlanStep> JobPlanBuilder::translateDataTransfer(
+    const nlohmann::json& cmd) {
+  // TODO(jni): create JobPlanStepH2D or JobPlanStepD2H
+  TORCH_CHECK(false,
+              "DataTransfer not yet implemented - waiting for deeptools PR to "
+              "be merged");
+
+  // Extract direction: 0 = H2D, 1 = D2H
+  TORCH_CHECK(cmd.contains("dirn"),
+              "DataTransfer command missing 'dirn' property");
+
+  std::string dirn_str = cmd["dirn"].get<std::string>();
+  TransferDirection direction = ParseTransferDirection(dirn_str);
+
+  switch (direction) {
+    case TransferDirection::HostToDevice: {
+      // Host-to-Device transfer
+      // Extract host and device addresses
+      TORCH_CHECK(cmd.contains("dev_ptr"),
+                  "DataTransfer H2D missing 'dev_ptr' property");
+
+      TORCH_CHECK(cmd.contains("size"),
+                  "DataTransfer H2D missing 'size' property");
+
+      std::string dev_ptr_str = cmd["dev_ptr"].get<std::string>();
+      std::string size_str = cmd["size"].get<std::string>();
+
+      // TODO(jni): host_handle should contain info about the host buffer
+      // to be copied, figure out how and connect host_addr
+      TORCH_CHECK(cmd.contains("host_handle"),
+                  "DataTransfer H2D missing 'host_handle' property");
+      std::string host_handle_str = cmd["host_handle"].get<std::string>();
+      void* host_addr = nullptr;
+      uint64_t device_ptr = std::stoull(dev_ptr_str);
+      size_t transfer_size = std::stoull(size_str);
+
+      // Compute CompositeAddress with offset
+      flex::CompositeAddress comp_addr = ComputeOffsetAddress(
+          job_allocation_.value(), device_ptr, transfer_size);
+
+      return std::make_unique<JobPlanStepH2D>(host_addr, std::move(comp_addr));
+    }
+
+    case TransferDirection::DeviceToHost: {
+      // Device-to-Host transfer
+      // Extract host and device addresses
+      TORCH_CHECK(cmd.contains("dev_ptr"),
+                  "DataTransfer D2H missing 'dev_ptr' property");
+
+      TORCH_CHECK(cmd.contains("size"),
+                  "DataTransfer D2H missing 'size' property");
+
+      std::string dev_ptr_str = cmd["dev_ptr"].get<std::string>();
+      std::string size_str = cmd["size"].get<std::string>();
+
+      // TODO(jni): host_handle should contain info about the host buffer
+      // to be copied to, figure out how and connect host_addr
+      TORCH_CHECK(cmd.contains("host_handle"),
+                  "DataTransfer D2H missing 'host_handle' property");
+      std::string host_handle_str = cmd["host_handle"].get<std::string>();
+      void* host_addr = nullptr;
+      uint64_t device_ptr = std::stoull(dev_ptr_str);
+      size_t transfer_size = std::stoull(size_str);
+
+      // Compute CompositeAddress with offset from device_addr
+      flex::CompositeAddress comp_addr = ComputeOffsetAddress(
+          job_allocation_.value(), device_ptr, transfer_size);
+
+      return std::make_unique<JobPlanStepD2H>(std::move(comp_addr), host_addr);
+    }
+
+    case TransferDirection::Unknown:
+    default:
+      TORCH_CHECK(false, "Invalid DataTransfer direction: ", dirn_str);
+  }
+
+  // Unreachable, but needed to suppress compiler warning
+  return nullptr;
+}
+
+std::unique_ptr<JobPlanStep> JobPlanBuilder::translateCommand(
+    const nlohmann::json& cmd) {
+  TORCH_CHECK(cmd.contains("command") && cmd["command"].is_string(),
+              "SpyreCode command missing 'command' field");
+
+  std::string command_type_str = cmd["command"].get<std::string>();
+  SpyreCodeCommandType command_type = ParseCommandType(command_type_str);
+  const auto& properties =
+      cmd.contains("properties") ? cmd["properties"] : nlohmann::json();
+
+  switch (command_type) {
+    case SpyreCodeCommandType::ComputeOnDevice:
+      return translateComputeOnDevice(properties);
+
+    case SpyreCodeCommandType::ComputeOnHost:
+      return translateComputeOnHost(properties);
+
+    case SpyreCodeCommandType::DataTransfer:
+      return translateDataTransfer(properties);
+
+    case SpyreCodeCommandType::Unknown:
+    default:
+      TORCH_CHECK(false, "Unknown SpyreCode command type: ", command_type_str);
+  }
+
+  // Unreachable, but needed to suppress compiler warning
+  return nullptr;
+}
+
+std::unique_ptr<JobPlan> JobPlanBuilder::translateJobExecPlan() {
+  auto job_exec_plan = spyrecode_json_["JobExecPlan"];
   TORCH_CHECK(job_exec_plan.is_array(), "JobExecPlan must be an array");
 
   // TODO(jni): check on the condition to specialize addresses
-  bool specialize_addresses = true;
   if (job_exec_plan.size() > 1) {
-    specialize_addresses = false;
+    specialize_addresses_ = false;
+  } else {
+    specialize_addresses_ = true;
   }
 
   // Parse each command in the JobExecPlan and create JobPlanSteps
   std::vector<std::unique_ptr<JobPlanStep>> steps;
   for (const auto& command : job_exec_plan) {
     try {
-      steps.push_back(
-          ParseSpyreCodeCommand(command, job_allocation, specialize_addresses));
+      steps.push_back(translateCommand(command));
     }
     catch (const std::exception& e) {
       TORCH_CHECK(false, "Failed to parse SpyreCode command: ", e.what());
@@ -447,58 +416,25 @@ std::unique_ptr<JobPlan> TranslateJobExecPlan(
   // in SpyreCode Create and return the JobPlan Use brace initialization to
   // construct JobPlan with moved members
   return std::make_unique<JobPlan>(JobPlan{
-      std::move(steps),           // steps
-      std::move(job_allocation),  // job_allocation
-      {},                         // expected_input_shapes
-      {}                          // pinned_buffers
+      std::move(steps),                    // steps
+      std::move(job_allocation_.value()),  // job_allocation
+      {},                                  // expected_input_shapes
+      {}                                   // pinned_buffers
   });
 }
 
-}  // namespace detail
+std::unique_ptr<JobPlan> JobPlanBuilder::build() {
+  // Execute job preparation plan (allocate + init transfers)
+  executeJobPreparationPlan();
+
+  // Translate job execution plan to JobPlan
+  return translateJobExecPlan();
+}
 
 std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,
                                        const SpyreStream* stream) {
-  std::filesystem::path spyrecode_dir_path(spyrecode_dir);
-
-  TORCH_CHECK(std::filesystem::exists(spyrecode_dir_path),
-              "SpyreCode directory does not exist: ", spyrecode_dir_path);
-
-  TORCH_CHECK(std::filesystem::is_directory(spyrecode_dir_path),
-              "Path is not a directory: ", spyrecode_dir_path);
-
-  auto spyrecode_json_path = spyrecode_dir_path / "spyrecode.json";
-  TORCH_CHECK(detail::FileExists(spyrecode_json_path),
-              "Required file spyrecode.json not found in directory: ",
-              spyrecode_dir_path);
-
-  std::string json_str = detail::ReadFileToString(spyrecode_json_path);
-  nlohmann::json spyrecode_json;
-
-  try {
-    spyrecode_json = nlohmann::json::parse(json_str);
-  }
-  catch (const std::exception& e) {
-    TORCH_CHECK(false, "Failed to parse spyrecode.json: ", e.what());
-  }
-
-  TORCH_CHECK(spyrecode_json.contains("JobPreparationPlan") &&
-                  spyrecode_json["JobPreparationPlan"].is_array(),
-              "SpyreCode JSON missing 'JobPreparationPlan' array");
-
-  // Use provided stream or get current stream
-  SpyreStream stream_to_use = stream ? *stream : getCurrentStream();
-
-  flex::CompositeAddress job_allocation = detail::ExecuteJobPreparationPlan(
-      spyrecode_json["JobPreparationPlan"], spyrecode_dir_path, stream_to_use);
-
-  TORCH_CHECK(spyrecode_json.contains("JobExecPlan") &&
-                  spyrecode_json["JobExecPlan"].is_array(),
-              "SpyreCode JSON missing 'JobExecPlan' array");
-
-  auto job_plan = detail::TranslateJobExecPlan(spyrecode_json["JobExecPlan"],
-                                               std::move(job_allocation));
-
-  return job_plan;
+  JobPlanBuilder builder(spyrecode_dir, stream);
+  return builder.build();
 }
 
 }  // namespace spyre

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -56,7 +56,7 @@ enum class TransferDirection {
  * @param command_str The command string from JSON
  * @return Corresponding SpyreCodeCommandType enum value
  */
-static SpyreCodeCommandType ParseCommandType(const std::string& command_str) {
+static SpyreCodeCommandType parse_command_type(const std::string& command_str) {
   static const std::unordered_map<std::string, SpyreCodeCommandType> mapping = {
       {"ComputeOnDevice", SpyreCodeCommandType::ComputeOnDevice},
       {"ComputeOnHost", SpyreCodeCommandType::ComputeOnHost},
@@ -73,7 +73,7 @@ static SpyreCodeCommandType ParseCommandType(const std::string& command_str) {
  * @param dirn_str The direction string from JSON ("false" = H2D, "true" = D2H)
  * @return Corresponding TransferDirection enum value
  */
-static TransferDirection ParseTransferDirection(const std::string& dirn_str) {
+static TransferDirection parse_transfer_direction(const std::string& dirn_str) {
   if (dirn_str == "false") {
     return TransferDirection::HostToDevice;
   } else if (dirn_str == "true") {
@@ -91,7 +91,7 @@ static const uint64_t prog_offset_limit =
  * @brief Helper to compute CompositeAddress with offset from device_addr for
  * program
  */
-static flex::CompositeAddress ComputeOffsetAddress(
+static flex::CompositeAddress compute_offset_address(
     const flex::CompositeAddress& job_allocation, uint64_t dev_ptr,
     size_t size = 0) {
   // Create CompositeAddress using program_address with offset
@@ -121,7 +121,7 @@ static flex::CompositeAddress ComputeOffsetAddress(
 /**
  * @brief Helper to check if a file exists
  */
-bool FileExists(const std::filesystem::path& path) {
+static bool file_exists(const std::filesystem::path& path) {
   return std::filesystem::exists(path) &&
          std::filesystem::is_regular_file(path);
 }
@@ -129,8 +129,8 @@ bool FileExists(const std::filesystem::path& path) {
 /**
  * @brief Helper to read entire file into string
  */
-std::string ReadFileToString(const std::filesystem::path& path) {
-  TORCH_CHECK(FileExists(path),
+static std::string read_file_to_string(const std::filesystem::path& path) {
+  TORCH_CHECK(file_exists(path),
               "Path does not exist, or not a regular file: ", path.string());
   std::ifstream file(path, std::ios::binary);
   TORCH_CHECK(file, "Failed to open file: ", path.string());
@@ -153,11 +153,11 @@ JobPlanBuilder::JobPlanBuilder(const std::string& spyrecode_dir,
 
   // Load and parse spyrecode.json
   auto spyrecode_json_path = spyrecode_dir_ / "spyrecode.json";
-  TORCH_CHECK(FileExists(spyrecode_json_path),
+  TORCH_CHECK(file_exists(spyrecode_json_path),
               "Required file spyrecode.json not found in directory: ",
               spyrecode_dir_.string());
 
-  std::string json_str = ReadFileToString(spyrecode_json_path);
+  std::string json_str = read_file_to_string(spyrecode_json_path);
 
   try {
     spyrecode_json_ = nlohmann::json::parse(json_str);
@@ -179,7 +179,7 @@ void JobPlanBuilder::executeAllocate(const nlohmann::json& cmd) {
               "Allocate command missing 'command' field");
 
   std::string allocate_type_str = cmd["command"].get<std::string>();
-  SpyreCodeCommandType allocate_type = ParseCommandType(allocate_type_str);
+  SpyreCodeCommandType allocate_type = parse_command_type(allocate_type_str);
   TORCH_CHECK(allocate_type == SpyreCodeCommandType::Allocate,
               "Expected 'Allocate' command, got: " + allocate_type_str);
 
@@ -205,7 +205,7 @@ void JobPlanBuilder::executeInitTransfer(const nlohmann::json& cmd) {
               "InitTransfer command missing 'command' field");
 
   std::string init_type_str = cmd["command"].get<std::string>();
-  SpyreCodeCommandType init_type = ParseCommandType(init_type_str);
+  SpyreCodeCommandType init_type = parse_command_type(init_type_str);
   TORCH_CHECK(init_type == SpyreCodeCommandType::InitTransfer,
               "Expected 'InitTransfer' command, got: " + init_type_str);
 
@@ -218,7 +218,7 @@ void JobPlanBuilder::executeInitTransfer(const nlohmann::json& cmd) {
   std::string binary_file = init_props["init_bin_file"].get<std::string>();
   std::filesystem::path binary_path = spyrecode_dir_ / binary_file;
 
-  std::string binary_data = ReadFileToString(binary_path);
+  std::string binary_data = read_file_to_string(binary_path);
 
   TORCH_CHECK(init_props.contains("dev_ptr"),
               "InitTransfer command missing 'dev_ptr' property");
@@ -233,7 +233,7 @@ void JobPlanBuilder::executeInitTransfer(const nlohmann::json& cmd) {
   size_t init_size = std::stoull(init_size_str);
 
   auto device_addr =
-      ComputeOffsetAddress(job_allocation_.value(), dev_ptr, init_size);
+      compute_offset_address(job_allocation_.value(), dev_ptr, init_size);
 
   stream_.copyProgramAsync(
       const_cast<void*>(static_cast<const void*>(binary_data.data())),
@@ -265,7 +265,7 @@ std::unique_ptr<JobPlanStep> JobPlanBuilder::translateComputeOnDevice(
   uint64_t job_bin_ptr = std::stoull(job_bin_ptr_str);
 
   auto job_bin_addr =
-      ComputeOffsetAddress(job_allocation_.value(), job_bin_ptr);
+      compute_offset_address(job_allocation_.value(), job_bin_ptr);
   // Create RuntimeOperationCompute with the allocated program address
   return std::make_unique<JobPlanStepCompute>(std::move(job_bin_addr),
                                               specialize_addresses_);
@@ -292,7 +292,7 @@ std::unique_ptr<JobPlanStep> JobPlanBuilder::translateDataTransfer(
               "DataTransfer command missing 'dirn' property");
 
   std::string dirn_str = cmd["dirn"].get<std::string>();
-  TransferDirection direction = ParseTransferDirection(dirn_str);
+  TransferDirection direction = parse_transfer_direction(dirn_str);
 
   switch (direction) {
     case TransferDirection::HostToDevice: {
@@ -317,7 +317,7 @@ std::unique_ptr<JobPlanStep> JobPlanBuilder::translateDataTransfer(
       size_t transfer_size = std::stoull(size_str);
 
       // Compute CompositeAddress with offset
-      flex::CompositeAddress comp_addr = ComputeOffsetAddress(
+      flex::CompositeAddress comp_addr = compute_offset_address(
           job_allocation_.value(), device_ptr, transfer_size);
 
       return std::make_unique<JobPlanStepH2D>(host_addr, std::move(comp_addr));
@@ -345,7 +345,7 @@ std::unique_ptr<JobPlanStep> JobPlanBuilder::translateDataTransfer(
       size_t transfer_size = std::stoull(size_str);
 
       // Compute CompositeAddress with offset from device_addr
-      flex::CompositeAddress comp_addr = ComputeOffsetAddress(
+      flex::CompositeAddress comp_addr = compute_offset_address(
           job_allocation_.value(), device_ptr, transfer_size);
 
       return std::make_unique<JobPlanStepD2H>(std::move(comp_addr), host_addr);
@@ -366,7 +366,7 @@ std::unique_ptr<JobPlanStep> JobPlanBuilder::translateCommand(
               "SpyreCode command missing 'command' field");
 
   std::string command_type_str = cmd["command"].get<std::string>();
-  SpyreCodeCommandType command_type = ParseCommandType(command_type_str);
+  SpyreCodeCommandType command_type = parse_command_type(command_type_str);
   const auto& properties =
       cmd.contains("properties") ? cmd["properties"] : nlohmann::json();
 
@@ -431,7 +431,7 @@ std::unique_ptr<JobPlan> JobPlanBuilder::build() {
   return translateJobExecPlan();
 }
 
-std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,
+std::unique_ptr<JobPlan> prepareKernel(const std::string& spyrecode_dir,
                                        const SpyreStream* stream) {
   JobPlanBuilder builder(spyrecode_dir, stream);
   return builder.build();

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -16,84 +16,13 @@
 
 #pragma once
 
-#include <c10/core/Allocator.h>
-
-#include <filesystem>  // NOLINT
 #include <memory>
 #include <string>
-#include <vector>
-
-#include "common/json.hpp"
-#include "job_plan.h"
-
-// Forward declarations for flex types
-namespace flex {
-class CompositeAddress;
-}
 
 namespace spyre {
 
 // Forward declarations
-class JobPlanStep;
-
-namespace detail {
-
-/**
- * @brief Helper to check if a file exists
- */
-bool FileExists(const std::filesystem::path& path);
-
-/**
- * @brief Helper to read entire file into string
- */
-std::string ReadFileToString(const std::filesystem::path& path);
-
-/**
- * @brief Helper to parse metadata JSON if present
- */
-std::vector<std::vector<int64_t>> ParseExpectedInputShapes(
-    const std::filesystem::path& metadata_path);
-
-/**
- * @brief Helper to parse a SpyreCode JSON command and create a JobPlanStep
- * @param command The JSON command to parse
- * @param program_address The composite address allocated for the program (used
- * for ComputeOnDevice)
- */
-JobPlanStep ParseSpyreCodeCommand(
-    const nlohmann::json& command,
-    const flex::CompositeAddress& program_address);
-
-/**
- * @brief Helper to execute Job Preparation Plan
- * @return Allocated DataPtr for program memory ownership
- */
-c10::DataPtr ExecuteJobPreparationPlan(
-    const nlohmann::json& job_prep_plan,
-    const std::filesystem::path& spyrecode_dir);
-
-/**
- * @brief Helper to translate Job Execution Plan to JobPlan
- * @param job_exec_plan The JSON job execution plan
- * @param program_address The composite address allocated for the program during
- * preparation
- */
-std::unique_ptr<JobPlan> TranslateJobExecPlan(
-    const nlohmann::json& job_exec_plan,
-    const flex::CompositeAddress& program_address);
-
-}  // namespace detail
-
-/**
- * @brief Validate that a directory contains required SpyreCode files
- *
- * @param spyrecode_dir_path Path to the SpyreCode directory
- * @param strict If true, performs additional validation (e.g., file size
- * checks)
- * @return true if directory is valid, false otherwise
- */
-bool ValidateSpyreCodeDir(const std::filesystem::path& spyrecode_dir_path,
-                          bool strict = false);
+class JobPlan;
 
 /**
  * @brief Prepare a kernel from a SpyreCode directory
@@ -102,10 +31,9 @@ bool ValidateSpyreCodeDir(const std::filesystem::path& spyrecode_dir_path,
  * translates the execution plan into a JobPlan, and optionally loads expected
  * input shapes from metadata.
  *
- * @param spyrecode_dir_path Path to the SpyreCode directory
+ * @param spyrecode_dir Path to the SpyreCode directory
  * @return Prepared JobPlan
  */
-std::unique_ptr<JobPlan> PrepareKernel(
-    const std::filesystem::path& spyrecode_dir_path);
+std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir);
 
 }  // namespace spyre

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -18,7 +18,7 @@
 
 #include <c10/core/Allocator.h>
 
-#include <filesystem>
+#include <filesystem>  // NOLINT
 #include <memory>
 #include <string>
 #include <vector>

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <c10/core/Allocator.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/json.hpp"
+#include "job_plan.h"
+
+// Forward declarations for flex types
+namespace flex {
+class CompositeAddress;
+}
+
+namespace spyre {
+
+// Forward declarations
+class JobPlanStep;
+
+namespace detail {
+
+/**
+ * @brief Helper to check if a file exists
+ */
+bool FileExists(const std::filesystem::path& path);
+
+/**
+ * @brief Helper to read entire file into string
+ */
+std::string ReadFileToString(const std::filesystem::path& path);
+
+/**
+ * @brief Helper to parse metadata JSON if present
+ */
+std::vector<std::vector<int64_t>> ParseExpectedInputShapes(
+    const std::filesystem::path& metadata_path);
+
+/**
+ * @brief Helper to parse a SpyreCode JSON command and create a JobPlanStep
+ * @param command The JSON command to parse
+ * @param program_address The composite address allocated for the program (used
+ * for ComputeOnDevice)
+ */
+JobPlanStep ParseSpyreCodeCommand(
+    const nlohmann::json& command,
+    const flex::CompositeAddress& program_address);
+
+/**
+ * @brief Helper to execute Job Preparation Plan
+ * @return Allocated DataPtr for program memory ownership
+ */
+c10::DataPtr ExecuteJobPreparationPlan(
+    const nlohmann::json& job_prep_plan,
+    const std::filesystem::path& spyrecode_dir);
+
+/**
+ * @brief Helper to translate Job Execution Plan to JobPlan
+ * @param job_exec_plan The JSON job execution plan
+ * @param program_address The composite address allocated for the program during
+ * preparation
+ */
+std::unique_ptr<JobPlan> TranslateJobExecPlan(
+    const nlohmann::json& job_exec_plan,
+    const flex::CompositeAddress& program_address);
+
+}  // namespace detail
+
+/**
+ * @brief Validate that a directory contains required SpyreCode files
+ *
+ * @param spyrecode_dir_path Path to the SpyreCode directory
+ * @param strict If true, performs additional validation (e.g., file size
+ * checks)
+ * @return true if directory is valid, false otherwise
+ */
+bool ValidateSpyreCodeDir(const std::filesystem::path& spyrecode_dir_path,
+                          bool strict = false);
+
+/**
+ * @brief Prepare a kernel from a SpyreCode directory
+ *
+ * Loads and validates SpyreCode artifacts, executes the job preparation plan,
+ * translates the execution plan into a JobPlan, and optionally loads expected
+ * input shapes from metadata.
+ *
+ * @param spyrecode_dir_path Path to the SpyreCode directory
+ * @return Prepared JobPlan
+ */
+std::unique_ptr<JobPlan> PrepareKernel(
+    const std::filesystem::path& spyrecode_dir_path);
+
+}  // namespace spyre

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -33,8 +33,8 @@ class SpyreStream;
  * input shapes from metadata.
  *
  * @param spyrecode_dir Path to the SpyreCode directory
- * @param stream Optional stream to use for initialization transfers. If nullptr,
- *               uses the current stream from getCurrentStream()
+ * @param stream Optional stream to use for initialization transfers. If
+ * nullptr, uses the current stream from getCurrentStream()
  * @return Prepared JobPlan
  */
 std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -70,8 +70,8 @@ class JobPlanBuilder {
   /// Device memory allocation for the job (set during preparation and moved to
   /// JobPlan in translation)
   std::optional<flex::CompositeAddress> job_allocation_;
-  /// Whether to specialize addresses for compute
-  bool specialize_addresses_;
+  /// Whether to bind inputs and outputs addresses for compute
+  bool bind_io_addresses_;
 
   /// Execute the job preparation plan (allocate + init transfers)
   void executeJobPreparationPlan();

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -16,25 +16,92 @@
 
 #pragma once
 
+#include <filesystem>  // NOLINT
 #include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
+
+#include "flex/flex.hpp"
+#include "spyre_stream.h"
 
 namespace spyre {
 
 // Forward declarations
 class JobPlan;
-class SpyreStream;
+class JobPlanStep;
+
+/**
+ * @brief Builder class for constructing JobPlan from SpyreCode
+ *
+ * This class encapsulates the logic for loading SpyreCode artifacts,
+ * executing the job preparation plan, and translating the execution
+ * plan into a JobPlan.
+ */
+class JobPlanBuilder {
+ public:
+  /**
+   * @brief Construct a JobPlanBuilder
+   *
+   * @param spyrecode_dir Path to the SpyreCode directory
+   * @param stream Optional stream to use for init transfers. If nullptr, uses
+   * the current stream from getCurrentStream()
+   */
+  JobPlanBuilder(const std::string& spyrecode_dir, const SpyreStream* stream);
+
+  /**
+   * @brief Build the JobPlan
+   *
+   * Executes the preparation pipeline:
+   * 1. Execute job preparation plan (allocate + init transfers)
+   * 2. Translate job execution plan to JobPlan
+   *
+   * @return Prepared JobPlan
+   */
+  std::unique_ptr<JobPlan> build();
+
+ private:
+  /// Path to the SpyreCode directory containing kernel artifacts
+  const std::filesystem::path spyrecode_dir_;
+  /// Parsed SpyreCode JSON containing preparation and execution plans
+  nlohmann::json spyrecode_json_;
+  /// Stream used for initialization transfers during preparation
+  const SpyreStream stream_;
+  /// Device memory allocation for the job (set during preparation and moved to
+  /// JobPlan in translation)
+  std::optional<flex::CompositeAddress> job_allocation_;
+  /// Whether to specialize addresses for compute
+  bool specialize_addresses_;
+
+  /// Execute the job preparation plan (allocate + init transfers)
+  void executeJobPreparationPlan();
+  /// Execute an Allocate command from the preparation plan
+  void executeAllocate(const nlohmann::json& cmd);
+  /// Execute an InitTransfer command from the preparation plan
+  void executeInitTransfer(const nlohmann::json& cmd);
+
+  /// Translate the job execution plan to a JobPlan
+  std::unique_ptr<JobPlan> translateJobExecPlan();
+  /// Translate a single command from the execution plan to a JobPlanStep
+  std::unique_ptr<JobPlanStep> translateCommand(const nlohmann::json& cmd);
+  /// Translate a ComputeOnDevice command to a JobPlanStepCompute
+  std::unique_ptr<JobPlanStep> translateComputeOnDevice(
+      const nlohmann::json& cmd);
+  /// Translate a ComputeOnHost command to a JobPlanStepHostCompute
+  std::unique_ptr<JobPlanStep> translateComputeOnHost(
+      const nlohmann::json& cmd);
+  /// Translate a DataTransfer command to a JobPlanStepH2D or JobPlanStepD2H
+  std::unique_ptr<JobPlanStep> translateDataTransfer(const nlohmann::json& cmd);
+};
 
 /**
  * @brief Prepare a kernel from a SpyreCode directory
  *
- * Loads and validates SpyreCode artifacts, executes the job preparation plan,
- * translates the execution plan into a JobPlan, and optionally loads expected
- * input shapes from metadata.
+ * Factory function that creates the JobPlan.
  *
  * @param spyrecode_dir Path to the SpyreCode directory
- * @param stream Optional stream to use for initialization transfers. If
- * nullptr, uses the current stream from getCurrentStream()
+ * @param stream Optional stream to use for init transfers. If nullptr, uses the
+ * current stream from getCurrentStream()
  * @return Prepared JobPlan
  */
 std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -23,6 +23,7 @@ namespace spyre {
 
 // Forward declarations
 class JobPlan;
+class SpyreStream;
 
 /**
  * @brief Prepare a kernel from a SpyreCode directory
@@ -32,8 +33,11 @@ class JobPlan;
  * input shapes from metadata.
  *
  * @param spyrecode_dir Path to the SpyreCode directory
+ * @param stream Optional stream to use for initialization transfers. If nullptr,
+ *               uses the current stream from getCurrentStream()
  * @return Prepared JobPlan
  */
-std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir);
+std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,
+                                       const SpyreStream* stream = nullptr);
 
 }  // namespace spyre

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -104,7 +104,7 @@ class JobPlanBuilder {
  * current stream from getCurrentStream()
  * @return Prepared JobPlan
  */
-std::unique_ptr<JobPlan> PrepareKernel(const std::string& spyrecode_dir,
+std::unique_ptr<JobPlan> prepareKernel(const std::string& spyrecode_dir,
                                        const SpyreStream* stream = nullptr);
 
 }  // namespace spyre


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR introduces the PrepareKernel functionality that translates SpyreCode artifacts into executable JobPlans for the Spyre AI Accelerator runtime.

Key Components Added
1. Core C++ Implementation (prepare_kernel.cpp/h)
PrepareKernel(spyrecode_dir): Main entry point that loads SpyreCode JSON, executes job preparation, and returns a JobPlan
Job Preparation Execution:
Allocates device memory via SpyreAllocator
Transfers program binaries to device using H2D operations
Returns CompositeAddress for the job allocation
Job Execution Plan Translation: Parses SpyreCode commands and creates corresponding JobPlanStep objects:
ComputeOnDevice → JobPlanStepComputeSpecialize
DataTransfer → JobPlanStepH2D / JobPlanStepD2H (partial implementation)
ComputeOnHost → Placeholder (awaiting deeptools PR)

2. Python Bindings (module.cpp)
torch_spyre._C.prepare_kernel(path): Python-accessible function to prepare kernels from SpyreCode directories
JobPlan Python Class: Exposes inspection methods:
num_steps(): Returns number of execution steps
job_allocation_size(): Returns allocated device memory size
get_step_type(index): Returns step type as string (e.g., "ComputeSpecialize")


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/1574

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change? no

#### Additional note:
