### PR TITLE
V1 of simple beam-style forward propagation restickify global optimizer.

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -22,22 +22,63 @@
 # Shapes use multiples of 64 (stick size = 64 fp16 elements) to ensure
 # stick-aligned inputs that exercise the restickify path rather than fallback.
 
+import math
+import os
+
 import pytest
 import torch
 
+import torch_spyre._inductor.insert_restickify as _insert_restickify
+import torch_spyre._inductor.optimize_restickify as _optimize_restickify
 from utils_inductor import _compile_and_run, compare_with_cpu
 
 DEVICE = torch.device("spyre")
+S = 128  # must be a multiple of 64
+T = 64  # side length for 4D tests (all dims equal)
 
 
-def _compare(fn, *args, check_strides=True):
-    spyre_result = _compile_and_run(fn, args, DEVICE)
-    compare_with_cpu(fn, *args, target=spyre_result, run_eager=False)
+def _verify_cost(expected_cost):
+    if not _insert_restickify.restickify_plan:
+        # Cache hit — finalize_layouts did not run, plan was not captured. Skip cost check.
+        return
+    actual = sum(
+        math.prod(int(s) for s in entry["target_layout"].size)
+        for entries in _insert_restickify.restickify_plan.values()
+        for entry in entries
+    )
+    assert actual == expected_cost, (
+        f"restickify cost: expected {expected_cost}, got {actual}"
+    )
+
+
+def _compare(fn, *args, check_strides=True, optimal_cost=None, skip_correctness=False):
+    """Run fn on Spyre, assert correctness against CPU, and optionally assert the restickify
+    plan has cost == optimal_cost. Restickify decisions and their cost normally remains inside
+    the compiler; the env var below instructs the compiler to stash it for us.
+    """
+    if optimal_cost is not None:
+        _insert_restickify.restickify_plan = {}
+        os.environ["SPYRE_CAPTURE_RESTICKIFY_PLAN"] = "1"
+        try:
+            spyre_result = _compile_and_run(fn, args, DEVICE)
+        finally:
+            del os.environ["SPYRE_CAPTURE_RESTICKIFY_PLAN"]
+    else:
+        spyre_result = _compile_and_run(fn, args, DEVICE)
+    if not skip_correctness:
+        compare_with_cpu(fn, *args, target=spyre_result, run_eager=False)
     if check_strides:
         cpu_result = fn(*args)
         assert cpu_result.stride() == spyre_result.stride(), (
             f"Stride mismatch: CPU {cpu_result.stride()} vs Spyre {spyre_result.stride()}"
         )
+    if optimal_cost is not None:
+        _verify_cost(optimal_cost)
+
+
+def _make_tensors(n, *shape):
+    """Make n scaled fp16 tensors of the given shape. Scale keeps values small enough for chained matmuls."""
+    return [torch.randn(*shape, dtype=torch.float16) * 0.1 for _ in range(n)]
 
 
 def _make_2d_tensors(s1, s2):
@@ -69,27 +110,28 @@ def tensors_2arg(request):
 
 def test_2arg_at_plus_x(tensors_2arg):
     A, _, X, _ = tensors_2arg
-    _compare(lambda a, x: a.t() + x, A, X)
+    _compare(lambda a, x: a.t() + x, A, X, optimal_cost=A.numel())
 
 
 def test_2arg_x_plus_at(tensors_2arg):
     A, _, X, _ = tensors_2arg
-    _compare(lambda a, x: x + a.t(), A, X)
+    _compare(lambda a, x: x + a.t(), A, X, optimal_cost=A.numel())
 
 
 def test_2arg_xt_plus_a(tensors_2arg):
     A, _, X, _ = tensors_2arg
-    _compare(lambda a, x: x.t() + a, A, X)
+    _compare(lambda a, x: x.t() + a, A, X, optimal_cost=X.numel())
 
 
 def test_2arg_a_plus_xt(tensors_2arg):
     A, _, X, _ = tensors_2arg
