### PR TITLE
Default lx_planning suite to a canonical test subset

### DIFF
--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import functools
 import torch_spyre
 import os
@@ -23,7 +24,7 @@ from torch.testing import FileCheck
 from torch._dynamo.testing import make_test_cls_with_patches
 
 import unittest
-from utils_inductor import compare_with_cpu, copy_tests
+from utils_inductor import compare_with_cpu
 
 _test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(_test_dir)
@@ -33,6 +34,12 @@ import inductor.test_inductor_ops  # noqa: E402
 tests_lx_planning_run_skips: bool = (
     os.environ.get("TEST_LX_PLANNING_RUN_SKIPS", "0") == "1"
 )
+
+# By default, only run one representative test per (prefix, op) cell of
+# TestOps.PARAMS plus all non-parameterized methods. Set this to "1" to
+# wrap every generated test — useful for thorough triage, skip-list
+# maintenance, and CI but slow for everyday dev workflow.
+tests_lx_planning_full: bool = os.environ.get("TEST_LX_PLANNING_FULL", "0") == "1"
 
 
 def make_lx_planning_class(cls):
@@ -44,6 +51,64 @@ def make_lx_planning_class(cls):
         (torch_spyre._inductor.config, "allow_all_ops_in_lx_planning", True),
         (torch_spyre._inductor.config, "sencores", 1),
     )
