### PR TITLE
Add utility to support PyTorch mark_dynamic API with max

### DIFF
--- a/tests/dynamic_shapes/mark_dynamic.py
+++ b/tests/dynamic_shapes/mark_dynamic.py
@@ -1,0 +1,51 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Compiled via torch.compile with an explicit dynamic dimension registered
+# through torch._dynamo.mark_dynamic.  Dim 0 is annotated with min=1, max=576,
+# so the ShapeEnv records a finite upper bound for that symbol. This is planned to
+# exercise the path where compute_max_size can return the
+# ShapeEnv bound directly rather than falling back to size_hint.
+# Right now this is a work in progress- the bound is not yet propagated into
+# the SDSC.  
+
+
+import torch
+import torch._dynamo as dynamo
+import torch.nn.functional as F
+
+DEVICE = torch.device("spyre")
+torch.manual_seed(0xAFFE)
+
+
+def gelu_fn(a):
+    return F.gelu(a)
+
+
+x = torch.rand(512, 1024, dtype=torch.float16)
+
+# Mark dim 0 as dynamic with an explicit upper bound.
+x_device = x.to(DEVICE)
+dynamo.mark_dynamic(x_device, 0, min=1, max=576)
+compiled_fn = torch.compile(gelu_fn, dynamic=True)
+cpu_result = gelu_fn(x)
+
+compiled_result = compiled_fn(x_device).cpu()
+
+# Compare results
+print(f"CPU result\n{cpu_result}")
+print(f"Spyre Compiled result\n{compiled_result}")
+cpu_delta = torch.abs(compiled_result - cpu_result).max()
+print(f"Max delta Compiled Spyre vs. CPU: {cpu_delta}")

--- a/tests/dynamic_shapes/mark_dynamic.py
+++ b/tests/dynamic_shapes/mark_dynamic.py
@@ -19,7 +19,7 @@
 # exercise the path where compute_max_size can return the
 # ShapeEnv bound directly rather than falling back to size_hint.
 # Right now this is a work in progress- the bound is not yet propagated into
-# the SDSC.  
+# the SDSC.
 
 
 import torch
@@ -39,7 +39,7 @@ x = torch.rand(512, 1024, dtype=torch.float16)
 # Mark dim 0 as dynamic with an explicit upper bound.
 x_device = x.to(DEVICE)
 dynamo.mark_dynamic(x_device, 0, min=1, max=576)
-compiled_fn = torch.compile(gelu_fn, dynamic=True)
+compiled_fn = torch.compile(gelu_fn)
 cpu_result = gelu_fn(x)
 
 compiled_result = compiled_fn(x_device).cpu()

--- a/tests/inductor/test_inductor_fx_passes.py
+++ b/tests/inductor/test_inductor_fx_passes.py
@@ -219,6 +219,47 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             result = concretize_index(index, loop_vars)
             assert result == index, f"Expected {index}, got {result}"
 
+    def test_compute_max_size(self):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        import sympy
+        from torch_spyre._inductor.pass_utils import compute_max_size
+
+        # branches that need no V.graph
+        assert compute_max_size(42) == 42
+        assert compute_max_size(sympy.Integer(7)) == 7
+        assert compute_max_size(sympy.Integer(3) + sympy.Integer(4)) == 7
+
+        s = sympy.Symbol("s0", integer=True, positive=True)
+
+        # finite upper bound: return it
+        mock_v = SimpleNamespace(
+            graph=SimpleNamespace(
+                sizevars=SimpleNamespace(
+                    shape_env=SimpleNamespace(
+                        bound_sympy=lambda _e: SimpleNamespace(upper=sympy.Integer(576))
+                    ),
+                    size_hint=lambda _e: 128,
+                )
+            )
+        )
+        with patch("torch_spyre._inductor.pass_utils.V", mock_v):
+            assert compute_max_size(s) == 576
+
+        # infinite upper: fall back to size_hint
+        mock_v2 = SimpleNamespace(
+            graph=SimpleNamespace(
+                sizevars=SimpleNamespace(
+                    shape_env=SimpleNamespace(
+                        bound_sympy=lambda _e: SimpleNamespace(upper=sympy.oo)
+                    ),
+                    size_hint=lambda _e: 64,
+                )
+            )
+        )
+        with patch("torch_spyre._inductor.pass_utils.V", mock_v2):
+            assert compute_max_size(s) == 64
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -124,6 +124,31 @@ def concretize_index(index: sympy.Expr, loop_vars: set) -> sympy.Expr:
     return result
 
 
