### PR TITLE
[TESTING] fix: always clean up markers.json sidecar via EXIT trap regardless of --junit-xml

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -551,6 +551,14 @@ _cleanup_wrappers() {
         rm -f "$YAML_CONFIG"
         echo "[spyre_run] Removed merged temp config: $YAML_CONFIG"
     fi
+    # Remove marker sidecar JSON written by TorchTestBase.instantiate_test.
+    # Normally deleted by _XML_INJECT_PY after injection, but when --junit-xml
+    # is not supplied _XML_INJECT_PY never runs
+    local _sidecar="${YAML_CONFIG}.markers.json"
+    if [[ -f "$_sidecar" ]]; then
+        rm -f "$_sidecar"
+        echo "[spyre_run] Cleaned up marker sidecar: $_sidecar"
+    fi
 }
 trap _cleanup_wrappers EXIT
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When --junit-xml is not passed, _XML_INJECT_PY never runs and the .markers.json sidecar written by TorchTestBase.instantiate_test was left behind. Fixed by adding sidecar cleanup to _cleanup_wrappers, which always runs via the EXIT trap.

#### Does this PR introduce a user-facing change? 
No
