### PR TITLE
Deprecate usage of matmul opfunc

### DIFF
--- a/.claude/skills/project-overview/SKILL.md
+++ b/.claude/skills/project-overview/SKILL.md
@@ -132,7 +132,7 @@ torch.compile(model)
 | `dsc.py` | `SuperDSCScheduling` — emits kernel definition code |
 | `wrapper.py` | `SpyrePythonWrapperCodegen` — host-side wrapper code |
 | `choices.py` | `SpyreHeuristics` — disables fusion/cooperative reductions |
-| `constants.py` | Op name constants (MATMUL_REDUCTION_OP, TRANSPOSE_OP, etc.) |
+| `constants.py` | Op name constants (BATCH_MATMUL_OP, TRANSPOSE_OP, etc.) |
 | `errors.py` | Spyre-specific error classes |
 | `temp_passes.py` | `relayout_linear_weights` — ensures weight contiguity for mm |
 | `runtime/__init__.py` | `KernelSpec`, `TensorArg`, `ConstantArg` dataclasses |

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -14,7 +14,6 @@
 
 BATCH_MATMUL_OP = "batchmatmul"
 IDENTITY_OP = "identity"
-MATMUL_REDUCTION_OP = "batchmatmul"
 RESTICKIFY_OP = "ReStickifyOpHBM"
 
 DEVICE_NAME = "spyre"

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -14,7 +14,7 @@
 
 BATCH_MATMUL_OP = "batchmatmul"
 IDENTITY_OP = "identity"
-MATMUL_REDUCTION_OP = "matmul"
+MATMUL_REDUCTION_OP = "batchmatmul"
 RESTICKIFY_OP = "ReStickifyOpHBM"
 
 DEVICE_NAME = "spyre"

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -33,7 +33,7 @@ from torch._inductor.ir import (
 from torch._inductor.dependencies import MemoryDep
 
 from .errors import Unsupported
-from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
+from .constants import BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
@@ -571,7 +571,7 @@ def divide_pointwise_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores)
 
 def divide_reduction_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores):
     red: Reduction = op.data
-    is_matmul = red.reduction_type in (MATMUL_REDUCTION_OP, BATCH_MATMUL_OP)
+    is_matmul = red.reduction_type == BATCH_MATMUL_OP
 
     it_space = iteration_space_from_op(op)
     input_tds, output_td = collect_tensor_deps(op, args)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -22,7 +22,7 @@ import torch._inductor.lowering as lowering
 
 from typing import Any, Callable, Union
 
-from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
+from .constants import BATCH_MATMUL_OP
 import torch_spyre._inductor.customops  # noqa: F401
 from torch_spyre.ops.fallbacks import fallback_ops
 from .ir import SpyreReduction
@@ -216,7 +216,6 @@ def lower_mm(x, y):
 
     # Handle 3D input with 2D weight (batched matmul)
     if x_ndim == 3 and y_ndim == 2:
-        reduction_type = BATCH_MATMUL_OP  # Use BATCH_MATMUL_OP for 3D×2D
         ranges = [x_size[0], x_size[1], y_size[1]]  # [B, M, N]
 
         def inner_fn(index, reduction_index):
@@ -224,7 +223,6 @@ def lower_mm(x, y):
             (r0,) = reduction_index
             return (x_loader([i0, i1, r0]), y_loader([r0, i2]))
     elif x_ndim == 2 and y_ndim == 2:
-        reduction_type = MATMUL_REDUCTION_OP  # Use MATMUL_REDUCTION_OP for 2D×2D
         ranges = [x_size[0], y_size[1]]
 
         def inner_fn(index, reduction_index):
@@ -242,7 +240,7 @@ def lower_mm(x, y):
         result = lowering.mul(x, y)
     else:
         result = Reduction.create(
-            reduction_type=reduction_type,
+            reduction_type=BATCH_MATMUL_OP,
             input_node=[x, y],
             device=x.get_device(),
             dst_dtype=x.get_dtype(),

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -30,7 +30,6 @@ from torch._inductor.utils import IndentedBuffer, sympy_subs
 from torch._inductor.virtualized import V
 
 from .constants import (
-    MATMUL_REDUCTION_OP,
     SPYRE_FP32_OPS,
     BATCH_MATMUL_OP,
     IDENTITY_OP,
@@ -548,7 +547,7 @@ class SpyreKernel(Kernel[CSEVariable]):
                 f"device_size={list(layout.device_layout.device_size)}, op_info={op_info}"
             )
 
-        if value.op == MATMUL_REDUCTION_OP or value.op == BATCH_MATMUL_OP:
+        if value.op == BATCH_MATMUL_OP:
             if (
                 len(value.arguments) != 2
                 or (not isinstance(value.arguments[0], TensorAccess))

--- a/torch_spyre/_inductor/stickify.py
+++ b/torch_spyre/_inductor/stickify.py
@@ -43,7 +43,7 @@ from torch_spyre._C import (
     get_elem_in_stick,
 )
 from .errors import Unsupported
-from .constants import MATMUL_REDUCTION_OP, BATCH_MATMUL_OP
+from .constants import BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
@@ -418,10 +418,7 @@ def reduction_layout(
     restickify_plan: dict[str, list[dict[str, Any]]],
 ) -> FixedTiledLayout:
     data = op.data
-    if (
-        data.reduction_type == MATMUL_REDUCTION_OP
-        or data.reduction_type == BATCH_MATMUL_OP
-    ):
+    if data.reduction_type == BATCH_MATMUL_OP:
         x = args[0]
         y = args[1]
         x_coords = host_coordinates(x.layout, x.dep)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

It's suggested by @vswagath1989 that we should deprecate matmul opfunc usage. 

- [x] Actually clean up the references to `MATMUL_REDUCTION_OP` as it's not different anymore

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
