### PR TITLE
[TESTING GHA] fix: mark failing tests in inductor ops lx planning to xfail and move model ops tests trigger to post merge

### DIFF
--- a/.github/workflows/model_ops_tests.yaml
+++ b/.github/workflows/model_ops_tests.yaml
@@ -4,10 +4,11 @@ on:
   # Run automatically on every merge to main
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-  merge_group:
-    types: [checks_requested]
+  # Removing from CICD till the ops tests get matured
+  # pull_request:
+  #   branches: [main]
+  # merge_group:
+  #   types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
@@ -13,3 +13,23 @@ test_suite_config:
       # than enumerating each LxPlanningTwoOpPointwiseAdditionTest:: and
       # LxPlanningTwoOpReductionTest:: test name explicitly.
       unlisted_test_mode: mandatory_success
+      tests:
+          ##########################################################################################
+          # The following tests are failing in the CICD currently -- hence moving these to xfail now
+          # Commented tests are passing now as per latest main (was failing previously in the CI)
+          ##########################################################################################
+        - names:
+            - LxPlanningTwoOpPointwiseAdditionTest::test_activation_cls_gelu_fp16_lx_planning_reduction
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_keepdim1_sum_3d_dim_1_lx_planning_pointwise
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all_lx_planning_pointwise
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all_lx_planning_pointwise
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all_lx_planning_reduction
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all_lx_planning_reduction
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_multidim_keepdim0_sum_5d_dim_1234_lx_planning_pointwise
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_multidim_keepdim0_sum_5d_dim_1234_lx_planning_reduction
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_multidim_keepdim1_sum_5d_dim_1234_lx_planning_reduction
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_multidim_keepdim1_sum_5d_dim_1234_lx_planning_pointwise
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_keepdim0_sum_3d_dim_1_lx_planning_pointwise
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_keepdim1_sum_3d_dim_1_lx_planning_reduction
+            # - LxPlanningTwoOpPointwiseAdditionTest::test_reduce_keepdim0_sum_3d_dim_1_lx_planning_reduction
+          mode: xfail

--- a/tests/configs/upstream_tests/test_view_ops_config.yaml
+++ b/tests/configs/upstream_tests/test_view_ops_config.yaml
@@ -11,6 +11,13 @@ test_suite_config:
             - TestOldViewOps::test_contiguous
             - TestOldViewOps::test_resize_as_preserves_strides
           mode: mandatory_success
+        #######################################################################
+        #### New test added in pytorch 2.11 which is failing - hence xfail ####
+        #######################################################################
+        - names:
+            - TestViewOps::test_maybe_view_chunk_cat
+          mode: xfail
+        #######################################################################
         - names: # Tests that pass with extra dtypes allowed
             - TestViewOps::test_conj_self
           mode: mandatory_success


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR does 3 things:
 - moves the trigger of models ops tests workflow post merge 
 - marks failing tests in `tests/configs/torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml` to xfail (until those are resolved)
 - mark the failing test in test view ops (new addition in pytorch 2.11) to xfail ( until this is resolved).
 
 #### Current passing inductor ops lx planning:


<img width="2452" height="328" alt="image" src="https://github.com/user-attachments/assets/b9f91678-f5b2-4bb2-b3f0-492ac6bbb117" />
