### PR TITLE
feat: add example of new cpu only fx pass test

### DIFF
--- a/tests/inductor/example_passes.py
+++ b/tests/inductor/example_passes.py
@@ -1,0 +1,53 @@
+import torch
+
+import torch._inductor.config as config
+from torch_spyre._inductor.passes import CustomPostPasses
+
+from torch._inductor.exc import InductorError
+
+# to make this a subclass of InductorError, requires some more structure
+class SpyreInductorEarlyExit(Exception):
+    pass
+
+def exit_fn(args):
+    raise SpyreInductorEarlyExit("hello there")
+
+def target_fn(a, b):
+    return torch.matmul(a, b)
+
+def test_pass(graph: torch.fx.Graph) -> None:
+    print(list(graph.nodes))
+    for node in list(graph.nodes):
+        print("Op: ", node.op, " Target: ", node.target)
+        if node.op == "call_function" and node.target == torch.matmul:
+            print("Checking matmul args")
+
+            arg = node.args[0]
+            shape = arg.meta["example_value"].shape
+            # take the second dimension
+            assert shape[1] % 64 == 0, (
+                "Expected 2nd dimension of arg0 to have been padded"
+            )
+
+config.force_disable_caches = True
+torch.compiler.reset()
+torch._dynamo.config.suppress_errors = False 
+
+a = torch.empty((10, 2), device="spyre", dtype=torch.float16)
+b = torch.empty((2, 10), device="spyre", dtype=torch.float16)
+
+CustomPostPasses.passes.insert(1, test_pass)
+CustomPostPasses.passes.insert(2, exit_fn)
+
+# replace with an expect here
+try:
+    cmp = torch.compile(target_fn)
+    res = cmp(a, b)
+except InductorError as e:
+    print(type(e.inner_exception))
+    print("Finished test by skipping device operation")
+
+# remove the exit fn
+CustomPostPasses.passes.pop(2)
+# remove the test fn
+CustomPostPasses.passes.pop(1)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds a new category of unit tests for Inductor FX Graph based passes. Part of a broader group of proposal from @dushyantbehl and myself on Device less Unit tests for the Inductor components of torch-spyre.

This can be run using Flex's mock mode without a Spyre device using the following command:
```
FLEX_DEVICE=MOCK FLEX_COMPUTE=NULL FLEX_SKIP_COMPUTE=TRUE FLEX_MOCK_DEVICE_MEMORY_SIZE=5368709120 python tests/inductor/example_passes.py
```

#### Which issue(s) this PR is related to:

TODO (link to top level Epic on Unit tests)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