-    _compare(lambda a, x: a + x.t(), A, X)
+    _compare(lambda a, x: a + x.t(), A, X, optimal_cost=X.numel())
 
 
 # 3-arg and 4-arg tests — run on a smaller set of size pairs
 SIZES_2D_SMALL = [
     (256, 128),
+    (128, 128),
 ]
 
 
@@ -101,51 +143,74 @@ def tensors_multiarg(request):
 
 def test_3arg_at_bt_x(tensors_multiarg):
     A, B, X, _ = tensors_multiarg
-    _compare(lambda a, b, x: a.t() + b.t() + x, A, B, X)
+    _compare(lambda a, b, x: a.t() + b.t() + x, A, B, X, optimal_cost=X.numel())
 
 
 def test_3arg_at_x_bt(tensors_multiarg):
     A, B, X, _ = tensors_multiarg
-    _compare(lambda a, b, x: a.t() + x + b.t(), A, B, X)
+    _compare(lambda a, b, x: a.t() + x + b.t(), A, B, X, optimal_cost=X.numel())
 
 
 def test_3arg_x_at_bt(tensors_multiarg):
     A, B, X, _ = tensors_multiarg
-    _compare(lambda a, b, x: x + a.t() + b.t(), A, B, X)
+    _compare(lambda a, b, x: x + a.t() + b.t(), A, B, X, optimal_cost=X.numel())
 
 
 def test_3arg_at_x_y(tensors_multiarg):
     A, _, X, Y = tensors_multiarg
