### PR TITLE
[TESTING CI] enforce CI coverage for all test_*.py files in torch_spyre

### DIFF
--- a/.github/workflows/check-test-ci-coverage.yaml
+++ b/.github/workflows/check-test-ci-coverage.yaml
@@ -1,0 +1,79 @@
+# Enforcement: every test_*.py must have a config YAML *and* be registered
+# in the torch-spyre-tests.yml workflow matrix.
+#
+# Runs on:
+#   - Every push that touches a test file or the workflow matrix
+#   - Every PR to main
+#   - Manual dispatch (workflow_dispatch)
+#
+# The job fails and will block the merge -- if any test_*.py is uncovered.
+
+name: Enforce Test CI Coverage
+
+on:
+  push:
+    paths:
+      - "tests/**/*.py"
+      - "tests/configs/**"
+      - ".github/workflows/torch-spyre-tests.yaml"
+      - ".github/workflows/check-test-ci-coverage.yml"
+    branches: [main]
+
+  pull_request:
+    branches: [main]
+    paths:
+      - "tests/**/*.py"
+      - "tests/configs/**"
+      - ".github/workflows/torch-spyre-tests.yaml"
+      - ".github/workflows/check-test-ci-coverage.yml"
+    
+  merge_group:
+    types: [checks_requested]
+
+  # Allow maintainers to trigger this manually at any time
+  workflow_dispatch:
+
+jobs:
+  coverage-check:
+    name: All test_*.py files wired into GHA CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ----- Run the coverage check -----
+      - name: Check every test file has a config and is in the workflow matrix
+        shell: bash
+        run: |
+          bash scripts/check_test_coverage.sh \
+            --workflow .github/workflows/torch-spyre-tests.yaml \
+            --configs  tests/configs/torch_spyre_tests \
+            --tests    tests
+
+      # --- On failure: provide a helpful summary in the PR/GHA UI ----
+      - name: Show fix instructions on failure
+        if: failure()
+        shell: bash
+        run: |
+          echo "::error title=Uncovered test files::One or more test_*.py files are not fully wired into CI."
+          echo ""
+          echo "Each uncovered file needs both of the following:"
+          echo ""
+          echo "  1. A torch-spyre config YAML somewhere under tests/configs/torch_spyre_tests that lists it"
+          echo "     under 'files:' with a 'path:' entry, e.g.:"
+          echo "       test_suite_config:
+          echo "         files:
+          echo "           - path: ${TORCH_DEVICE_ROOT}/tests/<path/to/test_file.py>
+          echo "             unlisted_test_mode: mandatory_success"
+          echo ""
+          echo "     For standalone tests:  tests/configs/torch_spyre_tests[/subdir]/"
+          echo "     For module test suites: tests/configs/module_tests/path/to/yaml"
+          echo "                            (add as a secondary 'path:' entry)"
+          echo "     For model ops test suites: tests/configs/model_ops_tests/path/to/yaml"
+          echo ""
+          echo "  2. That config file referenced in a workflow matrix under .github/workflows/:"
+          echo "       - name: <Human Readable Name>"
+          echo "         config: <subdir>/<config_filename>.yaml"
+          echo ""
+          echo "  See the CI/CD guide: tests/docs/enabling_torch_spyre_cicd_tests.md"

--- a/.github/workflows/check-test-ci-coverage.yaml
+++ b/.github/workflows/check-test-ci-coverage.yaml
@@ -61,9 +61,9 @@ jobs:
           echo ""
           echo "  1. A torch-spyre config YAML somewhere under tests/configs/torch_spyre_tests that lists it"
           echo "     under 'files:' with a 'path:' entry, e.g.:"
-          echo "       test_suite_config:
-          echo "         files:
-          echo "           - path: ${TORCH_DEVICE_ROOT}/tests/<path/to/test_file.py>
+          echo "       test_suite_config:"
+          echo "         files:"
+          echo "           - path: ${TORCH_DEVICE_ROOT}/tests/<path/to/test_file.py>"
           echo "             unlisted_test_mode: mandatory_success"
           echo ""
           echo "     For standalone tests:  tests/configs/torch_spyre_tests[/subdir]/"

--- a/.github/workflows/check-test-ci-coverage.yaml
+++ b/.github/workflows/check-test-ci-coverage.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           bash tests/scripts/check_test_coverage.sh \
             --workflows-dir .github/workflows \
-            --configs-root  tests/configs/torch_spyre_tests \
+            --configs-root  tests/configs \
             --tests    tests
 
       # --- On failure: provide a helpful summary in the PR/GHA UI ----

--- a/.github/workflows/check-test-ci-coverage.yaml
+++ b/.github/workflows/check-test-ci-coverage.yaml
@@ -13,25 +13,24 @@ name: Enforce Test CI Coverage
 on:
   push:
     paths:
