### PR TITLE
fix: spyre_layer_norm handles non-contiguous inputs

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1809,6 +1809,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                     cached_randn((128), dtype=torch.float16),  # weight
                     torch.zeros([128], dtype=torch.float16),  # bias
                 ),
+                "2d_transposed": (
+                    cached_randn((128, 256), dtype=torch.float16).transpose(0, 1),
+                    cached_randn((128), dtype=torch.float16),
+                    torch.zeros([128], dtype=torch.float16),
+                ),
             },
         },
         ("test_rmsnorm", "test_rmsnorm_cpu"): {

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -452,6 +452,12 @@ def spyre_layer_norm(
             f"spyre_layer_norm: only supports spyre device with normalized_shape of length 1, "
             f"got device={input.device.type}, normalized_shape={normalized_shape}"
         )
+    # F.layer_norm treats weight=None as identity and bias=None as zero;
+    # spyre.layernormnorm doesn't handle missing args, so substitute defaults.
+    if weight is None:
+        weight = input.new_ones(normalized_shape)
+    if bias is None:
+        bias = input.new_zeros(normalized_shape)
     mean = torch.ops.spyre.exx2(input, 1.0 / normalized_shape[0], False)
     norm_mean = torch.ops.spyre.layernormscale(mean, eps)
     return torch.ops.spyre.layernormnorm(input, mean, norm_mean, weight, bias)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -112,35 +112,19 @@ def _single_arg_op_layout(
     data = op.data
 
     if isinstance(data, Reduction):
-        if data.reduction_type == "exx2":
-            x_coords = host_coordinates(in_layout, dep)
-            x_dev_coords = device_coordinates(stl, dep)
-            x_stick_expr = x_dev_coords[-1]
-            x_stick_dim = matching_dim(x_coords, x_stick_expr)
-            if x_stick_dim is None or x_stick_dim != len(in_layout.size) - 1:
-                # TODO: Insert a restickify to enable the operation to be performed
-                raise Unsupported(f"exx2: illegal device layout {stl}")
-            dim_order = list(range(len(output.size))) + [-1]
-            c_size = [concretize_expr(s) for s in output.size]
-            c_stride = [concretize_expr(s) for s in output.stride]
-            return SpyreTensorLayout(c_size, c_stride, output.dtype, dim_order)
+        # Propagate input stick to output if the dim survives, else put stick last.
+        x_dev_coords = device_coordinates(stl, dep)
+        out_coords = host_coordinates(output, output_dep)
+        x_stick_expr = x_dev_coords[-1]
+        out_stick_dim = matching_dim(out_coords, x_stick_expr)
+        if out_stick_dim is None:
+            out_dim_order = list(range(len(output.size))) + [-1]
         else:
-            # Propagate input stick to output if the dim survives, else put stick last.
-            x_coords = host_coordinates(in_layout, dep)
-            x_dev_coords = device_coordinates(stl, dep)
-            out_coords = host_coordinates(output, output_dep)
-            x_stick_expr = x_dev_coords[-1]
-            out_stick_dim = matching_dim(out_coords, x_stick_expr)
-            if out_stick_dim is None:
-                out_dim_order = list(range(len(output.size))) + [-1]
-            else:
-                out_dim_order = [
-                    d for d in range(len(output.size)) if d != out_stick_dim
-                ]
-                out_dim_order = out_dim_order + [out_stick_dim]
-            c_size = [concretize_expr(s) for s in output.size]
-            c_stride = [concretize_expr(s) for s in output.stride]
-            return SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
+            out_dim_order = [d for d in range(len(output.size)) if d != out_stick_dim]
+            out_dim_order = out_dim_order + [out_stick_dim]
+        c_size = [concretize_expr(s) for s in output.size]
+        c_stride = [concretize_expr(s) for s in output.stride]
+        return SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
 
     # Single-arg pointwise
     assert isinstance(data, Pointwise)
@@ -203,6 +187,65 @@ def _single_arg_op_layout(
                 c_size = [concretize_expr(s) for s in output.size]
                 c_stride = [concretize_expr(s) for s in output.stride]
                 return SpyreTensorLayout(c_size, c_stride, output.dtype, dim_order)
+
+
+def _stick_on_last_dim_req_stl(
+    arg: PropArg,
+) -> SpyreTensorLayout:
+    """Build the required-input STL with stick on arg's last logical dim."""
+    x_coords = host_coordinates(arg.layout, arg.dep)
+    last_dim_coord = x_coords[-1]
+    candidate = next(iter(arg.layouts))
+    cand_dev_coords = device_coordinates(candidate, arg.dep)
+    # Compare iter var ids: stick exprs may be wrapped (e.g. Mod(d1, 64)).
+    if iter_var_id(cand_dev_coords[-1]) == iter_var_id(last_dim_coord):
+        return candidate
+    req = compute_restickify_target_layout(
+        candidate, arg.layout, last_dim_coord, x_coords, cand_dev_coords
+    )
+    if req is None:
+        raise Unsupported(
+            f"cannot restickify to last logical dim (host_size={list(arg.layout.size)})"
+        )
+    return req
+
+
+def _exx2_layout(
+    op: Operation,
+    output: FixedLayout,
+    output_dep: MemoryDep,
+    args: list[PropArg],
+) -> list[SpyreTensorLayout]:
+    """exx2 requires its input stick on the reduction dim (= last logical dim).
+    Use FixedInOutNode to schedule a restickify if the input stick is elsewhere.
+    """
+    x = args[0]
+    out_dim_order = list(range(len(output.size))) + [-1]
+    c_size = [concretize_expr(s) for s in output.size]
+    c_stride = [concretize_expr(s) for s in output.stride]
+    out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
+    req_in_stl = _stick_on_last_dim_req_stl(x)
+    op.restick_cost_fn = FixedInOutNode.from_args(args, out_stl, [req_in_stl])
+    return [out_stl]
+
+
+def _layernormnorm_layout(
+    op: Operation,
+    output: FixedLayout,
+    output_dep: MemoryDep,
+    args: list[PropArg],
+) -> list[SpyreTensorLayout]:
+    """layernormnorm requires x's stick to match mean/norm_mean (= last logical dim).
+    Use FixedInOutNode to schedule a restickify if x's stick is elsewhere.
+    """
+    x = args[0]
+    out_dim_order = list(range(len(output.size)))
+    c_size = [concretize_expr(s) for s in output.size]
+    c_stride = [concretize_expr(s) for s in output.stride]
+    out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
+    req_in_stl = _stick_on_last_dim_req_stl(x)
+    op.restick_cost_fn = FixedInOutNode.from_args(args[:1], out_stl, [req_in_stl])
+    return [out_stl]
 
 
 def _matmul_layouts(
@@ -463,24 +506,23 @@ def compute_layouts(
     if isinstance(data, Reduction) and data.reduction_type == BATCH_MATMUL_OP:
         return _matmul_layouts(op, output, output_dep, args)
 
+    if isinstance(data, Reduction) and data.reduction_type == "exx2":
+        return _exx2_layout(op, output, output_dep, args)
+
     if isinstance(data, Reduction) and data.reduction_type in TOPK_OPS:
         return _topk_layouts(op, output, output_dep, args)
 
     aten_op = next(iter(data.origins)).target if data.origins else None
     if aten_op == spyreop.layernormnorm.default:
-        # layernormnorm is pointwise but special: it has multiple args, input and output
-        # must have matching size/stride, but only the first arg drives the output layout.
+        # layernormnorm is pointwise but special: it has multiple args, input and
+        # output must have matching size/stride, and x's stick must match
+        # mean/norm_mean (last logical dim).
         in_layout = args[0].layout
         if in_layout.size != output.size or in_layout.stride != output.stride:
             raise Unsupported(
                 f"views not supported for spyre.layernormnorm({in_layout.size})=>{output.size})"
             )
-        layouts = [
-            _single_arg_op_layout(op, output, output_dep, args[0].dep, in_layout, stl)
-            for stl in args[0].layouts
-        ]
-        op.restick_cost_fn = AllSameNode.from_args(args[:1], layouts, output_dep)
-        return layouts
+        return _layernormnorm_layout(op, output, output_dep, args)
 
     if aten_op == aten.clone.default:
         # clone materializes a new buffer in a fixed row-major layout regardless of


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

LayerNorm is decomposed into 3 ops -- exx2, layernormscale and layernormnorm. 

exx2 requires its input stick on the reduction dim. For transposed inputs stick is on dim 0. This inserts a restickify before exx2 runs so the condition is met.

Also substitute default weight=ones / bias=zeros when the caller passes None to layernorm.

#### Which issue(s) this PR is related to:

Fixes #https://github.com/torch-spyre/torch-spyre/issues/1813

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
