### PR TITLE
Add spyre_clamp decomposition to fix NotImplementedError

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -3970,9 +3970,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         )
 
     def test_range_op(self, op, input, min, max, err):
-        self.compare_with_cpu(
-            lambda x: op(x, min, max), input, atol=err, rtol=err
-        )
+        self.compare_with_cpu(lambda x: op(x, min, max), input, atol=err, rtol=err)
 
     def test_activation_cls(self, op, input, kwargs, err):
         # Spyre activation custom ops (e.g. spyre::gelu) have a pass-through

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -3970,10 +3970,8 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         )
 
     def test_range_op(self, op, input, min, max, err):
-        # aten::clamp is not registered for Spyre eager dispatch; it uses the
-        # spyre::clamp custom op which only works inside torch.compile
         self.compare_with_cpu(
-            lambda x: op(x, min, max), input, atol=err, rtol=err, run_eager=False
+            lambda x: op(x, min, max), input, atol=err, rtol=err
         )
 
     def test_activation_cls(self, op, input, kwargs, err):

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -113,6 +113,7 @@ register_torch_compile_kernel(
         aten.minimum,
         aten.pow,
         aten.linalg_vector_norm,
+        aten.clamp,
     ]
 )
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Adds spyre_clamp decomposition in decompositions.py to register aten.clamp.default and aten.clamp.out for the Spyre PrivateUse1 dispatch key, fixing NotImplementedError in eager mode.


#### Which issue(s) this PR is related to:

#1387

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
