### PR TITLE
Clear FxGraphCache between tests to prevent stale compiled artifacts

### DIFF
--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -527,6 +527,7 @@ def _compile_and_run(
 ):
     """Compile and execute function on specified device/backend, returning result on CPU."""
     torch._dynamo.reset_code_caches()
+    torch._inductor.codecache.FxGraphCache.clear()
     device = torch.device(device) if isinstance(device, str) else device
     device_args = [
         arg.to(device) if isinstance(arg, torch.Tensor) else arg for arg in args


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

torch._dynamo.reset_code_caches() only clears the in-memory dynamo cache. The Inductor fxgraph disk cache persists across tests within a pytest session, so a later test with the same input shapes can get a cache hit on an artifact compiled for a different graph. Adding FxGraphCache.clear() ensures each test compiles fresh.

We need to do this until we include the SpyreTensorLayout in the key for the FxGraph cache.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
