### PR TITLE
[TESTING] Add multi-config YAML support to run_test.sh 

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 # run_test.sh -- Single-entry-point test runner for torch-spyre OOT tests.
 #
-# Usage:
-#   bash run_test.sh /path/to/test_suite_config.yaml [extra pytest args...]
+# Usage (single config):
+#   bash run_test.sh /path/to/yaml/config [extra pytest args...]
+#
+# Usage (multiple configs -- merged at runtime, temp file cleaned up on exit):
+#   bash run_test.sh config_a.yaml config_b.yaml [config_c.yaml ...] [extra pytest args...]
+#   bash run_test.sh config_a.yaml config_b.yaml -- [extra pytest args...]
+#
+# When more than one YAML file is supplied the configs are merged in order via
+# spyre_test_utilities.py
+#   - `files` entries with the same path are combined (tests deduplicated).
+#   - `global` list keys form a superset; identical items are deduplicated.
+#   - Conflicting scalar globals raise an error.
+# The merged temp file is removed by the EXIT trap at the end of the run.
 #
 # For each test file, any TestCase subclass that is NOT already passed to
 # instantiate_device_type_tests() is automatically wrapped: a temporary
@@ -32,16 +43,86 @@ if [[ $# -lt 1 ]]; then
     exit 1
 fi
 
-YAML_CONFIG="$(realpath "$1")"
-shift
-EXTRA_PYTEST_ARGS=("$@")
+# ---------------------------------------------------------------------------
+# Multi-config support (NEW)
+#
+# Collect all leading *.yaml / *.yml arguments that resolve to real files as
+# YAML configs.  The first non-YAML argument (or anything after "--") is the
+# start of extra pytest args.  A single YAML argument is the original
+# backward-compatible path and behaves exactly as before.
+# ---------------------------------------------------------------------------
+YAML_CONFIGS=()
+EXTRA_PYTEST_ARGS=()
+_parsing_yamls=1
 
-if [[ ! -f "$YAML_CONFIG" ]]; then
-    echo "ERROR: YAML config not found: $YAML_CONFIG" >&2
+for _arg in "$@"; do
+    if [[ "$_arg" == "--" ]]; then
+        _parsing_yamls=0
+        continue
+    fi
+    if [[ $_parsing_yamls -eq 1 && ( "$_arg" == *.yaml || "$_arg" == *.yml ) && -f "$_arg" ]]; then
+        YAML_CONFIGS+=("$(realpath "$_arg")")
+    else
+        _parsing_yamls=0
+        EXTRA_PYTEST_ARGS+=("$_arg")
+    fi
+done
+
+if [[ ${#YAML_CONFIGS[@]} -eq 0 ]]; then
+    echo "ERROR: No YAML config file(s) found in the arguments." >&2
+    echo "Usage: $0 <path/to/test_suite_config.yaml> [extra pytest args...]" >&2
     exit 1
 fi
 
-echo "[spyre_run] Using YAML config: $YAML_CONFIG"
+# MERGED_CONFIG_IS_TEMP=1 means we created the file and must delete it on EXIT.
+MERGED_CONFIG_IS_TEMP=0
+
+if [[ ${#YAML_CONFIGS[@]} -eq 1 ]]; then
+    # -----------------------------------------------------------------------
+    # Single-config path
+    # -----------------------------------------------------------------------
+    YAML_CONFIG="${YAML_CONFIGS[0]}"
+
+    if [[ ! -f "$YAML_CONFIG" ]]; then
+        echo "ERROR: YAML config not found: $YAML_CONFIG" >&2
+        exit 1
+    fi
+
+    echo "[spyre_run] Using YAML config: $YAML_CONFIG"
+else
+    # -----------------------------------------------------------------------
+    # Multi-config path -- merge via spyre_test_utilities.py
+    # -----------------------------------------------------------------------
+    echo "[spyre_run] Merging ${#YAML_CONFIGS[@]} YAML config(s):"
+    for _c in "${YAML_CONFIGS[@]}"; do
+        echo "[spyre_run]   $_c"
+    done
+
+    _script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    _UTILITIES_PY=""
+    if [[ -f "${_script_dir}/spyre_test_utilities.py" ]]; then
+        _UTILITIES_PY="${_script_dir}/spyre_test_utilities.py"
+    else
+        _first_config_dir="$(dirname "${YAML_CONFIGS[0]}")"
+        if [[ -f "${_first_config_dir}/spyre_test_utilities.py" ]]; then
+            _UTILITIES_PY="${_first_config_dir}/spyre_test_utilities.py"
+        fi
+    fi
+
+    if [[ -z "$_UTILITIES_PY" ]]; then
+        echo "ERROR: spyre_test_utilities.py not found beside run_test.sh or beside the first config." >&2
+        echo "       Place spyre_test_utilities.py in the same directory as run_test.sh." >&2
+        exit 1
+    fi
+
+    YAML_CONFIG=$(python3 "$_UTILITIES_PY" "${YAML_CONFIGS[@]}") || {
+        echo "ERROR: Failed to merge YAML configs." >&2
+        exit 1
+    }
+    MERGED_CONFIG_IS_TEMP=1
+    echo "[spyre_run] Merged config written to: $YAML_CONFIG"
+fi
+
 YAML_DIR="$(dirname "$YAML_CONFIG")"
 
 # ---------------------------------------------------------------------------
@@ -439,6 +520,11 @@ _cleanup_wrappers() {
         [[ -f "$wf" ]] && rm -f "$wf" && \
             echo "[spyre_run] Cleaned up wrapper: $wf"
     done
+    # Remove merged config temp file (only if we created it). (NEW)
+    if [[ $MERGED_CONFIG_IS_TEMP -eq 1 && -n "${YAML_CONFIG:-}" && -f "$YAML_CONFIG" ]]; then
+        rm -f "$YAML_CONFIG"
+        echo "[spyre_run] Removed merged temp config: $YAML_CONFIG"
+    fi
 }
 trap _cleanup_wrappers EXIT
 
@@ -973,6 +1059,60 @@ for i in "${!RUN_FILES[@]}"; do
         _FILE_PYTEST_ARGS=("${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}" "--junit-xml=${_SHARD_XML}")
     else
         _FILE_PYTEST_ARGS=("${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}")
+    fi
+
+    # ---------------------------------------------------------------------------
+    # -m marker pre-flight
+    #
+    # When a -m MARKEXPR is present, probe whether this specific file has any
+    # tests that match it before running.  The probe uses --collect-only which
+    # is fast as no test execution happens and runs from the file's own directory
+    # so conftest.py files are discovered correctly.
+    #
+    # If the probe finds 0 matching tests (exit code 5) the -m flag is stripped
+    # from _FILE_PYTEST_ARGS so the file's tests all run normally. 
+    # the marker filter applies to files that USE that marker
+    # family; files that don't use it are unaffected.
+    #
+    # ---------------------------------------------------------------------------
+    _HAS_M=0
+    for _a in "${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}"; do
+        [[ "$_a" == "-m" ]] && { _HAS_M=1; break; }
+    done
+
+    if [[ $_HAS_M -eq 1 ]]; then
+        # Extract just the -m args for the probe (no --junit-xml, no -v, etc.)
+        _PROBE_ARGS=()
+        _take_next=0
+        for _a in "${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}"; do
+            if [[ $_take_next -eq 1 ]]; then
+                _PROBE_ARGS+=("$_a")
+                _take_next=0
+                continue
+            fi
+            if [[ "$_a" == "-m" ]]; then
+                _PROBE_ARGS+=("$_a")
+                _take_next=1
+            fi
+        done
+
+        _probe_exit=0
+        (cd "$run_dir" && python3 -m pytest "$run_basename" \
+            "${_PROBE_ARGS[@]}" --collect-only -q 2>/dev/null)
+        _probe_exit=$?
+
+        if [[ $_probe_exit -eq 5 ]]; then
+            # 0 tests match this marker in this file — strip -m from args.
+            echo "[spyre_run] -m filter matched 0 tests in $(basename "$original_file"), running without -m" >&2
+            _ARGS_NO_M=()
+            _skip_m=0
+            for _a in "${_FILE_PYTEST_ARGS[@]+"${_FILE_PYTEST_ARGS[@]}"}"; do
+                if [[ $_skip_m -eq 1 ]]; then _skip_m=0; continue; fi
+                if [[ "$_a" == "-m" ]]; then _skip_m=1; continue; fi
+                _ARGS_NO_M+=("$_a")
+            done
+            _FILE_PYTEST_ARGS=("${_ARGS_NO_M[@]}")
+        fi
     fi
 
     (

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -44,7 +44,7 @@ if [[ $# -lt 1 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Multi-config support (NEW)
+# Multi-config support
 #
 # Collect all leading *.yaml / *.yml arguments that resolve to real files as
 # YAML configs.  The first non-YAML argument (or anything after "--") is the
@@ -520,7 +520,7 @@ _cleanup_wrappers() {
         [[ -f "$wf" ]] && rm -f "$wf" && \
             echo "[spyre_run] Cleaned up wrapper: $wf"
     done
-    # Remove merged config temp file (only if we created it). (NEW)
+    # Remove merged config temp file (only if we created it)
     if [[ $MERGED_CONFIG_IS_TEMP -eq 1 && -n "${YAML_CONFIG:-}" && -f "$YAML_CONFIG" ]]; then
         rm -f "$YAML_CONFIG"
         echo "[spyre_run] Removed merged temp config: $YAML_CONFIG"

--- a/tests/spyre_test_utilities.py
+++ b/tests/spyre_test_utilities.py
@@ -40,7 +40,10 @@ except ImportError as _yaml_err:  # pragma: no cover
 #     python3 spyre_test_utilities.py config_a.yaml config_b.yaml
 #     # prints the path of the merged (temp) YAML to stdout
 
-def _deep_merge_globals(base: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+
+def _deep_merge_globals(
+    base: Dict[str, Any], incoming: Dict[str, Any]
+) -> Dict[str, Any]:
     """Merge two `global:` dicts according to the superset rules.
 
     Rules (per key):
@@ -48,7 +51,7 @@ def _deep_merge_globals(base: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[
     - Key present in both, values equal  -> keep as-is (no duplication).
     - Key present in both, values differ:
         * If both values are lists       -> append unique incoming items
-                        
+
         * Otherwise (scalar)             -> raise ValueError; callers should
                                            not have conflicting scalar globals.
 
@@ -77,7 +80,9 @@ def _deep_merge_globals(base: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[
         if isinstance(base_val, list) and isinstance(incoming_val, list):
             # Use serialised YAML as the deduplication key so dict elements
             # are compared by value, not by Python object identity.
-            existing_keys = {yaml.dump(item, default_flow_style=True) for item in base_val}
+            existing_keys = {
+                yaml.dump(item, default_flow_style=True) for item in base_val
+            }
             merged_list = list(base_val)
             for item in incoming_val:
                 serialised = yaml.dump(item, default_flow_style=True)
@@ -153,6 +158,7 @@ def _merge_file_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def merge_yaml_configs(
     config_paths: Sequence[str | os.PathLike],
     *,
@@ -180,8 +186,7 @@ def merge_yaml_configs(
     Returns
     -------
     str
-        Absolute path to the merged temporary YAML file.  **The caller is
-        responsible for deleting this file when done.**
+        Absolute path to the merged temporary YAML file.
 
     Raises
     ------
@@ -198,14 +203,12 @@ def merge_yaml_configs(
         if not p.is_file():
             raise ValueError(f"Config file not found: {p}")
 
-    # Fast path: single config — just create a temp copy so the caller always
+    # single config - just create a temp copy so the caller always
     # gets a temp file it can safely delete.
     if len(paths) == 1:
         raw = paths[0].read_text(encoding="utf-8")
         dest_dir = output_dir or paths[0].parent
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=prefix, suffix=suffix, dir=str(dest_dir)
-        )
+        fd, tmp_path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=str(dest_dir))
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(raw)
         return tmp_path
@@ -225,9 +228,7 @@ def merge_yaml_configs(
     for i, (data, p) in enumerate(zip(loaded, paths)):
         suite = data.get("test_suite_config")
         if not isinstance(suite, dict):
-            raise ValueError(
-                f"Missing or invalid 'test_suite_config' key in: {p}"
-            )
+            raise ValueError(f"Missing or invalid 'test_suite_config' key in: {p}")
         suites.append(suite)
 
     # ---- Merge `files` entries ----------------------------------------
@@ -255,9 +256,7 @@ def merge_yaml_configs(
 
     # ---- Write to temp file ------------------------------------------
     dest_dir = output_dir or paths[0].parent
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=prefix, suffix=suffix, dir=str(dest_dir)
-    )
+    fd, tmp_path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=str(dest_dir))
     with os.fdopen(fd, "w", encoding="utf-8") as fh:
         yaml.dump(
             merged_doc,
@@ -273,6 +272,7 @@ def merge_yaml_configs(
 # ---------------------------------------------------------------------------
 # CLI entry-point (used by run_test.sh)
 # ---------------------------------------------------------------------------
+
 
 def _cli() -> None:
     """Print the merged temp-file path to stdout; all other output goes to stderr."""
@@ -313,7 +313,7 @@ def _cli() -> None:
         f"[spyre_merge] Merged {len(args.configs)} config(s) -> {merged}",
         file=sys.stderr,
     )
-    # The path (and only the path) goes to stdout for shell capture.
+    # The path goes to stdout for shell capture.
     print(merged)
 
 

--- a/tests/spyre_test_utilities.py
+++ b/tests/spyre_test_utilities.py
@@ -1,0 +1,321 @@
+"""
+spyre_test_utilities.py -- Utility functions for the torch-spyre OOT test framework.
+
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+# ---------------------------------------------------------------------------
+# Optional YAML import
+# ---------------------------------------------------------------------------
+try:
+    import yaml
+except ImportError as _yaml_err:  # pragma: no cover
+    raise ImportError(
+        "PyYAML is required for spyre_test_utilities. "
+        "Install it with: pip install pyyaml"
+    ) from _yaml_err
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Provides YAML config merging for multi-config test runs.
+
+# Usage (Python):
+#     from spyre_test_utilities import merge_yaml_configs
+
+#     merged_path = merge_yaml_configs(["config_a.yaml", "config_b.yaml"])
+#     # ... run tests ...
+#     os.unlink(merged_path)   # caller is responsible for cleanup
+
+# Usage (bash, via the CLI entry-point at the bottom):
+#     python3 spyre_test_utilities.py config_a.yaml config_b.yaml
+#     # prints the path of the merged (temp) YAML to stdout
+
+def _deep_merge_globals(base: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge two `global:` dicts according to the superset rules.
+
+    Rules (per key):
+    - Key absent in base                 -> copy incoming value as-is.
+    - Key present in both, values equal  -> keep as-is (no duplication).
+    - Key present in both, values differ:
+        * If both values are lists       -> append unique incoming items
+                        
+        * Otherwise (scalar)             -> raise ValueError; callers should
+                                           not have conflicting scalar globals.
+
+
+    Each list element is typically a dict such as ``{name: float16}`` or
+    ``{name: add, dtypes: [...], force_xfail: true}``.  Two elements are
+    considered *the same* when they serialise to identical YAML (i.e. all
+    their fields match), so a re-listed identical op is deduplicated while
+    an op with the same name but different sub-fields is appended as a new
+    entry (superset semantics).
+    """
+    result: Dict[str, Any] = dict(base)
+
+    for key, incoming_val in incoming.items():
+        if key not in result:
+            result[key] = incoming_val
+            continue
+
+        base_val = result[key]
+
+        if base_val == incoming_val:
+            # Identical — nothing to do.
+            continue
+
+        # Values differ — only lists are mergeable under superset rules.
+        if isinstance(base_val, list) and isinstance(incoming_val, list):
+            # Use serialised YAML as the deduplication key so dict elements
+            # are compared by value, not by Python object identity.
+            existing_keys = {yaml.dump(item, default_flow_style=True) for item in base_val}
+            merged_list = list(base_val)
+            for item in incoming_val:
+                serialised = yaml.dump(item, default_flow_style=True)
+                if serialised not in existing_keys:
+                    merged_list.append(item)
+                    existing_keys.add(serialised)
+            result[key] = merged_list
+        else:
+            # Scalar conflict - not automatically resolvable.
+            raise ValueError(
+                f"Conflicting scalar values for global key '{key}': "
+                f"{base_val!r} vs {incoming_val!r}. "
+                "Resolve the conflict manually before merging."
+            )
+
+    return result
+
+
+def _merge_file_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Merge per-file entries from all configs into a deduplicated list.
+
+    Two entries with the same ``path`` value are merged: their ``tests``
+    lists are concatenated (with deduplication by name) and their
+    ``unlisted_test_mode`` is kept from the first occurrence (a warning is
+    emitted if configs disagree).
+
+    Entries with distinct paths are appended in the order they appear.
+    """
+    # Preserve insertion order; key = resolved path string.
+    merged: Dict[str, Dict[str, Any]] = {}
+
+    for entry in entries:
+        path = entry.get("path", "")
+        if path not in merged:
+            # First time we see this path — deep-copy the entry.
+            merged[path] = {
+                "path": path,
+                "unlisted_test_mode": entry.get("unlisted_test_mode", "xfail"),
+                "tests": list(entry.get("tests") or []),
+            }
+        else:
+            existing = merged[path]
+
+            # Warn on unlisted_test_mode conflict; keep first value.
+            incoming_mode = entry.get("unlisted_test_mode", "xfail")
+            if existing["unlisted_test_mode"] != incoming_mode:
+                print(
+                    f"[spyre_merge] WARNING: conflicting unlisted_test_mode for "
+                    f"path '{path}': keeping '{existing['unlisted_test_mode']}', "
+                    f"ignoring '{incoming_mode}'.",
+                    file=sys.stderr,
+                )
+
+            # Merge tests: deduplicate by the set of names in each test block.
+            existing_test_names: set = set()
+            for t in existing["tests"]:
+                for n in t.get("names") or []:
+                    existing_test_names.add(n.strip())
+
+            for test_block in entry.get("tests") or []:
+                block_names = {n.strip() for n in (test_block.get("names") or [])}
+                # Append the whole block if ANY of its names is new.
+                # (Partial overlaps are very unlikely in practice but if they
+                # occur the block is still added so no test is silently lost.)
+                if not block_names.issubset(existing_test_names):
+                    existing["tests"].append(test_block)
+                    existing_test_names.update(block_names)
+
+    return list(merged.values())
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def merge_yaml_configs(
+    config_paths: Sequence[str | os.PathLike],
+    *,
+    output_dir: Optional[str | os.PathLike] = None,
+    prefix: str = "_spyre_merged_config_",
+    suffix: str = ".yaml",
+) -> str:
+    """Merge multiple YAML test-suite configs into one temporary file.
+
+    Parameters
+    ----------
+    config_paths:
+        Ordered sequence of paths to YAML config files.  At least one path
+        must be provided.  A single path is accepted for convenience (the
+        file is copied to a temp path so the caller's cleanup flow is
+        uniform).
+    output_dir:
+        Directory in which to create the temp file.  Defaults to the
+        directory of the first config file so that ``${TORCH_ROOT}`` /
+        ``${TORCH_DEVICE_ROOT}`` relative paths resolve correctly when the
+        YAML is loaded from the same location.
+    prefix / suffix:
+        Passed to ``tempfile.mkstemp``.
+
+    Returns
+    -------
+    str
+        Absolute path to the merged temporary YAML file.  **The caller is
+        responsible for deleting this file when done.**
+
+    Raises
+    ------
+    ValueError
+        If no paths are provided, any path does not exist, or irreconcilable
+        scalar conflicts are found in the ``global:`` section.
+    """
+    paths = [Path(p) for p in config_paths]
+
+    if not paths:
+        raise ValueError("At least one config path must be provided.")
+
+    for p in paths:
+        if not p.is_file():
+            raise ValueError(f"Config file not found: {p}")
+
+    # Fast path: single config — just create a temp copy so the caller always
+    # gets a temp file it can safely delete.
+    if len(paths) == 1:
+        raw = paths[0].read_text(encoding="utf-8")
+        dest_dir = output_dir or paths[0].parent
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=prefix, suffix=suffix, dir=str(dest_dir)
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(raw)
+        return tmp_path
+
+    # ------------------------------------------------------------------
+    # Multi-config merge
+    # ------------------------------------------------------------------
+    loaded: List[Dict[str, Any]] = []
+    for p in paths:
+        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"Top-level YAML value must be a mapping in: {p}")
+        loaded.append(data)
+
+    # All configs must have a `test_suite_config` top-level key.
+    suites = []
+    for i, (data, p) in enumerate(zip(loaded, paths)):
+        suite = data.get("test_suite_config")
+        if not isinstance(suite, dict):
+            raise ValueError(
+                f"Missing or invalid 'test_suite_config' key in: {p}"
+            )
+        suites.append(suite)
+
+    # ---- Merge `files` entries ----------------------------------------
+    all_file_entries: List[Dict[str, Any]] = []
+    for suite in suites:
+        all_file_entries.extend(suite.get("files") or [])
+
+    merged_files = _merge_file_entries(all_file_entries)
+
+    # ---- Merge `global` sections --------------------------------------
+    merged_global: Dict[str, Any] = {}
+    for suite in suites:
+        g = suite.get("global")
+        if isinstance(g, dict):
+            merged_global = _deep_merge_globals(merged_global, g)
+
+    # ---- Assemble final document --------------------------------------
+    merged_doc: Dict[str, Any] = {
+        "test_suite_config": {
+            "files": merged_files,
+        }
+    }
+    if merged_global:
+        merged_doc["test_suite_config"]["global"] = merged_global
+
+    # ---- Write to temp file ------------------------------------------
+    dest_dir = output_dir or paths[0].parent
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=prefix, suffix=suffix, dir=str(dest_dir)
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        yaml.dump(
+            merged_doc,
+            fh,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point (used by run_test.sh)
+# ---------------------------------------------------------------------------
+
+def _cli() -> None:
+    """Print the merged temp-file path to stdout; all other output goes to stderr."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="spyre_test_utilities",
+        description=(
+            "Merge multiple torch-spyre YAML test configs into one temporary file.\n"
+            "Prints the merged file path to stdout. The caller must delete it."
+        ),
+    )
+    parser.add_argument(
+        "configs",
+        nargs="+",
+        metavar="CONFIG",
+        help="Two or more YAML config file paths to merge.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        metavar="DIR",
+        default=None,
+        help=(
+            "Directory for the merged temp file "
+            "(default: directory of the first config)."
+        ),
+    )
+    args = parser.parse_args()
+
+    if len(args.configs) < 2:
+        # Single config — still honour the call so run_test.sh needn't
+        # special-case it; we just echo back a temp copy.
+        pass
+
+    merged = merge_yaml_configs(args.configs, output_dir=args.output_dir)
+    # Emit a human-readable note to stderr so it doesn't pollute the path.
+    print(
+        f"[spyre_merge] Merged {len(args.configs)} config(s) -> {merged}",
+        file=sys.stderr,
+    )
+    # The path (and only the path) goes to stdout for shell capture.
+    print(merged)
+
+
+if __name__ == "__main__":
+    _cli()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Extends the test runner to accept multiple YAML config files in a single invocation. Configs are merged at runtime into a temporary file that is cleaned up automatically on exit.

- `run_test.sh` -- argument parser now collects all leading *.yaml arguments as configs; single-config path is unchanged. Merged temp config is cleanup up and deleted by the existing _cleanup_wrappers EXIT trap.


- `spyre_test_utilities.py` (new script) -- standalone merge utility callable from Python or CLI. 


This is backward-compatible (i.e. works with single config file as usual)


#### Which issue(s) this PR is related to:

Fixes https://github.com/torch-spyre/torch-spyre/issues/1163
EPIC: https://github.com/torch-spyre/torch-spyre/issues/1156


#### Special notes for your reviewer:

Example Command (3 configs files)

```bash
bash run_test.sh configs/test_suite_config.yaml configs/test_profiler_config.yaml configs/example_test_config.yaml -v
```

All the test entry path combined are resolved:

<img width="1694" height="1008" alt="image" src="https://github.com/user-attachments/assets/4d40291b-ad4c-4ce0-933c-274e3559b602" />

Another example run (with 2 config files run):

<img width="3456" height="486" alt="image" src="https://github.com/user-attachments/assets/3110c69e-d6a4-4646-8086-a7eb0ad15381" />

<br><br>
#### Cleanup:
<img width="2976" height="96" alt="image" src="https://github.com/user-attachments/assets/2b23067c-2178-4691-8e98-a01539efe534" />







#### Does this PR introduce a user-facing change? No 

#### Additional note:
