### PR TITLE
tools to generate squad issues and PR reports

### DIFF
--- a/tools/list_prs_by_codeowner.py
+++ b/tools/list_prs_by_codeowner.py
@@ -28,7 +28,10 @@ import json
 import subprocess
 import sys
 from collections import defaultdict
+from datetime import datetime, timezone
 from pathlib import Path
+
+STALE_DAYS = 14
 
 
 def load_codeowners(repo_root: Path) -> list[tuple[str, list[str]]]:
@@ -112,12 +115,17 @@ def fetch_prs(repo: str, limit: int) -> list[dict]:
         "--repo",
         repo,
         "--json",
-        "number,title,author,files,url",
+        "number,title,author,files,url,createdAt",
         "--limit",
         str(limit),
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     return json.loads(result.stdout)
+
+
+def pr_age_days(pr: dict) -> int:
+    created = datetime.fromisoformat(pr["createdAt"].replace("Z", "+00:00"))
+    return (datetime.now(timezone.utc) - created).days
 
 
 def format_markdown(
@@ -130,14 +138,15 @@ def format_markdown(
         if owners_str:
             lines.append(f"*Owners: {owners_str}*")
         lines.append("")
-        lines.append("| # | Title | Author |")
-        lines.append("|---|---|---|")
+        lines.append("| # | Title | Author | Age (days) |")
+        lines.append("|---|---|---|---|")
         for pr in sorted(grouped[area], key=lambda p: p["number"], reverse=True):
             num = pr["number"]
             title = pr["title"]
             url = pr["url"]
             author = pr["author"]["login"]
-            lines.append(f"| [#{num}]({url}) | {title} | {author} |")
+            age = pr_age_days(pr)
+            lines.append(f"| [#{num}]({url}) | {title} | {author} | {age} |")
         lines.append("")
     return "\n".join(lines)
 
@@ -155,7 +164,8 @@ def format_text(
         lines.append("")
         for pr in sorted(grouped[area], key=lambda p: p["number"], reverse=True):
             author = pr["author"]["login"]
-            lines.append(f"  #{pr['number']:5d}  [{author}]  {pr['title']}")
+            age = pr_age_days(pr)
+            lines.append(f"  #{pr['number']:5d}  [{author}]  {pr['title']}  ({age}d)")
         lines.append("")
     return "\n".join(lines)
 
@@ -190,6 +200,11 @@ def main() -> None:
         default="",
         help="Filter to PRs that touch files under this repo path (e.g. torch_spyre/_inductor/)",
     )
+    parser.add_argument(
+        "--stale",
+        action="store_true",
+        help=f"Only show PRs that have been open more than {STALE_DAYS} days",
+    )
     args = parser.parse_args()
 
     # Resolve repo root for CODEOWNERS
@@ -219,6 +234,10 @@ def main() -> None:
     print(f"Fetching open PRs from {repo}...", file=sys.stderr)
     prs = fetch_prs(repo, args.limit)
     print(f"  {len(prs)} open PRs found", file=sys.stderr)
+
+    if args.stale:
+        prs = [pr for pr in prs if pr_age_days(pr) > STALE_DAYS]
+        print(f"  {len(prs)} PRs open more than {STALE_DAYS} days", file=sys.stderr)
 
     if args.path:
         filter_prefix = args.path.lstrip("/").rstrip("/") + "/"

--- a/tools/list_prs_by_codeowner.py
+++ b/tools/list_prs_by_codeowner.py
@@ -1,0 +1,253 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""List open PRs grouped by CODEOWNERS area.
+
+Usage:
+    python tools/list_prs_by_codeowner.py [--repo OWNER/REPO] [--limit N]
+
+Requires the `gh` CLI to be authenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def load_codeowners(repo_root: Path) -> list[tuple[str, list[str]]]:
+    """Parse CODEOWNERS into an ordered list of (pattern, owners) pairs."""
+    path = repo_root / "CODEOWNERS"
+    rules: list[tuple[str, list[str]]] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        pattern, owners = parts[0], parts[1:]
+        rules.append((pattern, owners))
+    return rules
+
+
+def owners_for_file(path: str, rules: list[tuple[str, list[str]]]) -> list[str]:
+    """Return owners for a file path using last-match-wins CODEOWNERS semantics."""
+    matched: list[str] = []
+    for pattern, owners in rules:
+        # Strip leading slash for matching
+        pat = pattern.lstrip("/")
+        # Directory patterns (ending with /) match everything beneath
+        if pattern.endswith("/"):
+            if fnmatch.fnmatch(path, pat + "*") or path.startswith(pat):
+                matched = owners
+        elif fnmatch.fnmatch(path, pat) or fnmatch.fnmatch(path, pat + "/*"):
+            matched = owners
+        elif pat == "*":
+            matched = owners
+    return matched
+
+
+def area_label(pattern: str, owners: list[str]) -> str:
+    """Derive a human-readable area name from a CODEOWNERS pattern."""
+    pat = pattern.strip("/").rstrip("/").rstrip("*")
+    if pat in ("", "*"):
+        return "Default / Build / Infrastructure"
+    return pat or pattern
+
+
+def dominant_area(
+    files: list[str],
+    rules: list[tuple[str, list[str]]],
+) -> tuple[str, list[str]]:
+    """Return the (area_label, owners) that owns the most files in this PR."""
+    area_counts: dict[str, int] = defaultdict(int)
+    area_owners: dict[str, list[str]] = {}
+
+    for f in files:
+        for pattern, owners in reversed(rules):
+            pat = pattern.lstrip("/")
+            matched = False
+            if pattern.endswith("/"):
+                matched = f.startswith(pat) or fnmatch.fnmatch(f, pat + "*")
+            elif fnmatch.fnmatch(f, pat) or fnmatch.fnmatch(f, pat + "/*"):
+                matched = True
+            elif pat == "*":
+                matched = True
+            if matched:
+                label = area_label(pattern, owners)
+                area_counts[label] += 1
+                area_owners[label] = owners
+                break
+
+    if not area_counts:
+        default_owners = rules[0][1] if rules else []
+        return ("Default / Build / Infrastructure", default_owners)
+
+    best = max(area_counts, key=lambda k: area_counts[k])
+    return best, area_owners[best]
+
+
+def fetch_prs(repo: str, limit: int) -> list[dict]:
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--json",
+        "number,title,author,files,url",
+        "--limit",
+        str(limit),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
+
+
+def format_markdown(
+    grouped: dict[str, list[dict]], area_owners: dict[str, list[str]]
+) -> str:
+    lines: list[str] = []
+    for area in sorted(grouped):
+        owners_str = " ".join(area_owners.get(area, []))
+        lines.append(f"### {area}")
+        if owners_str:
+            lines.append(f"*Owners: {owners_str}*")
+        lines.append("")
+        lines.append("| # | Title | Author |")
+        lines.append("|---|---|---|")
+        for pr in sorted(grouped[area], key=lambda p: p["number"], reverse=True):
+            num = pr["number"]
+            title = pr["title"]
+            url = pr["url"]
+            author = pr["author"]["login"]
+            lines.append(f"| [#{num}]({url}) | {title} | {author} |")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def format_text(
+    grouped: dict[str, list[dict]], area_owners: dict[str, list[str]]
+) -> str:
+    lines: list[str] = []
+    for area in sorted(grouped):
+        owners_str = " ".join(area_owners.get(area, []))
+        lines.append(f"{'=' * 60}")
+        lines.append(f"{area}")
+        if owners_str:
+            lines.append(f"Owners: {owners_str}")
+        lines.append("")
+        for pr in sorted(grouped[area], key=lambda p: p["number"], reverse=True):
+            author = pr["author"]["login"]
+            lines.append(f"  #{pr['number']:5d}  [{author}]  {pr['title']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default="",
+        help="GitHub repo as OWNER/REPO (default: detected from git remote)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Max number of PRs to fetch (default: 100)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "text"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--codeowners",
+        default="",
+        help="Path to CODEOWNERS file (default: auto-detect from git root)",
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="",
+        help="Filter to PRs that touch files under this repo path (e.g. torch_spyre/_inductor/)",
+    )
+    args = parser.parse_args()
+
+    # Resolve repo root for CODEOWNERS
+    if args.codeowners:
+        rules = load_codeowners(Path(args.codeowners).parent)
+    else:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        repo_root = Path(result.stdout.strip())
+        rules = load_codeowners(repo_root)
+
+    # Resolve GitHub repo slug
+    repo = args.repo
+    if not repo:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        repo = result.stdout.strip()
+
+    print(f"Fetching open PRs from {repo}...", file=sys.stderr)
+    prs = fetch_prs(repo, args.limit)
+    print(f"  {len(prs)} open PRs found", file=sys.stderr)
+
+    if args.path:
+        filter_prefix = args.path.lstrip("/").rstrip("/") + "/"
+        # Also match exact file names at the given path (no trailing slash needed)
+        filter_exact = args.path.lstrip("/").rstrip("/")
+        prs = [
+            pr
+            for pr in prs
+            if any(
+                f["path"].startswith(filter_prefix) or f["path"] == filter_exact
+                for f in pr.get("files", [])
+            )
+        ]
+        print(f"  {len(prs)} PRs touch '{args.path}'", file=sys.stderr)
+
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    area_owners_map: dict[str, list[str]] = {}
+
+    for pr in prs:
+        file_paths = [f["path"] for f in pr.get("files", [])]
+        area, owners = dominant_area(file_paths, rules)
+        grouped[area].append(pr)
+        area_owners_map[area] = owners
+
+    if args.format == "markdown":
+        print(format_markdown(grouped, area_owners_map))
+    else:
+        print(format_text(grouped, area_owners_map))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/list_prs_by_codeowner.py
+++ b/tools/list_prs_by_codeowner.py
@@ -138,15 +138,16 @@ def format_markdown(
         if owners_str:
             lines.append(f"*Owners: {owners_str}*")
         lines.append("")
-        lines.append("| # | Title | Author | Age (days) |")
+        lines.append("| # | Days open | Author | Title |")
         lines.append("|---|---|---|---|")
-        for pr in sorted(grouped[area], key=lambda p: p["number"], reverse=True):
+        for pr in sorted(grouped[area], key=lambda p: pr_age_days(p), reverse=True):
             num = pr["number"]
             title = pr["title"]
-            url = pr["url"]
+            if len(title) > 80:
+                title = title[:79] + "…"
             author = pr["author"]["login"]
             age = pr_age_days(pr)
-            lines.append(f"| [#{num}]({url}) | {title} | {author} | {age} |")
+            lines.append(f"| #{num} | {age} | {author} | {title} |")
         lines.append("")
     return "\n".join(lines)
 
@@ -154,6 +155,24 @@ def format_markdown(
 def format_text(
     grouped: dict[str, list[dict]], area_owners: dict[str, list[str]]
 ) -> str:
+    all_prs = [pr for prs in grouped.values() for pr in prs]
+    w_num = max((len(str(pr["number"])) for pr in all_prs), default=1) + 1  # leading #
+    w_age = (
+        max((len(str(pr_age_days(pr))) for pr in all_prs), default=1) + 1
+    )  # trailing d
+    w_author = max((len(pr["author"]["login"]) for pr in all_prs), default=6)
+
+    # Ensure column widths are at least as wide as the header labels
+    w_num = max(w_num, len("#"))
+    w_age = max(w_age, len("Days"))
+    w_author = max(w_author, len("Author"))
+
+    def header_line() -> str:
+        return f"  {'#':<{w_num}}  {'Days':<{w_age}}  {'Author':<{w_author}}  Title"
+
+    def separator_line() -> str:
+        return f"  {'-' * w_num}  {'-' * w_age}  {'-' * w_author}  -----"
+
     lines: list[str] = []
     for area in sorted(grouped):
         owners_str = " ".join(area_owners.get(area, []))
@@ -162,10 +181,18 @@ def format_text(
         if owners_str:
             lines.append(f"Owners: {owners_str}")
         lines.append("")
-        for pr in sorted(grouped[area], key=lambda p: p["number"], reverse=True):
+        lines.append(header_line())
+        lines.append(separator_line())
+        for pr in sorted(grouped[area], key=lambda p: pr_age_days(p), reverse=True):
+            num = f"#{pr['number']}"
+            age = f"{pr_age_days(pr)}d"
             author = pr["author"]["login"]
-            age = pr_age_days(pr)
-            lines.append(f"  #{pr['number']:5d}  [{author}]  {pr['title']}  ({age}d)")
+            title = pr["title"]
+            if len(title) > 80:
+                title = title[:79] + "…"
+            lines.append(
+                f"  {num:<{w_num}}  {age:<{w_age}}  {author:<{w_author}}  {title}"
+            )
         lines.append("")
     return "\n".join(lines)
 

--- a/tools/list_squad_issues.py
+++ b/tools/list_squad_issues.py
@@ -1,0 +1,266 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""List open issues with a given label from torch-spyre/torch-spyre.
+
+Usage:
+  list_inductor_issues.py <label> [--split-label LABEL]
+
+Arguments:
+  label               Primary label to filter issues (e.g. "inductor")
+  --split-label LABEL Optional label used to split the table into three
+                      sections: epics, non-epics without split-label,
+                      non-epics with split-label.  If omitted, a single
+                      table is printed.
+
+Sort order within each section: earliest month tag, then issue number.
+
+Requires: gh CLI authenticated, or GH_TOKEN set.
+"""
+
+import argparse
+import json
+import regex as re
+import subprocess
+import sys
+
+
+REPO = "torch-spyre/torch-spyre"
+
+_MONTH_RE = re.compile(
+    r"^(January|February|March|April|May|June|July|August|September|October|November|December)(\d{4})$"
+)
+
+_MONTH_ORDER = {
+    "January": 1,
+    "February": 2,
+    "March": 3,
+    "April": 4,
+    "May": 5,
+    "June": 6,
+    "July": 7,
+    "August": 8,
+    "September": 9,
+    "October": 10,
+    "November": 11,
+    "December": 12,
+}
+
+
+def month_label_sort_key(label: str) -> tuple[int, int]:
+    """Return (year, month_number) for a month label, for chronological sorting."""
+    m = _MONTH_RE.match(label)
+    if not m:
+        return (9999, 99)
+    return (int(m.group(2)), _MONTH_ORDER[m.group(1)])
+
+
+def fetch_issues(label: str) -> list[dict]:
+    cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        REPO,
+        "--label",
+        label,
+        "--state",
+        "open",
+        "--limit",
+        "500",
+        "--json",
+        "number,title,labels,url,assignees",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error fetching issues:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+def label_names(issue: dict) -> set[str]:
+    return {lbl["name"] for lbl in issue["labels"]}
+
+
+def is_month_label(name: str) -> bool:
+    return bool(_MONTH_RE.match(name))
+
+
+def month_tags(issue: dict) -> str:
+    months = sorted(
+        (lbl["name"] for lbl in issue["labels"] if is_month_label(lbl["name"])),
+        key=month_label_sort_key,
+    )
+    return ", ".join(months) if months else ""
+
+
+def earliest_month_key(issue: dict) -> tuple[int, int]:
+    """Return the sort key for the earliest month label, or a large sentinel if none."""
+    month_labels = [
+        lbl["name"] for lbl in issue["labels"] if is_month_label(lbl["name"])
+    ]
+    if not month_labels:
+        return (9999, 99)
+    return min(month_label_sort_key(m) for m in month_labels)
+
+
+def make_sort_key(split_label: str | None):
+    def sort_key(issue: dict) -> tuple:
+        labels = label_names(issue)
+        is_epic = "epic" in labels
+        has_split = split_label is not None and any(
+            lbl.startswith(split_label) for lbl in labels
+        )
+        if is_epic:
+            group = 0
+        elif not has_split:
+            group = 1
+        else:
+            group = 2
+        year, month = earliest_month_key(issue)
+        return (group, year, month, issue["number"])
+
+    return sort_key
+
+
+def format_table(issues: list[dict], primary_label: str) -> str:
+    col_num = "#"
+    col_title = "Title"
+    col_labels = "Labels"
+    col_months = "Months"
+    col_assignee = "Assignee"
+
+    rows = []
+    for issue in issues:
+        labels = label_names(issue)
+        display_labels = ", ".join(
+            sorted(
+                lbl
+                for lbl in labels
+                if lbl != primary_label and not is_month_label(lbl)
+            )
+        )
+        title = issue["title"]
+        if len(title) > 80:
+            title = title[:79] + "…"
+        assignee = ", ".join(a["login"] for a in issue.get("assignees", []))
+        rows.append(
+            {
+                "num": str(issue["number"]),
+                "title": title,
+                "labels": display_labels,
+                "months": month_tags(issue),
+                "assignee": assignee,
+            }
+        )
+
+    w_num = max(len(col_num), *(len(r["num"]) for r in rows))
+    w_title = max(len(col_title), *(len(r["title"]) for r in rows))
+    w_labels = max(len(col_labels), *(len(r["labels"]) for r in rows))
+    w_months = max(len(col_months), *(len(r["months"]) for r in rows))
+    w_assignee = max(len(col_assignee), *(len(r["assignee"]) for r in rows))
+
+    def row_line(num, title, months, assignee, labels):
+        return (
+            f"| {num:<{w_num}} "
+            f"| {title:<{w_title}} "
+            f"| {months:<{w_months}} "
+            f"| {assignee:<{w_assignee}} "
+            f"| {labels:<{w_labels}} |"
+        )
+
+    sep = (
+        f"|-{'-' * w_num}-"
+        f"|-{'-' * w_title}-"
+        f"|-{'-' * w_months}-"
+        f"|-{'-' * w_assignee}-"
+        f"|-{'-' * w_labels}-|"
+    )
+
+    lines = [
+        row_line(col_num, col_title, col_months, col_assignee, col_labels),
+        sep,
+    ]
+    for r in rows:
+        lines.append(
+            row_line(r["num"], r["title"], r["months"], r["assignee"], r["labels"])
+        )
+    return "\n".join(lines)
+
+
+def group_of(issue: dict, split_label: str | None) -> int:
+    labels = label_names(issue)
+    if "epic" in labels:
+        return 0
+    if split_label is not None and any(lbl.startswith(split_label) for lbl in labels):
+        return 2
+    return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List open issues with a given label from torch-spyre/torch-spyre."
+    )
+    parser.add_argument(
+        "label", help='Primary label to filter issues (e.g. "inductor")'
+    )
+    parser.add_argument(
+        "--split-label",
+        metavar="LABEL",
+        help=(
+            "Label used to further split non-epics into two sections: "
+            "non-epics without LABEL, and non-epics with LABEL. "
+            "If omitted, all non-epics appear in one table."
+        ),
+    )
+    args = parser.parse_args()
+
+    issues = fetch_issues(args.label)
+    issues.sort(key=make_sort_key(args.split_label))
+
+    if not issues:
+        print(f"No open issues found with label '{args.label}'.")
+        return
+
+    total = len(issues)
+    print(f"Open '{args.label}' issues in {REPO} ({total} total)\n")
+
+    by_group: dict[int, list[dict]] = {0: [], 1: [], 2: []}
+    for issue in issues:
+        by_group[group_of(issue, args.split_label)].append(issue)
+
+    if args.split_label is None:
+        sections = [
+            (0, "Epics"),
+            (1, "Non-epics"),
+        ]
+    else:
+        sections = [
+            (0, "Epics"),
+            (1, f"Non-epics (no '{args.split_label}' label)"),
+            (2, f"Non-epics (with '{args.split_label}' label)"),
+        ]
+
+    for group_id, section_title in sections:
+        group_issues = by_group[group_id]
+        print(f"## {section_title} ({len(group_issues)})\n")
+        if group_issues:
+            print(format_table(group_issues, args.label))
+        else:
+            print("(none)")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Adds a script to generate a basic issue report for a squad. 

For example:

```
(dt-inductor) [dgrove@groved-dev tools]$ python list_squad_issues.py inductor --split-label torch-ops 
Open 'inductor' issues in torch-spyre/torch-spyre (110 total)

## Epics (12)

| #    | Title                                                                   | Months   | Assignee                                   | Labels                                                     |
|------|-------------------------------------------------------------------------|----------|--------------------------------------------|------------------------------------------------------------|
| 39   | Flexible data types                                                     | May2026  | thoangtrvn                                 | epic                                                       |
| 43   | Symbolic shapes                                                         | May2026  | pradghos                                   | backend-compiler, driver-runtime, epic, torch-runtime      |
| 223  | Scratchpad management                                                   | May2026  |                                            | epic                                                       |
| 244  | Mock device                                                             | May2026  | shruthip-venkatesh                         | epic, torch-runtime                                        |
| 843  | Optimized and Automatic Tensor Device Layouts                           | May2026  |                                            | epic                                                       |
| 1333 | Add integrated storage offset support for view and data-copy operations | May2026  | michihirohorie, yoheiueda, AbhishekG4      | epic, tensor layout, torch-ops (models)                    |
| 1915 | SuperDSC Bundle with Symbolic Addresses                                 | May2026  |                                            | epic                                                       |
| 206  | Working set reduction                                                   | June2026 | pradghos                                   | epic                                                       |
| 696  | Support for Ministral 3 14B                                             | June2026 | ani300, RajalakshmiSR, saurabh-srivastava4 | epic, model-enablement                                     |
| 866  | Indirect access                                                         | June2026 | pradghos                                   | backend-compiler, epic, torch-runtime                      |
| 1538 | FP8 Support Epic                                                        | June2026 | pradghos                                   | epic, model-enablement, torch-ops (complex), torch-runtime |
| 42   | Increase coverage of op and tensor dimensions                           |          |                                            | epic                                                       |

## Non-epics (no 'torch-ops' label) (63)

| #    | Title                                                                            | Months    | Assignee            | Labels                                          |
|------|----------------------------------------------------------------------------------|-----------|---------------------|-------------------------------------------------|
| 1266 | Pooled memory allocation for intermediate tensors                                | April2026 | avery-blanchard     |                                                 |
| 1267 | Adapt Inductor's memory planner for pooled allocation for Spyre                  | April2026 | avery-blanchard     |                                                 |
| 1268 | SDSC codegen support for pooled memory allocation                                | April2026 | avery-blanchard     |                                                 |
| 1392 | [HF Granite 3.3-8b eager mode] Compiler fails with EAR overflow on large vocabu… | April2026 |                     | bug, model-enablement                           |
| 41   | Superdscs for type conversions                                                   | May2026   | nethra-khandige     | model-enablement, torch-runtime                 |
| 218  | Generate OpSpecs with symbolic values                                            | May2026   | Vivek1258           |                                                 |
| 219  | Constraints on symbols                                                           | May2026   | manid2              |                                                 |
| 220  | Generate superdscs with symbolic values                                          | May2026   |                     |                                                 |
| 221  | Launch kernels with symbolic arguments                                           | May2026   | Vivek1258           | backend-compiler, driver-runtime, torch-runtime |
| 234  | Implement scratchpad memory allocator                                            | May2026   | chichun-charlie-liu |                                                 |
| 235  | Scratchpad utilization                                                           | May2026   | chichun-charlie-liu |                                                 |
| 552  | SuperDSC validator                                                               | May2026   |                     | backend-compiler, good first issue              |
| 739  | Enhance algorithm for choosing device layout of compiler-created tensors         | May2026   | marnold-ibm         |                                                 |
| 741  | Pad non-stick dimensions to optimize work division                               | May2026   |                     |                                                 |
| 827  | Enable symbolic tensor addresses                                                 | May2026   |                     | backend-compiler, torch-runtime                 |
| 1065 | [Mock Device] Submit RFC for mock device                                         | May2026   |                     |                                                 |
| 1066 | [Mock Device] Base Prototype                                                     | May2026   | Urvashi2303         |                                                 |
| 1079 | [Mock Device] Core Data Classes                                                  | May2026   | shruthip-venkatesh  |                                                 |
| 1138 | Support fp32 to enable torch.float                                               | May2026   |                     |                                                 |
| 1153 | Exploration on creating sdsc for spyre type conversion operators - float16 to f… | May2026   | manid2              | backend-compiler                                |
| 1371 | Refactor FixedTiledLayout: Separate Compile-Time from Runtime Representation     | May2026   | Vivek1258           |                                                 |
| 1372 | Core Division: Bounded Bucket Strategy                                           | May2026   | Vivek1258           |                                                 |
| 1373 | Symbolic Coordinate Computation (views.py)                                       | May2026   | Vivek1258           |                                                 |
| 1497 | [BUG][Mistral-Small-3.2-24B-Instruct-2506]: Tensor.float() fails with RuntimeEr… | May2026   |                     | bug, model-enablement                           |
| 1505 | Generate SuperDSC bundle with fake symbols for tensor args                       | May2026   | dgrove-oss          |                                                 |
| 1540 | Data operations on FP8 tensors                                                   | May2026   | pradghos            | data type, model-enablement                     |
| 1671 | Define helper functions for inserting nodes in pre-scheduler LoopLevelIR         | May2026   | marnold-ibm         |                                                 |
| 1917 | Perform matmul padding on pre-scheduling loop level IR                           | May2026   | dgrove-oss          |                                                 |
| 642  | Enhancing Provenance Tracking                                                    | June2026  | ppnaik1890          | torch-profiler                                  |
| 1051 | Enhance the constant tensor solution to avoid CPU tensor creation while convert… | June2026  | joyalbin            |                                                 |
| 1077 | Split large tensors to meet hardware constraints                                 | June2026  |                     |                                                 |
| 1148 | Exploration: Indirectly Accessed Tensors — Use Cases, Dependencies (Phase1)      | June2026  | tanushree-ibm       |                                                 |
| 1357 | Define working set reduction triggering criteria                                 | June2026  | Hemaprasannakc      |                                                 |
| 1358 | loop representation in Inductor for chunked tensor execution                     | June2026  | Hemaprasannakc      |                                                 |
| 1359 | Implement working set reduction - 3d pointwise ops                               | June2026  | Hemaprasannakc      |                                                 |
| 1360 | Validate WSR for expected working and regression                                 | June2026  | Hemaprasannakc      |                                                 |
| 1361 | Create comprehensive test suite for working set reduction                        | June2026  | Hemaprasannakc      |                                                 |
| 1363 | Experiment on indirect tensor access for torch.gather operator                   | June2026  | shruthip-venkatesh  |                                                 |
| 1364 | Implement working set reduction - 3d Reduction ops                               | June2026  | Hemaprasannakc      |                                                 |
| 1474 | Support operations on Float8 (SEN143_FP8) tensors in Spyre backend               | June2026  |                     | model-enablement                                |
| 1479 | [BUG] [Mistral-Small-3.2-24B-Instruct-2506]: torch.getitem fails with error Int… | June2026  |                     | bug, model-enablement                           |
| 1541 | FP8 matrix multiplication                                                        | June2026  | pradghos            | data type, model-enablement                     |
| 1792 | Remove spyre::overwrite custom op                                                | June2026  | yoheiueda           |                                                 |
| 260  | Separate Compilation                                                             |           |                     |                                                 |
| 261  | Asynchronous invocation of backend compiler                                      |           |                     |                                                 |
| 262  | Enable caching of compiled kernels                                               |           | Tiwari-Avanish      |                                                 |
| 372  | Extend PyTorch shape check for compiled graphs to include SpyreTensorLayout of … |           | Hemaprasannakc      |                                                 |
| 414  | Error when compiling a SDSC for torch.outer()                                    |           |                     |                                                 |
| 515  | Fine-Grained logging for torch-spyre                                             |           | jamesnohilly        | good first issue, torch-runtime                 |
| 521  | Support multi-dimension reductions                                               |           |                     | good first issue                                |
| 574  | Support TORCH_LOGS for the SDSC generation                                       |           | kurtis318           | good first issue                                |
| 828  | Enable use of the unchanged upstream torch.nn.linear implementation              |           |                     | backend-compiler                                |
| 867  | Single dimension reduction operation giving worng results                        |           |                     |                                                 |
| 1046 | Enable multi‑dimension reduction test cases in test_inductor_ops.py              |           |                     |                                                 |
| 1047 | Add new test coverage for torch.mean with dimension reduction                    |           |                     |                                                 |
| 1137 | Support int64 tensors as an input for torch.clamp                                |           |                     | data type, integer arithmetic                   |
| 1173 | Implement torch.ops.spyre.compact using dl-dsc                                   |           |                     |                                                 |
| 1253 | Add new work division tests to ensure splitting is happening                     |           |                     | good first issue                                |
| 1344 | Consolidate logging infrastructure and configuration                             |           | kurtis318           | torch-runtime                                   |
| 1353 | Generalize view code to handle non-unit fractions                                |           |                     |                                                 |
| 1377 | [HF Granite 3.3-8b eager mode] Spyre backend fails with "nonuniform stick index… |           |                     | model-enablement                                |
| 1673 | Work division hint                                                               |           | cyang49             |                                                 |
| 1874 | Enable work division for non-matmul reductions along reduction dimension in the… |           | cyang49             |                                                 |

## Non-epics (with 'torch-ops' label) (35)

| #    | Title                                                                          | Months   | Assignee                  | Labels                                                    |
|------|--------------------------------------------------------------------------------|----------|---------------------------|-----------------------------------------------------------|
| 894  | Support non-zero storage offset of view-based eager ops                        | May2026  | yoheiueda                 | tensor layout, torch-ops (models)                         |
| 1464 | Identity handling for values smaller than a stick along the stick dimension    | May2026  | yoheiueda                 | tensor layout, torch-ops (models)                         |
| 1548 | Generalize storage offset support for view operations                          | May2026  | yoheiueda                 | tensor layout, torch-ops (models)                         |
| 1542 | FP8 quantization patterns                                                      | June2026 | pradghos                  | model-enablement, torch-ops (complex), torch-ops (models) |
| 45   | Implement multi-dimensional layernorm                                          |          |                           | torch-ops (complex)                                       |
| 112  | Improve reduction op coverage (3d tensor and reduction on multiple dimensions) |          | cyang49                   | torch-ops (complex)                                       |
| 148  | Enable torch.cumsum                                                            |          | yoheiueda                 | torch-ops (models)                                        |
| 157  | Enabe torch.chunk                                                              |          | michihirohorie, yoheiueda | torch-ops (simple)                                        |
| 267  | Enable torch.split                                                             |          | michihirohorie, yoheiueda | torch-ops (complex)                                       |
| 268  | Enable tensor slicing                                                          |          | michihirohorie, yoheiueda | torch-ops (simple)                                        |
| 342  | Enable torch.repeat                                                            |          | yoheiueda                 | torch-ops (simple)                                        |
| 374  | Enable torch.einsum                                                            |          |                           | torch-ops (complex)                                       |
| 391  | Enable torch.clone                                                             |          | inatatsu                  | torch-ops (simple)                                        |
| 441  | Enable torch.div                                                               |          |                           | torch-ops (simple)                                        |
| 442  | Enable operator.__truediv__                                                    |          |                           | torch-ops (simple)                                        |
| 453  | Enable torch.max                                                               |          | imaihal                   | torch-ops (simple)                                        |
| 461  | Enable torch.sum                                                               |          | imaihal                   | torch-ops (simple)                                        |
| 465  | Enable torch.copy_                                                             |          | yoheiueda                 | torch-ops (simple)                                        |
| 483  | Enable torch.nn.functional.multi_head_attention_forward                        |          | inatatsu                  | torch-ops (complex)                                       |
| 495  | Enable torch.all                                                               |          | Daniel-Schenker           | torch-ops (simple)                                        |
| 496  | Enable torch.nn.functional.glu                                                 |          | AbhishekG4                | torch-ops (simple)                                        |
| 497  | Enable torch.sym_sum                                                           |          |                           | torch-ops (simple)                                        |
| 498  | Enable torch.Tensor.type_as                                                    |          |                           | torch-ops (simple)                                        |
| 499  | Enable torch.nn.functional.softmax                                             |          |                           | torch-ops (simple)                                        |
| 514  | Enable torch.__eq__                                                            |          | michihirohorie            | torch-ops (simple)                                        |
| 582  | Enable torch.tril                                                              |          | AnishPahilajani           | fallback-impl, torch-ops (simple)                         |
| 600  | Enable torch.any                                                               |          |                           | torch-ops (simple)                                        |
| 612  | Enable torch.exp                                                               |          |                           | torch-ops (simple)                                        |
| 638  | Enable torch.nn.functional.pad                                                 |          | GOavi101                  | torch-ops (simple)                                        |
| 659  | Enable torch.triu                                                              |          |                           | fallback-impl, torch-ops (simple)                         |
| 673  | Enable torch.repeat_interleave                                                 |          |                           | torch-ops (failure analysis)                              |
| 743  | Enable torch.as_strided                                                        |          |                           | torch-ops (complex)                                       |
| 984  | Expand BMM tensor dimensions coverage                                          |          |                           | torch-ops (complex)                                       |
| 1393 | Support negative padding sizes with `torch.nn.functional.pad`                  |          |                           | torch-ops (models)                                        |
| 1480 | Support left padding with torch.nn.functional.pad                              |          | GOavi101                  | torch-ops (models)                                        |
```

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
