### PR TITLE
fix: propagate pytest exit code 1 (test failures) in run_test.sh

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1382,6 +1382,13 @@ _run_xdist_fallback() {
         echo "[spyre_run] WARNING: xdist fallback subshell exited abnormally for $_orig" >&2
     fi
 
+    # Propagate test failures from the xdist fallback run.
+    if [[ $_xexit -eq 1 ]]; then
+        [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+    elif [[ $_xexit -ne 0 && $_xexit -ne 5 ]]; then
+        OVERALL_EXIT=$_xexit
+    fi
+
     # Inject XML tags into the shard produced by the xdist run.
     if [[ -n "$_shard_xml" && -f "$_shard_xml" ]]; then
         python3 -c "$_XML_INJECT_PY" "$_shard_xml" "$YAML_CONFIG" || true
@@ -1512,19 +1519,25 @@ for i in "${!RUN_FILES[@]}"; do
     # Exit code handling
     #
     #   0   = all tests passed
-    #   1   = tests ran, some failed/errored  (reported by pytest; non-fatal)
-    #   5   = no tests collected              (warning only)
+    #   1   = tests ran, some failed/errored  (propagated → OVERALL_EXIT=1)
+    #   5   = no tests collected              (warning only; does not fail run)
     #   127 = command not found (python3/pytest missing) — fatal
     #   128+= signal/abnormal termination    — retry with -n1 (xdist fallback)
     #         Common: 139 (SIGSEGV), 255 (C abort).  130 (Ctrl-C) breaks loop.
     # -----------------------------------------------------------------------
     case $_exit in
-        0|1|5)
-            # Normal pytest outcomes (tests ran, some may have failed/xpassed).
-            # Individual results are visible in pytest output; run_test.sh
-            # always exits 0 for these so CI sees the report rather than a
-            # blanket failure.  Signal exits (>= 128) are the only codes that
-            # trigger the xdist fallback and propagate a non-zero exit.
+        0)
+            # All tests passed.
+            ;;
+        1)
+            # Some tests failed or errored — pytest already reported them.
+            # Propagate so CI marks the job as failed when mandatory_success
+            # tests do not pass.
+            [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+            ;;
+        5)
+            # No tests collected — warn but do not fail the overall run.
+            echo "[spyre_run] WARNING: no tests collected for $original_file" >&2
             ;;
         127)
             echo "[spyre_run] FATAL: python3 or pytest not found (exit 127) for $original_file" >&2


### PR DESCRIPTION
## Summary

`run_test.sh` was swallowing pytest exit code 1, so CI reported **success even when `mandatory_success` tests failed**. This PR fixes that.

## Root Cause

In the `case $_exit in` block (added by #1955), exit code 1 was grouped with 0 and 5 as "non-fatal":

```bash
case $_exit in
    0|1|5)
        # always exits 0 for these so CI sees the report rather than a blanket failure
        ;;
```

This meant `mandatory_success` failures were invisible in CI — jobs always showed green.

## Fix

- Exit code 1 (test failures) now sets `OVERALL_EXIT=1` → CI marks the job as failed
- Exit code 5 (no tests collected) still only warns, does not fail the run
- Same fix applied to `_run_xdist_fallback` which read `_xexit` but never acted on it

## Proof the fix works

The CI run for this PR ([run 25838764425](https://github.com/torch-spyre/torch-spyre/actions/runs/25838764425)) correctly reports **failure**:

- **[Inductor Ops LX Planning](https://github.com/torch-spyre/torch-spyre/actions/runs/25838764425/job/75923084510)** (job 75923084510): 5 failed, 2480 passed — job now correctly reports `failure`
- **[Run Spyre unit tests](https://github.com/torch-spyre/torch-spyre/actions/runs/25838764425/job/75924801507)** (gate job 75924801507): correctly fails because `needs.test.result == "failure"`

Previously, the same failures would have been silently ignored and CI would have shown all green (as seen in the original broken run for the example in #2054: [job 75903932253](https://github.com/torch-spyre/torch-spyre/actions/runs/25833667696/job/75903932253) showed 42 failed but reported success).

## Related

- Fixes CI masking issue tracked in #2054
- The 5 failing tests in this PR's CI run are tracked in #2054 and will be addressed by #2055

🤖 Generated with [Claude Code](https://claude.com/claude-code)