-      - "tests/**/*.py"
-      - "tests/configs/**"
-      - ".github/workflows/torch-spyre-tests.yaml"
-      - ".github/workflows/check-test-ci-coverage.yml"
+      - tests/**/*.py
+      - tests/configs/**
+      - .github/workflows/torch-spyre-tests.yaml
+      - .github/workflows/check-test-ci-coverage.yaml
     branches: [main]
 
   pull_request:
     branches: [main]
     paths:
-      - "tests/**/*.py"
-      - "tests/configs/**"
-      - ".github/workflows/torch-spyre-tests.yaml"
-      - ".github/workflows/check-test-ci-coverage.yml"
-    
+      - tests/**/*.py
+      - tests/configs/**
+      - .github/workflows/torch-spyre-tests.yaml
+      - .github/workflows/check-test-ci-coverage.yml
   merge_group:
     types: [checks_requested]
 
   # Allow maintainers to trigger this manually at any time
-  workflow_dispatch:
+  workflow_dispatch: null
 
 jobs:
   coverage-check:
@@ -55,7 +54,7 @@ jobs:
       - name: Show fix instructions on failure
         if: failure()
         shell: bash
-        run: |
+        run: |-
           echo "::error title=Uncovered test files::One or more test_*.py files are not fully wired into CI."
           echo ""
           echo "Each uncovered file needs both of the following:"

--- a/.github/workflows/check-test-ci-coverage.yaml
+++ b/.github/workflows/check-test-ci-coverage.yaml
@@ -45,9 +45,9 @@ jobs:
       - name: Check every test file has a config and is in the workflow matrix
         shell: bash
         run: |
-          bash scripts/check_test_coverage.sh \
-            --workflow .github/workflows/torch-spyre-tests.yaml \
-            --configs  tests/configs/torch_spyre_tests \
+          bash tests/scripts/check_test_coverage.sh \
+            --workflows-dir .github/workflows \
+            --configs-root  tests/configs/torch_spyre_tests \
             --tests    tests
 
       # --- On failure: provide a helpful summary in the PR/GHA UI ----

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -82,6 +82,10 @@ jobs:
             config: torch_spyre_tests/inductor/test_scratchpad_patterns_config.yaml
           - name: Inductor Scratchpad Use
             config: torch_spyre_tests/inductor/test_scratchpad_use_config.yaml
+          - name: Inductor Dtype Scalars
+            config: torch_spyre_tests/inductor/test_dtype_scalars_config.yaml
+          - name: Inductor Cache
+            config: torch_spyre_tests/inductor/test_cache_config.yaml
           # Tensor tests
           - name: Tensor Coordinates
             config: torch_spyre_tests/tensors/test_coordinates_config.yaml

--- a/tests/scripts/check_test_coverage.sh
+++ b/tests/scripts/check_test_coverage.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 # tests/scripts/check_test_coverage.sh
-#
+# Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
 # Enforces that every test_*.py under tests/ is referenced by at least one
 # config YAML anywhere under tests/configs/, AND that config is referenced
 # in at least one GitHub Actions workflow under .github/workflows/.
 #
-# Design notes
-# ────────────
+# Design flow
+# -------------
 # 1. Scans ALL of tests/configs/ (not just torch_spyre_tests/) because some
 #    test files appear as secondary entries inside model configs under
 #    tests/configs/module_tests/ or tests/configs/model_ops_tests/.
 #
-# 2. Extracts EVERY `path:` line from each YAML (not just the first) because
+# 2. Extracts EVERY `path:` line from each YAML because
 #    a single model config can reference multiple test files.
 #
 # 3. Handles both path prefixes used in configs:
 #      ${TORCH_DEVICE_ROOT}/tests/...  (this repo's tests)
-#      ${TORCH_ROOT}/test/...          (upstream PyTorch tests — singular "test")
+#      ${TORCH_ROOT}/test/...          (upstream PyTorch tests -- singular "test")
 #    Anchors on the filename (test_*.py) and verifies existence on disk to
 #    distinguish our files from upstream ones.
 #
@@ -31,7 +31,7 @@
 # 6. Writes workflow contents to a temp file and greps that directly to avoid
 #    the echo|grep -q broken-pipe / pipefail false-negative bug.
 #
-# Exit code: 0 = all tests covered, 1 = gaps found
+# Exit code: 0 -- all tests covered, 1 = gaps found
 #
 # Usage (run from repo root):
 #   bash tests/scripts/check_test_coverage.sh
@@ -43,7 +43,7 @@
 
 set -euo pipefail
 
-# ── Defaults ──────────────────────────────────────────────────────────────────
+# ------------- Defaults -------------
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
 CONFIGS_ROOT="${REPO_ROOT}/tests/configs"
@@ -102,7 +102,7 @@ fail=0
 [[ -d "$TESTS_DIR"     ]] || { echo -e "${RED}ERROR${RST}: tests dir not found: $TESTS_DIR";         fail=1; }
 [[ $fail -eq 0 ]] || { echo "Aborting."; exit 1; }
 
-# ── Step 1: Build map  test_rel_path -> config_rel_path ───────────────────────
+# --------------- Build map  test_rel_path --> config_rel_path ---------------
 #
 # For each config YAML, grep every line containing "path:" and extract the
 # file path value. Two path prefix conventions exist in the configs:
@@ -160,16 +160,16 @@ while IFS= read -r -d '' config_abs; do
 
     # If the file doesn't exist under our TESTS_DIR, it's upstream — skip
     if [[ ! -f "${TESTS_DIR}/${declared_path}" ]]; then
-      info "(upstream, skipping) $declared_path  ←  $config_rel"
+      info "(upstream, skipping) $declared_path  <--  $config_rel"
       continue
     fi
 
     # Record mapping (first config to claim a file wins; duplicates are fine)
     if [[ ! -v TEST_TO_CONFIG["$declared_path"] ]]; then
       TEST_TO_CONFIG["$declared_path"]="$config_rel"
-      info "$declared_path  ←  $config_rel"
+      info "$declared_path  <--  $config_rel"
     else
-      info "$declared_path  ←  $config_rel  (also covered by ${TEST_TO_CONFIG[$declared_path]})"
+      info "$declared_path  <--  $config_rel  (also covered by ${TEST_TO_CONFIG[$declared_path]})"
     fi
   done
 
@@ -178,12 +178,12 @@ done < <(find "$CONFIGS_ROOT" -name "*.yaml" -print0 | sort -z)
 echo ""
 info "Mapped ${#TEST_TO_CONFIG[@]} test file(s) from configs."
 
-# ── Step 2: Collect all workflow YAMLs into a temp file ───────────────────────
+# --------------- Collect all workflow YAMLs into a temp file ---------------
 #
 # Concatenate all workflow files into a single temp file and grep that,
 # instead of piping through echo|grep. The echo|grep -q pattern causes a
 # broken pipe (SIGPIPE) under set -o pipefail because grep -q exits as soon
-# as it finds a match, closing the pipe while echo is still writing — this
+# as it finds a match, closing the pipe while echo is still writing -- this
 # makes pipefail report a non-zero exit even on a successful match, producing
 # false "NOT in any workflow" negatives.
 
@@ -201,11 +201,11 @@ done < <(find "$WORKFLOWS_DIR" \( -name "*.yml" -o -name "*.yaml" \) -print0 2>/
 
 echo ""
 
-# ── Step 3: Walk every test_*.py and check coverage ───────────────────────────
+# --------------- Walk every test_*.py and check coverage ---------------
 header "Checking every test_*.py"
 
 if [[ ${#IGNORED_TEST_FILES[@]} -gt 0 ]]; then
-  echo -e "  ${YEL}Ignored test files (intentionally excluded from CI):${RST}"
+  echo -e "  ${YEL}Ignored test files (intentionally excluded from CI (NOTE: using test_model_ops_v2.py currently)):${RST}"
   for f in "${IGNORED_TEST_FILES[@]}"; do echo "    – tests/$f"; done
   echo ""
 fi
@@ -257,8 +257,7 @@ for test_abs in "${ALL_TEST_FILES[@]}"; do
   fi
 done
 
-# ── Step 4: Summary and actionable output ─────────────────────────────────────
-header "Summary"
+# --------------- Summary and actionable output ---------------
 
 n_no_config=${#missing_config[@]}
 n_no_workflow=${#missing_workflow[@]}
@@ -278,7 +277,7 @@ if [[ $n_bad -eq 0 ]]; then
   exit 0
 fi
 
-# ── Fix instructions ──────────────────────────────────────────────────────────
+# --------------- Fix instructions ---------------
 echo ""
 echo -e "${RED}${BLD}ACTION REQUIRED — $n_bad test file(s) not fully wired into CI.${RST}"
 echo ""

--- a/tests/scripts/check_test_coverage.sh
+++ b/tests/scripts/check_test_coverage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/check_test_coverage.sh
+# tests/scripts/check_test_coverage.sh
 #
 # Enforces that every test_*.py under tests/ is referenced by at least one
 # config YAML anywhere under tests/configs/, AND that config is referenced
@@ -8,21 +8,28 @@
 # Design notes
 # ────────────
 # 1. Scans ALL of tests/configs/ (not just torch_spyre_tests/) because some
-#    test files — like test_modules_custom.py — appear as secondary entries
-#    inside model configs under tests/configs/module_tests/.
+#    test files appear as secondary entries inside model configs under
+#    tests/configs/module_tests/ or tests/configs/model_ops_tests/.
 #
 # 2. Extracts EVERY `path:` line from each YAML (not just the first) because
-#    model configs list multiple test files in a single YAML, e.g.:
-#      - path: .../test_modules.py        <- primary
-#      - path: .../test_modules_custom.py <- secondary, same file
+#    a single model config can reference multiple test files.
 #
-# 3. Checks all workflow YAMLs under .github/workflows/ so that model configs
-#    registered in a different workflow (e.g. module-tests.yml) are accepted.
+# 3. Handles both path prefixes used in configs:
+#      ${TORCH_DEVICE_ROOT}/tests/...  (this repo's tests)
+#      ${TORCH_ROOT}/test/...          (upstream PyTorch tests — singular "test")
+#    Anchors on the filename (test_*.py) and verifies existence on disk to
+#    distinguish our files from upstream ones.
+#
+# 4. Checks all workflow YAMLs under .github/workflows/ so configs registered
+#    in different workflows (e.g. module-tests.yml) are also accepted.
+#
+# 5. Supports an ignore list (IGNORED_TEST_FILES) for test files that are
+#    intentionally not wired into CI (e.g. test harness helpers).
 #
 # Exit code: 0 = all tests covered, 1 = gaps found
 #
 # Usage (run from repo root):
-#   bash scripts/check_test_coverage.sh
+#   bash tests/scripts/check_test_coverage.sh
 #
 # Overrides (for local testing):
 #   --workflows-dir  path/to/.github/workflows/
@@ -34,8 +41,16 @@ set -euo pipefail
 # ── Defaults ──────────────────────────────────────────────────────────────────
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
-CONFIGS_ROOT="${REPO_ROOT}/tests/configs"      # scan everything underneath
+CONFIGS_ROOT="${REPO_ROOT}/tests/configs"
 TESTS_DIR="${REPO_ROOT}/tests"
+
+# ── Ignore list ───────────────────────────────────────────────────────────────
+# Paths relative to TESTS_DIR. These files are intentionally excluded from CI
+# (e.g. shared test harness helpers, not standalone test suites).
+# Add new entries here when a test_*.py file should never be gated on.
+IGNORED_TEST_FILES=(
+  "models/test_model_ops.py"   # base class / helper — not a standalone test suite
+)
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -53,9 +68,16 @@ CYN='\033[0;36m'; BLD='\033[1m';    RST='\033[0m'
 
 header() { echo -e "\n${BLD}── $* ──${RST}"; }
 ok()     { echo -e "  ${GRN}✔${RST}  $*"; }
+skip()   { echo -e "  ${YEL}–${RST}  $* (ignored)"; }
 error()  { echo -e "  ${RED}✘${RST}  $*"; }
 info()   { echo -e "  ${CYN}·${RST}  $*"; }
 warn()   { echo -e "  ${YEL}!${RST}  $*"; }
+
+# Build a fast lookup set from the ignore list
+declare -A IGNORED
+for f in "${IGNORED_TEST_FILES[@]}"; do
+  IGNORED["$f"]=1
+done
 
 # ── Sanity checks ─────────────────────────────────────────────────────────────
 fail=0
@@ -64,28 +86,27 @@ fail=0
 [[ -d "$TESTS_DIR"     ]] || { echo -e "${RED}ERROR${RST}: tests dir not found: $TESTS_DIR";         fail=1; }
 [[ $fail -eq 0 ]] || { echo "Aborting."; exit 1; }
 
-# ----- Step 1: Build map  test_rel_path -> config_rel_path  -----
+# ── Step 1: Build map  test_rel_path -> config_rel_path ───────────────────────
 #
-# Read ALL `path:` lines from every YAML under tests/configs/ (not just the
-# first), because a single model config can reference multiple test files.
+# For each config YAML, grep every line containing "path:" and extract the
+# file path value. Two path prefix conventions exist in the configs:
 #
-# path: lines look like either:
-#   - path: ${TORCH_DEVICE_ROOT}/tests/test_modules_custom.py
-#   - path: ${TORCH_ROOT}/test/test_modules.py
+#   ${TORCH_DEVICE_ROOT}/tests/models/test_foo.py   <- this repo, /tests/ (plural)
+#   ${TORCH_ROOT}/test/test_modules.py              <- upstream PyTorch, /test/ (singular)
 #
-# We extract the basename-anchor "/tests/" segment to normalise both forms.
-# Paths that don't contain "/tests/" (e.g. upstream test paths like
-# ${TORCH_ROOT}/test/) are tracked separately — they're expected and fine.
+# We anchor on: (1) filename is test_*.py, (2) file exists on disk under
+# TESTS_DIR. If it doesn't exist, it's an upstream file — skipped silently.
 
 header "Reading all config YAMLs under tests/configs/"
 
-declare -A TEST_TO_CONFIG     # test_rel_path -> config_rel_path (rel to tests/configs/)
-declare -A UPSTREAM_COVERED   # records test paths outside our tests/ tree (informational)
+declare -A TEST_TO_CONFIG   # test_rel_path -> config_rel_path (rel to tests/configs/)
 
 while IFS= read -r -d '' config_abs; do
   config_rel="${config_abs#${CONFIGS_ROOT}/}"
 
-  # Extract every line that contains "path:" — skips comment lines (#)
+  # Collect every line containing "path:", excluding comment lines.
+  # This also matches "module_path:" lines in model configs, but those are
+  # filtered out below by the test_*.py filename check.
   mapfile -t path_lines < <(grep 'path:' "$config_abs" 2>/dev/null | grep -v '^\s*#' || true)
 
   if [[ ${#path_lines[@]} -eq 0 ]]; then
@@ -94,35 +115,38 @@ while IFS= read -r -d '' config_abs; do
   fi
 
   for path_line in "${path_lines[@]}"; do
-    # Pull out the value after "path:" and trim whitespace
+    # Extract the value after "path:" and trim surrounding whitespace
     raw_value="${path_line#*path:}"
     raw_value="${raw_value#"${raw_value%%[![:space:]]*}"}"  # ltrim
-    raw_value="${raw_value%%[[:space:]]*}"                  # rtrim (remove trailing spaces/comments)
+    raw_value="${raw_value%%[[:space:]]*}"                  # rtrim
 
-    if [[ -z "$raw_value" ]]; then
+    [[ -z "$raw_value" ]] && continue
+
+    # Only care about test_*.py filenames — filters out module_path:, etc.
+    filename="${raw_value##*/}"
+    [[ "$filename" == test_*.py ]] || continue
+
+    # Resolve repo-relative path by stripping up to /tests/ or /test/
+    if [[ "$raw_value" == *"/tests/"* ]]; then
+      declared_path="${raw_value##*/tests/}"
+    elif [[ "$raw_value" == *"/test/"* ]]; then
+      declared_path="${raw_value##*/test/}"
+    else
       continue
     fi
 
