### PR TITLE
[TESTING GHA] Add JUnit XML reporting and artifact upload to upstream test workflow

### DIFF
--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -135,6 +135,7 @@ jobs:
           echo 'installing with dependencies, this could take a while...'
           pip install uv
           uv sync --all-extras --active --inexact --reinstall-package torch-spyre -v
+          echo "VENV_PATH=${GITHUB_WORKSPACE}/torch-spyre/.venv" >> "$GITHUB_ENV"
 
       - name: Run ${{ matrix.suite.name }} upstream test suite
         working-directory: torch-spyre/tests
@@ -143,6 +144,8 @@ jobs:
           # Example:
           #   test_suite_config.yaml    ->  test_suite_config.xml
           #   test_profiler_config.yaml ->  test_profiler_config.xml
+
+          source "${VENV_PATH}/bin/activate"
           CONFIG="${{ matrix.suite.config }}"
           REPORT_NAME="${CONFIG%.yaml}.xml"
           REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -4,8 +4,7 @@ on:
   # Run automatically on every merge to main
   push:
     branches: [main]
-  
-  pull_requests:
+  pull_request:
     branches: [main]
 
 concurrency:

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -4,6 +4,9 @@ on:
   # Run automatically on every merge to main
   push:
     branches: [main]
+  
+  pull_requests:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +30,9 @@ jobs:
     # To add a new upstream test suite, append an entry here:
     #   - name: <human-readable label shown in the GHA UI>
     #     config: <filename inside tests/configs/>
+    #
+    # The JUnit XML report is automatically named after the config file, e.g.:
+    #   test_suite_config.yaml  ->  test_suite_config.xml
     # ---------------------------------------------------------------------------
     strategy:
       fail-fast: false   # run all suites even if one fails
@@ -55,7 +61,7 @@ jobs:
         id: pytorch-branch
         working-directory: torch-spyre
         run: |
-          # Extract the version constraint, e.g. "2.10.0" from "torch~=2.10.0"
+          # Extract the version constraint, e.g. "2.10" from "torch~=2.10.0"
           VERSION=$(python3 - <<'PYEOF'
           import tomllib
 
@@ -71,6 +77,7 @@ jobs:
           BRANCH="release/${VERSION}"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "Derived PyTorch branch: $BRANCH"
+
       # ---------------------------------------------------------------------------
       # PyTorch source caching
       #
@@ -133,6 +140,37 @@ jobs:
       - name: Run ${{ matrix.suite.name }} upstream test suite
         working-directory: torch-spyre/tests
         run: |
-          echo 'Running ${{ matrix.suite.name }} upstream tests...'
-          bash run_test.sh configs/${{ matrix.suite.config }} -v
-          echo '${{ matrix.suite.name }} upstream tests done'
+          # Derive the XML report name from the config filename
+          # Example:
+          #   test_suite_config.yaml    ->  test_suite_config.xml
+          #   test_profiler_config.yaml ->  test_profiler_config.xml
+          CONFIG="${{ matrix.suite.config }}"
+          REPORT_NAME="${CONFIG%.yaml}.xml"
+          REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
+
+          echo "Running ${{ matrix.suite.name }} upstream tests..."
+          bash run_test.sh configs/${CONFIG} -v --junit-xml="${REPORT_PATH}"
+          echo "${{ matrix.suite.name }} upstream tests done"
+
+          # Expose report path/name to subsequent steps via GITHUB_ENV
+          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
+          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+
+      # ---------------------------------------------------------------------------
+      # Upload the JUnit XML as a GHA artifact so it can be downloaded and
+      # ingested by the Spyre dashboard.
+      #
+      # if: always() ensures the report is uploaded even when tests fail —
+      # a failed run is exactly when you most want the dashboard to show results.
+      #
+      # Artifact name matches the report filename so multiple matrix jobs don't
+      # overwrite each other (each config produces a distinct name).
+      # ---------------------------------------------------------------------------
+      - name: Upload JUnit XML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.REPORT_NAME }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: warn   # warn (not fail) if pytest itself crashed
+          retention-days: 90 # for now keep it for 90 days until we push to COS

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -4,8 +4,6 @@ on:
   # Run automatically on every merge to main
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Two additions to the `Run upstream test suite` step in `upstream_tests.yaml`:

**1. JUnit XML report generation**

Passes `--junit-xml` to `run_test.sh` so pytest generates a XML report. The report name is derived directly from the config filename:
```
test_suite_config.yaml    ->  test_suite_config.xml
test_profiler_config.yaml -> test_profiler_config.xml
```
Adding a new suite to the matrix automatically produces its own correctly named report.

**2. Artifact upload step**

Uploads the XML report as a GitHub Actions artifact after each run (`retention-days: 90`). 

Key details:
- `if: always()` --> uploads even when tests fail, since a failing run is when the report is most useful
- Each matrix job uploads under a distinct artifact name, so parallel suite runs don't overwrite each other
- `if-no-files-found: warn` --> degrades gracefully if pytest itself crashed before producing a report


The XML reports can be downloaded and ingested into the [Spyre dashboard](https://spyre-dashboard-spyre-cdev.apps.fmaas-backend.fmaas.res.ibm.com/) to track op/model coverage and pass rate trends across runs.

#### No functional change

Test execution is unchanged — `run_test.sh` receives the same arguments as before, plus the `--junit-xml` flag appended at the end.


#### Does this PR introduce a user-facing change?
No