### PR TITLE
core_division: prefer Split-K for small-M matmul shapes

### DIFF
--- a/tests/inductor/test_k_fast_planner.py
+++ b/tests/inductor/test_k_fast_planner.py
@@ -1,0 +1,258 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hardware-free unit tests for the k_fast planner override.
+
+Exercises core_division._try_k_fast_split() directly with synthetic
+iteration spaces and a stub output TensorDep. No torch.compile, no
+Spyre device required.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import sympy
+from sympy import Integer
+
+from torch_spyre._inductor import config
+from torch_spyre._inductor.core_division import _try_k_fast_split
+
+
+def _stub_output_td(m_sym, n_sym, elems_per_stick=64):
+    """Build a minimal output_td whose device_coords reference only M and N
+    (matmul output is (M, N)). The reduction dim is whatever else is in the
+    iteration space — typically K.
+
+    elems_per_stick=64 is the fp16 default.
+    """
+    ns = SimpleNamespace()
+    ns.device_coords = [m_sym, n_sym]  # output dims; K not in here
+    ns.layout = SimpleNamespace(
+        device_layout=SimpleNamespace(
+            device_dtype=SimpleNamespace(
+                elems_per_stick=lambda: elems_per_stick,
+            )
+        )
+    )
+    return ns
+
+
+def _it_space(M, N, K):
+    """Build an iteration_space dict with three matmul-style symbols
+    in canonical [M, N, K] order."""
+    m_sym = sympy.Symbol("m")
+    n_sym = sympy.Symbol("n")
+    k_sym = sympy.Symbol("k")
+    return (
+        {m_sym: Integer(M), n_sym: Integer(N), k_sym: Integer(K)},
+        m_sym,
+        n_sym,
+        k_sym,
+    )
+
+
+def _pure_m_split(m_sym, n_sym, k_sym, ncores=32):
+    return {m_sym: ncores, n_sym: 1, k_sym: 1}
+
+
+class TestKFastPlannerOverride(unittest.TestCase):
+    def setUp(self):
+        self._saved_flag = config.core_id_k_fast_emission
+        config.core_id_k_fast_emission = True
+
+    def tearDown(self):
+        config.core_id_k_fast_emission = self._saved_flag
+
+    # ------- positive cases (heuristic should fire) --------------------
+
+    def test_l3_70b_kv_proj_M128(self):
+        """L3-70B kv_proj at M=128: N=1024 (16 sticks), K=8192 (128 sticks).
+        Should propose (1, 16, 2)."""
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result[m], 1)
+        self.assertEqual(result[n], 16)
+        self.assertEqual(result[k], 2)
+
+    def test_dsv3_o_proj_M128(self):
+        """DSv3 o_proj at M=128: N=7168 (112 sticks), K=16384 (256 sticks).
+        n_sticks=112 ≥ 32 → pure-N IS valid. Heuristic should NOT fire even
+        though we measured this combo as a big win — pure-N is the right
+        target for a different planner change. Heuristic returns None here."""
+        it_space, m, n, k = _it_space(128, 7168, 16384)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_phi3_medium_kv_proj_M128(self):
+        """Phi-3 medium kv_proj: N=1280 (20 sticks), K=5120 (80 sticks).
+        n_sticks=20 doesn't divide 32 cleanly for n=16 (20%16!=0); should
+        pick n=4, k=8."""
+        it_space, m, n, k = _it_space(128, 1280, 5120)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result[m], 1)
+        self.assertEqual(result[n], 4)
+        self.assertEqual(result[k], 8)
+
+    def test_qa_proj_M128(self):
+        """DSv3 q_a_proj: N=1536 (24 sticks), K=7168 (112 sticks).
+        24 % 16 != 0 → fall through to n=8, k=4."""
+        it_space, m, n, k = _it_space(128, 1536, 7168)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result[n], 8)
+        self.assertEqual(result[k], 4)
+
+    # ------- negative cases (heuristic must skip) ----------------------
+
+    def test_M_too_large(self):
+        """M=2048 is outside the empirical band; planner is right."""
+        it_space, m, n, k = _it_space(2048, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_M_too_small(self):
+        """M=8 is below the empirical band; per-core compute too small."""
+        it_space, m, n, k = _it_space(8, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_N_too_wide(self):
+        """N=4096 (64 sticks) ≥ 32 → pure-N already valid; heuristic falls
+        through to default planner."""
+        it_space, m, n, k = _it_space(128, 4096, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_K_too_narrow(self):
+        """K=1024 (16 sticks) < 32 → PSUM cost dominates, no benefit."""
+        it_space, m, n, k = _it_space(128, 1024, 1024)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_planner_already_picked_k_split(self):
+        """If the planner already split K, don't override — respect its choice."""
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        existing = {m: 4, n: 1, k: 8}  # planner picked (4, 1, 8)
+        result = _try_k_fast_split(existing, it_space, out_td, None, max_cores=32)
+        self.assertIsNone(result)
+
+    def test_min_splits_constraint_on_k(self):
+        """If hardware-driven min_splits constrains K, don't override."""
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, {k: 4}, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_min_splits_constraint_on_m(self):
+        """If hardware-driven min_splits constrains M, don't override."""
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, {m: 4}, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_max_cores_not_32(self):
+        """Empirical band was characterized at SENCORES=32; don't fire elsewhere."""
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k, ncores=16), it_space, out_td, None, max_cores=16
+        )
+        self.assertIsNone(result)
+
+    def test_iteration_space_not_3d(self):
+        """Pointwise / 4D bmm / etc. — heuristic is matmul-(mm)-only for now."""
+        a, b, c, d = (sympy.Symbol(s) for s in "abcd")
+        it_space = {a: Integer(2), b: Integer(128), c: Integer(1024), d: Integer(8192)}
+        out_td = SimpleNamespace(
+            device_coords=[a, b, c],
+            layout=SimpleNamespace(
+                device_layout=SimpleNamespace(
+                    device_dtype=SimpleNamespace(elems_per_stick=lambda: 64)
+                )
+            ),
+        )
+        result = _try_k_fast_split(
+            {a: 1, b: 32, c: 1, d: 1}, it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    def test_flag_off_returns_none(self):
+        """Disabling the feature flag short-circuits the override."""
+        config.core_id_k_fast_emission = False
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNone(result)
+
+    # ------- validity properties --------------------------------------
+
+    def test_returned_split_product_equals_max_cores(self):
+        """For any returned split, n × k must equal max_cores (SENCORES=32)."""
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertIsNotNone(result)
+        product = result[m] * result[n] * result[k]
+        self.assertEqual(product, 32)
+
+    def test_largest_n_chosen_minimizes_k(self):
+        """The heuristic should pick the largest valid n so chain length k
+        is smallest. For N=1024 (16 sticks), we want n=16 (k=2), not
+        n=8 (k=4) or n=4 (k=8)."""
+        it_space, m, n, k = _it_space(128, 1024, 8192)
+        out_td = _stub_output_td(m, n)
+        result = _try_k_fast_split(
+            _pure_m_split(m, n, k), it_space, out_td, None, max_cores=32
+        )
+        self.assertEqual(result[n], 16)
+        self.assertEqual(result[k], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -23,4 +23,11 @@ dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))
 
+# Pack K-collaborators on adjacent ring cores: planner picks K-split for
+# narrow-N small-M matmul shapes; SDSC emitter permutes core IDs to
+# minimise PSUM chain hops. Set "0" to disable both layers.
+core_id_k_fast_emission: bool = (
+    os.environ.get("SPYRE_CORE_ID_K_FAST_EMISSION", "1") == "1"
+)
+
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/core_division.py
+++ b/torch_spyre/_inductor/core_division.py
@@ -569,6 +569,85 @@ def divide_pointwise_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores)
     warn_if_per_core_overflow(input_tds + [output_td], it_space, splits, op.get_name())
 
 
