### PR TITLE
feat: re-enable reduction dimension splitting for regular reductions

### DIFF
--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -100,8 +100,9 @@ For each operation, `work_distribution_pass`:
 2. Ranks the remaining dimensions (those not already committed by Pass 1) for
    additional core assignment (`prioritize_dimensions`): output dimensions
    first by decreasing stick-adjusted size, reduction dimensions last. For
-   non-matmul reductions, reduction dimensions are excluded entirely due to a
-   known backend limitation.
+   non-matmul reductions, at most one reduction dimension is eligible for
+   splitting — the one that maximises `core_split(size, remaining_cores)` after
+   output dimensions have absorbed their share of cores.
 3. Distributes all `max_cores` across committed and priority dimensions
    (`multi_dim_iteration_space_split`): first applies the committed splits as
    minimum requirements, then greedily assigns the largest valid divisor of
@@ -129,10 +130,12 @@ splits are computed jointly over all input and output tensors.
 
 ### Reduction Operations (non-matmul)
 
-Reduction dimensions are excluded from work division candidates due to a known
-backend limitation. Only output dimensions are split. Span-required splits are
-asserted to not involve reduction variables; if they do, the compiler raises an
-error.
+Output dimensions are split first, by decreasing size. After output dimensions
+have been assigned cores, at most one reduction dimension may also be split: the
+one whose size has the most useful divisors for the remaining core budget (i.e.
+maximises `core_split(size, remaining_cores)`). Span-required splits may include
+at most one reduction variable; if more than one reduction variable must be split
+to satisfy the 256 MB limit, the compiler raises an error.
 
 ### Matrix Multiplication
 
@@ -160,7 +163,6 @@ values range from 1 (no parallelization) to 32 (maximum supported cores).
 - Dimensions must divide evenly by the slice count (no uneven splits)
 - Only `Pointwise` and `Reduction` IR nodes are dispatched for work division;
   `ExternKernel` and `FallbackKernel` nodes are skipped
-- Non-matmul reductions cannot split along the reduction dimension
 
 **Potential future enhancements:**
 

--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -99,10 +99,11 @@ For each operation, `work_distribution_pass`:
    symbols are renamed.
 2. Ranks the remaining dimensions (those not already committed by Pass 1) for
    additional core assignment (`prioritize_dimensions`): output dimensions
-   first by decreasing stick-adjusted size, reduction dimensions last. For
-   non-matmul reductions, at most one reduction dimension is eligible for
-   splitting — the one that maximises `core_split(size, remaining_cores)` after
-   output dimensions have absorbed their share of cores.
+   first by decreasing stick-adjusted size, reduction dimensions last. At most
+   one reduction dimension is eligible for splitting — the one that maximises
+   `core_split(size, remaining_cores)` after output dimensions have absorbed
+   their share of cores. If Pass 1 already committed a reduction split, no
+   further reduction dimensions are eligible.
 3. Distributes all `max_cores` across committed and priority dimensions
    (`multi_dim_iteration_space_split`): first applies the committed splits as
    minimum requirements, then greedily assigns the largest valid divisor of
@@ -128,27 +129,24 @@ The iteration space is that of the output tensor. All output dimensions are
 candidates for splitting. There is no reduction dimension. Span-required
 splits are computed jointly over all input and output tensors.
 
-### Reduction Operations (non-matmul)
+### Reduction Operations
 
 Output dimensions are split first, by decreasing size. After output dimensions
 have been assigned cores, at most one reduction dimension may also be split: the
 one whose size has the most useful divisors for the remaining core budget (i.e.
-maximises `core_split(size, remaining_cores)`). Span-required splits may include
-at most one reduction variable; if more than one reduction variable must be split
-to satisfy the 256 MB limit, the compiler raises an error.
+maximises `core_split(size, remaining_cores)`). If Pass 1 already committed a
+reduction split to satisfy the span limit, no further reduction dimension is
+split in Pass 2.
 
-### Matrix Multiplication
+Span-required splits may include at most one reduction variable; if more than
+one reduction variable must be split to satisfy the 256 MB limit, the compiler
+raises an error.
 
