### PR TITLE
Make SpyreTensorLayout hashable in C++ and Python

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -116,12 +116,29 @@ class TestSpyreTensorLayout(TestCase):
         self.assertEqual(stl.device_size, [4, 512, 64])
         self.assertEqual(stl.stride_map, [64, 256, 1])
 
-    def test_equality(self):
+    def test_equality_and_hashable(self):
         x = SpyreTensorLayout([512, 256], torch.float16)
         y = SpyreTensorLayout([512, 256], [256, 1], torch.float16, [0, 1])
         z = SpyreTensorLayout([512, 256], [256, 1], torch.float16, [1, 0])
+        z2 = SpyreTensorLayout([512, 256], torch.float32)
+
         self.assertEqual(x, y)
         self.assertNotEqual(y, z)
+
+        # equal layouts must have equal hashes
+        self.assertEqual(hash(x), hash(y))
+
+        # different layouts should have different hashes
+        self.assertNotEqual(hash(x), hash(z))
+        self.assertNotEqual(hash(x), hash(z2))
+
+        # usable as dict key
+        d = {x: "value"}
+        self.assertEqual(d[y], "value")
+
+        # usable in a set
+        s = {x, y, z}
+        self.assertEqual(len(s), 2)
 
     def test_stl_pickleable(self):
         stl = SpyreTensorLayout([512, 256], [256, 1], torch.float16, [1, 0])

--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -122,14 +122,15 @@ class TestSpyreTensorLayout(TestCase):
         z = SpyreTensorLayout([512, 256], [256, 1], torch.float16, [1, 0])
         z2 = SpyreTensorLayout([512, 256], torch.float32)
 
-        self.assertEqual(x, y)
-        self.assertNotEqual(y, z)
+        self.assertEqual(hash(x), hash(x))
 
-        # equal layouts must have equal hashes
+        self.assertEqual(x, y)
         self.assertEqual(hash(x), hash(y))
 
-        # different layouts should have different hashes
-        self.assertNotEqual(hash(x), hash(z))
+        self.assertNotEqual(y, z)
+        self.assertNotEqual(hash(y), hash(z))
+
+        self.assertNotEqual(x, z2)
         self.assertNotEqual(hash(x), hash(z2))
 
         # usable as dict key

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -169,6 +169,10 @@ PYBIND11_MODULE(_C, m) {
            [](const spyre::SpyreTensorLayout& c) { return c.toString(); })
       .def("elems_per_stick", &spyre::SpyreTensorLayout::elems_per_stick)
       .def(py::self == py::self)
+      .def("__hash__",
+           [](const spyre::SpyreTensorLayout& c) {
+             return std::hash<spyre::SpyreTensorLayout>{}(c);
+           })
       .def(py::init<std::vector<int64_t>, c10::ScalarType>(),
            py::arg("host_size"), py::arg("dtype"))
       .def(py::init<std::vector<int64_t>, std::vector<int64_t>, c10::ScalarType,

--- a/torch_spyre/csrc/spyre_tensor_impl.h
+++ b/torch_spyre/csrc/spyre_tensor_impl.h
@@ -20,6 +20,7 @@
 #include <c10/util/intrusive_ptr.h>
 #include <util/sendefs.h>
 
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -151,3 +152,20 @@ void set_spyre_tensor_layout(const at::Tensor& tensor,
                              const SpyreTensorLayout& stl);
 
 }  // namespace spyre
+
+// Must be in namespace std so std::unordered_map/set find it automatically.
+namespace std {
+template <>
+struct hash<spyre::SpyreTensorLayout> {
+  size_t operator()(const spyre::SpyreTensorLayout& layout) const noexcept {
+    size_t seed = 0;
+    for (int64_t v : layout.device_size)
+      seed = c10::hash_combine(seed, std::hash<int64_t>{}(v));
+    for (int64_t v : layout.stride_map)
+      seed = c10::hash_combine(seed, std::hash<int64_t>{}(v));
+    seed = c10::hash_combine(
+        seed, std::hash<size_t>{}(static_cast<size_t>(layout.device_dtype)));
+    return seed;
+  }
+};
+}  // namespace std


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

We'd like to be able to use STL as a key, but the current SpyreTensorLayout class has no hash function.  
This PR adds a hash function to the STL, making it available to both C++ and Python.   

Equality tests augmented with hash equality tests.

#### Which issue(s) this PR is related to:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

The C++ std::hash specialization is not used today, but without it std::unordered_map<SpyreTensorLayout, V> would silently compile with pointer-identity hashing instead of value-based hashing, which seems like a latent bug waiting to happen.