### PR TITLE
Added yaml files of granite-4.1-8b model  for model op-level test cases

### DIFF
--- a/tests/resource/models/granite-4.1-8b.yaml
+++ b/tests/resource/models/granite-4.1-8b.yaml
@@ -1,0 +1,2489 @@
+test_suite_config:
+  global:
+    supported_dtypes:
+    - name: float16
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: bfloat16
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: float32
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: int16
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: int32
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    input_config:
+      seed: 123
+  files:
+  - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
+    unlisted_test_mode: skip
+    tests:
+    - names:
+      - TestSpyreModelOps::test_model_ops_db
+      mode: mandatory_success
+      tags:
+      - granite-4.1-8b
+      edits:
+        ops:
+          include:
+          - test_name: torch.nn.functional.embedding.1_granite-4.1-8b
+            name: torch.nn.functional.embedding
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11]
+                  stride: [11, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 100256
+              - value: null
+              - value: 2.0
+              - value: false
+              - value: false
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L437
+              in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.1_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 12.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L439
+              in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+              main diff with Llama'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.1_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [64]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - py: (None, slice(None, None, None), None)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.float.1_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.Tensor.expand.1_granite-4.1-8b
+            name: torch.Tensor.expand
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: -1
+              - value: 1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.to.1_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: cpu
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.2_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11]
+                  stride: [11, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - py: (slice(None, None, None), None, slice(None, None, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.float.2_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 11]
+                  stride: [11, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.float.3_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 11]
+                  stride: [11, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.matmul.1_granite-4.1-8b
+            name: torch.matmul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11]
+                  stride: [11, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.transpose.1_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 11]
+                  stride: [704, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.cat.1_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 11, 64]
+                  stride: [704, 1, 11]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+                - shape: [1, 11, 64]
+                  stride: [704, 1, 11]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L379
+              in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.cos.1_granite-4.1-8b
+            name: torch.cos
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.mul.2_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 1.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.sin.1_granite-4.1-8b
+            name: torch.sin
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L381
+              in forward, code: sin = emb.sin() * self.attention_scaling'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.to.2_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L383
+              in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+            kwargs:
+              dtype: torch.bfloat16
+          - test_name: torch._C._log_api_usage_once.1_granite-4.1-8b
+            name: torch._C._log_api_usage_once
+            sample_inputs_func:
+              args:
+              - value: python.nn_module
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L469
+              in forward, code: for decoder_layer in self.layers[: self.config.num_hidden_layers]:'
+            tags:
+            - constant
+          - test_name: torch.to.3_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: torch.float32
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L200
+              in forward, code: hidden_states = hidden_states.to(torch.float32)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.pow.1_granite-4.1-8b
+            name: torch.pow
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mean.1_granite-4.1-8b
+            name: torch.mean
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: -1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              keepdim: true
+          - test_name: torch.add.1_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 1]
+                  stride: [11, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 1.0e-05
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.rsqrt.1_granite-4.1-8b
+            name: torch.rsqrt
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 1]
+                  stride: [11, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.mul.3_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 1]
+                  stride: [11, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.to.4_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: torch.bfloat16
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.4_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [4096]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.1_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.1_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: (1, 11, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.2_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 32, 128]
+                  stride: [45056, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.2_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1024, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.2_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 1024]
+                  stride: [11264, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: (1, 11, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.3_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 8, 128]
+                  stride: [11264, 1024, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.unsqueeze.1_granite-4.1-8b
+            name: torch.unsqueeze
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L73
+              in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.5_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.getitem.3_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.1_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 64]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 64
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.cat.2_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 32, 11, 64]
+                  stride: [22528, 64, 2048, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+                - shape: [1, 32, 11, 64]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.6_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.add.2_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.mul.7_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.getitem.4_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.2_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 64]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 64
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.cat.3_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 8, 11, 64]
+                  stride: [5632, 64, 512, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+                - shape: [1, 8, 11, 64]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.8_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.add.3_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.zeros.1_granite-4.1-8b
+            name: torch.zeros
+            sample_inputs_func:
+              args:
+              - value: (1, 8, 2048, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L290
+              in lazy_initialization, code: self.keys = torch.zeros('
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dtype: torch.bfloat16
+              device: cpu
+          - test_name: torch.index_copy_.1_granite-4.1-8b
+            name: torch.index_copy_
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 2
+              - tensor:
+                  shape: [11]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 2048
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340
+              in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.5_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - py: (slice(None, None, None), slice(None, None, None), None, slice(None,
+                  None, None), slice(None, None, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24
+              in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+              num_key_value_heads, n_rep, slen, head_dim)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.expand.2_granite-4.1-8b
+            name: torch.Tensor.expand
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 2048, 128]
+                  stride: [2097152, 262144, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 8
+              - value: 4
+              - value: 2048
+              - value: 128
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24
+              in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+              num_key_value_heads, n_rep, slen, head_dim)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.reshape.1_granite-4.1-8b
+            name: torch.reshape
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 4, 2048, 128]
+                  stride: [2097152, 262144, 0, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: (1, 32, 2048, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L25
+              in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+              * n_rep, slen, head_dim)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.scaled_dot_product_attention.1_granite-4.1-8b
+            name: torch.nn.functional.scaled_dot_product_attention
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92
+              in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+            tags:
+            - bf16operation
+            - tensorsoncpu
+            kwargs:
+              dropout_p: 0.0
+              scale: 0.0078125
+              is_causal: false
+          - test_name: torch.transpose.4_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.1_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 32, 128]
+                  stride: [45056, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.reshape.2_granite-4.1-8b
+            name: torch.reshape
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 32, 128]
+                  stride: [45056, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: (1, 11, -1)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.2_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.add.4_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L286
+              in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.3_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [12800, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.silu.1_granite-4.1-8b
+            name: torch.nn.functional.silu
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103
+              in forward, code: return nn.functional.silu(input)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.mul.9_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.4_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 12800]
+                  stride: [12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.6_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - py: (slice(None, None, None), slice(-1, None, None), slice(None, None,
+                  None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.5_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 40960
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.truediv.1_granite-4.1-8b
+            name: torch.truediv
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 100352]
+                  stride: [100352, 100352, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 16.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L576
+              in forward, code: logits = logits / self.config.logits_scaling  # main
+              diff with Llama'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.embedding.2_granite-4.1-8b
+            name: torch.nn.functional.embedding
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1]
+                  stride: [1, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 100256
+              - value: null
+              - value: 2.0
+              - value: false
+              - value: false
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L437
+              in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.10_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 12.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L439
+              in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+              main diff with Llama'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.7_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1]
+                  stride: [1, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - py: (slice(None, None, None), None, slice(None, None, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.float.4_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.float.5_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.matmul.2_granite-4.1-8b
+            name: torch.matmul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.transpose.5_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.cat.4_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 1, 64]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+                - shape: [1, 1, 64]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L379
+              in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.cos.2_granite-4.1-8b
+            name: torch.cos
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.mul.11_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 1.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.sin.2_granite-4.1-8b
+            name: torch.sin
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L381
+              in forward, code: sin = emb.sin() * self.attention_scaling'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.to.5_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L383
+              in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+            kwargs:
+              dtype: torch.bfloat16
+          - test_name: torch.to.6_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: torch.float32
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L200
+              in forward, code: hidden_states = hidden_states.to(torch.float32)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.pow.2_granite-4.1-8b
+            name: torch.pow
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mean.2_granite-4.1-8b
+            name: torch.mean
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: -1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              keepdim: true
+          - test_name: torch.add.5_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: 1.0e-05
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.rsqrt.2_granite-4.1-8b
+            name: torch.rsqrt
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.mul.12_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - fp32operation
+            - tensorsoncpu
+          - test_name: torch.to.7_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float32
+                  device: cpu
+                  init: rand
+              - value: torch.bfloat16
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - fp32operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.13_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [4096]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.6_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.3_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: (1, 1, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.6_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 32, 128]
+                  stride: [4096, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.7_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1024, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.4_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1024]
+                  stride: [1024, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: (1, 1, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.7_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 8, 128]
+                  stride: [1024, 1024, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.unsqueeze.2_granite-4.1-8b
+            name: torch.unsqueeze
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L73
+              in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.14_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.getitem.8_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.3_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 64]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 64
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.cat.5_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 32, 1, 64]
+                  stride: [2048, 64, 64, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+                - shape: [1, 32, 1, 64]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.15_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.add.6_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.mul.16_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.getitem.9_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.4_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 64]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 64
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.cat.6_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 8, 1, 64]
+                  stride: [512, 64, 64, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+                - shape: [1, 8, 1, 64]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.17_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.add.7_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.index_copy_.2_granite-4.1-8b
+            name: torch.index_copy_
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 2
+              - tensor:
+                  shape: [1]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 2048
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340
+              in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.index_copy_.3_granite-4.1-8b
+            name: torch.index_copy_
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 2
+              - tensor:
+                  shape: [1]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 2048
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L341
+              in update, code: self.values.index_copy_(2, cache_position, value_states)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.scaled_dot_product_attention.2_granite-4.1-8b
+            name: torch.nn.functional.scaled_dot_product_attention
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92
+              in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+            tags:
+            - bf16operation
+            - tensorsoncpu
+            kwargs:
+              dropout_p: 0.0
+              scale: 0.0078125
+              is_causal: false
+          - test_name: torch.transpose.8_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.3_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 32, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.reshape.3_granite-4.1-8b
+            name: torch.reshape
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 32, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: (1, 1, -1)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.4_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.8_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L184
+              in forward, code: attn_output = self.o_proj(attn_output)'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.add.8_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L286
+              in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.9_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [12800, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.silu.2_granite-4.1-8b
+            name: torch.nn.functional.silu
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103
+              in forward, code: return nn.functional.silu(input)'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.mul.18_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - bf16operation
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.10_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 12800]
+                  stride: [12800, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.10_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - py: (slice(None, None, None), slice(-1, None, None), slice(None, None,
+                  None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.11_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.bfloat16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - bf16operation
+            - constant
+            - tensorsoncpu

--- a/tests/resource/models/granite-4.1-8b_spyre.yaml
+++ b/tests/resource/models/granite-4.1-8b_spyre.yaml
@@ -1,0 +1,2379 @@
+test_suite_config:
+  global:
+    supported_dtypes:
+    - name: float16
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: bfloat16
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: float32
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: int16
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    - name: int32
+      precision:
+        atol: 0.005
+        rtol: 0.005
+    input_config:
+      seed: 123
+  files:
+  - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
+    unlisted_test_mode: skip
+    tests:
+    - names:
+      - TestSpyreModelOps::test_model_ops_db
+      mode: mandatory_success
+      tags:
+      - granite-4.1-8b
+      edits:
+        ops:
+          include:
+          - test_name: torch.nn.functional.embedding.1_spyre_granite-4.1-8b
+            name: torch.nn.functional.embedding
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11]
+                  stride: [11, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 100256
+              - value: null
+              - value: 2.0
+              - value: false
+              - value: false
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L437
+              in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.1_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 12.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L439
+              in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+              main diff with Llama'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.1_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [64]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (None, slice(None, None, None), None)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.float.1_spyre_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.Tensor.expand.1_spyre_granite-4.1-8b
+            name: torch.Tensor.expand
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: -1
+              - value: 1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.to.1_spyre_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: cpu
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L373
+              in forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0],
+              -1, 1).to(x.device)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.2_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11]
+                  stride: [11, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - py: (slice(None, None, None), None, slice(None, None, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.float.2_spyre_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 11]
+                  stride: [11, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.float.3_spyre_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 11]
+                  stride: [11, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.matmul.1_spyre_granite-4.1-8b
+            name: torch.matmul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11]
+                  stride: [11, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.transpose.1_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 11]
+                  stride: [704, 11, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.cat.1_spyre_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 11, 64]
+                  stride: [704, 1, 11]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+                - shape: [1, 11, 64]
+                  stride: [704, 1, 11]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L379
+              in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.cos.1_spyre_granite-4.1-8b
+            name: torch.cos
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.2_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.sin.1_spyre_granite-4.1-8b
+            name: torch.sin
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L381
+              in forward, code: sin = emb.sin() * self.attention_scaling'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.to.2_spyre_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L383
+              in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+            tags:
+            - tensorsoncpu
+            kwargs:
+              dtype: torch.float16
+          - test_name: torch._C._log_api_usage_once.1_spyre_granite-4.1-8b
+            name: torch._C._log_api_usage_once
+            sample_inputs_func:
+              args:
+              - value: python.nn_module
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L469
+              in forward, code: for decoder_layer in self.layers[: self.config.num_hidden_layers]:'
+            tags:
+            - constant
+          - test_name: torch.to.3_spyre_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: torch.float32
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L200
+              in forward, code: hidden_states = hidden_states.to(torch.float32)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.pow.1_spyre_granite-4.1-8b
+            name: torch.pow
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mean.1_spyre_granite-4.1-8b
+            name: torch.mean
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: -1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              keepdim: true
+          - test_name: torch.add.1_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 1]
+                  stride: [11, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1.0e-05
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.rsqrt.1_spyre_granite-4.1-8b
+            name: torch.rsqrt
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 1]
+                  stride: [11, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.3_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 1]
+                  stride: [11, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.to.4_spyre_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: torch.bfloat16
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.4_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [4096]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.1_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.1_spyre_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: (1, 11, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.2_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 32, 128]
+                  stride: [45056, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.2_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1024, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.2_spyre_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 1024]
+                  stride: [11264, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: (1, 11, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.3_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 8, 128]
+                  stride: [11264, 1024, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.unsqueeze.1_spyre_granite-4.1-8b
+            name: torch.unsqueeze
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 128]
+                  stride: [1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L73
+              in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.5_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.getitem.3_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.1_spyre_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 64]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 64
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.cat.2_spyre_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 32, 11, 64]
+                  stride: [22528, 64, 2048, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+                - shape: [1, 32, 11, 64]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.6_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.add.2_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.7_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.getitem.4_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.2_spyre_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 64]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 64
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.cat.3_spyre_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 8, 11, 64]
+                  stride: [5632, 64, 512, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+                - shape: [1, 8, 11, 64]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.8_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 11, 128]
+                  stride: [1408, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.add.3_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 1408, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.zeros.1_spyre_granite-4.1-8b
+            name: torch.zeros
+            sample_inputs_func:
+              args:
+              - value: (1, 8, 2048, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L290
+              in lazy_initialization, code: self.keys = torch.zeros('
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dtype: torch.float16
+              device: cpu
+          - test_name: torch.index_copy_.1_spyre_granite-4.1-8b
+            name: torch.index_copy_
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 2
+              - tensor:
+                  shape: [11]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 2048
+              - tensor:
+                  shape: [1, 8, 11, 128]
+                  stride: [11264, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340
+              in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.5_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (slice(None, None, None), slice(None, None, None), None, slice(None,
+                  None, None), slice(None, None, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24
+              in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+              num_key_value_heads, n_rep, slen, head_dim)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.expand.2_spyre_granite-4.1-8b
+            name: torch.Tensor.expand
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 2048, 128]
+                  stride: [2097152, 262144, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 8
+              - value: 4
+              - value: 2048
+              - value: 128
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24
+              in repeat_kv, code: hidden_states = hidden_states[:, :, None, :, :].expand(batch,
+              num_key_value_heads, n_rep, slen, head_dim)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.reshape.1_spyre_granite-4.1-8b
+            name: torch.reshape
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 4, 2048, 128]
+                  stride: [2097152, 262144, 0, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: (1, 32, 2048, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L25
+              in repeat_kv, code: return hidden_states.reshape(batch, num_key_value_heads
+              * n_rep, slen, head_dim)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.scaled_dot_product_attention.1_spyre_granite-4.1-8b
+            name: torch.nn.functional.scaled_dot_product_attention
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92
+              in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+            tags:
+            - tensorsoncpu
+            kwargs:
+              dropout_p: 0.0
+              scale: 0.0078125
+              is_causal: false
+          - test_name: torch.transpose.4_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 11, 128]
+                  stride: [45056, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.1_spyre_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 32, 128]
+                  stride: [45056, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.reshape.2_spyre_granite-4.1-8b
+            name: torch.reshape
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 32, 128]
+                  stride: [45056, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: (1, 11, -1)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.2_spyre_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.add.4_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L286
+              in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.3_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [12800, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.silu.1_spyre_granite-4.1-8b
+            name: torch.nn.functional.silu
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103
+              in forward, code: return nn.functional.silu(input)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.9_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.4_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 12800]
+                  stride: [140800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 12800]
+                  stride: [12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.6_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 11, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (slice(None, None, None), slice(-1, None, None), slice(None, None,
+                  None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.5_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [45056, 4096, 1]
+                  storage_offset: 40960
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.truediv.1_spyre_granite-4.1-8b
+            name: torch.truediv
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 100352]
+                  stride: [100352, 100352, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 16.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L576
+              in forward, code: logits = logits / self.config.logits_scaling  # main
+              diff with Llama'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.embedding.2_spyre_granite-4.1-8b
+            name: torch.nn.functional.embedding
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1]
+                  stride: [1, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 100256
+              - value: null
+              - value: 2.0
+              - value: false
+              - value: false
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L437
+              in forward, code: inputs_embeds = self.embed_tokens(input_ids)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.10_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 12.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L439
+              in forward, code: inputs_embeds = inputs_embeds * self.embedding_multiplier  #
+              main diff with Llama'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.7_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1]
+                  stride: [1, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+              - py: (slice(None, None, None), None, slice(None, None, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.float.4_spyre_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 1000
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L374
+              in forward, code: position_ids_expanded = position_ids[:, None, :].float()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.float.5_spyre_granite-4.1-8b
+            name: torch.float
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.matmul.2_spyre_granite-4.1-8b
+            name: torch.matmul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.transpose.5_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 64, 1]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378
+              in forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.cat.4_spyre_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 1, 64]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+                - shape: [1, 1, 64]
+                  stride: [64, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L379
+              in forward, code: emb = torch.cat((freqs, freqs), dim=-1)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.cos.2_spyre_granite-4.1-8b
+            name: torch.cos
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.11_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1.0
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L380
+              in forward, code: cos = emb.cos() * self.attention_scaling'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.sin.2_spyre_granite-4.1-8b
+            name: torch.sin
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L381
+              in forward, code: sin = emb.sin() * self.attention_scaling'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.to.5_spyre_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L383
+              in forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
+            tags:
+            - tensorsoncpu
+            kwargs:
+              dtype: torch.float16
+          - test_name: torch.to.6_spyre_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: torch.float32
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L200
+              in forward, code: hidden_states = hidden_states.to(torch.float32)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.pow.2_spyre_granite-4.1-8b
+            name: torch.pow
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mean.2_spyre_granite-4.1-8b
+            name: torch.mean
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: -1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L201
+              in forward, code: variance = hidden_states.pow(2).mean(-1, keepdim=True)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              keepdim: true
+          - test_name: torch.add.5_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1.0e-05
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.rsqrt.2_spyre_granite-4.1-8b
+            name: torch.rsqrt
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.12_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1]
+                  stride: [1, 1, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L202
+              in forward, code: hidden_states = hidden_states * torch.rsqrt(variance
+              + self.variance_epsilon)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.to.7_spyre_granite-4.1-8b
+            name: torch.to
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: torch.bfloat16
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.13_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [4096]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L203
+              in forward, code: return self.weight * hidden_states.to(input_dtype)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.6_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.3_spyre_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: (1, 1, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.6_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 32, 128]
+                  stride: [4096, 4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156
+              in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.7_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1024, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.view.4_spyre_granite-4.1-8b
+            name: torch.Tensor.view
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 1024]
+                  stride: [1024, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: (1, 1, -1, 128)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.transpose.7_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 8, 128]
+                  stride: [1024, 1024, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157
+              in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1,
+              2)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.unsqueeze.2_spyre_granite-4.1-8b
+            name: torch.unsqueeze
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 128]
+                  stride: [128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L73
+              in apply_rotary_pos_emb, code: cos = cos.unsqueeze(unsqueeze_dim)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.mul.14_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.getitem.8_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.3_spyre_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 64]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 64
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.cat.5_spyre_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 32, 1, 64]
+                  stride: [2048, 64, 64, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+                - shape: [1, 32, 1, 64]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.15_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.add.6_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L75
+              in apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.16_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.getitem.9_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (Ellipsis, slice(None, 64, None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L49
+              in rotate_half, code: x1 = x[..., : x.shape[-1] // 2]'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.neg.4_spyre_granite-4.1-8b
+            name: torch.neg
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 64]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 64
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.cat.6_spyre_granite-4.1-8b
+            name: torch.cat
+            sample_inputs_func:
+              args:
+              - tensor_list:
+                - shape: [1, 8, 1, 64]
+                  stride: [512, 64, 64, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+                - shape: [1, 8, 1, 64]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L51
+              in rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
+            tags:
+            - constant
+            - tensorsoncpu
+            kwargs:
+              dim: -1
+          - test_name: torch.mul.17_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 1, 128]
+                  stride: [128, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.add.7_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L76
+              in apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k)
+              * sin)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.index_copy_.2_spyre_granite-4.1-8b
+            name: torch.index_copy_
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 2
+              - tensor:
+                  shape: [1]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 2048
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340
+              in update, code: self.keys.index_copy_(2, cache_position, key_states)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.index_copy_.3_spyre_granite-4.1-8b
+            name: torch.index_copy_
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 8, 2048, 128]
+                  stride: [2097152, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 2
+              - tensor:
+                  shape: [1]
+                  stride: [1]
+                  storage_offset: 0
+                  dtype: torch.int64
+                  device: cpu
+                  init: randint
+                  init_args:
+                    high: 2048
+              - tensor:
+                  shape: [1, 8, 1, 128]
+                  stride: [1024, 128, 1024, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L341
+              in update, code: self.values.index_copy_(2, cache_position, value_states)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.scaled_dot_product_attention.2_spyre_granite-4.1-8b
+            name: torch.nn.functional.scaled_dot_product_attention
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 32, 2048, 128]
+                  stride: [8388608, 262144, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92
+              in sdpa_attention_forward, code: attn_output = torch.nn.functional.scaled_dot_product_attention('
+            tags:
+            - tensorsoncpu
+            kwargs:
+              dropout_p: 0.0
+              scale: 0.0078125
+              is_causal: false
+          - test_name: torch.transpose.8_spyre_granite-4.1-8b
+            name: torch.transpose
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 32, 1, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: 1
+              - value: 2
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.3_spyre_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 32, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102
+              in sdpa_attention_forward, code: attn_output = attn_output.transpose(1,
+              2).contiguous()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.reshape.3_spyre_granite-4.1-8b
+            name: torch.reshape
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 32, 128]
+                  stride: [4096, 128, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: (1, 1, -1)
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.Tensor.contiguous.4_spyre_granite-4.1-8b
+            name: torch.Tensor.contiguous
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L183
+              in forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.8_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 128, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L184
+              in forward, code: attn_output = self.o_proj(attn_output)'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.add.8_spyre_granite-4.1-8b
+            name: torch.add
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L286
+              in forward, code: hidden_states = residual + hidden_states * self.residual_multiplier'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.9_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [12800, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.silu.2_spyre_granite-4.1-8b
+            name: torch.nn.functional.silu
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103
+              in forward, code: return nn.functional.silu(input)'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.mul.18_spyre_granite-4.1-8b
+            name: torch.mul
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.10_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 12800]
+                  stride: [12800, 12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [4096, 12800]
+                  stride: [12800, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221
+              in forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x))
+              * self.up_proj(x))'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.getitem.10_spyre_granite-4.1-8b
+            name: torch.getitem
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - py: (slice(None, None, None), slice(-1, None, None), slice(None, None,
+                  None))
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - constant
+            - tensorsoncpu
+          - test_name: torch.nn.functional.linear.11_spyre_granite-4.1-8b
+            name: torch.nn.functional.linear
+            sample_inputs_func:
+              args:
+              - tensor:
+                  shape: [1, 1, 4096]
+                  stride: [4096, 4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - tensor:
+                  shape: [100352, 4096]
+                  stride: [4096, 1]
+                  storage_offset: 0
+                  dtype: torch.float16
+                  device: cpu
+                  init: rand
+              - value: null
+            description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575
+              in forward, code: logits = self.lm_head(hidden_states[:, slice_indices,
+              :])'
+            tags:
+            - constant
+            - tensorsoncpu


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:
Added yaml files of granite-4.1-8b model  for model op-level test cases

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/699
https://github.com/torch-spyre/torch-spyre/pull/808

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

**Reproducible code**

```
import os
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer, StaticCache

from ..utils.test_config_torchop import TorchOpCollector
import logging

# Suppress warnings/errors from symbolic_shapes and recording
logging.getLogger("torch.fx.experimental.symbolic_shapes").setLevel(logging.CRITICAL)
logging.getLogger("torch.fx.experimental.recording").setLevel(logging.CRITICAL)


def main():

  model_path = "ibm-granite/granite-4.1-8b"
  prompt = "Where is the Thomas J. Watson Research Center located?"

  device = "cpu"
  model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto", dtype=torch.bfloat16)
  tokenizer = AutoTokenizer.from_pretrained(model_path)
  encoded_input = tokenizer(prompt, return_tensors='pt').to(device)

  past_key_values = StaticCache(config=model.config, max_cache_len=2048)

  torch.backends.cuda.enable_flash_sdp(False)
  torch.backends.cuda.enable_mem_efficient_sdp(False)
  torch.backends.cuda.enable_math_sdp(True)

  #torch._inductor.config.trace.enabled = True
  #torch._inductor.config.trace.debug_dir = None

  model.forward = torch.compile(model.forward)

  with TorchOpCollector(print_output=True, print_graph_module=True) as ctx:
  #with TorchOpCollector() as ctx:
    with torch.no_grad():
      output = model.generate(**encoded_input, past_key_values=past_key_values, use_cache=True)

  # print traced torch op
  for op in ctx.ops_list:
    print(op)

  # List of ops with generated test cases
  print(f"List of ops with test cases generated")
  for op in ctx.test_gen_ops:
    print(op, ctx.test_case_count[op])
  print(f"Total ops with test configs generated: {len(ctx.test_gen_ops)}")

  ctx.write_yaml(os.path.basename(model_path))

if __name__ == '__main__':
  main()
```

**op list**

```
torch.Tensor.contiguous
torch.Tensor.expand
torch.Tensor.view
torch._C._log_api_usage_once
torch.add
torch.cat
torch.cos
torch.float
torch.getitem
torch.index_copy_
torch.matmul
torch.mean
torch.mul
torch.neg
torch.nn.functional.embedding
torch.nn.functional.linear
torch.nn.functional.scaled_dot_product_attention
torch.nn.functional.silu
torch.pow
torch.reshape
torch.rsqrt
torch.sin
torch.to
torch.transpose
torch.truediv
torch.unsqueeze
torch.zeros
```