### PR TITLE
Make overwrite and device_from_d2d work on eager efficiently

### DIFF
--- a/tests/inductor/test_inductor_fx_passes.py
+++ b/tests/inductor/test_inductor_fx_passes.py
@@ -53,7 +53,7 @@ def _make_bmm_graph(x_shape, w_shape, dtype=torch.float16):
 
 
 def _overwrite_nodes(graph):
-    return [n for n in graph.nodes if n.target == torch.ops.spyre.overwrite.default]
+    return [n for n in graph.nodes if n.target == torch.ops.spyre.overwrite_f.default]
 
 
 class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1786,7 +1786,6 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        torch._inductor.config.fx_graph_cache = False
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_unary_op(self, op, x):

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1786,6 +1786,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        torch._inductor.config.fx_graph_cache = False
 
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     def test_unary_op(self, op, x):

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -255,6 +255,19 @@ def _(
     return None
 
 
+@torch.library.register_kernel("spyre::overwrite", ["cpu"])
+def overwrite_cpu(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    dims: Sequence[int],
+    offsets: Sequence[int],
+) -> None:
+    sliced_t = output
+    for i, dim in enumerate(dims):
+        sliced_t = torch.ops.aten.slice(sliced_t, dim, offsets[i], offsets[i] + 1)
+    sliced_t = input
+
+
 @torch.library.custom_op("spyre::restickify", mutates_args=(), device_types="spyre")
 def restickify(  # type: ignore[empty-body]
     x: torch.Tensor,

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -16,10 +16,9 @@ from typing import Optional, Sequence
 import torch
 from torch._inductor.fx_passes.reinplace import inplaceable_ops, InplaceableOp
 from torch_spyre.ops.fallbacks import warn_fallback
+from torch_spyre.codegen_ops import compile_once
 
 from .errors import Unsupported
-
-eager_paths = {}
 
 
 @torch.library.custom_op("spyre::softplus", mutates_args=(), device_types="spyre")
@@ -213,13 +212,13 @@ def _ones_scalar_fake(
 @torch.library.custom_op(
     "spyre::copy_from_d2d", mutates_args=("dst",), device_types="spyre"
 )
+@compile_once("spyre.copy_from_d2d")
 def copy_from_d2d(
     src: torch.Tensor,
     dst: torch.Tensor,
+    compiled,
 ) -> None:
-    if "copy_from_d2d" not in eager_paths:
-        eager_paths["copy_from_d2d"] = torch.compile(torch.ops.spyre.copy_from_d2d)
-    return eager_paths["copy_from_d2d"](src, dst)
+    return compiled(src, dst)
 
 
 @copy_from_d2d.register_fake
@@ -235,15 +234,15 @@ def _(
 @torch.library.custom_op(
     "spyre::overwrite", mutates_args=("output",), device_types="spyre"
 )
+@compile_once("spyre.overwrite")
 def overwrite(
     input: torch.Tensor,
     output: torch.Tensor,
     dims: Sequence[int],
     offsets: Sequence[int],
+    compiled,
 ) -> None:
-    if "overwrite" not in eager_paths:
-        eager_paths["overwrite"] = torch.compile(torch.ops.spyre.overwrite)
-    return eager_paths["overwrite"](input, output, dims, offsets)
+    return compiled(input, output, dims, offsets)
 
 
 @overwrite.register_fake
@@ -265,8 +264,8 @@ def overwrite_cpu(
 ) -> None:
     sliced_t = output
     for i, dim in enumerate(dims):
-        sliced_t = torch.ops.aten.slice(sliced_t, dim, offsets[i], offsets[i] + 1)
-    sliced_t = input
+        sliced_t = torch.narrow(sliced_t, dim, offsets[i], 1)
+    sliced_t.copy_(input)
 
 
 @torch.library.custom_op("spyre::overwrite_f", mutates_args=(), device_types="spyre")
@@ -276,10 +275,8 @@ def overwrite_f(
     dims: Sequence[int],
     offsets: Sequence[int],
 ) -> torch.Tensor:
-    if "overwrite" not in eager_paths:
-        eager_paths["overwrite"] = torch.compile(torch.ops.spyre.overwrite)
     result = output.clone()
-    eager_paths["overwrite"](input, result, dims, offsets)
+    torch.ops.spyre.overwrite(input, result, dims, offsets)
     return result
 
 

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -18,6 +18,8 @@ from torch_spyre.ops.fallbacks import warn_fallback
 
 from .errors import Unsupported
 
+eager_paths = {}
+
 
 @torch.library.custom_op("spyre::softplus", mutates_args=(), device_types="spyre")
 def softplus(
@@ -214,10 +216,9 @@ def copy_from_d2d(
     src: torch.Tensor,
     dst: torch.Tensor,
 ) -> None:
-    _compiled_copy_from_d2d = torch.compile(
-        torch.ops.spyre.copy_from_d2d, dynamic=False
-    )
-    return _compiled_copy_from_d2d(src, dst)
+    if "copy_from_d2d" not in eager_paths:
+        eager_paths["copy_from_d2d"] = torch.compile(torch.ops.spyre.copy_from_d2d)
+    return eager_paths["copy_from_d2d"](src, dst)
 
 
 @copy_from_d2d.register_fake
@@ -230,14 +231,18 @@ def _(
 
 # Copy input into output starting at offsets along dimensions dims and
 # return the updated output.
-@torch.library.custom_op("spyre::overwrite", mutates_args=(), device_types="spyre")
+@torch.library.custom_op(
+    "spyre::overwrite", mutates_args=("output",), device_types="spyre"
+)
 def overwrite(
     input: torch.Tensor,
     output: torch.Tensor,
     dims: Sequence[int],
     offsets: Sequence[int],
-) -> torch.Tensor:
-    pass
+) -> None:
+    if "overwrite" not in eager_paths:
+        eager_paths["overwrite"] = torch.compile(torch.ops.spyre.overwrite)
+    return eager_paths["overwrite"](input, output, dims, offsets)
 
 
 @overwrite.register_fake
@@ -246,8 +251,8 @@ def _(
     output: torch.Tensor,
     dims: Sequence[int],
     offsets: Sequence[int],
-) -> torch.Tensor:
-    return output
+) -> None:
+    return None
 
 
 @torch.library.custom_op("spyre::restickify", mutates_args=(), device_types="spyre")

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -14,6 +14,7 @@
 
 from typing import Optional, Sequence
 import torch
+from torch._inductor.fx_passes.reinplace import inplaceable_ops, InplaceableOp
 from torch_spyre.ops.fallbacks import warn_fallback
 
 from .errors import Unsupported
@@ -266,6 +267,35 @@ def overwrite_cpu(
     for i, dim in enumerate(dims):
         sliced_t = torch.ops.aten.slice(sliced_t, dim, offsets[i], offsets[i] + 1)
     sliced_t = input
+
+
+@torch.library.custom_op("spyre::overwrite_f", mutates_args=(), device_types="spyre")
+def overwrite_f(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    dims: Sequence[int],
+    offsets: Sequence[int],
+) -> torch.Tensor:
+    if "overwrite" not in eager_paths:
+        eager_paths["overwrite"] = torch.compile(torch.ops.spyre.overwrite)
+    result = output.clone()
+    eager_paths["overwrite"](input, result, dims, offsets)
+    return result
+
+
+@overwrite_f.register_fake
+def _(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    dims: Sequence[int],
+    offsets: Sequence[int],
+) -> torch.Tensor:
+    return output.clone()
+
+
+inplaceable_ops[torch.ops.spyre.overwrite_f.default] = InplaceableOp(
+    torch.ops.spyre.overwrite.default, 1
+)
 
 
 @torch.library.custom_op("spyre::restickify", mutates_args=(), device_types="spyre")

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -599,7 +599,7 @@ def decompose_cat(
         output = tensors[0].new_empty(output_size)
         offset = 0
         for input in tensors:
-            output = torch.ops.spyre.overwrite(
+            torch.ops.spyre.overwrite(
                 input=input, output=output, dims=[dim], offsets=[offset]
             )
             offset += input.size(dim)
@@ -659,9 +659,8 @@ def pad_decomp(
         return input
 
     output = scalar.expand(output_size).clone()
-    return torch.ops.spyre.overwrite(
-        input=input, output=output, dims=dims, offsets=offsets
-    )
+    torch.ops.spyre.overwrite(input=input, output=output, dims=dims, offsets=offsets)
+    return output
 
 
 @register_spyre_decomposition([torch.ops.aten.bitwise_not])

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -599,7 +599,7 @@ def decompose_cat(
         output = tensors[0].new_empty(output_size)
         offset = 0
         for input in tensors:
-            torch.ops.spyre.overwrite(
+            output = torch.ops.spyre.overwrite_f(
                 input=input, output=output, dims=[dim], offsets=[offset]
             )
             offset += input.size(dim)
@@ -659,7 +659,9 @@ def pad_decomp(
         return input
 
     output = scalar.expand(output_size).clone()
-    torch.ops.spyre.overwrite(input=input, output=output, dims=dims, offsets=offsets)
+    output = torch.ops.spyre.overwrite_f(
+        input=input, output=output, dims=dims, offsets=offsets
+    )
     return output
 
 

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -70,7 +70,7 @@ def pad_arg(graph: torch.fx.Graph, node: torch.fx.Node, arg_i: int, dim: int) ->
             output.meta["val"] = torch.empty(output_shape, dtype=dtype, device=device)
         with graph.inserting_after(output):
             padded = graph.call_function(
-                torch.ops.spyre.overwrite.default,
+                torch.ops.spyre.overwrite_f.default,
                 args=(arg, output, [dim], [0]),
             )
             padded.meta["val"] = torch.empty(output_shape, dtype=dtype, device=device)

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -17,6 +17,8 @@ import torch_spyre.ops.fallbacks  # noqa: F401
 import torch_spyre._C as _C
 import warnings
 import functools
+import inspect
+import operator
 
 
 # Decorator to keep track of compiled variant
@@ -27,9 +29,20 @@ def compile_once(op, **compile_kwargs):
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             nonlocal compiled
+            nonlocal op
             if compiled is None:
+                if isinstance(op, str):
+                    op = operator.attrgetter(op)(torch.ops)
                 compiled = torch.compile(op, **compile_kwargs)
             return fn(*args, compiled=compiled, **kwargs)
+
+        # We remove the `compiled` arg from the signature to have
+        # a clean signature.
+        old_signature = inspect.signature(fn)
+        params = dict(old_signature.parameters)
+        params.pop("compiled")
+        new_signature = old_signature.replace(parameters=params.values())
+        wrapper.__signature__ = new_signature
 
         return wrapper
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] feature

#### What this PR does:

While enabling fully eager support for Granite e2e runs, I found overwrite was hitting some issues. This PR fixes them.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
