### PR TITLE
Improved stick compatibility test

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -28,6 +28,7 @@ import os
 import pytest
 import torch
 
+import torch._inductor.exc
 import torch_spyre._inductor.insert_restickify as _insert_restickify
 import torch_spyre._inductor.optimize_restickify as _optimize_restickify
 from utils_inductor import _compile_and_run, compare_with_cpu
@@ -731,3 +732,21 @@ def test_opt_matmul_both_inputs_upstream_conflict():
         d,
         optimal_cost=2 * S * S,
     )
+
+
+# ------- Unsupported stick configurations ---------
+
+
+def test_sparse_dense_pointwise_unsupported():
+    """a.sum(1) + b - pointwise of sparse and dense tensors not yet supported.
+
+    There is no restickify resolution for this configuration so we must catch this and report error
+    """
+    a = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
+    b = torch.randn((S, S), dtype=torch.float16).to(DEVICE)
+    cfn = torch.compile(lambda a, b: a.sum(1) + b)
+    with pytest.raises(
+        torch._inductor.exc.InductorError,
+        match="NotImplementedError",
+    ):
+        cfn(a, b)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -351,6 +351,26 @@ def compute_restickify_target_layout(
     return SpyreTensorLayout(device_size, stride_map, stl.device_dtype)
 
 
+def stick_compatible(coords: "list[list[sympy.Expr]]") -> bool:
+    """Return True if all tensors are stick-compatible.
+
+    coords: list of device_coordinates() results, one per tensor.
+
+    Compatible means: the union of stick variables (free symbols in the last
+    device coordinate) across all tensors has at most one element, and is
+    disjoint from the union of nonstick variables (free symbols in all other
+    device coordinates, excluding each tensor's own stick variable).
+    """
+    stick_vars: set[sympy.Symbol] = set()
+    nonstick_vars: set[sympy.Symbol] = set()
+    for dc in coords:
+        tensor_stick_vars = dc[-1].free_symbols
+        stick_vars |= tensor_stick_vars
+        for coord in dc[:-1]:
+            nonstick_vars |= coord.free_symbols - tensor_stick_vars
+    return len(stick_vars) <= 1 and stick_vars.isdisjoint(nonstick_vars)
+
+
 def compute_restickify_needed(
     in_stl: SpyreTensorLayout,
     in_host: FixedLayout,
@@ -364,15 +384,15 @@ def compute_restickify_needed(
     different index than the input (e.g. a transposed read).
 
     Returns:
-      (False, None)   — same stick or broadcast: no restickify needed
+      (False, None)   — stick-compatible: no restickify needed
       (True, stl)     — restickify needed, stl is the target STL for the restickified input
       (True, None)    — restickify needed but infeasible
     """
     idc = device_coordinates(in_stl, in_dep)
     out_idc = device_coordinates(out_stl, out_dep)
-    if iter_var_id(idc[-1]) == -1 or not out_idc or iter_var_id(out_idc[-1]) == -1:
-        return False, None
-    if out_idc[-1] == idc[-1]:
+    assert idc, "device_coordinates returned empty list for input"
+    assert out_idc, "device_coordinates returned empty list for output"
+    if stick_compatible([idc, out_idc]):
         return False, None
     ic = host_coordinates(in_host, in_dep)
     return True, compute_restickify_target_layout(in_stl, in_host, out_idc[-1], ic, idc)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR improves the robustness of stick compatibility testing.  The old code used exact equality testing on the stick expressions in device_coordinates[-1], with an exception for `0` to allow broadcast dimensions to also match.  

The problem is that check is both too permissive and too restrictive at times.

**Too Permissive** :  Sparse tensors have a `0` in the stick dimension so the old test allows sparse tensors to be considered compatible with dense tensors, which is incorrect.

**Too Restrictive**:  Type conversions produce stick expressions that vary by only the stick size, so you may see `Mod(d1, 64)` and `Mod(d1,32)`  These need special handling but they are not mismatched sticks, so the stick compatibility tests will pass and this conversion will be handled elsewhere

The intuition of the test is as follows:
- Match on the coordinates variable rather than the full expression (more permissive)
- if Tensor A with idc[-1] is 0 is not _always_ compatible.  If tensor B has stick variable d0, d0 must not appear as a non-stick coordinate in A

#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/pull/1691
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Error messaging for various incompatibility failures will be improved in following PR but submitting this to unblock others