### PR TITLE
Implement aten.min.dim on Spyre for fp16

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -2872,15 +2872,6 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             },
             "expect_fail": [
-                "fp16_2d_dim_0",
-                "fp16_2d_dim_1",
-                "fp16_3d_dim_0",
-                "fp16_3d_dim_1",
-                "fp16_3d_dim_2",
-                "fp16_4d_dim_0",
-                "fp16_4d_dim_1",
-                "fp16_4d_dim_2",
-                "fp16_4d_dim_3",
                 "fp32_2d_dim_0",
                 "fp32_2d_dim_1",
                 "fp32_3d_dim_0",
@@ -3009,14 +3000,6 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             },
             "expect_fail": [
-                "fp16_2d_dim_0",
-                "fp16_2d_dim_1",
-                "fp16_3d_dim_1",
-                "fp16_3d_dim_2",
-                "fp16_4d_dim_0",
-                "fp16_4d_dim_1",
-                "fp16_4d_dim_2",
-                "fp16_4d_dim_3",
                 "fp32_2d_dim_0",
                 "fp32_2d_dim_1",
                 "fp32_3d_dim_1",
@@ -3198,15 +3181,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             lambda x: torch.topk(x, k, dim=dim)[0], x, run_eager=False
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "Spyre compiled backend does not support the integer index tensor in "
-            "torch.min(dim) tuple outputs yet (stable error signature: "
-            "Unsupported: operation on DataFormats.IEEE_INT32)"
-        ),
-        strict=True,
-    )
-    def test_min_tuple_output_keepdim0_known_xfail(self):
+    def test_min_tuple_output_keepdim0(self):
         x = unique_randn_along_dim((5, 7), dim=1)
         self.compare_with_cpu(
             lambda x: torch.min(x, dim=1, keepdim=False),
@@ -3214,15 +3189,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             run_eager=False,
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "Spyre compiled backend does not support integer index outputs from "
-            "argmin yet (stable error signature: Unsupported: operation on "
-            "DataFormats.IEEE_INT32)"
-        ),
-        strict=True,
-    )
-    def test_argmin_keepdim0_known_xfail(self):
+    def test_argmin_keepdim0(self):
         x = unique_randn_along_dim((5, 7), dim=1)
         self.compare_with_cpu(
             lambda x: torch.argmin(x, dim=1, keepdim=False),

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -415,6 +415,38 @@ def _(input: torch.Tensor, dim: int, keepdim: bool = False):
     return (values, indices)
 
 
+@torch.library.custom_op("spyre::min_dim_int64_fallback", mutates_args=())
+def min_dim_int64_fallback(
+    input: torch.Tensor, dim: int, keepdim: bool = False
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    CPU fallback for torch.min(input, dim) when input is int64.
+    This custom op will be registered with a CPU fallback in fallbacks.py.
+    Returns a tuple (values, indices) as expected by torch.min.
+    """
+    raise RuntimeError(
+        "spyre::min_dim_int64_fallback should be handled by CPU fallback registration"
+    )
+
+
+@min_dim_int64_fallback.register_fake
+def _(input: torch.Tensor, dim: int, keepdim: bool = False):
+    """
+    Fake implementation for shape inference.
+    Returns the expected output shapes for torch.min(input, dim, keepdim).
+    """
+    if keepdim:
+        output_shape = list(input.size())
+        output_shape[dim] = 1
+    else:
+        output_shape = list(input.size())
+        output_shape.pop(dim)
+
+    values = input.new_empty(output_shape)
+    indices = torch.empty(output_shape, dtype=torch.int64, device=input.device)
+    return (values, indices)
+
+
 ## TODO (imaihal): This needs scalar tensor support from Spyre to CPU. issues #1172
 #
 # @torch.library.custom_op("spyre::max_default_int64_fallback", mutates_args=())

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -641,6 +641,23 @@ def spyre_max_dim_decomp(input, dim, keepdim=False):
         return torch.return_types.max((values, indices))
 
 
+@register_spyre_decomposition([torch.ops.aten.min.dim])
+def spyre_min_dim_decomp(input, dim, keepdim=False):
+    """
+    Decompose torch.min(input, dim) with conditional CPU fallback for int64.
+
+    Mirrors spyre_max_dim_decomp: int64 inputs go through a CPU-fallback custom
+    op; other dtypes are decomposed into amin (Spyre-native) and argmin (CPU
+    fallback). Returns a named tuple (values, indices) as expected by torch.min.
+    """
+    if input.dtype == torch.int64:
+        return torch.ops.spyre.min_dim_int64_fallback(input, dim, keepdim)
+    else:
+        values = torch.ops.aten.amin(input, dim=dim, keepdim=keepdim)
+        indices = torch.ops.aten.argmin(input, dim=dim, keepdim=keepdim)
+        return torch.return_types.min((values, indices))
+
+
 @register_spyre_decomposition([torch.ops.aten.cat.default])
 def decompose_cat(
     tensors: list[torch.Tensor],

--- a/torch_spyre/ops/fallbacks.py
+++ b/torch_spyre/ops/fallbacks.py
@@ -250,6 +250,7 @@ register_fallback_default(
         aten.bitwise_or.Tensor,
         aten.bitwise_or.Tensor_out,
         aten.argmax.default,
+        aten.argmin.default,
     ]
 )
 
@@ -267,6 +268,14 @@ def spyre__max_dim_int64_fallback(input, dim, keepdim=False, **kwargs):
     CPU fallback for torch.max(input, dim) when input is int64.
     """
     return torch.max(input, dim=dim, keepdim=keepdim, **kwargs)
+
+
+@register_fallback(["spyre::min_dim_int64_fallback"])
+def spyre__min_dim_int64_fallback(input, dim, keepdim=False, **kwargs):
+    """
+    CPU fallback for torch.min(input, dim) when input is int64.
+    """
+    return torch.min(input, dim=dim, keepdim=keepdim, **kwargs)
 
 
 @register_fallback(["spyre::max_default_int64_fallback"])


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

`torch.min(x, dim=)` was not lowered for Spyre, leaving the fp16 `test_min_keepdim*` cases failing with `NotImplementedError` on `aten::min.dim_min` under the lx_planning suite. `amin` is already a recognized Spyre reduction and `argmin` can fall back to CPU the same way `argmax` does, so the symmetric path mirrors the existing max.dim support end-to-end:

- `_inductor/decompositions.py`: `spyre_min_dim_decomp` routes int64 through a new fallback custom op and decomposes other dtypes into amin (Spyre) + argmin (CPU fallback).
- `_inductor/customops.py`: `spyre::min_dim_int64_fallback` custom op + fake impl, mirroring `max_dim_int64_fallback`.
- `ops/fallbacks.py`: register the new custom op for CPU fallback and add `aten.argmin.default` to the default fallback list.

fp16 `min.dim` cases that previously XFAIL'd now pass through this decomposition. Drop fp16_* entries from the expect_fail lists in `test_min_keepdim0` and `test_min_keepdim1` so those cases report as PASS rather than XPASS-strict.

##### Regarding fp32 `torch.min`

`torch.min(x, dim=)` for fp32 can work for 22 of 28 `test_min_keepdim*` cases. Adding `"min"` to `SPYRE_FP32_OPS` in `_inductor/constants.py` clears the codegen gate, after which the decomposition into `amin` + `argmin` (CPU fallback) compiles and runs correctly on the device.

The remaining 6 cases — all reducing along the innermost dim (2d/dim_1, 3d/dim_2, 4d/dim_3) — still fail. The Python pipeline runs to completion and produces a valid `sdsc_fused_amin_*` bundle, but `dxp_standalone` crashes during DDL conversion.

This PR does not modify anything for fp32 the xfails remain in place.

#### Which issue(s) this PR is related to:

Resolves #1870 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
