### PR TITLE
Add aten::resize_ support for Spyre backend

### DIFF
--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -19,6 +19,7 @@
 #include <ATen/EmptyTensor.h>
 #include <ATen/detail/PrivateUse1HooksInterface.h>
 #include <ATen/native/Resize.h>
+#include <ATen/ops/_copy_from.h>
 #include <ATen/ops/set_cpu_dispatch.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/TensorOptions.h>
@@ -580,10 +581,79 @@ at::Tensor py_empty_with_layout(
                            pin_memory_opt, memory_format_opt);
 }
 
+const at::Tensor& spyre_resize_(
+    const at::Tensor& self, c10::SymIntArrayRef size,
+    std::optional<c10::MemoryFormat> memory_format_opt) {
+  auto size_int = c10::asIntArrayRefUnchecked(size);
+
+  if (self.sizes() == size_int) {
+    return self;
+  }
+
+  TORCH_CHECK(!memory_format_opt.has_value() ||
+                  *memory_format_opt == c10::MemoryFormat::Contiguous,
+              "aten::resize_ on Spyre only supports contiguous memory format");
+
+  const auto dtype = c10::typeMetaToScalarType(self.dtype());
+  TORCH_CHECK(spyre::is_supported_dtype(dtype),
+              "Spyre backend does not support dtype ", dtype);
+
+  auto new_layout = SpyreTensorLayout(size_int.vec(), dtype);
+  size_t new_size_bytes = get_device_size_in_bytes(new_layout);
+
+  std::vector<int64_t> new_strides(size_int.size());
+  int64_t stride = 1;
+  for (int i = static_cast<int>(size_int.size()) - 1; i >= 0; --i) {
+    new_strides[i] = stride;
+    stride *= size_int[i];
+  }
+
+  auto* spyre_impl = static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl());
+  constexpr c10::DispatchKeySet pu1_dks(c10::DispatchKey::PrivateUse1);
+
+  // A direct D2D copy cannot model the flat-byte reinterpretation that CPU
+  // resize_ performs: Spyre's tiled layout for (3,4) and (2,3) place the same
+  // logical elements at different physical byte offsets, so reading old-layout
+  // storage through new-layout offsets produces wrong values.
+  //
+  // Instead: D2H using old layout -> CPU resize_ (pure metadata) -> H2D using
+  // new layout. This matches the CPU resize_ semantic of reinterpreting the
+  // flat storage bytes with new contiguous strides.
+  auto cpu_buf = self.cpu();
+  cpu_buf.resize_(size_int);
+
+  auto new_storage_impl = c10::make_intrusive<SpyreStorageImpl>(
+      c10::StorageImpl::use_byte_size_t(), new_size_bytes,
+      &SpyreAllocator::instance(),
+      /*resizeable=*/true);
+
+  at::Tensor tmp = at::detail::make_tensor_base<SpyreTensorImpl>(
+      c10::Storage(new_storage_impl), pu1_dks,
+      c10::scalarTypeToTypeMeta(dtype));
+  auto* tmp_impl = static_cast<SpyreTensorImpl*>(tmp.unsafeGetTensorImpl());
+  tmp_impl->set_sizes_contiguous(size_int);
+  tmp_impl->spyre_layout = new_layout;
+  tmp_impl->dma_sizes = size_int.vec();
+  tmp_impl->dma_strides = new_strides;
+  at::_copy_from(cpu_buf, tmp, /*non_blocking=*/false);
+
+  spyre_impl->set_storage_keep_dtype(c10::Storage(new_storage_impl));
+  spyre_impl->set_sizes_contiguous(size_int);
+  spyre_impl->spyre_layout = new_layout;
+  spyre_impl->dma_sizes = size_int.vec();
+  spyre_impl->dma_strides = new_strides;
+
+  DEBUGINFO("resize_ to shape=", size_int,
+            " new_layout=", new_layout.toString());
+  return self;
+}
+
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("empty.memory_format", TORCH_FN(spyre_empty));
   m.impl("empty_strided", TORCH_FN(spyre_empty_strided));
   m.impl("set_.source_Storage_storage_offset", TORCH_FN(spyre_set_storage));
