### PR TITLE
fix: xfail 5 fp32 lx-planning tests broken by revert of #1663

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
@@ -13,3 +13,15 @@ test_suite_config:
       # than enumerating each LxPlanningTwoOpPointwiseAdditionTest:: and
       # LxPlanningTwoOpReductionTest:: test name explicitly.
       unlisted_test_mode: mandatory_success
+      tests:
+        - names:
+            # fp32 reduction tests failing because dxp_standalone --bundle aborts on fp32
+            # reduction ops. Root cause: PR #2051 reverted fp32 reduction support (#1663),
+            # but PR #1711 added these tests as mandatory_success before the revert.
+            # Tracked in: https://github.com/torch-spyre/torch-spyre/issues/2054
+            - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all_lx_planning_pointwise
+            - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all_lx_planning_pointwise
+            - LxPlanningTwoOpReductionTest::test_activation_cls_gelu_fp16_lx_planning_reduction
+            - LxPlanningTwoOpReductionTest::test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all_lx_planning_reduction
+            - LxPlanningTwoOpReductionTest::test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all_lx_planning_reduction
+          mode: xfail

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1382,6 +1382,13 @@ _run_xdist_fallback() {
         echo "[spyre_run] WARNING: xdist fallback subshell exited abnormally for $_orig" >&2
     fi
 
+    # Propagate test failures from the xdist fallback run.
+    if [[ $_xexit -eq 1 ]]; then
+        [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+    elif [[ $_xexit -ne 0 && $_xexit -ne 5 ]]; then
+        OVERALL_EXIT=$_xexit
+    fi
+
     # Inject XML tags into the shard produced by the xdist run.
     if [[ -n "$_shard_xml" && -f "$_shard_xml" ]]; then
         python3 -c "$_XML_INJECT_PY" "$_shard_xml" "$YAML_CONFIG" || true
@@ -1512,19 +1519,25 @@ for i in "${!RUN_FILES[@]}"; do
     # Exit code handling
     #
     #   0   = all tests passed
-    #   1   = tests ran, some failed/errored  (reported by pytest; non-fatal)
-    #   5   = no tests collected              (warning only)
+    #   1   = tests ran, some failed/errored  (propagated → OVERALL_EXIT=1)
+    #   5   = no tests collected              (warning only; does not fail run)
     #   127 = command not found (python3/pytest missing) — fatal
     #   128+= signal/abnormal termination    — retry with -n1 (xdist fallback)
     #         Common: 139 (SIGSEGV), 255 (C abort).  130 (Ctrl-C) breaks loop.
     # -----------------------------------------------------------------------
     case $_exit in
-        0|1|5)
-            # Normal pytest outcomes (tests ran, some may have failed/xpassed).
-            # Individual results are visible in pytest output; run_test.sh
-            # always exits 0 for these so CI sees the report rather than a
-            # blanket failure.  Signal exits (>= 128) are the only codes that
-            # trigger the xdist fallback and propagate a non-zero exit.
+        0)
+            # All tests passed.
+            ;;
+        1)
+            # Some tests failed or errored — pytest already reported them.
+            # Propagate so CI marks the job as failed when mandatory_success
+            # tests do not pass.
+            [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
+            ;;
+        5)
+            # No tests collected — warn but do not fail the overall run.
+            echo "[spyre_run] WARNING: no tests collected for $original_file" >&2
             ;;
         127)
             echo "[spyre_run] FATAL: python3 or pytest not found (exit 127) for $original_file" >&2


### PR DESCRIPTION
## Summary

Mark 5 fp32 lx-planning tests as `xfail` in `test_ops_lx_planning_config.yaml`. These tests are failing on `main` because:

- PR #1711 added fp32 reduction tests as `mandatory_success` in the lx-planning config
- PR #2051 reverted fp32 reduction support, causing `dxp_standalone --bundle` to abort with SIGABRT on fp32 reduction ops

**Stacked on**: PR #2053 (`fix/run-test-propagate-exit-code`), which makes CI correctly propagate test failures instead of swallowing them.

## Failing tests (5)

All in [CI run 25838764425](https://github.com/torch-spyre/torch-spyre/actions/runs/25838764425), specifically the **Inductor Ops LX Planning** job ([job 75923084510](https://github.com/torch-spyre/torch-spyre/actions/runs/25838764425/job/75923084510)) which is the job that failed and gated the run:

```
LxPlanningTwoOpPointwiseAdditionTestPRIVATEUSE1::test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all_lx_planning_pointwise_spyre
LxPlanningTwoOpPointwiseAdditionTestPRIVATEUSE1::test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all_lx_planning_pointwise_spyre
LxPlanningTwoOpReductionTestPRIVATEUSE1::test_activation_cls_gelu_fp16_lx_planning_reduction_spyre
LxPlanningTwoOpReductionTestPRIVATEUSE1::test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all_lx_planning_reduction_spyre
LxPlanningTwoOpReductionTestPRIVATEUSE1::test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all_lx_planning_reduction_spyre
```

Root error: `dxp_standalone --bundle` dies with SIGABRT for fp32 reduction ops (e.g. `sdsc_fused_mean_0`).

## Long-term fix

Re-enable fp32 reductions on Spyre (re-land #1663 or equivalent). Tracked in https://github.com/torch-spyre/torch-spyre/issues/2054.

## Test plan

- [ ] CI run with this PR stacked on #2053 should show the 5 tests passing as xfail (expected failure → passes gate)
- [ ] All other lx-planning tests continue to pass as mandatory_success