+
+
+def _canonical_test_names(test_cls):
+    """Pick one representative test name per (prefix, op) cell of
+    ``test_cls.PARAMS``, plus all non-parameterized test methods.
+
+    For a PARAMS entry with an ``ops_dict``, every op gets one shape (the
+    first ``param_sets`` case); without an ``ops_dict``, only the first
+    case is emitted.
+    """
+    params = getattr(test_cls, "PARAMS", {})
+    canonical = set()
+    parameterized_prefixes = []
+    for (prefix, _base_func_name), cases in params.items():
+        param_sets = cases.get("param_sets", {})
+        if not param_sets:
+            continue
+        parameterized_prefixes.append(prefix)
+        first_case = next(iter(param_sets))
+        ops_dict = cases.get("ops_dict")
+        if ops_dict:
+            for op_name in ops_dict:
+                canonical.add(f"{prefix}_{op_name}_{first_case}")
+        else:
+            canonical.add(f"{prefix}_{first_case}")
+    for name in vars(test_cls):
+        if name.startswith("test_") and not any(
+            name.startswith(p + "_") for p in parameterized_prefixes
+        ):
+            canonical.add(name)
+    return canonical
+
+
+def _copy_canonical_tests(src_cls, dst_cls, suffix, test_failures):
+    """Copy test methods from ``src_cls`` into ``dst_cls`` with ``_{suffix}``
+    appended to each name. Unless ``TEST_LX_PLANNING_FULL`` is set, restrict
+    to the canonical subset derived from ``TestOps.PARAMS``."""
+    keep = (
+        None
+        if tests_lx_planning_full
+        else _canonical_test_names(inductor.test_inductor_ops.TestOps)
+    )
+    for name, value in src_cls.__dict__.items():
+        if not name.startswith("test_"):
+            continue
+        if keep is not None and name not in keep:
+            continue
+
+        @functools.wraps(value)
+        def new_test(self, value=value):
+            return value(self)
+
+        new_test.__dict__ = copy.deepcopy(value.__dict__)
+        if test_failures and name in test_failures:
+            new_test = unittest.skip("Skipped!")(new_test)
+        setattr(dst_cls, f"{name}_{suffix}", new_test)
+    if hasattr(src_cls, "is_dtype_supported"):
+        dst_cls.is_dtype_supported = src_cls.is_dtype_supported
 
 
 POINTWISE_TEST_FAILURES = [
@@ -64,6 +129,8 @@ POINTWISE_TEST_FAILURES = [
     "test_cat_4d_dim2",
     "test_cat_4d_dim3",
     "test_cat_4d_dim3_fp32",
+    "test_core_reduction_invalid_dims_api",
+    "test_core_reduction_invalid_dims_spyre",
     "test_einsum_einsum_55x2_2x99",
     "test_einsum_einsum_67x255_255x128",
     "test_einsum_einsum_67x256_256x128",
@@ -99,6 +166,10 @@ POINTWISE_TEST_FAILURES = [
     "test_pad_3d_last_dim_right",
     "test_pad_4d_dim0_left",
     "test_qkv_attn_paths_fms_decode_gqa",
+    "test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all",
+    "test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all",
+    "test_single_dim_reduction_invalid_dims_api",
+    "test_single_dim_reduction_invalid_dims_spyre",
     "test_squeeze_reduction_sum_3d0",
     "test_squeeze_reduction_sum_4d0",
     "test_squeeze_single_3d0",
@@ -172,7 +243,7 @@ class LxPlanningTwoOpPointwiseAdditionTest(_LxPlanningTwoOpTestBase):
         return make_seq_of_ops
 
 
-copy_tests(
+_copy_canonical_tests(
     make_lx_planning_class(inductor.test_inductor_ops.TestOps),
     LxPlanningTwoOpPointwiseAdditionTest,
     "lx_planning_pointwise",
@@ -181,6 +252,7 @@ copy_tests(
 
 
 REDUCTION_TEST_FAILURES = [
+    "test_activation_cls_gelu_fp16",
     "test_addmm_out_basic",
     "test_addmm_scaled_alpha_0_5",
     "test_alias_operands_cube_67x71x256",
@@ -204,6 +276,8 @@ REDUCTION_TEST_FAILURES = [
     "test_cat_4d_dim3_fp32",
     "test_copy_roundtrip_3d",
     "test_copy_roundtrip_4d_stick",
+    "test_core_reduction_invalid_dims_api",
+    "test_core_reduction_invalid_dims_spyre",
     "test_einsum_einsum_55x2_2x99",
     "test_einsum_einsum_67x255_255x128",
     "test_einsum_einsum_67x256_256x128",
@@ -250,12 +324,16 @@ REDUCTION_TEST_FAILURES = [
     "test_pointwise_unary_op_reciprocal_67x256",
     "test_pointwise_unary_op_reciprocal_67x71x256",
     "test_qkv_attn_paths_fms_decode_gqa",
+    "test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all",
+    "test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all",
     "test_rmsnorm_2d",
     "test_scalar_cpu_combined_3d",
     "test_scalar_cpu_combined_4d",
     "test_scalar_cpu_div_2d",
     "test_scalar_cpu_mul_2d",
     "test_scalar_cpu_true_divide_2d",
+    "test_single_dim_reduction_invalid_dims_api",
+    "test_single_dim_reduction_invalid_dims_spyre",
     "test_split_split3_1d0s0",
     "test_split_split3_1d0s1",
     "test_split_split3_1d0s2",
@@ -299,7 +377,7 @@ class LxPlanningTwoOpReductionTest(_LxPlanningTwoOpTestBase):
         return make_seq_of_ops
 
 
-copy_tests(
+_copy_canonical_tests(
     make_lx_planning_class(inductor.test_inductor_ops.TestOps),
     LxPlanningTwoOpReductionTest,
     "lx_planning_reduction",


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`test_inductor_ops_lx_planning.py` wraps every test in `TestOps` with a pointwise-add or reduction-sum follow-on op. Because `TestOps` generates ~740 methods via `PARAMS` (many op x shape cells per prefix), the LX-planning suite was producing ~1500 tests across the two wrap classes, most of which exercise the same backend path with different shapes.

Walk `TestOps.PARAMS` and pick one representative per (prefix, op) cell (the first param_sets case, all ops), plus every non-parameterized concrete test method. Default mode now wraps ~157 tests per class. `TEST_LX_PLANNING_FULL=1` restores the full ~740-per-class set for thorough triage and skip-list maintenance.

Skip-list format is unchanged; entries that point to non-canonical test names are inert in default mode.

For example, these 14 tests generated in `test_inductor_ops.py`

          <TestCaseFunction test_unsqueeze_single_1d0>
          <TestCaseFunction test_unsqueeze_single_1d1>
          <TestCaseFunction test_unsqueeze_single_2d0>
          <TestCaseFunction test_unsqueeze_single_2d1>
          <TestCaseFunction test_unsqueeze_single_2d2>
          <TestCaseFunction test_unsqueeze_single_3d0>
          <TestCaseFunction test_unsqueeze_single_3d1>
          <TestCaseFunction test_unsqueeze_single_3d2>
          <TestCaseFunction test_unsqueeze_single_3d3>
          <TestCaseFunction test_unsqueeze_single_4d0>
          <TestCaseFunction test_unsqueeze_single_4d1>
          <TestCaseFunction test_unsqueeze_single_4d2>
          <TestCaseFunction test_unsqueeze_single_4d3>
          <TestCaseFunction test_unsqueeze_single_4d4>

are reduced to these two class variants:

          <TestCaseFunction test_unsqueeze_single_1d0_lx_planning_pointwise>
          <TestCaseFunction test_unsqueeze_single_1d0_lx_planning_reduction>

Do note that with `TEST_LX_PLANNING_FULL=1` the 14 tests above would be expanded to 28 in the lx_planning tests.

> [!NOTE]
> To update the skip lists, you will need to run the lx planning tests with `TEST_LX_PLANNING_FULL=1` and `TEST_LX_PLANNING_RUN_SKIPS=1`.

#### Which issue(s) this PR is related to:

resolves #2047 

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