-The iteration space covers the M (rows), K (reduction), and N (columns)
-dimensions. All three are candidates. The priority order after span-required
-splits is: output dimensions (M and N) by decreasing size, then K last. K is
-only split when M and N cannot utilize all available cores.
-
-### Batched Matrix Multiplication
-
-Same as matrix multiplication, with additional batch dimensions prepended.
-Batch dimensions appear as output dimensions and receive the highest priority
-(largest size first), followed by N, M, and finally K.
+For matrix multiplication the reduction dimension is K. Since all matrix
+multiply variants (mm, bmm) have exactly one K dimension, K is treated as any
+other reduction dimension: output dimensions (batch, M, N) take priority by
+decreasing size, and K is only split when the output dimensions cannot utilise
+all available cores.
 
 ## Configuration
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -530,6 +530,9 @@ def span_reduction_pass(
 
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
     reduction_vars_to_split = set(min_splits) - coord_vars
+    # Each entry in Reduction.reduction_ranges maps to at most one Symbol via
+    # index_vars_squeeze (size-1 entries are squeezed away). So len > 1 means
+    # genuinely distinct reduction dimensions, not multiple symbols from one dim.
     if len(reduction_vars_to_split) > 1:
         raise Unsupported(
             f"Cannot satisfy hardware memory span limit "

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -122,12 +122,19 @@ def multi_dim_iteration_space_split(
 
     The product of all splits will be <= max_cores.
     """
-    is_reduction = bool(reduction_dims)
+    is_reduction_included = bool(reduction_dims)
 
     splits = {v: 1 for v in iteration_space.keys()}
     n_cores_remaining = max_cores
 
     if min_splits:
+        # Sanity check: making sure that reduction_dims list is cleared up if
+        #               any reduction dim is already selected during span reduction
+        assert (
+            not is_reduction_included  # not empty
+            or not any(v in min_splits for v in reduction_dims)  # no overlap
+        )
+
         for var, min_split in min_splits.items():
             assert var not in output_dims and var not in reduction_dims
 
@@ -151,7 +158,7 @@ def multi_dim_iteration_space_split(
             splits[v] = best_split
             n_cores_remaining = n_cores_remaining // best_split
 
-    if is_reduction and n_cores_remaining > 1:
+    if is_reduction_included and n_cores_remaining > 1:
         result = _most_splittable_dim(
             reduction_dims, iteration_space, n_cores_remaining
         )

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -592,6 +592,13 @@ def work_distribution_pass(
         s: e for s, e in it_space_adjusted.items() if s not in committed_splits
     }
     output_dims, reduction_dims = prioritize_dimensions(output_td, it_space_remaining)
+
+    # If span_reduction_pass already committed a reduction split, suppress further
+    # reduction splitting so the final result never exceeds one reduction dim split.
+    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    if any(v not in coord_vars for v in committed_splits):
+        reduction_dims = []
+
     # Pass max_cores, not remaining_cores: multi_dim_iteration_space_split
     # accounts for committed_splits in its first pass, consuming those cores
     # itself before distributing the rest by priority.

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -106,6 +106,8 @@ def multi_dim_iteration_space_split(
 
     The product of all splits will be <= max_cores.
     """
+    assert reduction_split_limit is None or 0 <= reduction_split_limit <= 1
+
     splits = {v: 1 for v in iteration_space.keys()}
     n_cores_remaining = max_cores
 
@@ -123,7 +125,10 @@ def multi_dim_iteration_space_split(
             splits[var] = min_split
             n_cores_remaining = n_cores_remaining // min_split
 
-    for v in output_dims:
+    greedy_dims = (
+        output_dims + reduction_dims if reduction_split_limit is None else output_dims
+    )
+    for v in greedy_dims:
         if n_cores_remaining <= 1:
             break
         # TODO(issue#1372): with symbolic work division, concretize_expr
@@ -133,17 +138,7 @@ def multi_dim_iteration_space_split(
             splits[v] = best_split
             n_cores_remaining = n_cores_remaining // best_split
 
-    if reduction_split_limit is None:
-        for v in reduction_dims:
-            if n_cores_remaining <= 1:
-                break
-            best_split = core_split(
-                concretize_expr(iteration_space[v]), n_cores_remaining
-            )
-            if best_split > 1:
-                splits[v] = best_split
-                n_cores_remaining = n_cores_remaining // best_split
-    elif reduction_split_limit >= 1 and n_cores_remaining > 1:
+    if reduction_split_limit == 1 and n_cores_remaining > 1:
         best_dim, best_split = None, 0
         for d in reduction_dims:
             s = core_split(concretize_expr(iteration_space[d]), n_cores_remaining)

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -34,7 +34,7 @@ from torch._inductor.ir import (
 from torch._inductor.dependencies import MemoryDep
 
 from .errors import Unsupported
-from .constants import BATCH_MATMUL_OP, TOPK_OPS
+from .constants import TOPK_OPS
 from .ir import FixedTiledLayout
 from .pass_utils import (
     SchedNodeArg,
@@ -110,7 +110,6 @@ def multi_dim_iteration_space_split(
     max_cores: int,
     output_dims: list[Symbol],
     reduction_dims: list[Symbol],
-    reduction_split_limit: int | None = None,
     min_splits: dict[Symbol, int] | None = None,
 ) -> dict[Symbol, int]:
     """Distribute max_cores across the iteration space.
@@ -118,12 +117,12 @@ def multi_dim_iteration_space_split(
     Three-pass algorithm:
       1. Satisfy min_splits (span-reduction commitments).
       2. Distribute remaining cores to output_dims in priority order.
-      3. Distribute remaining cores to reduction_dims subject to
-         reduction_split_limit (None = unlimited, 0 = skip, 1 = pick best).
+      3. If this is a reduction op, pick the single most-splittable reduction dim
+         for any remaining cores.
 
     The product of all splits will be <= max_cores.
     """
-    assert reduction_split_limit is None or 0 <= reduction_split_limit <= 1
+    is_reduction = bool(reduction_dims)
 
     splits = {v: 1 for v in iteration_space.keys()}
     n_cores_remaining = max_cores
@@ -142,9 +141,7 @@ def multi_dim_iteration_space_split(
             splits[var] = min_split
             n_cores_remaining = n_cores_remaining // min_split
 
-    greedy_dims = (
-        output_dims + reduction_dims if reduction_split_limit is None else output_dims
-    )
+    greedy_dims = output_dims if is_reduction else output_dims + reduction_dims
     for v in greedy_dims:
         if n_cores_remaining <= 1:
             break
@@ -155,7 +152,7 @@ def multi_dim_iteration_space_split(
             splits[v] = best_split
             n_cores_remaining = n_cores_remaining // best_split
 
-    if reduction_split_limit == 1 and n_cores_remaining > 1:
+    if is_reduction and n_cores_remaining > 1:
         result = _most_splittable_dim(
             reduction_dims, iteration_space, n_cores_remaining
         )
@@ -516,7 +513,6 @@ def span_reduction_pass(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
     max_cores: int,
-    reduction_split_limit: int | None,
 ) -> None:
     """Mandatory per-op pass: compute minimum splits to satisfy the 256MB span limit.
 
@@ -532,17 +528,15 @@ def span_reduction_pass(
         all_tds, it_space, it_space_adjusted, stick_vars, max_cores
     )
 
-    if reduction_split_limit is not None:
-        coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
-        reduction_vars_to_split = set(min_splits) - coord_vars
-        if len(reduction_vars_to_split) > reduction_split_limit:
-            raise Unsupported(
-                f"Cannot satisfy hardware memory span limit "
-                f"({MAX_SPAN_BYTES // (1024 * 1024)}MB) without splitting "
-                f"{len(reduction_vars_to_split)} reduction dimension(s) "
-                f"({reduction_vars_to_split}), but the backend supports at most "
-                f"{reduction_split_limit}."
-            )
+    coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
+    reduction_vars_to_split = set(min_splits) - coord_vars
+    if len(reduction_vars_to_split) > 1:
+        raise Unsupported(
+            f"Cannot satisfy hardware memory span limit "
+            f"({MAX_SPAN_BYTES // (1024 * 1024)}MB) without splitting "
+            f"{len(reduction_vars_to_split)} reduction dimension(s) "
+            f"({reduction_vars_to_split}), but the backend supports at most 1."
+        )
 
     apply_splits(
         op,
@@ -560,7 +554,6 @@ def work_distribution_pass(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
     max_cores: int,
-    reduction_split_limit: int | None,
 ) -> None:
     """Optional per-op pass: distribute remaining cores to maximize parallelism.
 
@@ -607,7 +600,6 @@ def work_distribution_pass(
         max_cores,
         output_dims,
         reduction_dims,
-        reduction_split_limit,
         committed_splits,
     )
     apply_splits(
@@ -629,7 +621,7 @@ def divide_pointwise_op(
     max_cores: int,
     pass_fn: Callable,
 ) -> None:
-    pass_fn(op, args, max_cores, reduction_split_limit=None)
+    pass_fn(op, args, max_cores)
 
 
 def divide_reduction_op(
@@ -645,9 +637,7 @@ def divide_reduction_op(
     if red.reduction_type in TOPK_OPS:
         return
 
-    is_matmul = red.reduction_type == BATCH_MATMUL_OP
-    reduction_split_limit = None if is_matmul else 1
-    pass_fn(op, args, max_cores, reduction_split_limit=reduction_split_limit)
+    pass_fn(op, args, max_cores)
 
 
 def _validate_max_cores() -> int:

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -141,8 +141,7 @@ def multi_dim_iteration_space_split(
             splits[var] = min_split
             n_cores_remaining = n_cores_remaining // min_split
 
-    greedy_dims = output_dims if is_reduction else output_dims + reduction_dims
-    for v in greedy_dims:
+    for v in output_dims:
         if n_cores_remaining <= 1:
             break
         # TODO(issue#1372): with symbolic work division, concretize_expr

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -91,50 +91,39 @@ def core_split(size: int, max_cores: int) -> int:
 def multi_dim_iteration_space_split(
     iteration_space: dict[Symbol, Expr],
     max_cores: int,
-    priorities: list[Symbol],
+    output_dims: list[Symbol],
+    reduction_dims: list[Symbol],
+    reduction_split_limit: int | None = None,
     min_splits: dict[Symbol, int] | None = None,
 ) -> dict[Symbol, int]:
-    """
-    Distribute max_cores across multiple dimensions of an iteration space.
+    """Distribute max_cores across the iteration space.
 
-    This function tries to split cores across multiple dimensions to maximize
-    parallelism while ensuring even division. It uses a two-pass approach:
-    1. First pass: satisfy minimum split requirements (hardware constraints)
-    2. Second pass: distribute remaining cores by priority
+    Three-pass algorithm:
+      1. Satisfy min_splits (span-reduction commitments).
+      2. Distribute remaining cores to output_dims in priority order.
+      3. Distribute remaining cores to reduction_dims subject to
+         reduction_split_limit (None = unlimited, 0 = skip, 1 = pick best).
 
-    Args:
-        iteration_space: The iteration space to be parallelized
-        max_cores: Total number of cores available
-        priorities: Order in which to consider the dimensions
-        min_splits: Minimum splits required for each dimension (optional)
-
-    Returns:
-        The core splits for the iteration_space
-        The product of all splits will be <= max_cores
+    The product of all splits will be <= max_cores.
     """
     splits = {v: 1 for v in iteration_space.keys()}
     n_cores_remaining = max_cores
 
-    # First pass: satisfy minimum split requirements
     if min_splits:
         for var, min_split in min_splits.items():
-            assert var not in priorities  # there shouldn't be an overlap
+            assert var not in output_dims and var not in reduction_dims
 
-            # Check if we have enough cores for this minimum split
             if n_cores_remaining // min_split <= 0:
                 logger.critical(
                     f"Cannot satisfy minimum split requirement for {var}: "
                     f"need {min_split} splits but only {n_cores_remaining} cores remaining. "
                     f"Skipping this constraint - hardware span limit may be violated."
                 )
-                continue  # Skip this variable, leave splits[var] = 1
-
-            # Safe to apply the minimum split
+                continue
             splits[var] = min_split
             n_cores_remaining = n_cores_remaining // min_split
 
-    # Second pass: distribute remaining cores by priority
-    for v in priorities:
+    for v in output_dims:
         if n_cores_remaining <= 1:
             break
         # TODO(issue#1372): with symbolic work division, concretize_expr
@@ -143,6 +132,25 @@ def multi_dim_iteration_space_split(
         if best_split > 1:
             splits[v] = best_split
             n_cores_remaining = n_cores_remaining // best_split
+
+    if reduction_split_limit is None:
+        for v in reduction_dims:
+            if n_cores_remaining <= 1:
+                break
+            best_split = core_split(
+                concretize_expr(iteration_space[v]), n_cores_remaining
+            )
+            if best_split > 1:
+                splits[v] = best_split
+                n_cores_remaining = n_cores_remaining // best_split
+    elif reduction_split_limit >= 1 and n_cores_remaining > 1:
+        best_dim, best_split = None, 0
+        for d in reduction_dims:
+            s = core_split(concretize_expr(iteration_space[d]), n_cores_remaining)
+            if s > best_split:
+                best_dim, best_split = d, s
+        if best_split > 1:
+            splits[best_dim] = best_split
 
     return splits
 
@@ -403,40 +411,32 @@ def must_split_vars(
 def prioritize_dimensions(
     output: TensorDep,
     it_space_adjusted: dict[Symbol, Expr],
-    exclude_reduction: bool = False,
-) -> list[Symbol]:
-    """Return iteration variables in priority order for work distribution.
+) -> tuple[list[Symbol], list[Symbol]]:
+    """Partition iteration variables into output dims and reduction dims.
+
+    Output dims are those whose symbols appear in the output tensor's device
+    coordinate expressions (excluding the stick coordinate). Reduction dims are
+    the remainder. Both lists are sorted by decreasing concrete size.
 
     Variables already committed as min_splits should be filtered out of
     it_space_adjusted before calling this function.
-
-    Priority tiers:
-      1. Output dims (present in output device coords), by decreasing size.
-      2. Reduction dims (absent from output coords), by decreasing size.
     """
     coord_vars = {v for e in output.device_coords[:-1] for v in e.free_symbols}
 
-    remaining_output = []
-    reduction_dims: list[tuple[Symbol, Expr]] = []
+    output_pairs: list[tuple[Symbol, Expr]] = []
+    reduction_pairs: list[tuple[Symbol, Expr]] = []
     for s, e in it_space_adjusted.items():
-        if s in coord_vars:
-            remaining_output.append((s, e))
-        else:
-            reduction_dims.append((s, e))
+        (output_pairs if s in coord_vars else reduction_pairs).append((s, e))
 
     # Concretize sort keys: comparing two sympy Symbols returns a Relational
     # whose truth value is undefined and would raise inside Python's sort.
     # The priority order is a structural decision (largest dim first) that
     # needs a concrete numeric ordering.
     # TODO(issue#1372): Symbolic work division will keep this symbolic.
-    remaining_output.sort(key=lambda t: concretize_expr(t[1]), reverse=True)
-    reduction_dims.sort(key=lambda t: concretize_expr(t[1]), reverse=True)
+    output_pairs.sort(key=lambda t: concretize_expr(t[1]), reverse=True)
+    reduction_pairs.sort(key=lambda t: concretize_expr(t[1]), reverse=True)
 
-    priority = [t[0] for t in remaining_output]
-    if not exclude_reduction:
-        priority += [t[0] for t in reduction_dims]
-
-    return priority
+    return [t[0] for t in output_pairs], [t[0] for t in reduction_pairs]
 
 
 def _resolve_layout(op: ComputedBuffer) -> "FixedTiledLayout":
@@ -505,7 +505,7 @@ def span_reduction_pass(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
     max_cores: int,
-    exclude_reduction: bool,
+    reduction_split_limit: int | None,
 ) -> None:
     """Mandatory per-op pass: compute minimum splits to satisfy the 256MB span limit.
 
@@ -521,15 +521,16 @@ def span_reduction_pass(
         all_tds, it_space, it_space_adjusted, stick_vars, max_cores
     )
 
-    if exclude_reduction:
+    if reduction_split_limit is not None:
         coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
         reduction_vars_to_split = set(min_splits) - coord_vars
-        if reduction_vars_to_split:
+        if len(reduction_vars_to_split) > reduction_split_limit:
             raise Unsupported(
                 f"Cannot satisfy hardware memory span limit "
-                f"({MAX_SPAN_BYTES // (1024 * 1024)}MB) without splitting reduction "
-                f"dimensions {reduction_vars_to_split}, but the backend does not "
-                f"support splitting reduction dimensions for this operation type."
+                f"({MAX_SPAN_BYTES // (1024 * 1024)}MB) without splitting "
+                f"{len(reduction_vars_to_split)} reduction dimension(s) "
+                f"({reduction_vars_to_split}), but the backend supports at most "
+                f"{reduction_split_limit}."
             )
 
     apply_splits(
@@ -548,7 +549,7 @@ def work_distribution_pass(
     op: ComputedBuffer,
     args: list[SchedNodeArg],
     max_cores: int,
-    exclude_reduction: bool,
+    reduction_split_limit: int | None,
 ) -> None:
     """Optional per-op pass: distribute remaining cores to maximize parallelism.
 
@@ -586,14 +587,17 @@ def work_distribution_pass(
     it_space_remaining = {
         s: e for s, e in it_space_adjusted.items() if s not in committed_splits
     }
-    priorities = prioritize_dimensions(
-        output_td, it_space_remaining, exclude_reduction=exclude_reduction
-    )
+    output_dims, reduction_dims = prioritize_dimensions(output_td, it_space_remaining)
     # Pass max_cores, not remaining_cores: multi_dim_iteration_space_split
     # accounts for committed_splits in its first pass, consuming those cores
     # itself before distributing the rest by priority.
     splits = multi_dim_iteration_space_split(
-        it_space_adjusted, max_cores, priorities, committed_splits
+        it_space_adjusted,
+        max_cores,
+        output_dims,
+        reduction_dims,
+        reduction_split_limit,
+        committed_splits,
     )
     apply_splits(
         op,
@@ -601,7 +605,7 @@ def work_distribution_pass(
         output_td,
         it_space,
         it_space_adjusted,
-        priorities,
+        output_dims + reduction_dims,
         committed_splits,
         kind="work_distribution",
     )
@@ -614,7 +618,7 @@ def divide_pointwise_op(
     max_cores: int,
     pass_fn: Callable,
 ) -> None:
-    pass_fn(op, args, max_cores, exclude_reduction=False)
+    pass_fn(op, args, max_cores, reduction_split_limit=None)
 
 
 def divide_reduction_op(
@@ -631,10 +635,8 @@ def divide_reduction_op(
         return
 
     is_matmul = red.reduction_type == BATCH_MATMUL_OP
-    # FIXME: For non-matmul reduction, excluding reduction dimensions from work
-    #        division candidates temporarily till known backend issue is fixed
-    #        https://github.com/torch-spyre/torch-spyre/issues/1304
-    pass_fn(op, args, max_cores, exclude_reduction=not is_matmul)
+    reduction_split_limit = None if is_matmul else 1
+    pass_fn(op, args, max_cores, reduction_split_limit=reduction_split_limit)
 
 
 def _validate_max_cores() -> int:

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -88,6 +88,23 @@ def core_split(size: int, max_cores: int) -> int:
     return 1
 
 
+def _most_splittable_dim(
+    dims: list[Symbol],
+    iteration_space: dict[Symbol, Expr],
+    n_cores: int,
+) -> tuple[Symbol, int] | None:
+    """Return (dim, split) for the dim in dims that maximises core_split(size, n_cores).
+
+    Returns None if no dim yields a split > 1.
+    """
+    best_dim, best_split = None, 0
+    for d in dims:
+        s = core_split(concretize_expr(iteration_space[d]), n_cores)
+        if s > best_split:
+            best_dim, best_split = d, s
+    return (best_dim, best_split) if best_split > 1 else None
+
+
 def multi_dim_iteration_space_split(
     iteration_space: dict[Symbol, Expr],
     max_cores: int,
@@ -139,12 +156,11 @@ def multi_dim_iteration_space_split(
             n_cores_remaining = n_cores_remaining // best_split
 
     if reduction_split_limit == 1 and n_cores_remaining > 1:
-        best_dim, best_split = None, 0
-        for d in reduction_dims:
-            s = core_split(concretize_expr(iteration_space[d]), n_cores_remaining)
-            if s > best_split:
-                best_dim, best_split = d, s
-        if best_split > 1:
+        result = _most_splittable_dim(
+            reduction_dims, iteration_space, n_cores_remaining
+        )
+        if result is not None:
+            best_dim, best_split = result
             splits[best_dim] = best_split
 
     return splits

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -484,17 +484,10 @@ def apply_splits(
     op: ComputedBuffer,
     splits: dict,
     output_td: TensorDep,
-    it_space: dict,
-    it_space_adjusted: dict,
-    priorities: list,
-    min_splits: dict,
-    kind: str,
 ) -> None:
-    """Commit splits to op and emit a debug log entry.
+    """Commit splits to op.
 
     Does nothing when the product of splits is 1 (no parallelism).
-    kind is a short label used in the log message (e.g. "span_reduction" or
-    "work_distribution").
     """
     cores_used = math.prod(splits.values())
     if cores_used <= 1:
@@ -505,14 +498,6 @@ def apply_splits(
     first_read = next(iter(rw.reads), None)
     read_index = first_read.index if first_read is not None else write_index
     op.op_it_space_splits = splits_by_index_coeff(splits, write_index, read_index)
-
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.debug(
-            f"{kind} work_division {op.get_name()}: cores={cores_used}, "
-            f"iteration_space={it_space}, it_space_adjusted={it_space_adjusted}, "
-            f"priorities={priorities}, min_splits={min_splits}, "
-            f"op_it_space_splits={op.op_it_space_splits}"
-        )
 
 
 def span_reduction_pass(
@@ -547,16 +532,15 @@ def span_reduction_pass(
             f"({reduction_vars_to_split}), but the backend supports at most 1."
         )
 
-    apply_splits(
-        op,
-        min_splits,
-        output_td,
-        it_space,
-        it_space_adjusted,
-        [],
-        min_splits,
-        kind="span_reduction",
-    )
+    apply_splits(op, min_splits, output_td)
+
+    if logger.isEnabledFor(logging.DEBUG) and math.prod(min_splits.values()) > 1:
+        logger.debug(
+            f"span_reduction work_division {op.get_name()}: cores={math.prod(min_splits.values())}, "
+            f"iteration_space={it_space}, it_space_adjusted={it_space_adjusted}, "
+            f"priorities=[], min_splits={min_splits}, "
+            f"op_it_space_splits={op.op_it_space_splits}"
+        )
 
 
 def work_distribution_pass(
@@ -618,16 +602,16 @@ def work_distribution_pass(
         reduction_dims,
         committed_splits,
     )
-    apply_splits(
-        op,
-        splits,
-        output_td,
-        it_space,
-        it_space_adjusted,
-        output_dims + reduction_dims,
-        committed_splits,
-        kind="work_distribution",
-    )
+    apply_splits(op, splits, output_td)
+
+    if logger.isEnabledFor(logging.DEBUG) and math.prod(splits.values()) > 1:
+        logger.debug(
+            f"work_distribution work_division {op.get_name()}: cores={math.prod(splits.values())}, "
+            f"iteration_space={it_space}, it_space_adjusted={it_space_adjusted}, "
+            f"priorities={output_dims + reduction_dims}, min_splits={committed_splits}, "
+            f"op_it_space_splits={op.op_it_space_splits}"
+        )
+
     warn_if_per_core_overflow(all_tds, it_space, splits, op.get_name())
 
 


### PR DESCRIPTION
Now that issue #1304 is resolved, non-matmul reduction ops can split reduction dimensions. 

For reductions (including matmul and non-matmul), multi_dim_iteration_space_split picks the single reduction dim that maximizes core_split(size, remaining_cores) after output dims have absorbed their share — not simply the largest dim.

Also refactors prioritize_dimensions to return (output_dims, reduction_dims) as separate lists, removing the exclude_reduction parameter.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [x] documentation
- [x] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

Fixes #1874

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
