### PR TITLE
[TESTING GHA] move 2 tests failing in inductor ops to xfail

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_config.yaml
@@ -14,3 +14,12 @@ test_suite_config:
       # tests automatically, consistent with what pytest collects when run
       # directly.
       unlisted_test_mode: mandatory_success
+      tests:
+          ##########################################################################################
+          # The following tests are failing in the GHA CICD currently -- hence moving these to xfail now
+          ##########################################################################################
+        - names:
+            - TestOps::test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all
+            - TestOps::test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all
+          mode: xfail
+


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

PR moves 2 teats from indcutor ops config to xfail.