### PR TITLE
Add LLama-3.1-8B-Instruct for model-centric verification

### DIFF
--- a/tests/resource/models/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/tests/resource/models/Meta-Llama-3.1-8B-Instruct.yaml
@@ -1,0 +1,2064 @@
+model: Meta-Llama-3.1-8B-Instruct
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          stride: [12, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L395 in forward, code: inputs_embeds:
+      torch.Tensor = self.embed_tokens(input_ids)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.getitem.1
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.float.1
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+    marks: fp32operation
+  - name: torch.Tensor.expand.1
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.to.1
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: cuda:0
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.getitem.2
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          stride: [12, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          stride: [12, 12, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+  - name: torch.float.3
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          stride: [12, 12, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks: fp32operation
+  - name: torch.matmul.1
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12]
+          stride: [12, 12, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks: fp32operation
+  - name: torch.transpose.1
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 12]
+          stride: [768, 12, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.cat.1
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 12, 64]
+            stride: [768, 1, 12]
+            storage_offset: 0
+            dtype: torch.float32
+            device: cuda:0
+            init: rand
+          - shape: [1, 12, 64]
+            stride: [768, 1, 12]
+            storage_offset: 0
+            dtype: torch.float32
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L131 in forward, code: emb = torch.cat((freqs,
+      freqs), dim=-1)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.1
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.mul.1
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 1.0
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.sin.1
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L133 in forward, code: sin = emb.sin()
+      * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.to.2
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L135 in forward, code: return
+      cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    marks: fp32operation
+    kwmap:
+      dtype: torch.bfloat16
+  - name: torch._C._log_api_usage_once.1
+    op: torch._C._log_api_usage_once
+    inputs:
+      - value: python.nn_module
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L421 in forward, code: for decoder_layer
+      in self.layers[: self.config.num_hidden_layers]:'
+    marks: constant
+  - name: torch.to.3
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: torch.float32
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L64 in forward, code: hidden_states
+      = hidden_states.to(torch.float32)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.pow.1
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.1
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: -1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.1
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 12, 1]
+          stride: [12, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 1.0e-05
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.1
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 12, 1]
+          stride: [12, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.2
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 1]
+          stride: [12, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.to.4
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: torch.bfloat16
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mul.3
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.1
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.1
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: (1, 12, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.2
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 12, 32, 128]
+          stride: [49152, 4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.linear.2
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.2
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 12, 1024]
+          stride: [12288, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: (1, 12, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.3
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 12, 8, 128]
+          stride: [12288, 1024, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.unsqueeze.1
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L164 in apply_rotary_pos_emb,
+      code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.mul.4
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+    marks: bf16operation
+  - name: torch.getitem.3
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.neg.1
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 64]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 64
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: bf16operation
+  - name: torch.cat.2
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 32, 12, 64]
+            stride: [24576, 64, 2048, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+          - shape: [1, 32, 12, 64]
+            stride: [49152, 128, 4096, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - bf16operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.5
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+    marks: bf16operation
+  - name: torch.add.2
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+    marks: bf16operation
+  - name: torch.mul.6
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+    marks: bf16operation
+  - name: torch.getitem.4
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.neg.2
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 64]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 64
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: bf16operation
+  - name: torch.cat.3
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 12, 64]
+            stride: [6144, 64, 512, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+          - shape: [1, 8, 12, 64]
+            stride: [12288, 128, 1024, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - bf16operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.7
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+    marks: bf16operation
+  - name: torch.add.3
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+    marks: bf16operation
+  - name: torch.zeros.1
+    op: torch.zeros
+    inputs:
+      - value: (1, 8, 2048, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L290 in lazy_initialization, code: self.keys =
+      torch.zeros('
+    marks: constant
+    kwmap:
+      dtype: torch.bfloat16
+      device: cuda:0
+  - name: torch.index_copy_.1
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [12]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 2048
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340 in update, code: self.keys.index_copy_(2,
+      cache_position, key_states)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.getitem.5
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24 in repeat_kv, code: hidden_states
+      = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.expand.2
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 2048, 128]
+          stride: [2097152, 262144, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 2048
+      - value: 128
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24 in repeat_kv, code: hidden_states
+      = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.reshape.1
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 2048, 128]
+          stride: [2097152, 262144, 0, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: (1, 32, 2048, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L25 in repeat_kv, code: return
+      hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92 in sdpa_attention_forward,
+      code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: bf16operation
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.08838834764831845
+      is_causal: false
+  - name: torch.transpose.4
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.contiguous.1
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 12, 32, 128]
+          stride: [49152, 128, 1536, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+    marks: bf16operation
+  - name: torch.reshape.2
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 12, 32, 128]
+          stride: [49152, 4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: (1, 12, -1)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.contiguous.2
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: bf16operation
+  - name: torch.add.4
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L330 in forward, code: hidden_states
+      = residual + hidden_states'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.3
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [14336, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.silu.1
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103 in forward, code: return nn.functional.silu(input)'
+    marks: bf16operation
+  - name: torch.mul.8
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.4
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 14336]
+          stride: [14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.getitem.6
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.linear.5
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 45056
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.embedding.2
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          stride: [1, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L395 in forward, code: inputs_embeds:
+      torch.Tensor = self.embed_tokens(input_ids)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.getitem.7
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          stride: [1, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.4
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+  - name: torch.float.5
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks: fp32operation
+  - name: torch.matmul.2
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks: fp32operation
+  - name: torch.transpose.5
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.cat.4
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1, 64]
+            stride: [64, 1, 1]
+            storage_offset: 0
+            dtype: torch.float32
+            device: cuda:0
+            init: rand
+          - shape: [1, 1, 64]
+            stride: [64, 1, 1]
+            storage_offset: 0
+            dtype: torch.float32
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L131 in forward, code: emb = torch.cat((freqs,
+      freqs), dim=-1)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.2
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.mul.9
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 1.0
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.sin.2
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L133 in forward, code: sin = emb.sin()
+      * self.attention_scaling'
+    marks: fp32operation
+  - name: torch.to.5
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L135 in forward, code: return
+      cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    marks: fp32operation
+    kwmap:
+      dtype: torch.bfloat16
+  - name: torch.to.6
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: torch.float32
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L64 in forward, code: hidden_states
+      = hidden_states.to(torch.float32)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.pow.2
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mean.2
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: -1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks:
+      - fp32operation
+      - constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.5
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: 1.0e-05
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.rsqrt.2
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.mul.10
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks: fp32operation
+  - name: torch.to.7
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float32
+          device: cuda:0
+          init: rand
+      - value: torch.bfloat16
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+    marks:
+      - fp32operation
+      - constant
+  - name: torch.mul.11
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.6
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.3
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.6
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          stride: [4096, 4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.linear.7
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.view.4
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          stride: [1024, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.transpose.7
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 8, 128]
+          stride: [1024, 1024, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.unsqueeze.2
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L164 in apply_rotary_pos_emb,
+      code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.mul.12
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+    marks: bf16operation
+  - name: torch.getitem.8
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.neg.3
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 64]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 64
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: bf16operation
+  - name: torch.cat.5
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 32, 1, 64]
+            stride: [2048, 64, 64, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+          - shape: [1, 32, 1, 64]
+            stride: [4096, 128, 4096, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - bf16operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.13
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+    marks: bf16operation
+  - name: torch.add.6
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+    marks: bf16operation
+  - name: torch.mul.14
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+    marks: bf16operation
+  - name: torch.getitem.9
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.neg.4
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 64]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 64
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: bf16operation
+  - name: torch.cat.6
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 1, 64]
+            stride: [512, 64, 64, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+          - shape: [1, 8, 1, 64]
+            stride: [1024, 128, 1024, 1]
+            storage_offset: 0
+            dtype: torch.bfloat16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks:
+      - bf16operation
+      - constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.15
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+    marks: bf16operation
+  - name: torch.add.7
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+    marks: bf16operation
+  - name: torch.index_copy_.2
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 2048
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340 in update, code: self.keys.index_copy_(2,
+      cache_position, key_states)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.index_copy_.3
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 2048
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L341 in update, code: self.values.index_copy_(2,
+      cache_position, value_states)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92 in sdpa_attention_forward,
+      code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    marks: bf16operation
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.08838834764831845
+      is_causal: false
+  - name: torch.transpose.8
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.contiguous.3
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+    marks: bf16operation
+  - name: torch.reshape.3
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: (1, 1, -1)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.Tensor.contiguous.4
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.8
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L291 in forward, code: attn_output
+      = self.o_proj(attn_output)'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.add.8
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L330 in forward, code: hidden_states
+      = residual + hidden_states'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.9
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [14336, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.silu.2
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103 in forward, code: return nn.functional.silu(input)'
+    marks: bf16operation
+  - name: torch.mul.16
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks: bf16operation
+  - name: torch.nn.functional.linear.10
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 14336]
+          stride: [14336, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.getitem.10
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks:
+      - bf16operation
+      - constant
+  - name: torch.nn.functional.linear.11
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.bfloat16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks:
+      - bf16operation
+      - constant

--- a/tests/resource/models/Meta-Llama-3.1-8B-Instruct_spyre.yaml
+++ b/tests/resource/models/Meta-Llama-3.1-8B-Instruct_spyre.yaml
@@ -1,0 +1,1895 @@
+model: Meta-Llama-3.1-8B-Instruct
+defaults:
+  dtype: fp16
+  seed: 123
+  atol: 0.005
+  rtol: 0.005
+cases:
+  - name: torch.nn.functional.embedding.1_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          stride: [12, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L395 in forward, code: inputs_embeds:
+      torch.Tensor = self.embed_tokens(input_ids)'
+    marks: constant
+  - name: torch.getitem.1_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [64]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (None, slice(None, None, None), None)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.float.1_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+  - name: torch.Tensor.expand.1_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: -1
+      - value: 1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.to.1_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: cuda:0
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L125 in forward, code: inv_freq_expanded
+      = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
+    marks: constant
+  - name: torch.getitem.2_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12]
+          stride: [12, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.2
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          stride: [12, 12, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+  - name: torch.float.3_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 12]
+          stride: [12, 12, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+  - name: torch.matmul.1_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12]
+          stride: [12, 12, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+  - name: torch.transpose.1_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 12]
+          stride: [768, 12, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks: constant
+  - name: torch.cat.1_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 12, 64]
+            stride: [768, 1, 12]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+          - shape: [1, 12, 64]
+            stride: [768, 1, 12]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L131 in forward, code: emb = torch.cat((freqs,
+      freqs), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.1_spyre
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+  - name: torch.mul.1_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1.0
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+    marks: constant
+  - name: torch.sin.1_spyre
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L133 in forward, code: sin = emb.sin()
+      * self.attention_scaling'
+  - name: torch.to.2_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L135 in forward, code: return
+      cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    kwmap:
+      dtype: torch.float16
+  - name: torch._C._log_api_usage_once.1_spyre
+    op: torch._C._log_api_usage_once
+    inputs:
+      - value: python.nn_module
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L421 in forward, code: for decoder_layer
+      in self.layers[: self.config.num_hidden_layers]:'
+    marks: constant
+  - name: torch.to.3_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: torch.float32
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L64 in forward, code: hidden_states
+      = hidden_states.to(torch.float32)'
+    marks: constant
+  - name: torch.pow.1_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+  - name: torch.mean.1_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: -1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.1_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 12, 1]
+          stride: [12, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1.0e-05
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.1_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 12, 1]
+          stride: [12, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.mul.2_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 1]
+          stride: [12, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.to.4_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: torch.bfloat16
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+    marks: constant
+  - name: torch.mul.3_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.1_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.Tensor.view.1_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: (1, 12, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.2_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 12, 32, 128]
+          stride: [49152, 4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.nn.functional.linear.2_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.Tensor.view.2_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 12, 1024]
+          stride: [12288, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: (1, 12, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.3_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 12, 8, 128]
+          stride: [12288, 1024, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.unsqueeze.1_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 12, 128]
+          stride: [1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L164 in apply_rotary_pos_emb,
+      code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.4_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+  - name: torch.getitem.3_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.1_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 64]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 64
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.2_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 32, 12, 64]
+            stride: [24576, 64, 2048, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+          - shape: [1, 32, 12, 64]
+            stride: [49152, 128, 4096, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.5_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+  - name: torch.add.2_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+  - name: torch.mul.6_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+  - name: torch.getitem.4_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.2_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 64]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 64
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.3_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 12, 64]
+            stride: [6144, 64, 512, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+          - shape: [1, 8, 12, 64]
+            stride: [12288, 128, 1024, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.7_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 12, 128]
+          stride: [1536, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+  - name: torch.add.3_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+  - name: torch.zeros.1_spyre
+    op: torch.zeros
+    inputs:
+      - value: (1, 8, 2048, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L290 in lazy_initialization, code: self.keys =
+      torch.zeros('
+    marks: constant
+    kwmap:
+      dtype: torch.float16
+      device: cuda:0
+  - name: torch.index_copy_.1_spyre
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [12]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 2048
+      - tensor:
+          shape: [1, 8, 12, 128]
+          stride: [12288, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340 in update, code: self.keys.index_copy_(2,
+      cache_position, key_states)'
+    marks: constant
+  - name: torch.getitem.5_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24 in repeat_kv, code: hidden_states
+      = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.Tensor.expand.2_spyre
+    op: torch.Tensor.expand
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 2048, 128]
+          stride: [2097152, 262144, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 8
+      - value: 4
+      - value: 2048
+      - value: 128
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24 in repeat_kv, code: hidden_states
+      = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.reshape.1_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 8, 4, 2048, 128]
+          stride: [2097152, 262144, 0, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: (1, 32, 2048, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L25 in repeat_kv, code: return
+      hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.1_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92 in sdpa_attention_forward,
+      code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.08838834764831845
+      is_causal: false
+  - name: torch.transpose.4_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 12, 128]
+          stride: [49152, 1536, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.1_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 12, 32, 128]
+          stride: [49152, 128, 1536, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+  - name: torch.reshape.2_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 12, 32, 128]
+          stride: [49152, 4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: (1, 12, -1)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.2_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.add.4_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L330 in forward, code: hidden_states
+      = residual + hidden_states'
+  - name: torch.nn.functional.linear.3_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [14336, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.silu.1_spyre
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.8_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+  - name: torch.nn.functional.linear.4_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 12, 14336]
+          stride: [172032, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 14336]
+          stride: [14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks: constant
+  - name: torch.getitem.6_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 12, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.nn.functional.linear.5_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [49152, 4096, 1]
+          storage_offset: 45056
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.nn.functional.embedding.2_spyre
+    op: torch.nn.functional.embedding
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          stride: [1, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+      - value: null
+      - value: 2.0
+      - value: false
+      - value: false
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L395 in forward, code: inputs_embeds:
+      torch.Tensor = self.embed_tokens(input_ids)'
+    marks: constant
+  - name: torch.getitem.7_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1]
+          stride: [1, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+      - py: (slice(None, None, None), None, slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+    marks: constant
+  - name: torch.float.4
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 1000
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L126 in forward, code: position_ids_expanded
+      = position_ids[:, None, :].float()'
+  - name: torch.float.5_spyre
+    op: torch.float
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+  - name: torch.matmul.2_spyre
+    op: torch.matmul
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+  - name: torch.transpose.5_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 64, 1]
+          stride: [64, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
+      (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
+    marks: constant
+  - name: torch.cat.4_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 1, 64]
+            stride: [64, 1, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+          - shape: [1, 1, 64]
+            stride: [64, 1, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L131 in forward, code: emb = torch.cat((freqs,
+      freqs), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.cos.2_spyre
+    op: torch.cos
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+  - name: torch.mul.9_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1.0
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L132 in forward, code: cos = emb.cos()
+      * self.attention_scaling'
+    marks: constant
+  - name: torch.sin.2_spyre
+    op: torch.sin
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L133 in forward, code: sin = emb.sin()
+      * self.attention_scaling'
+  - name: torch.to.5_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L135 in forward, code: return
+      cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+    kwmap:
+      dtype: torch.float16
+  - name: torch.to.6_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: torch.float32
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L64 in forward, code: hidden_states
+      = hidden_states.to(torch.float32)'
+    marks: constant
+  - name: torch.pow.2_spyre
+    op: torch.pow
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+  - name: torch.mean.2_spyre
+    op: torch.mean
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: -1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L65 in forward, code: variance
+      = hidden_states.pow(2).mean(-1, keepdim=True)'
+    marks: constant
+    kwmap:
+      keepdim: true
+  - name: torch.add.5_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1.0e-05
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+    marks: constant
+  - name: torch.rsqrt.2_spyre
+    op: torch.rsqrt
+    inputs:
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.mul.10_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1]
+          stride: [1, 1, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L66 in forward, code: hidden_states
+      = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
+  - name: torch.to.7_spyre
+    op: torch.to
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: torch.bfloat16
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+    marks: constant
+  - name: torch.mul.11_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [4096]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L67 in forward, code: return self.weight
+      * hidden_states.to(input_dtype)'
+  - name: torch.nn.functional.linear.6_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.Tensor.view.3_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.6_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          stride: [4096, 4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
+      = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.nn.functional.linear.7_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1024, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.Tensor.view.4_spyre
+    op: torch.Tensor.view
+    inputs:
+      - tensor:
+          shape: [1, 1, 1024]
+          stride: [1024, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: (1, 1, -1, 128)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.transpose.7_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 1, 8, 128]
+          stride: [1024, 1024, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
+      = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
+    marks: constant
+  - name: torch.unsqueeze.2_spyre
+    op: torch.unsqueeze
+    inputs:
+      - tensor:
+          shape: [1, 1, 128]
+          stride: [128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L164 in apply_rotary_pos_emb,
+      code: cos = cos.unsqueeze(unsqueeze_dim)'
+    marks: constant
+  - name: torch.mul.12_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+  - name: torch.getitem.8_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.3_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 64]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 64
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.5_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 32, 1, 64]
+            stride: [2048, 64, 64, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+          - shape: [1, 32, 1, 64]
+            stride: [4096, 128, 4096, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.13_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+  - name: torch.add.6_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L166 in apply_rotary_pos_emb,
+      code: q_embed = (q * cos) + (rotate_half(q) * sin)'
+  - name: torch.mul.14_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+  - name: torch.getitem.9_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (Ellipsis, slice(None, 64, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L140 in rotate_half, code: x1
+      = x[..., : x.shape[-1] // 2]'
+    marks: constant
+  - name: torch.neg.4_spyre
+    op: torch.neg
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 64]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 64
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+  - name: torch.cat.6_spyre
+    op: torch.cat
+    inputs:
+      - tensor_list:
+          - shape: [1, 8, 1, 64]
+            stride: [512, 64, 64, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+          - shape: [1, 8, 1, 64]
+            stride: [1024, 128, 1024, 1]
+            storage_offset: 0
+            dtype: torch.float16
+            device: cuda:0
+            init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L142 in rotate_half, code: return
+      torch.cat((-x2, x1), dim=-1)'
+    marks: constant
+    kwmap:
+      dim: -1
+  - name: torch.mul.15_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 1, 128]
+          stride: [128, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+  - name: torch.add.7_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L167 in apply_rotary_pos_emb,
+      code: k_embed = (k * cos) + (rotate_half(k) * sin)'
+  - name: torch.index_copy_.2_spyre
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 2048
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340 in update, code: self.keys.index_copy_(2,
+      cache_position, key_states)'
+    marks: constant
+  - name: torch.index_copy_.3_spyre
+    op: torch.index_copy_
+    inputs:
+      - tensor:
+          shape: [1, 8, 2048, 128]
+          stride: [2097152, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 2
+      - tensor:
+          shape: [1]
+          stride: [1]
+          storage_offset: 0
+          dtype: torch.int64
+          device: cuda:0
+          init: randint
+          init_args:
+            high: 2048
+      - tensor:
+          shape: [1, 8, 1, 128]
+          stride: [1024, 128, 1024, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L341 in update, code: self.values.index_copy_(2,
+      cache_position, value_states)'
+    marks: constant
+  - name: torch.nn.functional.scaled_dot_product_attention.2_spyre
+    op: torch.nn.functional.scaled_dot_product_attention
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 32, 2048, 128]
+          stride: [8388608, 262144, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92 in sdpa_attention_forward,
+      code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+    kwmap:
+      dropout_p: 0.0
+      scale: 0.08838834764831845
+      is_causal: false
+  - name: torch.transpose.8_spyre
+    op: torch.transpose
+    inputs:
+      - tensor:
+          shape: [1, 32, 1, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: 1
+      - value: 2
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.3_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
+      code: attn_output = attn_output.transpose(1, 2).contiguous()'
+  - name: torch.reshape.3_spyre
+    op: torch.reshape
+    inputs:
+      - tensor:
+          shape: [1, 1, 32, 128]
+          stride: [4096, 128, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: (1, 1, -1)
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+    marks: constant
+  - name: torch.Tensor.contiguous.4_spyre
+    op: torch.Tensor.contiguous
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L290 in forward, code: attn_output
+      = attn_output.reshape(*input_shape, -1).contiguous()'
+  - name: torch.nn.functional.linear.8_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 128, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L291 in forward, code: attn_output
+      = self.o_proj(attn_output)'
+    marks: constant
+  - name: torch.add.8_spyre
+    op: torch.add
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L330 in forward, code: hidden_states
+      = residual + hidden_states'
+  - name: torch.nn.functional.linear.9_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [14336, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks: constant
+  - name: torch.nn.functional.silu.2_spyre
+    op: torch.nn.functional.silu
+    inputs:
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103 in forward, code: return nn.functional.silu(input)'
+  - name: torch.mul.16_spyre
+    op: torch.mul
+    inputs:
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+  - name: torch.nn.functional.linear.10_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 14336]
+          stride: [14336, 14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [4096, 14336]
+          stride: [14336, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
+      = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
+    marks: constant
+  - name: torch.getitem.10_spyre
+    op: torch.getitem
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant
+  - name: torch.nn.functional.linear.11_spyre
+    op: torch.nn.functional.linear
+    inputs:
+      - tensor:
+          shape: [1, 1, 4096]
+          stride: [4096, 4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - tensor:
+          shape: [128256, 4096]
+          stride: [4096, 1]
+          storage_offset: 0
+          dtype: torch.float16
+          device: cuda:0
+          init: rand
+      - value: null
+    description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
+      = self.lm_head(hidden_states[:, slice_indices, :])'
+    marks: constant


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

Add yaml files of LLama-3.1-8B-Instruct for model-centric opFunc verification

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#808
#898

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
sample script

```
import os
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer, StaticCache

from ..utils.test_config_torchop import TorchOpCollector
import logging

# Suppress warnings/errors from symbolic_shapes and recording
logging.getLogger("torch.fx.experimental.symbolic_shapes").setLevel(logging.CRITICAL)
logging.getLogger("torch.fx.experimental.recording").setLevel(logging.CRITICAL)


def main():

  model_path = "meta-llama/Meta-Llama-3.1-8B-Instruct"
  prompt = "Where is the Thomas J. Watson Research Center located?"

  device = "cuda"
  model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto", dtype=torch.bfloat16)
  tokenizer = AutoTokenizer.from_pretrained(model_path)
  encoded_input = tokenizer(prompt, return_tensors='pt').to(device)

  past_key_values = StaticCache(config=model.config, max_cache_len=2048)

  torch.backends.cuda.enable_flash_sdp(False)
  torch.backends.cuda.enable_mem_efficient_sdp(False)
  torch.backends.cuda.enable_math_sdp(True)

  #torch._inductor.config.trace.enabled = True
  #torch._inductor.config.trace.debug_dir = None

  model.forward = torch.compile(model.forward)

  with TorchOpCollector(print_output=True, print_graph_module=True) as ctx:
  #with TorchOpCollector() as ctx:
    with torch.no_grad():
      output = model.generate(**encoded_input, past_key_values=past_key_values, use_cache=True)

  # print traced torch op
  for op in ctx.ops_list:
    print(op)

  # List of ops with generated test cases
  print(f"List of ops with test cases generated")
  for op in ctx.test_gen_ops:
    print(op, ctx.test_case_count[op])
  print(f"Total ops with test configs generated: {len(ctx.test_gen_ops)}")

  ctx.write_yaml(os.path.basename(model_path))

if __name__ == '__main__':
  main()
```

oplist
```
torch.Tensor.contiguous
torch.Tensor.expand
torch.Tensor.view
torch._C._log_api_usage_once
torch.add
torch.cat
torch.cos
torch.float
torch.getitem
torch.index_copy_
torch.matmul
torch.mean
torch.mul
torch.neg
torch.nn.functional.embedding
torch.nn.functional.linear
torch.nn.functional.scaled_dot_product_attention
torch.nn.functional.silu
torch.pow
torch.reshape
torch.rsqrt
torch.sin
torch.to
torch.transpose
torch.unsqueeze
torch.zeros
```