+  m.impl("_copy_from", TORCH_FN(spyre_copy_from));
+  m.impl("resize_", TORCH_FN(spyre_resize_));
 }
 
 }  // namespace spyre

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -586,10 +586,17 @@ const at::Tensor& spyre_resize_(
     std::optional<c10::MemoryFormat> memory_format_opt) {
   auto size_int = c10::asIntArrayRefUnchecked(size);
 
+  // No-op: requested shape already matches the current shape.
   if (self.sizes() == size_int) {
     return self;
   }
 
+  // Spyre tensors are always contiguous; treat Preserve as Contiguous.
+  if (memory_format_opt == c10::MemoryFormat::Preserve) {
+    memory_format_opt = c10::MemoryFormat::Contiguous;
+  }
+  // Reject non-contiguous formats (e.g. ChannelsLast) that Spyre cannot
+  // represent in hardware.
   TORCH_CHECK(!memory_format_opt.has_value() ||
                   *memory_format_opt == c10::MemoryFormat::Contiguous,
               "aten::resize_ on Spyre only supports contiguous memory format");
@@ -611,14 +618,11 @@ const at::Tensor& spyre_resize_(
   auto* spyre_impl = static_cast<SpyreTensorImpl*>(self.unsafeGetTensorImpl());
   constexpr c10::DispatchKeySet pu1_dks(c10::DispatchKey::PrivateUse1);
 
-  // A direct D2D copy cannot model the flat-byte reinterpretation that CPU
-  // resize_ performs: Spyre's tiled layout for (3,4) and (2,3) place the same
-  // logical elements at different physical byte offsets, so reading old-layout
-  // storage through new-layout offsets produces wrong values.
-  //
-  // Instead: D2H using old layout -> CPU resize_ (pure metadata) -> H2D using
-  // new layout. This matches the CPU resize_ semantic of reinterpreting the
-  // flat storage bytes with new contiguous strides.
+  // TODO: Enhance to avoid the D2H -> CPU resize_ -> H2D round-trip. A direct
+  // D2D reinterpretation is incorrect because Spyre's tiled layout places the
+  // same logical elements at different physical byte offsets for different
+  // shapes, so reading old-layout storage through new-layout offsets produces
+  // wrong values.
   auto cpu_buf = self.cpu();
   cpu_buf.resize_(size_int);
 
@@ -627,6 +631,8 @@ const at::Tensor& spyre_resize_(
       &SpyreAllocator::instance(),
       /*resizeable=*/true);
 
+  // Build a temporary Spyre tensor backed by the new storage and copy the
+  // resized CPU buffer into it using the new tiled layout (H2D transfer).
   at::Tensor tmp = at::detail::make_tensor_base<SpyreTensorImpl>(
       c10::Storage(new_storage_impl), pu1_dks,
       c10::scalarTypeToTypeMeta(dtype));
@@ -637,6 +643,8 @@ const at::Tensor& spyre_resize_(
   tmp_impl->dma_strides = new_strides;
   at::_copy_from(cpu_buf, tmp, /*non_blocking=*/false);
 
+  // Swap storage and update all metadata on self in-place so the caller's
+  // tensor reference reflects the new shape, layout, and backing device memory.
   spyre_impl->set_storage_keep_dtype(c10::Storage(new_storage_impl));
   spyre_impl->set_sizes_contiguous(size_int);
   spyre_impl->spyre_layout = new_layout;


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

## What this PR does

Implements `aten::resize_` for the Spyre backend (`torch_spyre/csrc/spyre_mem.cpp`).

Previously, calling `resize_()` on a Spyre tensor would fall through to an
unregistered dispatch path and fail. This PR registers a native Spyre handler
for `resize_` that correctly matches CPU `resize_` semantics.

A direct device-to-device (D2D) copy between the old and new layouts is not
possible because Spyre's tiled physical layout is shape-specific: the same
logical elements are placed at different physical byte offsets for `(3,4)` vs
`(2,3)`, so reading old-layout storage through new-layout offsets produces
wrong values (verified by regression tests).

The implementation uses a CPU-mediated path:

1. **D2H** — copy Spyre tensor to CPU using the old layout (flat row-major bytes)
2. **CPU `resize_`** — pure metadata update; reinterprets flat bytes with new
   contiguous strides (no data moves for shrink)
3. **H2D** — copy reshaped CPU tensor into fresh Spyre storage using the new layout

This exactly mirrors how CPU `resize_` works (flat-byte reinterpretation with
new contiguous strides). `resize_` is a setup/initialization-time operation so
the CPU round-trip overhead is acceptable.

Also registers `aten::_copy_from` (`spyre_copy_from` was already implemented
but missing from `TORCH_LIBRARY_IMPL`) and adds the required
`#include <ATen/ops/_copy_from.h>`.

### Changes

- `torch_spyre/csrc/spyre_mem.cpp`
  - Add `#include <ATen/ops/_copy_from.h>`
  - Add `spyre_resize_()` implementation
  - Register `aten::_copy_from` and `aten::resize_` in `TORCH_LIBRARY_IMPL`

### Test cases validated (43/43 passed)

**resize_ expand (grow) — 15/15**

| Case | Description | Result |
|------|-------------|--------|
| 1 | 1D expand `(4,) -> (8,)`: shape correct, first 4 values preserved, matches CPU | PASS |
| 2 | 2D expand `(2,3) -> (3,4)`: shape correct, contiguous, row values match CPU | PASS |

**resize_ shrink — 15/15**

| Case | Description | Result |
|------|-------------|--------|
| 1 | 1D shrink `(8,) -> (4,)`: shape correct, first 4 values preserved, matches CPU | PASS |
| 2 | 2D shrink `(3,4) -> (2,3)` shape correct, contiguous, row values match CPU | PASS |

**resize_ no shape change — 13/13**

| Case | Description | Result |
|------|-------------|--------|
| 1 | 1D same `(4,) -> (4,)`: `data_ptr` unchanged (no realloc), values preserved | PASS |
| 2 | 2D same `(3,4) -> (3,4)`: `data_ptr` unchanged, all 12 values preserved | PASS |

## Which issue(s) this PR is related to

[#1382](https://github.com/torch-spyre/torch-spyre/issues/1382)
[#730](https://github.com/torch-spyre/torch-spyre/issues/730)

## Special notes for your reviewer

The D2D approach (giving `self_view` the new layout over old storage) was
attempted first and produces wrong results for any reshape that changes row
stride — e.g. `(3,4)->(2,3)` gives `[[1,2,3],[5,6,7]]` instead of
`[[1,2,3],[4,5,6]]`. The CPU-mediated path is the minimal correct fix.

## Does this PR introduce a user-facing change?

Yes — `aten::resize_` now works on Spyre tensors. Previously it would raise
an unregistered dispatch error.

## Additional note

`resize_` is typically called during model initialization (e.g. KV-cache
pre-allocation), not on the inference hot path, so the CPU round-trip is
acceptable.