-    if [[ "$raw_value" == *"/tests/"* ]]; then
-      # Strip everything up to and including the last "/tests/" occurrence
-      # to get the path relative to a tests/ root
-      declared_path="${raw_value##*/tests/}"
+    # If the file doesn't exist under our TESTS_DIR, it's upstream — skip
+    if [[ ! -f "${TESTS_DIR}/${declared_path}" ]]; then
+      info "(upstream, skipping) $declared_path  ←  $config_rel"
+      continue
+    fi
 
-      # Only track paths that look like our test_*.py files
-      if [[ "$declared_path" == test_*.py || "$declared_path" == */test_*.py ]]; then
-        # If this path was already claimed by another config, keep the first
-        # (multiple model configs can cover the same test file — that's fine)
-        if [[ ! -v TEST_TO_CONFIG["$declared_path"] ]]; then
-          TEST_TO_CONFIG["$declared_path"]="$config_rel"
-          info "$declared_path  ←  $config_rel"
-        else
-          info "$declared_path  ←  $config_rel  (also covered by ${TEST_TO_CONFIG[$declared_path]})"
-        fi
-      fi
+    # Record mapping (first config to claim a file wins; duplicates are fine)
+    if [[ ! -v TEST_TO_CONFIG["$declared_path"] ]]; then
+      TEST_TO_CONFIG["$declared_path"]="$config_rel"
+      info "$declared_path  ←  $config_rel"
     else