+def _try_k_fast_split(
+    current_splits: dict[Symbol, int],
+    it_space: dict[Symbol, Expr],
+    output_td: TensorDep,
+    min_splits: dict[Symbol, int] | None,
+    max_cores: int,
+) -> dict[Symbol, int] | None:
+    """Propose (1, n, k>1) split for narrow-N small-M matmul shapes.
+
+    Returns None to defer to the default planner. Conditions to fire:
+      - feature flag on, max_cores == 32
+      - 3D iteration space (matmul mm)
+      - planner did not already choose a K-split
+      - M in [32, 512]
+      - N stick-count < 32, K stick-count >= 32
+      - no min_splits constraint on M or K
+
+    Picks the largest valid n so k = max_cores/n is minimised (shorter
+    PSUM chain on the SFP ring under the k_fast core-id permutation).
+    """
+    if not config.core_id_k_fast_emission:
+        return None
+    if max_cores != 32:
+        return None
+    if len(it_space) != 3:
+        return None
+
+    dims = list(it_space.keys())
+    output_coord_vars = {v for e in output_td.device_coords for v in e.free_symbols}
+    reduction_dims = [d for d in dims if d not in output_coord_vars]
+    output_dims = [d for d in dims if d in output_coord_vars]
+    if len(reduction_dims) != 1 or len(output_dims) != 2:
+        return None
+    k_dim = reduction_dims[0]
+    m_dim, n_dim = output_dims
+
+    # Don't override planner picks that already include K-split.
+    if current_splits.get(k_dim, 1) > 1:
+        return None
+
+    M = concretize_expr(it_space[m_dim])
+    N = concretize_expr(it_space[n_dim])
+    K = concretize_expr(it_space[k_dim])
+
+    # Use the output tensor's stick width as the dtype reference. For matmul
+    # the output is the reduction result, so its dtype matches the matmul
+    # accumulation dtype (typically fp16 with 64 elems/stick).
+    elems_per_stick = output_td.layout.device_layout.device_dtype.elems_per_stick()
+    n_sticks = N // elems_per_stick
+    k_sticks = K // elems_per_stick
+
+    # Empirical win-band: M and stick-count thresholds derived from cross-model
+    # measurements of pure-M vs (1, n, k>1) + k_fast.
+    if M < 32 or M > 512:
+        return None
+    if n_sticks >= 32:  # pure-N (1, max_cores, 1) already valid; planner's choice
+        return None
+    if k_sticks < 32:  # K too narrow; PSUM cost dominates the saving
+        return None
+
+    # Hardware-driven min_splits constraints take precedence: never override
+    # them. We only override pure-M / non-K-split planner picks where M and K
+    # are unconstrained.
+    if min_splits and (m_dim in min_splits or k_dim in min_splits):
+        return None
+
+    # Pick the largest valid n. n must divide both n_sticks and max_cores;
+    # k = max_cores / n must divide k_sticks.
+    for n in (16, 8, 4, 2):
+        if max_cores % n != 0 or n_sticks % n != 0:
+            continue
+        k = max_cores // n
+        if k_sticks < k or k_sticks % k != 0:
+            continue
+        return {m_dim: 1, n_dim: n, k_dim: k}
+
+    return None
+
+
 def divide_reduction_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores):
     red: Reduction = op.data
     is_matmul = red.reduction_type == BATCH_MATMUL_OP
