### PR TITLE
test: Improve matmul test stability with Xavier initialization

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -154,7 +154,8 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     ((55, 2), (2, 99)),
                     ((67, 67), (67, 67)),
                     ((67, 255), (255, 128)),
-                ]
+                ],
+                rand_type="xavier",
             ),
         },
         ("test_bmm", "test_mm_relaxed"): {
@@ -167,7 +168,8 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     # Padding
                     ((2, 55, 2), (2, 2, 99)),
                     ((2, 99, 65), (2, 65, 55)),
-                ]
+                ],
+                rand_type="xavier",
             ),
         },
         ("test_matmul", "test_binary_op_cpu"): {
@@ -195,7 +197,8 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     ((2, 99, 65), (2, 65, 55)),
                     ((2, 3, 55, 2), (2, 3, 2, 99)),
                     ((2, 3, 99, 65), (2, 3, 65, 55)),
-                ]
+                ],
+                rand_type="xavier",
             ),
         },
         ("test_large_matmul", "test_mm_relaxed"): {

--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -340,10 +340,18 @@ def unique_randn_along_dim(
 
 
 # init_helper initiates tensors given a list of shape tuples
-def init_helper(shapes, dtype=torch.float16, cached=True):
-    randn_func = cached_randn if cached else torch.randn
+def init_helper(shapes, dtype=torch.float16, cached=True, rand_type="randn"):
+    def uncached_xavier(shape, dtype):
+        return torch.nn.init.xavier_uniform_(torch.empty(shape, dtype=dtype))
+
+    cached_fn, uncached_fn = {
+        "randn": (cached_randn, torch.randn),
+        "xavier": (cached_xavier, uncached_xavier),
+    }[rand_type]
+    rand_fn = cached_fn if cached else uncached_fn
+
     return tuple(
-        randn_func(shape, differentiation=i, dtype=dtype)
+        rand_fn(shape, dtype=dtype, **({"differentiation": i} if cached else {}))
         for i, shape in enumerate(shapes)
     )
 
@@ -357,8 +365,10 @@ def shapes2key(shapes):
 
 
 # cases: Tuple of cases. Each case is defined by shapes of tensors
-def make_param_dict(cases):
-    return {shapes2key(shapes): init_helper(shapes) for shapes in cases}
+def make_param_dict(cases, rand_type="randn"):
+    return {
+        shapes2key(shapes): init_helper(shapes, rand_type=rand_type) for shapes in cases
+    }
 
 
 # ParameterizedTestMeta injects parameterized test methods


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Use Xavier uniform initialization instead of random normal initialization for matmul test inputs to improve numerical stability. Xavier initialization provides better-scaled initial values that are less sensitive to random seed variations, making the matmul tests more stable and reliable.

#### Which issue(s) this PR is related to:

This addresses the testing issue found in this PR:
- #1771 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

All matmul tests pass as before.

When new tests are introduced before the matmul tests, the existing matmul tests will not be affected by changes in input tensor values due to shifts in the random number sequence.

#### Additional note:

CC: @cyang49 @imaihal 