-      # Path outside our tests/ tree (e.g. ${TORCH_ROOT}/test/test_modules.py)
-      # Record it as informational — not our responsibility to gate on
-      UPSTREAM_COVERED["$raw_value"]="$config_rel"
+      info "$declared_path  ←  $config_rel  (also covered by ${TEST_TO_CONFIG[$declared_path]})"
     fi
   done
 
@@ -131,12 +155,8 @@ done < <(find "$CONFIGS_ROOT" -name "*.yaml" -print0 | sort -z)
 echo ""
 info "Mapped ${#TEST_TO_CONFIG[@]} test file(s) from configs."
 
-# ----- Step 2: Build set of config paths referenced across ALL workflows -----
+# ── Step 2: Collect contents of all workflow YAMLs ────────────────────────────
 header "Reading all workflow YAMLs under .github/workflows/"
-
-# We grep every workflow file for config: entries and collect all mentioned
-# config paths into a single lookup string (WORKFLOW_CONTENTS).
-# Using grep -h to suppress filenames and concatenate all matches.
 
 WORKFLOW_CONTENTS=""
 while IFS= read -r -d '' wf; do
@@ -150,26 +170,33 @@ done < <(find "$WORKFLOWS_DIR" \( -name "*.yml" -o -name "*.yaml" \) -print0 2>/
 
 echo ""
 
-# ----- Step 3: Walk every test_*.py and check coverage -----
+# ── Step 3: Walk every test_*.py and check coverage ───────────────────────────
 header "Checking every test_*.py"
 
-SCAN_DIRS=(
-  "$TESTS_DIR"
-  "$TESTS_DIR/inductor"
-  "$TESTS_DIR/tensor"
-  "$TESTS_DIR/models"
+if [[ ${#IGNORED_TEST_FILES[@]} -gt 0 ]]; then
+  echo -e "  ${YEL}Ignored files (intentionally excluded from CI):${RST}"
+  for f in "${IGNORED_TEST_FILES[@]}"; do echo "    – tests/$f"; done
+  echo ""
+fi
+
+mapfile -d '' ALL_TEST_FILES < <(
+  find "$TESTS_DIR" -maxdepth 2 -name "test_*.py" -print0 | sort -z
 )
 
 missing_config=()
 missing_workflow=()
 
-while IFS= read -r -d '' test_abs; do
+for test_abs in "${ALL_TEST_FILES[@]}"; do
   test_rel="${test_abs#${TESTS_DIR}/}"
+
+  # Skip explicitly ignored files
+  if [[ -v IGNORED["$test_rel"] ]]; then
+    skip "tests/${test_rel}"
+    continue
+  fi
 
   if [[ -v TEST_TO_CONFIG["$test_rel"] ]]; then
     config_rel="${TEST_TO_CONFIG[$test_rel]}"
-
-    # Check if this config's path appears anywhere in any workflow file
     if echo "$WORKFLOW_CONTENTS" | grep -qF "$config_rel" 2>/dev/null; then
       ok "tests/${test_rel}"
     else
@@ -183,25 +210,23 @@ while IFS= read -r -d '' test_abs; do
     echo "       No config YAML references this file anywhere under tests/configs/"
     missing_config+=("tests/${test_rel}")
   fi
+done
 
-done < <(
-  for d in "${SCAN_DIRS[@]}"; do
-    [[ -d "$d" ]] && find "$d" -maxdepth 1 -name "test_*.py" -print0
-  done | sort -z
-)
+# ── Step 4: Summary and actionable output ─────────────────────────────────────
+header "Summary"
 
-# ----- Step 4: Summary and actionable output -----
-
+n_ignored=${#IGNORED_TEST_FILES[@]}
 n_no_config=${#missing_config[@]}
 n_no_workflow=${#missing_workflow[@]}
 n_bad=$(( n_no_config + n_no_workflow ))
 n_covered=$(( ${#TEST_TO_CONFIG[@]} - n_no_workflow ))
 
-echo "  Config YAMLs scanned : all files under tests/configs/"
-echo "  Test files mapped    : ${#TEST_TO_CONFIG[@]}"
-echo -e "  ${GRN}Fully covered${RST}        : $n_covered"
-echo -e "  ${RED}No config at all${RST}     : $n_no_config"
-echo -e "  ${RED}Config not in any workflow${RST}: $n_no_workflow"
+echo "  Config YAMLs scanned      : all files under tests/configs/"
+echo "  Test files mapped         : ${#TEST_TO_CONFIG[@]}"
+echo -e "  ${YEL}Intentionally ignored${RST}     : $n_ignored"
+echo -e "  ${GRN}Fully covered${RST}             : $n_covered"
+echo -e "  ${RED}No config at all${RST}          : $n_no_config"
+echo -e "  ${RED}Config not in any workflow${RST} : $n_no_workflow"
 
 if [[ $n_bad -eq 0 ]]; then
   echo ""
@@ -212,13 +237,15 @@ fi
 # ── Fix instructions ──────────────────────────────────────────────────────────
 echo ""
 echo -e "${RED}${BLD}ACTION REQUIRED — $n_bad test file(s) not fully wired into CI.${RST}"
+echo ""
+echo "If a file should never be in CI, add it to IGNORED_TEST_FILES"
+echo "at the top of tests/scripts/check_test_coverage.sh."
 
 if [[ ${#missing_config[@]} -gt 0 ]]; then
   echo ""
   echo -e "${BLD}Files not referenced by any config YAML:${RST}"
   for f in "${missing_config[@]}"; do echo "  • $f"; done
   echo ""
-  echo "  These files need a config entry somewhere under tests/configs/."
   echo "  For a standalone test, create tests/configs/torch_spyre_tests[/subdir]/test_<name>_config.yaml:"
   echo ""
   echo "    test_suite_config:"
@@ -226,8 +253,8 @@ if [[ ${#missing_config[@]} -gt 0 ]]; then
   echo "        - path: \${TORCH_DEVICE_ROOT}/tests/<path/to/test_file.py>"
   echo "          unlisted_test_mode: mandatory_success"
   echo ""
-  echo "  Or add the file as a secondary entry inside an existing model config"
-  echo "  under tests/configs/module_tests/ if it belongs to a model test suite."
+  echo "  Or add as a secondary path: entry inside an existing model config"
+  echo "  under tests/configs/module_tests/ or tests/configs/model_ops_tests/."
 fi
 
 if [[ ${#missing_workflow[@]} -gt 0 ]]; then

--- a/tests/scripts/check_test_coverage.sh
+++ b/tests/scripts/check_test_coverage.sh
@@ -21,10 +21,15 @@
 #    distinguish our files from upstream ones.
 #
 # 4. Checks all workflow YAMLs under .github/workflows/ so configs registered
-#    in different workflows (e.g. module-tests.yml) are also accepted.
+#    in different workflows (e.g. module_tests.yml) are also accepted.
+#    Workflow matrices may use either the full relative config path OR just the
+#    bare filename — both forms are matched.
 #
-# 5. Supports an ignore list (IGNORED_TEST_FILES) for test files that are
-#    intentionally not wired into CI (e.g. test harness helpers).
+# 5. Supports an ignore list (IGNORED_TEST_FILES) for test files and
+#    (IGNORED_CONFIGS) for config files that should be excluded from scanning.
+#
+# 6. Writes workflow contents to a temp file and greps that directly to avoid
+#    the echo|grep -q broken-pipe / pipefail false-negative bug.
 #
 # Exit code: 0 = all tests covered, 1 = gaps found
 #
@@ -44,12 +49,18 @@ WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
 CONFIGS_ROOT="${REPO_ROOT}/tests/configs"
 TESTS_DIR="${REPO_ROOT}/tests"
 
-# ── Ignore list ───────────────────────────────────────────────────────────────
-# Paths relative to TESTS_DIR. These files are intentionally excluded from CI
+# ── Ignore list: test files ───────────────────────────────────────────────────
+# Paths relative to TESTS_DIR. Intentionally excluded from CI gating
 # (e.g. shared test harness helpers, not standalone test suites).
-# Add new entries here when a test_*.py file should never be gated on.
 IGNORED_TEST_FILES=(
   "models/test_model_ops.py"   # base class / helper — not a standalone test suite
+)
+
+# ── Ignore list: config files ─────────────────────────────────────────────────
+# Paths relative to CONFIGS_ROOT. These configs are excluded from scanning
+# (e.g. example/template configs that are not real test suites).
+IGNORED_CONFIGS=(
+  "example_test_config.yaml"   # example template — not a real test suite
 )
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
@@ -73,11 +84,16 @@ error()  { echo -e "  ${RED}✘${RST}  $*"; }
 info()   { echo -e "  ${CYN}·${RST}  $*"; }
 warn()   { echo -e "  ${YEL}!${RST}  $*"; }
 
-# Build a fast lookup set from the ignore list
-declare -A IGNORED
-for f in "${IGNORED_TEST_FILES[@]}"; do
-  IGNORED["$f"]=1
-done
+# Build fast lookup sets from ignore lists
+declare -A IGNORED_TEST
+for f in "${IGNORED_TEST_FILES[@]}"; do IGNORED_TEST["$f"]=1; done
+
+declare -A IGNORED_CFG
+for f in "${IGNORED_CONFIGS[@]}"; do IGNORED_CFG["$f"]=1; done
+
+# ── Temp file for workflow contents (avoids echo|grep broken-pipe/pipefail bug) ──
+WORKFLOW_TMPFILE="$(mktemp)"
+trap 'rm -f "$WORKFLOW_TMPFILE"' EXIT
 
 # ── Sanity checks ─────────────────────────────────────────────────────────────
 fail=0
@@ -95,7 +111,7 @@ fail=0
 #   ${TORCH_ROOT}/test/test_modules.py              <- upstream PyTorch, /test/ (singular)
 #
 # We anchor on: (1) filename is test_*.py, (2) file exists on disk under
-# TESTS_DIR. If it doesn't exist, it's an upstream file — skipped silently.
+# TESTS_DIR. If it doesn't exist on disk it's an upstream file — skipped.
 
 header "Reading all config YAMLs under tests/configs/"
 
@@ -104,8 +120,15 @@ declare -A TEST_TO_CONFIG   # test_rel_path -> config_rel_path (rel to tests/con
 while IFS= read -r -d '' config_abs; do
   config_rel="${config_abs#${CONFIGS_ROOT}/}"
 
+  # Skip ignored config files (matched by basename or full relative path)
+  config_basename="${config_abs##*/}"
+  if [[ -v IGNORED_CFG["$config_basename"] || -v IGNORED_CFG["$config_rel"] ]]; then
+    warn "Skipping ignored config: $config_rel"
+    continue
+  fi
+
   # Collect every line containing "path:", excluding comment lines.
-  # This also matches "module_path:" lines in model configs, but those are
+  # Also catches "module_path:" lines in model configs, but those are
   # filtered out below by the test_*.py filename check.
   mapfile -t path_lines < <(grep 'path:' "$config_abs" 2>/dev/null | grep -v '^\s*#' || true)
 
@@ -155,16 +178,24 @@ done < <(find "$CONFIGS_ROOT" -name "*.yaml" -print0 | sort -z)
 echo ""
 info "Mapped ${#TEST_TO_CONFIG[@]} test file(s) from configs."
 
-# ── Step 2: Collect contents of all workflow YAMLs ────────────────────────────
+# ── Step 2: Collect all workflow YAMLs into a temp file ───────────────────────
+#
+# Concatenate all workflow files into a single temp file and grep that,
+# instead of piping through echo|grep. The echo|grep -q pattern causes a
+# broken pipe (SIGPIPE) under set -o pipefail because grep -q exits as soon
+# as it finds a match, closing the pipe while echo is still writing — this
+# makes pipefail report a non-zero exit even on a successful match, producing
+# false "NOT in any workflow" negatives.
+
 header "Reading all workflow YAMLs under .github/workflows/"
 
-WORKFLOW_CONTENTS=""
 while IFS= read -r -d '' wf; do
   wf_rel="${wf#${REPO_ROOT}/}"
   count=$(grep -c 'config:' "$wf" 2>/dev/null || true)
   if [[ $count -gt 0 ]]; then
     info "$wf_rel ($count config: entries)"
-    WORKFLOW_CONTENTS+=$'\n'"$(cat "$wf")"
+    cat "$wf" >> "$WORKFLOW_TMPFILE"
+    echo "" >> "$WORKFLOW_TMPFILE"
   fi
 done < <(find "$WORKFLOWS_DIR" \( -name "*.yml" -o -name "*.yaml" \) -print0 2>/dev/null | sort -z)
 
@@ -174,8 +205,14 @@ echo ""
 header "Checking every test_*.py"
 
 if [[ ${#IGNORED_TEST_FILES[@]} -gt 0 ]]; then
-  echo -e "  ${YEL}Ignored files (intentionally excluded from CI):${RST}"
+  echo -e "  ${YEL}Ignored test files (intentionally excluded from CI):${RST}"
   for f in "${IGNORED_TEST_FILES[@]}"; do echo "    – tests/$f"; done
+  echo ""
+fi
+
+if [[ ${#IGNORED_CONFIGS[@]} -gt 0 ]]; then
+  echo -e "  ${YEL}Ignored config files (excluded from scanning):${RST}"
+  for f in "${IGNORED_CONFIGS[@]}"; do echo "    – tests/configs/$f"; done
   echo ""
 fi
 
@@ -189,15 +226,23 @@ missing_workflow=()
 for test_abs in "${ALL_TEST_FILES[@]}"; do
   test_rel="${test_abs#${TESTS_DIR}/}"
 
-  # Skip explicitly ignored files
-  if [[ -v IGNORED["$test_rel"] ]]; then
+  # Skip explicitly ignored test files
+  if [[ -v IGNORED_TEST["$test_rel"] ]]; then
     skip "tests/${test_rel}"
     continue
   fi
 
   if [[ -v TEST_TO_CONFIG["$test_rel"] ]]; then
     config_rel="${TEST_TO_CONFIG[$test_rel]}"
-    if echo "$WORKFLOW_CONTENTS" | grep -qF "$config_rel" 2>/dev/null; then
+    config_basename="${config_rel##*/}"
+
+    # Match against the workflow temp file using BOTH the full relative path
+    # and the bare filename — different workflows use different conventions:
+    #   torch_spyre_tests:  config: torch_spyre_tests/inductor/test_foo_config.yaml
+    #   module_tests:       config: granite_3_3_8b_instruct_spyre.yaml   (bare name)
+    #   model_ops_tests:    config: gpt_oss_20b_spyre.yaml               (bare name)
+    if grep -qF "$config_rel" "$WORKFLOW_TMPFILE" 2>/dev/null || \
+       grep -qF "$config_basename" "$WORKFLOW_TMPFILE" 2>/dev/null; then
       ok "tests/${test_rel}"
     else
       error "tests/${test_rel}"
@@ -215,15 +260,14 @@ done
 # ── Step 4: Summary and actionable output ─────────────────────────────────────
 header "Summary"
 
-n_ignored=${#IGNORED_TEST_FILES[@]}
 n_no_config=${#missing_config[@]}
 n_no_workflow=${#missing_workflow[@]}
 n_bad=$(( n_no_config + n_no_workflow ))
 n_covered=$(( ${#TEST_TO_CONFIG[@]} - n_no_workflow ))
 
 echo "  Config YAMLs scanned      : all files under tests/configs/"
+echo -e "  ${YEL}Intentionally ignored${RST}     : ${#IGNORED_TEST_FILES[@]} test file(s), ${#IGNORED_CONFIGS[@]} config(s)"
 echo "  Test files mapped         : ${#TEST_TO_CONFIG[@]}"
-echo -e "  ${YEL}Intentionally ignored${RST}     : $n_ignored"
 echo -e "  ${GRN}Fully covered${RST}             : $n_covered"
 echo -e "  ${RED}No config at all${RST}          : $n_no_config"
 echo -e "  ${RED}Config not in any workflow${RST} : $n_no_workflow"
@@ -240,6 +284,7 @@ echo -e "${RED}${BLD}ACTION REQUIRED — $n_bad test file(s) not fully wired int
 echo ""
 echo "If a file should never be in CI, add it to IGNORED_TEST_FILES"
 echo "at the top of tests/scripts/check_test_coverage.sh."
+echo "If a config should be excluded from scanning, add it to IGNORED_CONFIGS."
 
 if [[ ${#missing_config[@]} -gt 0 ]]; then
   echo ""
@@ -264,7 +309,7 @@ if [[ ${#missing_workflow[@]} -gt 0 ]]; then
   echo ""
   echo "  Add the config to the appropriate workflow matrix, e.g.:"
   echo "    - name: <Human Readable Name>"
-  echo "      config: <config path relative to tests/configs/>"
+  echo "      config: <config filename>"
 fi
 
 echo ""

--- a/tests/scripts/check_test_coverage.sh
+++ b/tests/scripts/check_test_coverage.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# scripts/check_test_coverage.sh
+#
+# Enforces that every test_*.py under tests/ is referenced by at least one
+# config YAML anywhere under tests/configs/, AND that config is referenced
+# in at least one GitHub Actions workflow under .github/workflows/.
+#
+# Design notes
+# ────────────
+# 1. Scans ALL of tests/configs/ (not just torch_spyre_tests/) because some
+#    test files — like test_modules_custom.py — appear as secondary entries
+#    inside model configs under tests/configs/module_tests/.
+#
+# 2. Extracts EVERY `path:` line from each YAML (not just the first) because
+#    model configs list multiple test files in a single YAML, e.g.:
+#      - path: .../test_modules.py        <- primary
+#      - path: .../test_modules_custom.py <- secondary, same file
+#
+# 3. Checks all workflow YAMLs under .github/workflows/ so that model configs
+#    registered in a different workflow (e.g. module-tests.yml) are accepted.
+#
+# Exit code: 0 = all tests covered, 1 = gaps found
+#
+# Usage (run from repo root):
+#   bash scripts/check_test_coverage.sh
+#
+# Overrides (for local testing):
+#   --workflows-dir  path/to/.github/workflows/
+#   --configs-root   path/to/tests/configs/
+#   --tests          path/to/tests/
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+CONFIGS_ROOT="${REPO_ROOT}/tests/configs"      # scan everything underneath
+TESTS_DIR="${REPO_ROOT}/tests"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflows-dir) WORKFLOWS_DIR="$2"; shift 2 ;;
+    --configs-root)  CONFIGS_ROOT="$2";  shift 2 ;;
+    --tests)         TESTS_DIR="$2";     shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GRN='\033[0;32m'; YEL='\033[1;33m'
+CYN='\033[0;36m'; BLD='\033[1m';    RST='\033[0m'
+
+header() { echo -e "\n${BLD}── $* ──${RST}"; }
+ok()     { echo -e "  ${GRN}✔${RST}  $*"; }
+error()  { echo -e "  ${RED}✘${RST}  $*"; }
+info()   { echo -e "  ${CYN}·${RST}  $*"; }
+warn()   { echo -e "  ${YEL}!${RST}  $*"; }
+
+# ── Sanity checks ─────────────────────────────────────────────────────────────
+fail=0
+[[ -d "$WORKFLOWS_DIR" ]] || { echo -e "${RED}ERROR${RST}: workflows dir not found: $WORKFLOWS_DIR"; fail=1; }
+[[ -d "$CONFIGS_ROOT"  ]] || { echo -e "${RED}ERROR${RST}: configs root not found: $CONFIGS_ROOT";   fail=1; }
+[[ -d "$TESTS_DIR"     ]] || { echo -e "${RED}ERROR${RST}: tests dir not found: $TESTS_DIR";         fail=1; }
+[[ $fail -eq 0 ]] || { echo "Aborting."; exit 1; }
+
+# ----- Step 1: Build map  test_rel_path -> config_rel_path  -----
+#
+# Read ALL `path:` lines from every YAML under tests/configs/ (not just the
+# first), because a single model config can reference multiple test files.
+#
+# path: lines look like either:
+#   - path: ${TORCH_DEVICE_ROOT}/tests/test_modules_custom.py
+#   - path: ${TORCH_ROOT}/test/test_modules.py
+#
+# We extract the basename-anchor "/tests/" segment to normalise both forms.
+# Paths that don't contain "/tests/" (e.g. upstream test paths like
+# ${TORCH_ROOT}/test/) are tracked separately — they're expected and fine.
+
+header "Reading all config YAMLs under tests/configs/"
+
+declare -A TEST_TO_CONFIG     # test_rel_path -> config_rel_path (rel to tests/configs/)
+declare -A UPSTREAM_COVERED   # records test paths outside our tests/ tree (informational)
+
+while IFS= read -r -d '' config_abs; do
+  config_rel="${config_abs#${CONFIGS_ROOT}/}"
+
+  # Extract every line that contains "path:" — skips comment lines (#)
+  mapfile -t path_lines < <(grep 'path:' "$config_abs" 2>/dev/null | grep -v '^\s*#' || true)
+
+  if [[ ${#path_lines[@]} -eq 0 ]]; then
+    warn "$config_rel — no 'path:' fields, skipping"
+    continue
+  fi
+
+  for path_line in "${path_lines[@]}"; do
+    # Pull out the value after "path:" and trim whitespace
+    raw_value="${path_line#*path:}"
+    raw_value="${raw_value#"${raw_value%%[![:space:]]*}"}"  # ltrim
+    raw_value="${raw_value%%[[:space:]]*}"                  # rtrim (remove trailing spaces/comments)
+
+    if [[ -z "$raw_value" ]]; then
+      continue
+    fi
+
+    if [[ "$raw_value" == *"/tests/"* ]]; then
+      # Strip everything up to and including the last "/tests/" occurrence
+      # to get the path relative to a tests/ root
+      declared_path="${raw_value##*/tests/}"
+
+      # Only track paths that look like our test_*.py files
+      if [[ "$declared_path" == test_*.py || "$declared_path" == */test_*.py ]]; then
+        # If this path was already claimed by another config, keep the first
+        # (multiple model configs can cover the same test file — that's fine)
+        if [[ ! -v TEST_TO_CONFIG["$declared_path"] ]]; then
+          TEST_TO_CONFIG["$declared_path"]="$config_rel"
+          info "$declared_path  ←  $config_rel"
+        else
+          info "$declared_path  ←  $config_rel  (also covered by ${TEST_TO_CONFIG[$declared_path]})"
+        fi
+      fi
+    else
+      # Path outside our tests/ tree (e.g. ${TORCH_ROOT}/test/test_modules.py)
+      # Record it as informational — not our responsibility to gate on
+      UPSTREAM_COVERED["$raw_value"]="$config_rel"
+    fi
+  done
+
+done < <(find "$CONFIGS_ROOT" -name "*.yaml" -print0 | sort -z)
+
+echo ""
+info "Mapped ${#TEST_TO_CONFIG[@]} test file(s) from configs."
+
+# ----- Step 2: Build set of config paths referenced across ALL workflows -----
+header "Reading all workflow YAMLs under .github/workflows/"
+
+# We grep every workflow file for config: entries and collect all mentioned
+# config paths into a single lookup string (WORKFLOW_CONTENTS).
+# Using grep -h to suppress filenames and concatenate all matches.
+
+WORKFLOW_CONTENTS=""
+while IFS= read -r -d '' wf; do
+  wf_rel="${wf#${REPO_ROOT}/}"
+  count=$(grep -c 'config:' "$wf" 2>/dev/null || true)
+  if [[ $count -gt 0 ]]; then
+    info "$wf_rel ($count config: entries)"
+    WORKFLOW_CONTENTS+=$'\n'"$(cat "$wf")"
+  fi
+done < <(find "$WORKFLOWS_DIR" \( -name "*.yml" -o -name "*.yaml" \) -print0 2>/dev/null | sort -z)
+
+echo ""
+
+# ----- Step 3: Walk every test_*.py and check coverage -----
+header "Checking every test_*.py"
+
+SCAN_DIRS=(
+  "$TESTS_DIR"
+  "$TESTS_DIR/inductor"
+  "$TESTS_DIR/tensor"
+  "$TESTS_DIR/models"
+)
+
+missing_config=()
+missing_workflow=()
+
+while IFS= read -r -d '' test_abs; do
+  test_rel="${test_abs#${TESTS_DIR}/}"
+
+  if [[ -v TEST_TO_CONFIG["$test_rel"] ]]; then
+    config_rel="${TEST_TO_CONFIG[$test_rel]}"
+
+    # Check if this config's path appears anywhere in any workflow file
+    if echo "$WORKFLOW_CONTENTS" | grep -qF "$config_rel" 2>/dev/null; then
+      ok "tests/${test_rel}"
+    else
+      error "tests/${test_rel}"
+      echo "       Config found  : tests/configs/${config_rel}"
+      echo -e "       ${RED}NOT in any workflow${RST} under .github/workflows/"
+      missing_workflow+=("tests/${test_rel}  [config: tests/configs/${config_rel}]")
+    fi
+  else
+    error "tests/${test_rel}"
+    echo "       No config YAML references this file anywhere under tests/configs/"
+    missing_config+=("tests/${test_rel}")
+  fi
+
+done < <(
+  for d in "${SCAN_DIRS[@]}"; do
+    [[ -d "$d" ]] && find "$d" -maxdepth 1 -name "test_*.py" -print0
+  done | sort -z
+)
+
+# ----- Step 4: Summary and actionable output -----
+
+n_no_config=${#missing_config[@]}
+n_no_workflow=${#missing_workflow[@]}
+n_bad=$(( n_no_config + n_no_workflow ))
+n_covered=$(( ${#TEST_TO_CONFIG[@]} - n_no_workflow ))
+
+echo "  Config YAMLs scanned : all files under tests/configs/"
+echo "  Test files mapped    : ${#TEST_TO_CONFIG[@]}"
+echo -e "  ${GRN}Fully covered${RST}        : $n_covered"
+echo -e "  ${RED}No config at all${RST}     : $n_no_config"
+echo -e "  ${RED}Config not in any workflow${RST}: $n_no_workflow"
+
+if [[ $n_bad -eq 0 ]]; then
+  echo ""
+  echo -e "${GRN}${BLD}All test files are covered — CI is up to date.${RST}"
+  exit 0
+fi
+
+# ── Fix instructions ──────────────────────────────────────────────────────────
+echo ""
+echo -e "${RED}${BLD}ACTION REQUIRED — $n_bad test file(s) not fully wired into CI.${RST}"
+
+if [[ ${#missing_config[@]} -gt 0 ]]; then
+  echo ""
+  echo -e "${BLD}Files not referenced by any config YAML:${RST}"
+  for f in "${missing_config[@]}"; do echo "  • $f"; done
+  echo ""
+  echo "  These files need a config entry somewhere under tests/configs/."
+  echo "  For a standalone test, create tests/configs/torch_spyre_tests[/subdir]/test_<name>_config.yaml:"
+  echo ""
+  echo "    test_suite_config:"
+  echo "      files:"
+  echo "        - path: \${TORCH_DEVICE_ROOT}/tests/<path/to/test_file.py>"
+  echo "          unlisted_test_mode: mandatory_success"
+  echo ""
+  echo "  Or add the file as a secondary entry inside an existing model config"
+  echo "  under tests/configs/module_tests/ if it belongs to a model test suite."
+fi
+
+if [[ ${#missing_workflow[@]} -gt 0 ]]; then
+  echo ""
+  echo -e "${BLD}Files whose config is not referenced in any workflow:${RST}"
+  for f in "${missing_workflow[@]}"; do echo "  • $f"; done
+  echo ""
+  echo "  Add the config to the appropriate workflow matrix, e.g.:"
+  echo "    - name: <Human Readable Name>"
+  echo "      config: <config path relative to tests/configs/>"
+fi
+
+echo ""
+echo "Full guide: tests/docs/enabling_torch_spyre_cicd_tests.md"
+exit 1


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

## What this PR does:

Adds a script `scripts/check_test_coverage.sh` and a GHA workflow `.github/workflows/check-test-ci-coverage.yaml` that block merges if any test_*.py file is not referenced by a config YAML under `tests/configs/` and registered in a workflow matrix. Covers all config subdirectories including torch_spyre_tests/ and module_tests/, etc and handles cases where a single model config covers multiple test files.

#### The CI triggers in 4 situations:

- Push to `main` (post-merge) but only when the pushed commits touch a test file (tests/**/*.py), any config (tests/configs/**), or either workflow file.
- Any PR to `main` — same path filters apply, so it only runs if the PR actually modifies a test, config, or workflow file. A PR that only changes source code won't trigger it.
- Merge queue (merge_group) — runs when a PR is added to the merge queue before it lands on main,
- Manual dispatch — any maintainer can trigger it on demand from the GitHub Actions UI without needing a code change

#### Special notes for your reviewer:
No

### Scenario 1: No new test files added or configs updated/added ( CI passes )
<img width="1620" height="784" alt="image" src="https://github.com/user-attachments/assets/8dbcd2d2-77bd-48db-acee-b655126445f9" /><br><br> 

### Scenario 2: Add a dummy test file called tests/test_dummy.py without having a coresponding test config + workflow matrix and CI fails (Run: https://github.com/torch-spyre/torch-spyre/actions/runs/25884801486/job/76073532853?pr=2078)

```bash
touch tests/test_dummy.py
git add tests/test_dummy.py
git commit -s -m "test: add dummy test to test enforcement into CI rules"
git push
```
Snippet:
#### Trigged the pipeline and failed as expected:
<img width="1604" height="158" alt="image" src="https://github.com/user-attachments/assets/f05306b7-d70a-46c2-823a-9ce7165a37e6" /> <br><br>

Failure message with stats and further instructions:
<img width="2680" height="1522" alt="image" src="https://github.com/user-attachments/assets/6cb22abb-7501-4293-8ded-9b5d3bb9d62b" />

### Scenario 3: Add a dummy test in tests/inductor/test_inductor_dummy.py without integrating it to CICD

```bash
touch tests/inductor/test_inductor_dummy.py
git add tests/inductor/test_inductor_dummy.py
git commit -s -m "test: add dummy test to different directory to test enforcement into CI rules"
git push
```

<img width="1604" height="158" alt="image" src="https://github.com/user-attachments/assets/9eadee99-c095-40f0-aec9-27344415235b" /> <br><br>

<img width="1780" height="1738" alt="image" src="https://github.com/user-attachments/assets/9b132dbe-764e-4cb3-9370-9739170a1598" /><br>

### Scenario 4: Add a completely separate folder with a test file in it without integrating it to CICD
```bash
mkdir -p tests/dummy_tests/
touch tests/dummy_tests/test_dummy.py
git add tests/dummy_tests/test_dummy.py
git commit -s -m "test: add new dummt test folder + test file to test enforcement into CI rules"
git push
```
<img width="1748" height="1740" alt="image" src="https://github.com/user-attachments/assets/770474f0-eeae-4dbd-a090-57f4e652bfb5" />
