### PR TITLE
[TESTING GHA] Add back flags verbose output for pytest logs for spyre unit tests in workflow

### DIFF
--- a/.github/workflows/runtests.yaml
+++ b/.github/workflows/runtests.yaml
@@ -90,7 +90,7 @@ jobs:
           cd
           cd "$CLONED_TORCH_SPYRE_DIR" || exit 1
           EXIT_CODE=0
-          pytest || EXIT_CODE=$?
+          pytest tests/ -vvv -s || EXIT_CODE=$?
           echo "pytest EXIT_CODE: ${EXIT_CODE}"
           if [[ "$EXIT_CODE" == '0' ]] ; then
             echo 'pytest success'


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Thr PR restores verbose pytest output in CI
The `-vvv -s` flags were dropped from the `pytest` command during a recent workflow refactor, resulting in suppressed test output and shorter, less informative CI logs.
This PR adds them back to restore full verbose output and stdout capture in the test step.

#### Does this PR introduce a user-facing change?
No