### PR TITLE
Fix incorrect pointer passed to reportMemoryUsageToProfiler

### DIFF
--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -84,7 +84,7 @@ void SpyreAllocator::recordAlloc(size_t nbytes, void* data, int device_id) {
   c10::Device curr_device =
       c10::Device(c10::DeviceType::PrivateUse1, device_id);
   c10::reportMemoryUsageToProfiler(
-      &data,
+      data,
       nbytes,  // alloc_size
       stats_
           .allocated_bytes[static_cast<size_t>(
@@ -107,7 +107,7 @@ void SpyreAllocator::recordRelease(size_t nbytes, void* data, int device_id) {
   c10::Device curr_device =
       c10::Device(c10::DeviceType::PrivateUse1, device_id);
   c10::reportMemoryUsageToProfiler(
-      &data,
+      data,
       -nbytes,  // alloc_size
       stats_
           .allocated_bytes[static_cast<size_t>(


### PR DESCRIPTION
## Summary

- `recordAlloc()` and `recordRelease()` in `SpyreAllocator` pass `&data` (address of the local stack variable) instead of `data` (the actual device memory pointer) to `c10::reportMemoryUsageToProfiler()`
- This causes `[memory]` trace events to contain stack addresses in the `Addr` field, preventing TensorBoard from pairing alloc/free events                                                       
- Fix: change `&data` → `data` in both functions (2 lines)
                                                                                                   
## Root Cause                                                                                  
                                                                                                   
  ```cpp
  // BEFORE (bug): passes address OF the stack variable                                            
  c10::reportMemoryUsageToProfiler(                                                                
      &data,    // void** implicitly cast to void* — wrong!                                        
      ...);                                                                                        
                                                                                                   
  // AFTER (fix): passes the actual device pointer                                                 
  c10::reportMemoryUsageToProfiler(                                                              
      data,     // void* — the real device memory address                                          
      ...);
```                                                                                       
                                                                                                   
This matches the pattern used by CPUAllocator and CUDACachingAllocator.    
                           
#### What type of PR is this?                                                                    
                                                                                                  
- [x] bug                                                                                        
- [ ] feature                                                                                    
- [ ] documentation                                                                              
- [ ] cleanup                                                                                    

#### What this PR does:

Fixes `recordAlloc()` and `recordRelease()` in `SpyreAllocator` which pass
`&data` (address of the local stack variable) instead of `data` (the actual
device memory pointer) to `c10::reportMemoryUsageToProfiler()`.                                                               

#### Which issue(s) this PR is related to:

Fixes #846

#### Special notes for your reviewer:

The bug was introduced in PR #770 (commit `9c19bb9`) which added                                 
`c10::reportMemoryUsageToProfiler()` calls to `SpyreAllocator`. The first
parameter expects `void*` (the memory address), but `&data` passes a `void**`                    
(address of the stack variable holding the pointer), which gets implicitly cast
to `void*` with no compiler warning.

**Verification with TensorBoard Memory View (PrivateUse1 device):**

Before fix — alloc/free have different stack addresses, no pairing possible:
<img width="2402" height="1224" alt="image" src="https://github.com/user-attachments/assets/bca76e72-0979-442b-a865-34843edd2fd1" />

                                                                                                  
After fix — 8 alloc/free pairs share the same heap address, Duration shown:                      
<img width="2403" height="1196" alt="image" src="https://github.com/user-attachments/assets/66442161-343a-472f-9b53-919aebe66dff" />
                                      
                                                                                                  
#### Does this PR introduce a user-facing change?                                                
  
Yes — profiling traces now contain correct device memory addresses in `[memory]`                 
events, enabling TensorBoard to properly display memory allocation lifetimes
and pairing for Spyre devices.

#### Additional note:

All C++ checks (clang-format, cpplint) pass.