-    _compare(lambda a, x, y: a.t() + x + y, A, X, Y)
+    _compare(lambda a, x, y: a.t() + x + y, A, X, Y, optimal_cost=A.numel())
 
 
 def test_4arg_at_bt_x_y(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
-    _compare(lambda a, b, x, y: a.t() + b.t() + x + y, A, B, X, Y)
+    _compare(
+        lambda a, b, x, y: a.t() + b.t() + x + y, A, B, X, Y, optimal_cost=A.numel()
+    )
 
 
 def test_4arg_at_x_bt_y(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
-    _compare(lambda a, b, x, y: a.t() + x + b.t() + y, A, B, X, Y)
+    _compare(
+        lambda a, b, x, y: a.t() + x + b.t() + y, A, B, X, Y, optimal_cost=2 * A.numel()
+    )
 
 
 def test_4arg_x_at_y_bt(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
-    _compare(lambda a, b, x, y: x + a.t() + y + b.t(), A, B, X, Y)
+    _compare(
+        lambda a, b, x, y: x + a.t() + y + b.t(), A, B, X, Y, optimal_cost=2 * A.numel()
+    )
 
 
 def test_4arg_at_x_y_bt(tensors_multiarg):
     A, B, X, Y = tensors_multiarg
-    _compare(lambda a, b, x, y: a.t() + x + y + b.t(), A, B, X, Y)
+    _compare(
+        lambda a, b, x, y: a.t() + x + y + b.t(), A, B, X, Y, optimal_cost=2 * A.numel()
+    )
 
 
-def test_4arg_a_bt_c_d_square():
-    s = 128
-    A = torch.randn((s, s), dtype=torch.float16)
-    B = torch.randn((s, s), dtype=torch.float16)
-    C = torch.randn((s, s), dtype=torch.float16)
-    D = torch.randn((s, s), dtype=torch.float16)
-    _compare(lambda a, b, c, d: a + b.t() + c + d, A, B, C, D)
+def test_4arg_at_x_y_z(tensors_multiarg):
+    A, _, X, Y = tensors_multiarg
+    Z = torch.randn_like(X)
+    _compare(lambda a, x, y, z: a.t() + x + y + z, A, X, Y, Z, optimal_cost=A.numel())
+
+
+def test_4arg_x_at_y_z(tensors_multiarg):
+    A, _, X, Y = tensors_multiarg
+    Z = torch.randn_like(X)
+    _compare(lambda a, x, y, z: x + a.t() + y + z, A, X, Y, Z, optimal_cost=A.numel())
+
+
+def test_4arg_x_y_at_z(tensors_multiarg):
+    A, _, X, Y = tensors_multiarg
+    Z = torch.randn_like(X)
+    _compare(lambda a, x, y, z: x + y + a.t() + z, A, X, Y, Z, optimal_cost=A.numel())
+
+
+def test_4arg_x_y_z_at(tensors_multiarg):
+    A, _, X, Y = tensors_multiarg
+    Z = torch.randn_like(X)
+    _compare(lambda a, x, y, z: x + y + z + a.t(), A, X, Y, Z, optimal_cost=A.numel())
 
 
 # 3D tests
@@ -329,19 +394,29 @@ def matmul_tensors_ab_ba(request):
     return x, y
 
 
+def test_matmul_x_y(matmul_tensors_ab_ba):
+    x, y = matmul_tensors_ab_ba
+    _compare(lambda x, y: torch.matmul(x, y), x, y, optimal_cost=0)
+
+
 def test_matmul_xt_y(matmul_tensors_ab):
     x, y = matmul_tensors_ab
-    _compare(lambda x, y: torch.matmul(x.t(), y), x, y)
+    _compare(lambda x, y: torch.matmul(x.t(), y), x, y, optimal_cost=x.numel())
 
 
 def test_matmul_x_yt(matmul_tensors_ab):
     x, y = matmul_tensors_ab
-    _compare(lambda x, y: torch.matmul(x, y.t()), x, y)
+    _compare(lambda x, y: torch.matmul(x, y.t()), x, y, optimal_cost=y.numel())
 
 
 def test_matmul_xt_yt(matmul_tensors_ab_ba):
     x, y = matmul_tensors_ab_ba
-    _compare(lambda x, y: torch.matmul(x.t(), y.t()), x, y)
+    _compare(
+        lambda x, y: torch.matmul(x.t(), y.t()),
+        x,
+        y,
+        optimal_cost=x.numel() + y.numel(),
+    )
 
 
 # ------- Batched Matmul Tests ---------
@@ -399,3 +474,249 @@ def test_bmm_with_inplace_mutation():
 
     spyre_result = _compile_and_run(func, (x, weight, cache), DEVICE)
     compare_with_cpu(func, x, weight, cache, target=spyre_result, run_eager=False)
+
+
+# Optimizer correctness + optimality tests: verify both output values and
+# minimum-cost restickify plan across a range of graph patterns.
+
+
+def test_opt_parens_one_conflict():
+    """((a + b) + (c.t() + d)) + (e + f) — conflict only in inner group."""
+    a, b, c, d, e, f = _make_tensors(6, S, S)
+    _compare(
+        lambda a, b, c, d, e, f: (((a + b) + (c.t() + d)) + (e + f)),
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        optimal_cost=S * S,
+    )
+
+
+def test_opt_adds_then_matmul_x():
+    """(a + b.t() + c.t() + d.t()) @ e — upstream optimal + forced matmul x cost."""
+    a, b, c, d, e = _make_tensors(5, S, S)
+    _compare(
+        lambda a, b, c, d, e: ((a + b.t() + c.t() + d.t()) @ e),
+        a,
+        b,
+        c,
+        d,
+        e,
+        optimal_cost=2 * S * S,
+    )
+
+
+def test_opt_adds_then_matmul_y():
+    """a @ (b + c.t()) — beam picks upstream stick to avoid extra matmul cost."""
+    a, b, c = _make_tensors(3, S, S)
+    _compare(lambda a, b, c: (a @ (b + c.t())), a, b, c, optimal_cost=S * S)
+
+
+def test_opt_adds_then_matmul_y_long_chain():
+    """a @ (b + c.t() + d.t() + e.t()) — majority transposed going into y."""
+    a, b, c, d, e = _make_tensors(5, S, S)
+    _compare(
+        lambda a, b, c, d, e: (a @ (b + c.t() + d.t() + e.t())),
+        a,
+        b,
+        c,
+        d,
+        e,
+        optimal_cost=2 * S * S,
+    )
+
+
+def test_opt_matmul_x_and_y_conflict():
+    """a.t() @ (b + c.t()) — x wrong stick + y upstream conflict."""
+    a, b, c = _make_tensors(3, S, S)
+    _compare(lambda a, b, c: (a.t() @ (b + c.t())), a, b, c, optimal_cost=2 * S * S)
+
+
+def test_opt_matmul_then_adds():
+    """(a @ b) + c.t() — matmul output stick vs transposed input."""
+    a, b, c = _make_tensors(3, S, S)
+    _compare(lambda a, b, c: ((a @ b) + c.t()), a, b, c, optimal_cost=S * S)
+
+
+def test_opt_matmul_then_long_adds():
+    """(a @ b) + c.t() + d.t() — keep matmul stick, restickify one input."""
+    a, b, c, d = _make_tensors(4, S, S)
+    _compare(
+        lambda a, b, c, d: ((a @ b) + c.t() + d.t()), a, b, c, d, optimal_cost=S * S
+    )
+
+
+def test_opt_chained_matmuls():
+    """(a @ b) @ c — no restickify needed."""
+    a, b, c = _make_tensors(3, S, S)
+    _compare(lambda a, b, c: ((a @ b) @ c), a, b, c, optimal_cost=0)
+
+
+def test_opt_two_independent_conflicts():
+    """(a+b.t()) + (e.t()+f.t()+g) — two separate conflicts."""
+    a, b, e, f, g = _make_tensors(5, S, S)
+    _compare(
+        lambda a, b, e, f, g: ((a + b.t()) + (e.t() + f.t() + g)),
+        a,
+        b,
+        e,
+        f,
+        g,
+        optimal_cost=2 * S * S,
+    )
+
+
+def test_opt_fanout_intermediate():
+    """buf = a + b.t(); (buf + c) + (buf + d.t()) — buf consumed twice."""
+    a, b, c, d = _make_tensors(4, S, S)
+
+    def fn(a, b, c, d):
+        buf = a + b.t()
+        return buf + c + (buf + d.t())
+
+    _compare(fn, a, b, c, d, optimal_cost=2 * S * S)
+
+
+def test_opt_diamond():
+    """buf = a + b.t(); buf + buf — same intermediate read twice."""
+    a, b = _make_tensors(2, S, S)
+
+    def fn(a, b):
+        buf = a + b.t()
+        return buf + buf
+
+    _compare(fn, a, b, optimal_cost=S * S)
+
+
+def test_opt_matmul_rect_x_wrong_stick():
+    """(64x128).t() @ (64x192) — cost uses buffer size not reduction dim."""
+    M, K, N = 64, 128, 192
+    (a,) = _make_tensors(1, M, K)
+    (b,) = _make_tensors(1, M, N)
+    _compare(lambda a, b: (a.t() @ b), a, b, optimal_cost=M * K)
+
+
+def test_opt_sum_between_pointwise():
+    """(a + b.t()).sum(1) + c — reduction between two pointwise stages."""
+    a, b = _make_tensors(2, S, S)
+    (c,) = _make_tensors(1, S)
+    # Note: sum() below may fail correctness depending which stick flows in
+    # because propagate_layouts does not yet properly detect incompatibility
+    # of sparse/non-sparse sticks in a pointwise op.  Disabling correctness
+    # check until that is resolved
+    _compare(
+        lambda a, b, c: ((a + b.t()).sum(0) + c),
+        a,
+        b,
+        c,
+        optimal_cost=S * S,
+        skip_correctness=True,
+    )
+
+
+def test_opt_chain_transposed_intermediate():
+    """(a.t() + b).t() + c — intermediate consumed transposed."""
+    a, b, c = _make_tensors(3, S, S)
+    _compare(lambda a, b, c: ((a.t() + b).t() + c), a, b, c, optimal_cost=S * S)
+
+
+def test_opt_beam_trim(monkeypatch):
+    """Three ops each with 2 candidate layouts: beam grows to 8 before trimming.
+
+    BEAM_WIDTH=2 forces trimming at every step; verifies correctness is preserved.
+    """
+    monkeypatch.setattr(_optimize_restickify, "BEAM_WIDTH", 2)
+    a, b, c, d, e, f = _make_tensors(6, S, S)
+    _compare(
+        lambda a, b, c, d, e, f: (a.t() + b) + (c.t() + d) + (e.t() + f),
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+    )
+
+
+def test_opt_4d_one_conflict():
+    """a.transpose(0,3) + b + c + d — one input with stick on dim 0."""
+    a, b, c, d = _make_tensors(4, T, T, T, T)
+    _compare(
+        lambda a, b, c, d: (a.transpose(0, 3) + b + c + d),
+        a,
+        b,
+        c,
+        d,
+        optimal_cost=T**4,
+    )
+
+
+def test_opt_4d_mixed_conflicts():
+    """a.transpose(0,3) + b.transpose(1,3) + c.transpose(2,3) + d — three non-matching sticks."""
+    a, b, c, d = _make_tensors(4, T, T, T, T)
+    _compare(
+        lambda a, b, c, d: (
+            a.transpose(0, 3) + b.transpose(1, 3) + c.transpose(2, 3) + d
+        ),
+        a,
+        b,
+        c,
+        d,
+        optimal_cost=3 * T**4,
+    )
+
+
+def test_opt_4d_majority_wins():
+    """a.transpose(0,3) + b.transpose(0,3) + c.transpose(0,3) + d — three stick on dim 0."""
+    a, b, c, d = _make_tensors(4, T, T, T, T)
+    _compare(
+        lambda a, b, c, d: (
+            a.transpose(0, 3) + b.transpose(0, 3) + c.transpose(0, 3) + d
+        ),
+        a,
+        b,
+        c,
+        d,
+        optimal_cost=T**4,
+    )
+
+
+def test_opt_4d_chain_transposed_intermediate():
+    """(a.transpose(2,3) + b).transpose(2,3) + c — 4D version of transposed intermediate."""
+    a, b, c = _make_tensors(3, T, T, T, T)
+    _compare(
+        lambda a, b, c: ((a.transpose(2, 3) + b).transpose(2, 3) + c),
+        a,
+        b,
+        c,
+        optimal_cost=T**4,
+    )
+
+
+def test_opt_two_matmuls_wrong_inputs():
+    """(a.t() @ b) + (c @ d.t()) — each matmul has one wrong-stick input."""
+    a, b, c, d = _make_tensors(4, S, S)
+    _compare(
+        lambda a, b, c, d: ((a.t() @ b) + (c @ d.t())),
+        a,
+        b,
+        c,
+        d,
+        optimal_cost=2 * S * S,
+    )
+
+
+def test_opt_matmul_both_inputs_upstream_conflict():
+    """(a + b.t()) @ (c + d.t()) — both inputs have upstream stick conflicts."""
+    a, b, c, d = _make_tensors(4, S, S)
+    _compare(
+        lambda a, b, c, d: ((a + b.t()) @ (c + d.t())),
+        a,
+        b,
+        c,
+        d,
+        optimal_cost=2 * S * S,
+    )

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -19,6 +19,8 @@ from torch.utils._config_module import install_config_module
 
 lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
 
+global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == "1"
+
 allow_all_ops_in_lx_planning: bool = False
 
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
+import logging
+import os
 from collections import defaultdict
+
+import torch
 
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
@@ -38,6 +41,9 @@ from torch.utils._ordered_set import OrderedSet
 from .errors import Unsupported
 
 logger = get_inductor_logger("insert_restickify")
+
+# Populated by finalize_layouts when SPYRE_CAPTURE_RESTICKIFY_PLAN is set. For testing only.
+restickify_plan: dict = {}
 
 
 def _fixed_tiled(layout: FixedLayout, stl: SpyreTensorLayout) -> FixedTiledLayout:
@@ -212,6 +218,7 @@ def insert_restickify(operations: list[Operation]) -> None:
 
 
 def finalize_layouts(operations: list) -> None:
+    global restickify_plan
     """Convert committed STLs (set by the optimizer) to FixedTiledLayouts and build
     V.graph.restickify_plan for insert_restickify.
 
@@ -240,7 +247,7 @@ def finalize_layouts(operations: list) -> None:
             input_buf.layout = _fixed_tiled(input_buf.layout, stl)
             del tensor_box.layouts
 
-    restickify_plan: dict = defaultdict(list)
+    plan: dict = defaultdict(list)
 
     for op in operations:
         cost_fn = getattr(op, "restick_cost_fn", None)
@@ -271,7 +278,7 @@ def finalize_layouts(operations: list) -> None:
                 f"Injecting restickify on {op.get_name()} input {edge.dep.name}: "
                 f"{list(in_stl.stride_map)} -> {list(target_stl.stride_map)}"
             )
-            _record_restickify(op, edge.dep.name, restick_target, restickify_plan)
+            _record_restickify(op, edge.dep.name, restick_target, plan)
 
     # Handle mutation ops: check if their inputs need restickifying to match target buffer's stick.
     for op in operations:
@@ -312,6 +319,42 @@ def finalize_layouts(operations: list) -> None:
                 f"Injecting restickify on {op.get_name()} input {dep.name}: "
                 f"{list(in_stl.stride_map)} -> {list(target_stl.stride_map)}"
             )
-            _record_restickify(op, dep.name, restick_target, restickify_plan)
+            _record_restickify(op, dep.name, restick_target, plan)
 
-    V.graph.restickify_plan = restickify_plan
+    V.graph.restickify_plan = plan
+    if logger.isEnabledFor(logging.DEBUG):
+        if plan:
+            lines = ["restickify plan:"]
+            for op_name, resticks in plan.items():
+                consumer = V.graph.get_buffer(op_name)
+                if isinstance(consumer, ComputedBuffer) and hasattr(
+                    consumer.data, "reduction_type"
+                ):
+                    op_kind = f"reduction:{consumer.data.reduction_type}"
+                elif isinstance(consumer, ComputedBuffer):
+                    op_kind = "pointwise"
+                else:
+                    op_kind = type(consumer).__name__
+                for r in resticks:
+                    tgt = r["target_layout"]
+                    arg_name = r["arg_name"]
+                    arg_buf = V.graph.get_buffer(arg_name)
+                    if (
+                        isinstance(arg_buf, TensorBox)
+                        and isinstance(arg_buf.data, StorageBox)
+                        and isinstance(arg_buf.data.data, InputBuffer)
+                    ):
+                        buf_kind = "graph_input"
+                    elif isinstance(arg_buf, ComputedBuffer):
+                        buf_kind = "computed"
+                    else:
+                        buf_kind = type(arg_buf).__name__
+                    lines.append(
+                        f"  restickify {arg_name} ({buf_kind}) -> {op_name} ({op_kind})"
+                        f"  stride_map={list(tgt.device_layout.stride_map)}"
+                    )
+            logger.debug("\n".join(lines))
+        else:
+            logger.debug("restickify plan: (none)")
+    if os.getenv("SPYRE_CAPTURE_RESTICKIFY_PLAN"):
+        restickify_plan = dict(plan)

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -357,7 +357,6 @@ class Frontier:
         return state.assignments[idx]
 
     def best(self) -> BeamState:
-        assert self.states, "beam is empty — all candidate layouts produced INF cost"
         return self.states[0]
 
     def trim(self) -> None:
@@ -441,6 +440,10 @@ def beam_global_min_cost(operations: list) -> None:
 
         frontier.states = next_states
         frontier.trim()
+        if not frontier.states:
+            raise RuntimeError(
+                f"beam search: no feasible layout combination found after op {op.get_name()}"
+            )
         max_states = max(max_states, len(frontier.states))
         if logger.isEnabledFor(logging.DEBUG):
             lines = [f"beam after {op.get_name()} [{len(frontier.states)} states]:"]

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -14,10 +14,14 @@
 
 
 import abc
+import logging
 import math
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
+
+from . import config
+from .logging_utils import get_inductor_logger
 
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.ir import (
@@ -31,6 +35,8 @@ from torch_spyre._C import SpyreTensorLayout
 from .pass_utils import compute_restickify_needed
 
 INF = math.inf
+
+logger = get_inductor_logger("optimize_restickify")
 
 
 @dataclass(frozen=True)
@@ -237,14 +243,6 @@ class AnyInNode(RestickNodeCost):
         return []
 
 
-def optimize_restickify_locations(operations: list) -> None:
-    """Select restickify locations for all ops, minimizing total restickify cost.
-
-    Currently uses a greedy local algorithm; intended to be replaced with a global optimizer.
-    """
-    greedy_local_min_cost(operations)
-
-
 def greedy_local_min_cost(operations: list) -> None:
     """Greedy layout selection: process ops in topological order, picking the output layout with minimum local restick cost.
 
@@ -307,3 +305,170 @@ def greedy_local_min_cost(operations: list) -> None:
         )
 
         op.committed_stl = out_stl
+
+
+# Global Stick Optimizer
+#
+# The global optimizer is a simple forward-propagation algorithm that tracks a frontier of possible
+# "states" and their corresponding cost. A state is a combination of concrete restickify decisions
+# that have been made so far. The cost is a proxy for the runtime cost of executing those restickify
+# decisions.
+#
+# The number of states can grow exponentially. To prevent this blow-up the number of states is bounded
+# by a "beam width". When beam width is exceeded, the highest cost states are trimmed. Optimal cost is
+# only achieved if the optimal state always remains in the beam.
+#
+# Future improvements include (a) using live node analysis to prune dead states and (b) back-propagating
+# a "min_cost" to avoid dropping states that become important later. These will be added only once
+# we see evidence it matters in the models we are targeting.
+
+
+@dataclass
+class BeamState:
+    """One hypothesis in the beam: a partial assignment of STLs to ops, with accumulated cost.
+
+    assignments is a tuple parallel to a shared buf_names list — index i holds the
+    chosen SpyreTensorLayout for buf_names[i], or None for passthrough ops.
+    """
+
+    assignments: tuple  # tuple[SpyreTensorLayout | None, ...]
+    cost: float
+
+
+BEAM_WIDTH = 64
+
+
+class Frontier:
+    """Beam search frontier: shared buf_names index plus a list of BeamStates."""
+
+    def __init__(self, K: int):
+        self.K = K
+        self.buf_names: list[str] = []  # parallel index for BeamState.assignments
+        self._buf_idx: dict[str, int] = {}  # name -> index into buf_names
+        self.states: list[BeamState] = [BeamState(assignments=(), cost=0.0)]
+
+    def add_buf(self, name: str) -> None:
+        self._buf_idx[name] = len(self.buf_names)
+        self.buf_names.append(name)
+
+    def input_stl(self, state: BeamState, name: str) -> "SpyreTensorLayout | None":
+        """Return the hypothesized STL for an input buffer in this state."""
+        idx = self._buf_idx[name]
+        return state.assignments[idx]
+
+    def best(self) -> BeamState:
+        assert self.states, "beam is empty — all candidate layouts produced INF cost"
+        return self.states[0]
+
+    def trim(self) -> None:
+        self.states.sort(key=lambda s: s.cost)
+        before = len(self.states)
+        self.states = self.states[: self.K]
+        if len(self.states) < before:
+            logger.debug(
+                "beam trimmed: %d -> %d states (beam_width=%d)",
+                before,
+                len(self.states),
+                self.K,
+            )
+
+
+def beam_global_min_cost(operations: list) -> None:
+    """Global beam search layout selection.
+
+    Processes ops in topological order. For each op with a restick_cost_fn,
+    expands every current state by branching over candidate output STLs and
+    accumulating cost. After each op the beam is pruned to K best states.
+    At the end, the best state's assignments are committed to the ops.
+    """
+    # Commit graph inputs — fixed STL, same across all states.
+    for name in V.graph.graph_input_names:
+        tb = V.graph.graph_inputs[name]
+        if (
+            isinstance(tb, TensorBox)
+            and isinstance(tb.data, StorageBox)
+            and isinstance(tb.data.data, InputBuffer)
+            and hasattr(tb, "layouts")
+        ):
+            stl = next(iter(tb.layouts))
+            tb.data.data.committed_stl = stl
+            tb.committed_stl = stl
+
+    frontier = Frontier(BEAM_WIDTH)
+    max_states = 1
+
+    for op in operations:
+        if not hasattr(op, "layouts"):
+            continue
+
+        frontier.add_buf(op.get_name())
+
+        if not hasattr(op, "restick_cost_fn"):
+            assert len(op.layouts) == 1, (
+                f"passthrough op {op.get_name()} has {len(op.layouts)} layouts, expected 1"
+            )
+            frontier.states = [
+                BeamState(
+                    assignments=state.assignments + (op.layouts[0],),
+                    cost=state.cost,
+                )
+                for state in frontier.states
+            ]
+            continue
+
+        cost_fn = op.restick_cost_fn
+        deps = [dep for dep in op.get_read_writes().reads if isinstance(dep, MemoryDep)]
+
+        next_states = []
+        for state in frontier.states:
+            in_layouts = []
+            for dep in deps:
+                if dep.name in V.graph.graph_input_names:
+                    # When we allow multiple STLs for inputs this special case will go away
+                    in_layouts.append(V.graph.get_buffer(dep.name).committed_stl)
+                else:
+                    in_layouts.append(frontier.input_stl(state, dep.name))
+
+            for candidate_stl in op.layouts:
+                extra_cost = cost_fn.cost(in_layouts, candidate_stl)
+                if extra_cost < INF:
+                    next_states.append(
+                        BeamState(
+                            assignments=state.assignments + (candidate_stl,),
+                            cost=state.cost + extra_cost,
+                        )
+                    )
+
+        frontier.states = next_states
+        frontier.trim()
+        max_states = max(max_states, len(frontier.states))
+        if logger.isEnabledFor(logging.DEBUG):
+            lines = [f"beam after {op.get_name()} [{len(frontier.states)} states]:"]
+            for i, s in enumerate(frontier.states):
+                lines.append(f"  state {i} (cost={s.cost}):")
+                for name, stl in zip(frontier.buf_names, s.assignments):
+                    lines.append(f"    {name}: stride_map={list(stl.stride_map)}")
+            logger.debug("\n".join(lines))
+
+    logger.info(
+        "beam search done: max states = %d, best cost = %s",
+        max_states,
+        frontier.best().cost,
+    )
+
+    # Commit the best state's assignments to all ops.
+    best = frontier.best()
+    for name, stl in zip(frontier.buf_names, best.assignments):
+        op = V.graph.get_buffer(name)
+        if not isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+            op.committed_stl = stl
+
+
+def optimize_restickify_locations(operations: list) -> None:
+    """Select restickify locations for all ops, minimizing total restickify cost."""
+    if config.global_stick_optimizer:
+        logger.info("optimizer: beam (global)")
+        beam_global_min_cost(operations)
+    else:
+        logger.info("optimizer: greedy (local)")
+        greedy_local_min_cost(operations)


### PR DESCRIPTION
Augment restickify tests to check output correctness but also optimal cost of the restickify plan created

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The current restickify optimizer is a local greedy algorithm only.  This PR adds V1 of a global optimizer.

It is a simple beam-style forward-propagation algorithm that tracks a frontier of possible "states" and their corresponding cost. A state is a combination of concrete restickify decisions that have been made so far.  Cost is a proxy for the runtime cost of executing those restickify decisions.

The number of states can grow exponentially. To prevent this blow-up the number of states is bounded by a "beam width". When beam width is exceeded, the highest cost states are trimmed. Optimal cost is only achieved if the optimal state always remains in the beam.

Future improvements include (a) using live node analysis to prune dead states and (b) back-propagating a "min_cost" to avoid dropping states that become important later. These will be added only once we see evidence it matters in the models we are targeting.

An external optimized solver can also be added if warranted.


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/739

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Granite passes