### PR TITLE
[Feature-1314]  Added pre-commit and linter check for metadata.yaml

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -47,3 +47,17 @@ jobs:
 
       - name: Run pre-commit
         run: pre-commit run --all-files
+        
+  check-metadata-sorted:
+    name: Metadata.yaml alphabetical order
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check Metadata.yaml is sorted
+        run: python tools/check_metadata_sorted.py codegen/inputs/Metadata.yaml

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -47,17 +47,3 @@ jobs:
 
       - name: Run pre-commit
         run: pre-commit run --all-files
-        
-  check-metadata-sorted:
-    name: Metadata.yaml alphabetical order
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Check Metadata.yaml is sorted
-        run: python tools/check_metadata_sorted.py codegen/inputs/Metadata.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,14 +51,6 @@ repos:
         exclude: codegen/.*
   - repo: local
     hooks:
-    - id: check-metadata-sorted
-      name: Check Metadata.yaml operator_name entries are alphabetically sorted
-      language: python
-      entry: python tools/check_metadata_sorted.py
-      files: ^codegen/inputs/Metadata\.yaml$
-      pass_filenames: true
-  - repo: local
-    hooks:
       - id: forbid-pytest-ini
         name: Forbid pytest.ini (use pyproject.toml instead)
         language: fail
@@ -97,6 +89,13 @@ repos:
         language: python
         types: [python]
         pass_filenames: false
+        additional_dependencies: [regex]
+      - id: check-metadata-sorted
+        name: Check Metadata.yaml operator_name entries are alphabetically sorted
+        language: python
+        entry: python tools/check_metadata_sorted.py
+        files: ^codegen/inputs/Metadata\.yaml$
+        pass_filenames: true
         additional_dependencies: [regex]
       # Keep `suggestion` last
       - id: suggestion

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,14 @@ repos:
         exclude: codegen/.*
   - repo: local
     hooks:
+    - id: check-metadata-sorted
+      name: Check Metadata.yaml operator_name entries are alphabetically sorted
+      language: python
+      entry: python tools/check_metadata_sorted.py
+      files: ^codegen/inputs/Metadata\.yaml$
+      pass_filenames: true
+  - repo: local
+    hooks:
       - id: forbid-pytest-ini
         name: Forbid pytest.ini (use pyproject.toml instead)
         language: fail

--- a/codegen/inputs/Metadata.yaml
+++ b/codegen/inputs/Metadata.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- operator_name: _softmax
+  template_name: base
+  torch_prefix: torch.ops.aten
 - operator_name: abs
   template_name: base
 - operator_name: add
@@ -47,6 +50,8 @@
   template_name: base
 - operator_name: ge
   template_name: base
+- operator_name: gt
+  template_name: base
 - operator_name: linalg_vector_norm
   template_name: base
   torch_prefix: torch.linalg
@@ -57,8 +62,6 @@
 - operator_name: logical_not
   template_name: base
 - operator_name: lt
-  template_name: base
-- operator_name: gt
   template_name: base
 - operator_name: maximum
   template_name: base
@@ -79,9 +82,6 @@
 - operator_name: rsqrt
   template_name: base
 - operator_name: sigmoid
-  template_name: base
-  torch_prefix: torch.ops.aten
-- operator_name: _softmax
   template_name: base
   torch_prefix: torch.ops.aten
 - operator_name: sqrt

