### PR TITLE
Add CODEOWNERS for distributed subdirectories

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,11 @@
 /torch_spyre/memory/     @JRosenkranz @thoangtrvn
 /torch_spyre/csrc/       @JRosenkranz @thoangtrvn
 
+# Distributed / collective communication (spyre_ccl)
+/torch_spyre/csrc/distributed/  @jjhursey @JRosenkranz @thoangtrvn
+/tests/distributed/              @jjhursey @thoangtrvn @avery-blanchard
+/examples/distributed/           @jjhursey @thoangtrvn @avery-blanchard
+
 # Profiler
 /torch_spyre/profiler/   @ppnaik1890 @kaoutar55 @flop1971
 


### PR DESCRIPTION
## Summary
- Adds `@jjhursey` as primary code owner for `torch_spyre/csrc/distributed/`, `tests/distributed/`, and `examples/distributed/`
- Retains `@JRosenkranz`, `@thoangtrvn`, and `@avery-blanchard` as co-owners for review coverage
- Requested in https://github.com/torch-spyre/torch-spyre/pull/816#issuecomment-4442490255

## Test plan
- [ ] Verify CODEOWNERS syntax is valid (GitHub parses it without errors)
- [ ] Confirm PR #816 files would trigger the new ownership rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)