### PR TITLE
Fix scalar torch.ones decomposition for zero-dimensional tensors

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -237,7 +237,6 @@ class TestSpyre(TestCase):
                 check_dtype=False,
             )
 
-    # ISSUE: https://github.com/torch-spyre/torch-spyre/issues/1187
     @parametrize(
         "factory_name",
         [

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -325,8 +325,7 @@ def ones_decomp(
     assert layout in (torch.strided, None), f"doesn't support layout={layout}"
     assert not pin_memory, f"doesn't support pin_memory={pin_memory}"
     scalar = torch.ops.spyre.ones_scalar(device, dtype=dtype)
-    expanded = scalar.expand(size)
-    return expanded.clone()
+    return scalar.reshape(()) if not size else scalar.expand(size).clone()
 
 
 @register_spyre_decomposition([torch.ops.aten.new_ones.default])
@@ -344,8 +343,7 @@ def new_ones_decomp(
     dev = device if device is not None else self.device
     dt = dtype if dtype is not None else self.dtype
     scalar = torch.ops.spyre.ones_scalar(dev, dtype=dt)
-    expanded = scalar.expand(size)
-    return expanded.clone()
+    return scalar.reshape(()) if not size else scalar.expand(size).clone()
 
 
 # To avoid constant folding, we introduce a custom op `spyre::full` that runs


### PR DESCRIPTION
Fix scalar torch.ones failure for zero-dimensional tensors

Avoid calling expand() for empty shape in ones decomposition. Return scalar tensor directly to match CPU behavior.

Fixes :- https://github.com/torch-spyre/torch-spyre/issues/1187

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:


Fixes a failure in torch.ones when called with a zero-dimensional (scalar) shape on the spyre device.

Previously, the decomposition logic always attempted to call expand(size).
For scalar inputs (size=()), this resulted in:
`RuntimeError: expand: the requested shape has too few dimensions!`

This PR updates the decomposition to:

- Detect scalar (empty shape) inputs
- Skip the expand() call
- Return a scalar tensor directly

This ensures behavior is consistent with CPU:
`torch.ones(()) -> tensor(1.)`

#### Which issue(s) this PR is related to:

Fixes #1187

#### Special notes for your reviewer:

- Change is minimal and localized to ones_decomp
- No impact on non-scalar tensor paths
- Aligns with existing PyTorch behavior for zero-dimensional tensors
- Tested with:
```
>>> import torch
>>> a = torch.ones((), device="spyre", dtype=torch.float16)
>>> a
tensor(1., dtype=torch.float16, device='spyre:0')
>>> a.shape
torch.Size([])
>>> a.device
device(type='spyre', index=0)
>>> a.dtype
torch.float16
```

#### Does this PR introduce a user-facing change?

#### Additional note:
