### PR TITLE
Move the zero-numel guard before self/dst checks

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1018,6 +1018,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     cached_randn((2, 4, 8, 64), dtype=torch.float16),
                     cached_randn((2, 4, 12, 64), dtype=torch.float16),
                 ),
+                "4d_dim2_zero": (
+                    2,
+                    cached_randn((0)),
+                    cached_randn((1, 8, 14, 64), dtype=torch.float16),
+                ),
                 "4d_dim3": (
                     3,
                     cached_randn((2, 4, 8, 64), dtype=torch.float16),

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -170,6 +170,9 @@ def spyre__local_scalar_dense(self):
 
 @torch.library.register_kernel("aten::_copy_from", ["spyre"])
 def spyre__copy_from(self, dst, non_blocking=False):
+    if self.numel() == 0:
+        return dst
+
     # Check if views of same data
     if (
         self.data_ptr() == dst.data_ptr()
@@ -180,9 +183,6 @@ def spyre__copy_from(self, dst, non_blocking=False):
         and self.is_conj() == dst.is_conj()
         and self.is_neg() == dst.is_neg()
     ):
-        return dst
-
-    if self.numel() == 0:
         return dst
 
     if (self.device.type == "cpu" and dst.device.type == "spyre") or (


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fix to change the order of zero-numel guard and self/dst comparisons to avoid unnecessary checks in `spyre__copy_from`.

#### Which issue(s) this PR is related to:

Fixes issue #1407

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
