### PR TITLE
Enable torch.floor

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -29,11 +29,16 @@ POINTWISE_UNARY_OPS_DICT = {
     "abs": torch.abs,
     "cos": torch.cos,
     "exp": torch.exp,
+    "floor": torch.floor,
     "neg": torch.neg,
     "reciprocal": torch.reciprocal,
     "relu": torch.relu,
     "sin": torch.sin,
     "tanh": torch.tanh,
+}
+
+POINTWISE_UNARY_OPS_FP32_DICT = {
+    "floor": torch.floor,
 }
 
 POINTWISE_BINARY_OPS_DICT = {
@@ -2967,6 +2972,17 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "fp32_4d_dim_3",
             ],
         },
+        (
+            "test_pointwise_unary_op_fp32",
+            "test_unary_op",
+        ): {
+            "ops_dict": POINTWISE_UNARY_OPS_FP32_DICT,
+            "param_sets": {
+                "256": (cached_randn((256,), dtype=torch.float32),),
+                "67x256": (cached_randn((67, 256), dtype=torch.float32),),
+                "67x71x256": (cached_randn((67, 71, 256), dtype=torch.float32),),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -2984,6 +3000,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             # TODO: Division by 0 or near-zero differs on Spyre from CPU, sidestep for now.
             tiny_value_mask = torch.abs(x) < FP16_EPS
             x[tiny_value_mask] = FP16_EPS
+        elif op == torch.floor:
+            # To avoid cpu mismatch due to a negative fp16 having a fraction 0b0000000001
+            x = x.to("spyre").cpu()
 
         self.compare_with_cpu(op, x)
 

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -48,6 +48,7 @@ SPYRE_FP32_OPS = [
     "overwrite",
     "topkvalue",
     "topkindex",
+    "floor",
 ]
 
 TOPK_OPS = {"topkvalue", "topkindex"}

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -167,6 +167,10 @@ class SpyreOpFuncs:
         return f"spyre.exx2({a} {b} {c})"
 
     @staticmethod
+    def floor(x):
+        return PointwiseOp("floor", [x])
+
+    @staticmethod
     def ge(a, b):
         return PointwiseOp("greaterequal", [a, b])
 

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -89,6 +89,7 @@ register_torch_compile_kernel(
         aten.cat,
         aten.div,
         aten.exp,
+        aten.floor,
         aten.log,
         aten.mean,
         aten.mul,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Enables `torch.floor` on Spyre.

#### Which issue(s) this PR is related to:

Closes #1580.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional note:

The function `test_unary_op` is changed to send an input tensor to a spyre device and get it back to cpu before running `torch.floor` on cpu and spyre. This is a workaround to avoid a corner case such that an input float16 element has a fraction finer than 9-bits (i.e `-2.002`). For example, the following code snippet:
```python
import torch

x = torch.tensor([-2.002], dtype=torch.float16)
print("x=", x)
for val, bit in zip(x, x.view(torch.int16)):
    bin_str = f"{bit.item() & 0xFFFF:16b}"
    print(f"x.item()= (-1)^{bin_str[:1]}*2^(0b{bin_str[1:6]}-15)*0b1.{bin_str[6:]}")
print("x.floor().item()=", x.floor().item())
print('x.to("spyre").floor().cpu().item()=', x.to("spyre").floor().cpu().item())
```
gives an output like:
```
x= tensor([-2.0020], dtype=torch.float16)
x.item()= (-1)^1*2^(0b10000-15)*0b1.0000000001
x.floor().item()= -3.0
x.to("spyre").floor().cpu().item()= -2.0
```
This causes cpu value mismatch when an input random tensor is large.