### PR TITLE
Simplify global optimizer main loop

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -455,6 +455,17 @@ def test_bmm_xt_yt(bmm_tensors_ab_ba):
     _compare(lambda x, y: torch.matmul(x.transpose(1, 2), y.transpose(1, 2)), x, y)
 
 
+# ------- FallbackKernel + restickify regression test ---------
+
+
+@pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
+def test_fallback_with_restickify():
+    # FallbackKernel (torch.sin) produces a MultiOutput node. Verify the optimizer
+    # handles it via AnyInNode and still makes a correct restickify decision downstream.
+    x, y = _make_tensors(2, S, S)
+    _compare(lambda x, y: torch.sin(x) + y.t(), x, y, optimal_cost=S * S)
+
+
 # ------- Mutation + restickify regression test ---------
 
 

--- a/torch_spyre/_inductor/optimize_restickify.py
+++ b/torch_spyre/_inductor/optimize_restickify.py
@@ -271,11 +271,9 @@ def greedy_local_min_cost(operations: list) -> None:
         if not hasattr(op, "layouts"):
             continue  # FallbackKernel and other unhandled op types
 
-        if not hasattr(op, "restick_cost_fn"):
-            if not isinstance(op.layout, MutationLayoutSHOULDREMOVE):
-                op.committed_stl = op.layouts[0]
-            continue
-
+        assert hasattr(op, "restick_cost_fn"), (
+            f"op {op.get_name()} has layouts but no restick_cost_fn"
+        )
         cost_fn = op.restick_cost_fn
 
         # Collect each input arg's committed layout (finalized by earlier topo iterations).
@@ -380,7 +378,8 @@ def beam_global_min_cost(operations: list) -> None:
     accumulating cost. After each op the beam is pruned to K best states.
     At the end, the best state's assignments are committed to the ops.
     """
-    # Commit graph inputs — fixed STL, same across all states.
+    frontier = Frontier(BEAM_WIDTH)
+    # Commit graph inputs and seed into the frontier so input_stl() works uniformly for all deps.
     for name in V.graph.graph_input_names:
         tb = V.graph.graph_inputs[name]
         if (
@@ -391,9 +390,12 @@ def beam_global_min_cost(operations: list) -> None:
         ):
             stl = next(iter(tb.layouts))
             tb.data.data.committed_stl = stl
-            tb.committed_stl = stl
+            frontier.add_buf(name)
+            frontier.states = [
+                BeamState(assignments=state.assignments + (stl,), cost=state.cost)
+                for state in frontier.states
+            ]
 
-    frontier = Frontier(BEAM_WIDTH)
     max_states = 1
 
     for op in operations:
@@ -402,31 +404,15 @@ def beam_global_min_cost(operations: list) -> None:
 
         frontier.add_buf(op.get_name())
 
-        if not hasattr(op, "restick_cost_fn"):
-            assert len(op.layouts) == 1, (
-                f"passthrough op {op.get_name()} has {len(op.layouts)} layouts, expected 1"
-            )
-            frontier.states = [
-                BeamState(
-                    assignments=state.assignments + (op.layouts[0],),
-                    cost=state.cost,
-                )
-                for state in frontier.states
-            ]
-            continue
-
+        assert hasattr(op, "restick_cost_fn"), (
+            f"op {op.get_name()} has layouts but no restick_cost_fn"
+        )
         cost_fn = op.restick_cost_fn
         deps = [dep for dep in op.get_read_writes().reads if isinstance(dep, MemoryDep)]
 
         next_states = []
         for state in frontier.states:
-            in_layouts = []
-            for dep in deps:
-                if dep.name in V.graph.graph_input_names:
-                    # When we allow multiple STLs for inputs this special case will go away
-                    in_layouts.append(V.graph.get_buffer(dep.name).committed_stl)
-                else:
-                    in_layouts.append(frontier.input_stl(state, dep.name))
+            in_layouts = [frontier.input_stl(state, dep.name) for dep in deps]
 
             for candidate_stl in op.layouts:
                 extra_cost = cost_fn.cost(in_layouts, candidate_stl)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -545,6 +545,7 @@ def propagate_spyre_tensor_layouts(
     for op in it:
         if op.is_no_op():
             op.layouts = [generic_layout(op)]
+            op.restick_cost_fn = AnyInNode.from_args()
         elif isinstance(op, ComputedBuffer):
             if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
                 continue
@@ -562,6 +563,7 @@ def propagate_spyre_tensor_layouts(
             if not isinstance(op, MultiOutput):
                 raise RuntimeError("FallbackKernel must be followed by MultiOutput")
             op.layouts = [generic_layout(op)]
+            op.restick_cost_fn = AnyInNode.from_args()
         elif isinstance(op, SpyreConstantFallback):
             op.layouts = [generic_layout(op)]
             op.restick_cost_fn = AnyInNode.from_args()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR is two small changes to the global restickify optimizer to remove the special cases from the main loop.  Now the main loop is just (a) initialize from inputs (b) topological propagation

Changes are:

1. Make sure all node types have cost functions, to eliminate the need to handle nodes missing cost functions.  The only ones missing were `no-op` and `multi_output`

2. Insert inputs into the beam state up front during existing input initialization, so the loop doesn't need to check for inputs and handle them differently.


#### Which issue(s) this PR is related to:

#739

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