+def compute_max_size(expr: Union[Expr, int]) -> int:
+    """Return the maximum value a symbolic size expression can take.
+
+    Uses the ShapeEnv upper bound when one is recorded (i.e. the symbol was
+    created with an explicit ``max=`` constraint using mark_dynamic API). Falls
+    back to ``size_hint`` when no finite upper bound exists.
+
+    Needed for dynamic shape support.
+
+    # TODO: To be used in size_hint call-sites in superdsc.py and work_division.py
+    #       to get the maxSize in SDSC and work planning respectively
+    """
+    if isinstance(expr, int):
+        return expr
+    if isinstance(expr, sympy.Integer):
+        return int(expr)
+    if not (hasattr(expr, "free_symbols") and expr.free_symbols):
+        return int(expr)
+    shape_env = V.graph.sizevars.shape_env
+    vr = shape_env.bound_sympy(expr)
+    if isinstance(vr.upper, sympy.Integer) and int(vr.upper) > 0:
+        return int(vr.upper)
+    return V.graph.sizevars.size_hint(expr)
+
+
 def get_mem_deps_from_rw(read_writes: ReadWrites) -> list[SchedNodeArg]:
     res: list[SchedNodeArg] = []
     for arg in read_writes.reads:

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -93,6 +93,31 @@ def concretize_index(index: sympy.Expr, loop_vars: set) -> sympy.Expr:
     return result
 
 
+def compute_max_size(expr: Union[Expr, int]) -> int:
+    """Return the maximum value a symbolic size expression can take.
+
+    Uses the ShapeEnv upper bound when one is recorded (i.e. the symbol was
+    created with an explicit ``max=`` constraint using mark_dynamic API). Falls
+    back to ``size_hint`` when no finite upper bound exists.
+
+    Needed for dynamic shape support.
+
+    # TODO: To be used in size_hint call-sites in superdsc.py and work_division.py
+    #       to get the maxSize in SDSC and work planning respectively
+    """
+    if isinstance(expr, int):
+        return expr
+    if isinstance(expr, sympy.Integer):
+        return int(expr)
+    if not (hasattr(expr, "free_symbols") and expr.free_symbols):
+        return int(expr)
+    shape_env = V.graph.sizevars.shape_env
+    vr = shape_env.bound_sympy(expr)
+    if isinstance(vr.upper, sympy.Integer) and int(vr.upper) > 0:
+        return int(vr.upper)
+    return V.graph.sizevars.size_hint(expr)
+
+
 def get_mem_deps_from_rw(read_writes: ReadWrites) -> list[SchedNodeArg]:
     res: list[SchedNodeArg] = []
     for arg in read_writes.reads:

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -144,7 +144,7 @@ def compute_max_size(expr: Union[Expr, int]) -> int:
         return int(expr)
     shape_env = V.graph.sizevars.shape_env
     vr = shape_env.bound_sympy(expr)
-    if isinstance(vr.upper, sympy.Integer) and int(vr.upper) > 0:
+    if isinstance(vr.upper, sympy.Integer) and vr.upper.is_finite and int(vr.upper) > 0:
         return int(vr.upper)
     return V.graph.sizevars.size_hint(expr)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [*] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When tensors have symbolic dimensions, _DeepTools_ requires the maximum size for each symbolic dimension to correctly size device allocations and compute descriptors. 

To provide explicit upper bounds, users must use `mark_dynamic(tensor, dim, min=1, max=576)`. The `mark_dynamic` with an explicit `max` gives ShapeEnv a concrete upper bound to work with. Without the explicit `max`, ShapeEnv records the dimension as unbounded (`int_oo`) and no upper bound can be extracted which is a must need in SDSC for DeepTools to use.

If `mark_dynamic(tensor, dim, min, max)` will result in usage of the trace time values due to max value not present in the ShapeEnv.

This PR:

- Adds `compute_max_size` helper in `pass_utils.py`: given a symbolic size expression, returns the ShapeEnv upper bound when a finite bound is recorded (i.e. via `mark_dynamic` with an explicit max), falling back to `size_hint` otherwise. This lays the foundation for `superdsc.py` and `work_division.py` to consume upper bounds directly once symbolic iteration-space sizes are threaded through those code paths. 

- `Adds tests/dynamic_shapes/mark_dynamic.py`: provides the test scenario for the finite-upper-bound case that `compute_max_size` is designed to serve : a mark_dynamic call with explicit min=1, max=576 so ShapeEnv records a concrete upper bound on dim 0. This will become the end-to-end test once `compute_max_size` is wired into `superdsc.py`and `work_division.py` along with other changes.


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
http://github.com/torch-spyre/torch-spyre/issues/43
https://github.com/torch-spyre/torch-spyre/issues/2284

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
Yes. To use dynamic shapes correctly, users must now use `mark_dynamic` and an explicit upper and lower bound:


```
compiled_fn = torch.compile(fn)
mark_dynamic(x, 0, min=1, max=576)
compiled_fn(x)
```
Using `mark_dynamic` alone is not sufficient i.e.  without an explicit max, ShapeEnv has no concrete upper bound.

#### Additional note:
The user-facing usage pattern introduced here (mark_dynamic with explicit max). A documentation update covering this pattern and its constraints (explicit max required, behaviour without max) should be tracked as follow-up work.


Logs for `tests/dynamic_shapes/mark_dynamic.py`: 
[pr2003_log_mark_dynamic.log](https://github.com/user-attachments/files/27803426/pr2003_log_mark_dynamic.log)



CC: @Vivek1258 @dgrove-oss  @tardieu @pradghos @joyalbin 