### PR TITLE
fix: inductor tests, both fallback and decompositions defined at the same time

### DIFF
--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -686,6 +686,34 @@ def bitwise_and(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
 
 
 ###############################################################################################
+##         Remove decompositions for fallback ops at module import time.                      ##
+###############################################################################################
+# Fallback ops need to have their PyTorch decompositions removed from the global
+# decomposition registry before torch-spyre's lowering module is imported. This prevents
+# PyTorch's make_fallback from detecting conflicts between fallbacks and decompositions.
+#
+# This must happen at module scope (not in enable_spyre_decompositions CM) so that:
+# 1. The removal happens before lowering.py is imported
+# 2. The removal is permanent and thread-safe (not just during compilation)
+# 3. PyTorch's Inductor sees no decomposition when it tries to register fallbacks
+def _remove_fallback_ops_decompositions():
+    from torch_spyre.ops.fallbacks import fallback_ops
+    from torch._ops import OpOverload, OpOverloadPacket
+
+    decomps = torch._inductor.decomposition.decompositions
+    for op in fallback_ops:
+        if isinstance(op, OpOverloadPacket):
+            for overload_name in op.overloads():
+                opo = getattr(op, overload_name)
+                decomps.pop(opo, None)
+        elif isinstance(op, OpOverload):
+            decomps.pop(op, None)
+
+
+_remove_fallback_ops_decompositions()
+
+
+###############################################################################################
 ##                           Register custom kernels for Spyre.                              ##
 ###############################################################################################
 # Kernels are registered permanently in the C++ dispatcher by


### PR DESCRIPTION
  Fix Summary: PyTorch Test Failures Resolution

  Problem

  - 33 test failures in GitHub Actions (CI=true)
  - All 765 tests pass in Kubernetes pod (no CI env var)
  - Root cause: PyTorch Inductor detects conflicts between fallback operators and their decompositions

  Root Cause Analysis

  1. torch-spyre registers fallback operators in torch_spyre/ops/fallbacks.py
    - Examples: aten.sin, aten.cos, aten.arange, aten.embedding, aten.bitwise_xor, aten.bitwise_or, etc.
  2. PyTorch Inductor has default decompositions for these same operators
  3. When CI=true, PyTorch's make_fallback() function raises an AssertionError with the message: make_fallback(aten.XXX): a decomposition exists, we should switch to it
  4. Critical timing issue: This check happens at module import time (in lowering.py) before:
    - The Spyre compilation context managers can remove the conflicting decompositions
    - The torch.compile flow is even reached

  Solution Applied

  Added module-level code in torch_spyre/_inductor/decompositions.py that:

  1. ✅ Defines _remove_fallback_ops_decompositions() function
  2. ✅ Executes at module import time (before lowering.py is loaded)
  3. ✅ Permanently removes all fallback ops' decompositions from PyTorch's global registry
  4. ✅ Prevents PyTorch's make_fallback() from ever detecting a conflict

  Implementation Details

  - Iterates through all fallback_ops from torch_spyre/ops/fallbacks.py
  - Handles both OpOverloadPacket (e.g., torch.ops.aten.sin) and OpOverload (e.g., torch.ops.aten.sin.default)
  - Uses decomps.pop(op, None) to safely remove decompositions if they exist
  - Runs globally at module scope, not transient like the context manager

  Files Modified

  - torch_spyre/_inductor/decompositions.py — Added _remove_fallback_ops_decompositions() and module-level call

  This fix ensures consistent test results across all environments (CI and non-CI, GitHub Actions and Kubernetes pods).

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