@@ -588,6 +667,15 @@ def divide_reduction_op(op: ComputedBuffer, args: list[SchedNodeArg], max_cores)
             max_cores,
             exclude_reduction=not is_matmul,
         )
+        if is_matmul:
+            forced = _try_k_fast_split(
+                splits, it_space, output_td, min_splits, max_cores
+            )
+            if forced is not None:
+                logger.debug(
+                    f"k_fast override for {op.get_name()}: {splits} -> {forced}"
+                )
+                splits = forced
         apply_splits(
             op,
             splits,


### PR DESCRIPTION
Adds a planner override that picks (1, n, k>1) over pure-M when:

  - 3D iteration space (matmul mm)
  - planner did not already choose a K-split
  - M in [32, 512]
  - N stick-count < 32, K stick-count >= 32
  - no min_splits constraint on M or K
  - SENCORES == 32

Largest valid n is chosen so k = num_cores/n is minimised. Falls through to the existing planner outside the band.

Pure-M splits M elements across 32 cores, leaving the PT array under-utilised at small M. K-split keeps full M per core and pays PSUM cost, which the k_fast core-id emission permutation in compute_ops minimises.

Two-PR sequence
---------------

Both PRs share the SPYRE_CORE_ID_K_FAST_EMISSION flag (default on):

- Companion PR (compute_ops): k_fast core-id permutation.

- This PR (core_division): planner override that activates the companion permutation. *Without* the companion permutation, the (1, n, k>1) splits this PR forces would run slower than the planner's pure-M default (PSUM chains traverse m*n ring hops instead of 1).

Tests: 16 hardware-free unit tests for the decision rule.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/1931

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
