### PR TITLE
[TESTING] feat: inject op__/dtype__/module__ dynamic markers into JUnit XML properties via instantiate_test's sidecar

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -893,7 +893,7 @@ echo ""
 # ---------------------------------------------------------------------------
 
 _XML_INJECT_PY='
-import sys, re
+import sys, re, json, os
 from pathlib import Path
 try:
     import yaml
@@ -902,8 +902,20 @@ except ImportError:
 
 xml_path, yaml_path = sys.argv[1], sys.argv[2]
 
+# Load sidecar written by TorchTestBase.instantiate_test.
+# Keys are bare method names matching the XML `name=` attribute exactly.
+# Values are already-merged lists of all tags (YAML tests tags + op__ + dtype__ + module__ markers).
+_sidecar: dict = {}
+_sidecar_path = yaml_path + ".markers.json"
+try:
+    with open(_sidecar_path) as _f:
+        _sidecar = json.load(_f)
+except Exception:
+    pass
+
+# Fallback YAML-only tag_map for tests not in sidecar
 data = yaml.safe_load(open(yaml_path)) or {}
-tag_map = {}
+tag_map: dict = {}
 for fe in data.get("test_suite_config", {}).get("files", []):
     for te in fe.get("tests", []):
         tags = sorted(set(te.get("tags", []) or []))
@@ -914,7 +926,11 @@ for fe in data.get("test_suite_config", {}).get("files", []):
             if name:
                 tag_map.setdefault(name, set()).update(tags)
 
-def match_tags(classname, testname):
+def _all_tags(classname, testname):
+    # Sidecar has the full merged tag list -- use it when available.
+    if testname in _sidecar:
+        return sorted(_sidecar[testname])
+    # Fallback: YAML tests `tags` only lookup.
     matched = set()
     for yaml_name, tags in tag_map.items():
         if "::" in yaml_name:
@@ -936,15 +952,23 @@ def build_props(tags):
 
 def inject_full(m):
     attrs, content = m.group(1), m.group(2)
-    if "<properties>" in content:
-        return m.group(0)
     cn = re.search(r"classname=\"([^\"]*)\"", attrs)
     tn = re.search(r"(?<![a-z])name=\"([^\"]*)\"", attrs)
     if not cn or not tn:
         return m.group(0)
-    tags = match_tags(cn.group(1), tn.group(1))
+    tags = _all_tags(cn.group(1), tn.group(1))
     if not tags:
         return m.group(0)
+    if "<properties>" in content:
+        existing = set(re.findall(r"<property name=\"tag\" value=\"([^\"]*)\"/>", content))
+        new_props = "".join(
+            f"<property name=\"tag\" value=\"{t}\"/>"
+            for t in tags if t not in existing
+        )
+        if not new_props:
+            return m.group(0)
+        content = content.replace("</properties>", new_props + "</properties>", 1)
+        return f"<testcase{attrs}>{content}</testcase>"
     return f"<testcase{attrs}>{build_props(tags)}{content}</testcase>"
 
 def inject_self_closing(m):
@@ -953,7 +977,7 @@ def inject_self_closing(m):
     tn = re.search(r"(?<![a-z])name=\"([^\"]*)\"", attrs)
     if not cn or not tn:
         return m.group(0)
-    tags = match_tags(cn.group(1), tn.group(1))
+    tags = _all_tags(cn.group(1), tn.group(1))
     if not tags:
         return m.group(0)
     return f"<testcase{attrs}>{build_props(tags)}</testcase>"
@@ -962,6 +986,12 @@ xml = Path(xml_path).read_text()
 xml = re.sub(r"<testcase([^>]*)>(.*?)</testcase>", inject_full,        xml, flags=re.DOTALL)
 xml = re.sub(r"<testcase([^>]*?)/>",               inject_self_closing, xml)
 Path(xml_path).write_text(xml)
+
+try:
+    os.remove(_sidecar_path)
+except OSError:
+    pass
+
 print(f"[spyre_run] Tags injected into XML: {xml_path}", flush=True)
 '
 