--- a/tools/check_metadata_sorted.py
+++ b/tools/check_metadata_sorted.py
@@ -1,0 +1,173 @@
+"""
+check_metadata_sorted.py
+------------------------
+Pre-commit linter that verifies codegen/inputs/Metadata.yaml lists all
+operator entries in strict alphabetical order by operator_name.
+
+Sorting rules
+-------------
+- Standard Python / ASCII lexicographic order on the operator_name string.
+- Underscore ('_') has ASCII value 95, which is less than any lowercase
+  letter (97–122), so names like _softmax sort BEFORE abs.
+- Comparison is case-insensitive to avoid surprises if upper-case names
+  are ever added (e.g. "Abs" and "abs" would be treated as equal).
+
+Exit codes
+----------
+0  All operator_name entries are in sorted order. No issues found.
+1  One or more entries are out of order. Violations are printed to stderr.
+
+Usage
+-----
+    # Run directly:
+    python tools/check_metadata_sorted.py
+
+    # Run against an explicit path (e.g. in CI or for testing):
+    python tools/check_metadata_sorted.py codegen/inputs/Metadata.yaml
+
+    # Run via pre-commit (path injected automatically by the framework):
+    #   see .pre-commit-config.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+import regex as re
+
+
+_DEFAULT_YAML = Path(__file__).parent.parent / "codegen" / "inputs" / "Metadata.yaml"
+
+
+def _parse_operator_names(path: Path) -> List[Tuple[int, str]]:
+    """
+    Return a list of (line_number, operator_name) for every *active*
+    (non-commented-out) ``- operator_name:`` entry in the YAML file.
+
+    We parse with a regex rather than a full YAML parser so that:
+    - The file does not need to be importable as a Python dependency.
+    - We preserve exact line numbers for error messages.
+    - We avoid any YAML-library version dependencies.
+
+    Only lines that match the pattern ``^- operator_name: <name>`` (with
+    optional leading whitespace) are collected.  Lines that start with one
+    or more ``#`` characters before the dash are explicitly skipped so that
+    commented-out operators (e.g. ``embedding``) do not affect the check.
+    """
+    pattern = re.compile(r"^-\s+operator_name:\s+(\S+)")
+    entries: List[Tuple[int, str]] = []
+
+    with path.open(encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            stripped = line.lstrip()
+            # Skip comment lines regardless of indentation.
+            if stripped.startswith("#"):
+                continue
+            m = pattern.match(line)
+            if m:
+                entries.append((lineno, m.group(1)))
+
+    return entries
+
+
+def _sort_key(name: str) -> str:
+    """
+    Case-insensitive sort key.
+    Preserving underscore-first ordering: '_' (ASCII 95) < 'a' (ASCII 97)
+    is already correct in Python's default string comparison, so we only
+    need to lower-case the name to make the check case-insensitive.
+    """
+    return name.lower()
+
+
+def check_sorted(path: Path) -> bool:
+    """
+    Check that all active operator_name entries in *path* are in sorted order.
+    Returns True if sorted, False if any violation is found.
+    """
+    entries = _parse_operator_names(path)
+
+    if not entries:
+        # File exists but contains no active operator entries — treat as OK
+        # so the check does not block an empty or comment-only file.
+        print(f"check_metadata_sorted: {path}: no active operator entries found.")
+        return True
+
+    violations: List[str] = []
+
+    for i in range(1, len(entries)):
+        prev_lineno, prev_name = entries[i - 1]
+        curr_lineno, curr_name = entries[i]
+
+        if _sort_key(curr_name) < _sort_key(prev_name):
+            violations.append(
+                f"  line {curr_lineno}: '{curr_name}' should come before "
+                f"'{prev_name}' (line {prev_lineno})"
+            )
+
+    if violations:
+        print(
+            f"check_metadata_sorted: {path}: operator_name entries are NOT "
+            f"in alphabetical order. Found {len(violations)} violation(s):",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(v, file=sys.stderr)
+        print(
+            "\nTo fix: re-order the entries in the file alphabetically by "
+            "operator_name.  Underscore-prefixed names (e.g. '_softmax') "
+            "sort before regular letters.",
+            file=sys.stderr,
+        )
+        return False
+
+    return True
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify that codegen/inputs/Metadata.yaml lists operator entries "
+            "in strict alphabetical order by operator_name."
+        )
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        metavar="FILE",
+        help=(
+            "Path(s) to Metadata.yaml file(s) to check. "
+            "When omitted, defaults to codegen/inputs/Metadata.yaml "
+            "relative to the repository root."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    # pre-commit passes the matched filenames as positional arguments.
+    # If none are given (direct invocation), fall back to the default path.
+    targets = [Path(f) for f in args.files] if args.files else [_DEFAULT_YAML]
+
+    all_ok = True
+    for target in targets:
+        if not target.exists():
+            print(
+                f"check_metadata_sorted: {target}: file not found.",
+                file=sys.stderr,
+            )
+            all_ok = False
+            continue
+        if not check_sorted(target):
+            all_ok = False
+
+    if all_ok:
+        # Quiet on success — consistent with standard linter conventions.
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Added the pre-commit check for  the alphabetical sorting metadat.yaml in .pre-commit-config.yaml
Added the job in the linter.yaml to check before merging or push to main
Added the Python script which will check metadata.yaml is sorted or not

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/1314


#### Does this PR introduce a user-facing change?
Its to enhance to ease of maintenance

#### Additional note:
If there is no metadata.yaml changes

```
torch-spyre) [prasannagn@prasannagn-spyre-dev-pf torch-spyre]$ git commit -m "1314 -  added pre-commit and linter for metadata.yaml"
ruff check................................................................................Passed
ruff format...............................................................................Passed
PyMarkdown............................................................(no files to check)Skipped
Lint GitHub Actions workflow files....................................(no files to check)Skipped
clang-format..........................................................(no files to check)Skipped
cpplint...............................................................(no files to check)Skipped
mypy......................................................................................Passed
Format YAML files.....................................................(no files to check)Skipped
Check Metadata.yaml operator_name entries are alphabetically sorted.......................Skipped
Forbid pytest.ini (use pyproject.toml instead)........................(no files to check)Skipped
Check requirements/dev.txt sync.......................................(no files to check)Skipped
Check for spaces in all filenames.........................................................Passed
```

scanned the metadata.yaml on commit
```
(torch-spyre) [prasannagn@prasannagn-spyre-dev-pf torch-spyre]$ git commit -m "1314 -  added pre-commit and linter for metadata.yaml"
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/prasannagn/.cache/pre-commit/patch1777466980-188561.
ruff check................................................................................Passed
ruff format...............................................................................Passed
PyMarkdown............................................................(no files to check)Skipped
Lint GitHub Actions workflow files....................................(no files to check)Skipped
clang-format..........................................................(no files to check)Skipped
cpplint...............................................................(no files to check)Skipped
mypy......................................................................................Passed
Format YAML files.....................................................(no files to check)Skipped
Check Metadata.yaml operator_name entries are alphabetically sorted.......................Failed
- hook id: check-metadata-sorted
- exit code: 1

check_metadata_sorted: codegen/inputs/Metadata.yaml: operator_name entries are NOT in alphabetical order. Found 3 violation(s):
  line 25: 'bmm' should come before 'cat' (line 23)
  line 61: 'gt' should come before 'lt' (line 59)
  line 84: '_softmax' should come before 'sigmoid' (line 81)

To fix: re-order the entries in the file alphabetically by operator_name.  Underscore-prefixed names (e.g. '_softmax') sort before regular letters.

Forbid pytest.ini (use pyproject.toml instead)........................(no files to check)Skipped
Check requirements/dev.txt sync.......................................(no files to check)Skipped
Check for spaces in all filenames.........................................................Passed
```

After fix:
```
torch-spyre) [prasannagn@prasannagn-spyre-dev-pf torch-spyre]$ git commit -m "1314 -  added pre-commit and linter for metadata.yaml"
ruff check................................................................................Passed
ruff format...............................................................................Passed
PyMarkdown............................................................(no files to check)Skipped
Lint GitHub Actions workflow files....................................(no files to check)Skipped
clang-format..........................................................(no files to check)Skipped
cpplint...............................................................(no files to check)Skipped
mypy......................................................................................Passed
Format YAML files.....................................................(no files to check)Skipped
Check Metadata.yaml operator_name entries are alphabetically sorted.......................Passed
Forbid pytest.ini (use pyproject.toml instead)........................(no files to check)Skipped
Check requirements/dev.txt sync.......................................(no files to check)Skipped
Check for spaces in all filenames.........................................................Passed
```