### PR TITLE
Remove check for missing restickify_plan due to cache hits now that

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -38,9 +38,9 @@ T = 64  # side length for 4D tests (all dims equal)
 
 
 def _verify_cost(expected_cost):
-    if not _insert_restickify.restickify_plan:
-        # Cache hit — finalize_layouts did not run, plan was not captured. Skip cost check.
-        return
+    # None means finalize_layouts never ran (cache hit); {} means it ran but no restickify is needed
+    if _insert_restickify.restickify_plan is None:
+        raise AssertionError("restickify_plan is None")
     actual = sum(
         math.prod(int(s) for s in entry["target_layout"].size)
         for entries in _insert_restickify.restickify_plan.values()
@@ -57,7 +57,7 @@ def _compare(fn, *args, check_strides=True, optimal_cost=None, skip_correctness=
     the compiler; the env var below instructs the compiler to stash it for us.
     """
     if optimal_cost is not None:
-        _insert_restickify.restickify_plan = {}
+        _insert_restickify.restickify_plan = None
         os.environ["SPYRE_CAPTURE_RESTICKIFY_PLAN"] = "1"
         try:
             spyre_result = _compile_and_run(fn, args, DEVICE)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Now that #2033 cache clearing bug was fixed, the check for missing restickify_plans in test_restickify is no longer needed.  There should always be a plan. Added assertion in case something goes wrong in the future.


#### Which issue(s) this PR is related to:
None
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