--- a/tests/spyre_test_base_common.py
+++ b/tests/spyre_test_base_common.py
@@ -4,6 +4,7 @@ Shared class and methods for all OOT PyTorch test overrides.
 """
 
 import os
+import json
 from typing import Dict, List, Optional, Set
 import warnings
 
@@ -415,6 +416,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         super().instantiate_test(name, test, generic_cls=generic_cls)
         new_methods = set(cls.__dict__.keys()) - existing_methods
 
+        _tags_to_write: Dict[str, List[str]] = {}
         for method_name in new_methods:
             enabled, reason, is_xfail, is_strict = cls._should_run(
                 method_name=method_name,
@@ -447,14 +449,33 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
             #     setattr(cls, method_name, _skip)
             #     continue
 
-            # apply pytest tags as marks
-            if all_tags:
+            # Collect dynamic markers (op__, dtype__, module__) that the
+            # patchers attached to this specific instantiated method, and
+            # union them with the YAML-declared tags so _XML_INJECT_PY
+            # only needs to handle one flat tag list per method.
+            _DYNAMIC_PREFIXES = ("op__", "dtype__", "module__")
+            existing_fn = cls.__dict__.get(method_name)
+            dynamic_tags: List[str] = []
+            if existing_fn is not None:
+                dynamic_tags = sorted(
+                    {
+                        m.name
+                        for m in getattr(existing_fn, "pytestmark", [])
+                        if any(m.name.startswith(p) for p in _DYNAMIC_PREFIXES)
+                    }
+                )
+
+            method_tags = all_tags + [t for t in dynamic_tags if t not in set(all_tags)]
+
+            # apply all tags (YAML + dynamic) as marks
+            if method_tags:
                 existing_fn = cls.__dict__.get(method_name)
                 if existing_fn is not None:
                     marked_fn = existing_fn
-                    for tag in all_tags:
+                    for tag in method_tags:
                         marked_fn = pytest.mark.__getattr__(tag)(marked_fn)
                     setattr(cls, method_name, marked_fn)
+                _tags_to_write[method_name] = method_tags
 
             # apply xfail if needed
             if is_xfail:
@@ -465,6 +486,25 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                         method_name,
                         pytest.mark.xfail(strict=is_strict)(existing_fn),
                     )
+
+        # Flush {method_name: [tags]} to sidecar for _XML_INJECT_PY.
+        # so that XML reads global + op/dtype/module tags in one shot
+        if _tags_to_write:
+            _cfg = os.environ.get(ENV_TEST_CONFIG, "")
+            if _cfg:
+                _sidecar = _cfg + ".markers.json"
+                _existing_tags: dict = {}
+                try:
+                    with open(_sidecar) as _sf:
+                        _existing_tags = json.load(_sf)
+                except Exception:
+                    pass
+                _existing_tags.update(_tags_to_write)
+                try:
+                    with open(_sidecar, "w") as _sf:
+                        json.dump(_existing_tags, _sf)
+                except Exception:
+                    pass
 
 
 TEST_CLASS = TorchTestBase


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

#### Inject dynamic op/dtype/module markers into JUnit XML so that gobal level tags + ops/dtype/mpdule level tags are captured in the XML report

The OOT patchers (`_OOTOpMarkerPatcher`, `_OOTModuleMarkerPatcher`) attach op__*, dtype__*, and module__* pytest markers to test methods at instantiation time, but pytest currently was not writing these to JUnit XML for unittest.TestCase items.

This PR fixes that by accumulating the full merged tag list (YAML tags + dynamic markers) in `TorchTestBase.instantiate_test` and flushing it to a sidecar JSON file ($PYTORCH_TEST_CONFIG.markers.json). The existing _XML_INJECT_PY post-processor in `run_test.sh` is updated to read this sidecar and inject all tags as <properties> elements, falling back to YAML-only lookup for tests not in the sidecar.

Example Result: Each <testcase> in the XML now carries the complete tag set, e.g. constant, gpt-oss-20b, op__torch_add, dtype__float16 (added as snippet).


#### Special notes for your reviewer:

Command:

```bash
bash run_test.sh configs/gpt_oss_20b_spyre.yaml -v -m "op__torch_add" --junit-xml=/dev/shm/dt-inductor/torch-spyre-anu-forked/tests/configs/report1.xml
```

Output:
<img width="2510" height="1408" alt="image" src="https://github.com/user-attachments/assets/569b1206-2cf0-4d2d-a840-8fac16c94287" />


#### Does this PR introduce a user-facing change? 
No