### PR TITLE
:bug: specialize ints for spyre.overwrite

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -144,6 +144,8 @@ jobs:
             config: torch_spyre_tests/inductor/test_dedup_constants_config.yaml
           - name: Inductor Padding
             config: torch_spyre_tests/inductor/test_padding_config.yaml
+          - name: Inductor Overwrite
+            config: torch_spyre_tests/inductor/test_overwrite.yaml
           - name: Inductor Restickify
             config: torch_spyre_tests/inductor/test_restickify_config.yaml
           - name: Inductor Scratchpad Patterns

--- a/tests/configs/torch_spyre_tests/inductor/test_overwrite.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_overwrite.yaml
@@ -1,0 +1,4 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_overwrite.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_overwrite.py
+++ b/tests/inductor/test_overwrite.py
@@ -147,6 +147,38 @@ class TestOverwriteNonZeroDim(unittest.TestCase):
             )
 
 
+class TestOverwriteIssue1765(unittest.TestCase):
+    """Reproducer from torch-spyre#1765: sequential overwrites at
+    progressively increasing offsets accumulated divergence from the
+    CPU reference (max_diff growing 4.4 → 5.3 across iterations 0–9).
+    This is the multi-call manifestation of the dynamo specialize_int
+    bug — each call writes to the first call's offset instead of its
+    own, so the CPU-vs-Spyre diff at distinct positions compounds."""
+
+    def test_issue_1765_sequential_overwrites_4d_dim2(self):
+        torch.manual_seed(42)
+
+        cache = torch.randn(1, 8, 64, 128, dtype=DTYPE)
+        cache_sp = cache.to(DEVICE)
+        ref = cache.clone()
+
+        for i in range(10):
+            new_val = torch.randn(1, 8, 1, 128, dtype=DTYPE)
+            ref[:, :, i:i + 1, :] = new_val
+            torch.ops.spyre.overwrite(
+                input=new_val.to(DEVICE),
+                output=cache_sp,
+                dims=[2],
+                offsets=[i],
+            )
+
+        out = cache_sp.to("cpu")
+        max_diff = (ref - out).abs().max().item()
+        # fp16 round-trip noise is ~2e-3; the issue reports max_diff
+        # growing past 5.0 across iterations on the unfixed tree.
+        self.assertLess(max_diff, 0.01, f"max_diff={max_diff}")
+
+
 class TestOverwriteCpuFallback(unittest.TestCase):
     """Smoke check for the CPU kernel registration. The fix does not
     touch CPU behavior, but co-locating asserts the API contract is

--- a/tests/inductor/test_overwrite.py
+++ b/tests/inductor/test_overwrite.py
@@ -1,0 +1,201 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for spyre.overwrite with runtime-varying offsets.
+
+Guards against the paged-KV-cache scatter regression: a Python loop of
+overwrite() calls with varying offsets used to silently reuse the first
+call's compiled binary because dynamo's default specialize_int=False
+left int-list args un-guarded. See customops.py for the fix.
+"""
+import unittest
+
+import torch
+import torch_spyre  # noqa: F401
+
+DEVICE = "spyre"
+DTYPE = torch.float16
+
+
+def _make_cache(shape, sentinel=-1.0):
+    return torch.full(shape, sentinel, dtype=DTYPE).to(DEVICE)
+
+
+def _make_chunk(shape, value):
+    return torch.full(shape, float(value), dtype=DTYPE).to(DEVICE)
+
+
+class TestOverwriteSingleCall(unittest.TestCase):
+    def test_single_call_writes_single_slot(self):
+        cache = _make_cache((8, 4, 64))
+        token = _make_chunk((1, 4, 64), 7)
+        torch.ops.spyre.overwrite(token, cache, [0], [3])
+        out = cache.to("cpu")
+        torch.testing.assert_close(out[3, 0, 0], torch.tensor(7.0, dtype=DTYPE))
+        for i in [0, 1, 2, 4, 5, 6, 7]:
+            torch.testing.assert_close(out[i, 0, 0], torch.tensor(-1.0, dtype=DTYPE))
+
+    def test_single_call_writes_multi_slot_chunk(self):
+        cache = _make_cache((16, 4, 64))
+        chunk = torch.stack(
+            [torch.full((4, 64), float(i + 1), dtype=DTYPE) for i in range(5)]
+        ).to(DEVICE)
+        torch.ops.spyre.overwrite(chunk, cache, [0], [2])
+        out = cache.to("cpu")
+        for i in range(5):
+            torch.testing.assert_close(
+                out[2 + i, 0, 0], torch.tensor(float(i + 1), dtype=DTYPE)
+            )
+
+
+class TestOverwriteRuntimeVaryingOffsets(unittest.TestCase):
+    """Regression coverage for the paged-KV-cache scatter pattern.
+
+    On the unfixed tree every call after the first silently wrote to
+    the first call's offsets, leaving the requested slots at sentinel.
+    """
+
+    def test_loop_int_offsets(self):
+        cache = _make_cache((64, 4, 32))
+        slots = [3, 17, 18, 42, 63]
+        for i, slot in enumerate(slots):
+            tok = _make_chunk((1, 4, 32), i + 1)
+            torch.ops.spyre.overwrite(tok, cache, [0], [slot])
+        out = cache.to("cpu")
+        for i, slot in enumerate(slots):
+            torch.testing.assert_close(
+                out[slot, 0, 0],
+                torch.tensor(float(i + 1), dtype=DTYPE),
+                msg=f"slot {slot}: expected {i + 1}, got {out[slot, 0, 0].item()}",
+            )
+
+    def test_revisit_offset_correctness(self):
+        """Revisiting a previously-seen offset still produces correct
+        output (regardless of whether the underlying compiled binary
+        is reused or recompiled — that's an implementation detail).
+        """
+        cache = _make_cache((32, 4, 64))
+        sequence = [3, 17, 3, 25, 17]
+        last_value_at_slot = {}
+        for i, slot in enumerate(sequence):
+            value = float(i + 100)
+            tok = _make_chunk((1, 4, 64), value)
+            torch.ops.spyre.overwrite(tok, cache, [0], [slot])
+            last_value_at_slot[slot] = value
+        out = cache.to("cpu")
+        for slot, expected in last_value_at_slot.items():
+            torch.testing.assert_close(
+                out[slot, 0, 0], torch.tensor(expected, dtype=DTYPE)
+            )
+
+    def test_loop_does_not_disturb_unrelated_slots(self):
+        cache = _make_cache((16, 4, 64))
+        written = [2, 5, 11]
+        for i, slot in enumerate(written):
+            tok = _make_chunk((1, 4, 64), i + 1)
+            torch.ops.spyre.overwrite(tok, cache, [0], [slot])
+        out = cache.to("cpu")
+        for slot in range(16):
+            if slot in written:
+                idx = written.index(slot)
+                torch.testing.assert_close(
+                    out[slot, 0, 0], torch.tensor(float(idx + 1), dtype=DTYPE)
+                )
+            else:
+                torch.testing.assert_close(
+                    out[slot, 0, 0], torch.tensor(-1.0, dtype=DTYPE)
+                )
+
+
+class TestOverwriteNonZeroDim(unittest.TestCase):
+    """Coverage for dim != 0 — the fix should not be axis-specific."""
+
+    def test_loop_dim1(self):
+        cache = _make_cache((4, 8, 64))
+        slots = [1, 5, 7, 2]
+        for i, slot in enumerate(slots):
+            tok = _make_chunk((4, 1, 64), i + 1)
+            torch.ops.spyre.overwrite(tok, cache, [1], [slot])
+        out = cache.to("cpu")
+        for i, slot in enumerate(slots):
+            torch.testing.assert_close(
+                out[0, slot, 0], torch.tensor(float(i + 1), dtype=DTYPE)
+            )
+
+    def test_loop_multi_dim(self):
+        cache = _make_cache((8, 8, 64))
+        # Write a 1x1x64 chunk at varying (dim0, dim1) coordinates.
+        coords = [(1, 2), (3, 5), (7, 0), (4, 6)]
+        for i, (d0, d1) in enumerate(coords):
+            tok = _make_chunk((1, 1, 64), i + 1)
+            torch.ops.spyre.overwrite(tok, cache, [0, 1], [d0, d1])
+        out = cache.to("cpu")
+        for i, (d0, d1) in enumerate(coords):
+            torch.testing.assert_close(
+                out[d0, d1, 0], torch.tensor(float(i + 1), dtype=DTYPE)
+            )
+
+
+class TestOverwriteCpuFallback(unittest.TestCase):
+    """Smoke check for the CPU kernel registration. The fix does not
+    touch CPU behavior, but co-locating asserts the API contract is
+    identical across devices so future refactors can't drift them.
+    """
+
+    def test_cpu_loop_writes_each_slot(self):
+        cache = torch.full((16, 4, 32), -1.0, dtype=DTYPE)
+        slots = [1, 7, 14]
+        for i, slot in enumerate(slots):
+            tok = torch.full((1, 4, 32), float(i + 1), dtype=DTYPE)
+            torch.ops.spyre.overwrite(tok, cache, [0], [slot])
+        for i, slot in enumerate(slots):
+            torch.testing.assert_close(
+                cache[slot, 0, 0], torch.tensor(float(i + 1), dtype=DTYPE)
+            )
+
+
+class TestOverwriteFunctionalReinplace(unittest.TestCase):
+    """Exercise the spyre.overwrite_f → spyre.overwrite path that the
+    inductor reinplace pass takes when overwrite_f is invoked inside
+    a torch.compile'd function. Confirms the fix carries through
+    reinplacing.
+    """
+
+    def test_overwrite_f_in_compiled_loop(self):
+        slots = [3, 11, 7, 19]
+
+        def scatter(cache, tokens, slots_tensor):
+            # tokens: (N, ...); slots_tensor: (N,) ints — but custom op
+            # takes int list, so we unroll. Keep this simple: one
+            # overwrite_f per slot, returning new cache each time.
+            for i in range(len(slots)):
+                cache = torch.ops.spyre.overwrite_f(
+                    tokens[i:i + 1], cache, [0], [slots[i]]
+                )
+            return cache
+
+        compiled_scatter = torch.compile(scatter)
+
+        cache = _make_cache((32, 4, 64))
+        tokens = torch.stack(
+            [torch.full((4, 64), float(i + 1), dtype=DTYPE) for i in range(len(slots))]
+        ).to(DEVICE)
+        slots_t = torch.tensor(slots, dtype=torch.int64).to(DEVICE)
+
+        result = compiled_scatter(cache, tokens, slots_t)
+        out = result.to("cpu")
+        for i, slot in enumerate(slots):
+            torch.testing.assert_close(
+                out[slot, 0, 0], torch.tensor(float(i + 1), dtype=DTYPE)
+            )

--- a/tests/inductor/test_overwrite.py
+++ b/tests/inductor/test_overwrite.py
@@ -19,6 +19,7 @@ overwrite() calls with varying offsets used to silently reuse the first
 call's compiled binary because dynamo's default specialize_int=False
 left int-list args un-guarded. See customops.py for the fix.
 """
+
 import unittest
 
 import torch
@@ -164,7 +165,7 @@ class TestOverwriteIssue1765(unittest.TestCase):
 
         for i in range(10):
             new_val = torch.randn(1, 8, 1, 128, dtype=DTYPE)
-            ref[:, :, i:i + 1, :] = new_val
+            ref[:, :, i : i + 1, :] = new_val
             torch.ops.spyre.overwrite(
                 input=new_val.to(DEVICE),
                 output=cache_sp,
@@ -213,7 +214,7 @@ class TestOverwriteFunctionalReinplace(unittest.TestCase):
             # overwrite_f per slot, returning new cache each time.
             for i in range(len(slots)):
                 cache = torch.ops.spyre.overwrite_f(
-                    tokens[i:i + 1], cache, [0], [slots[i]]
+                    tokens[i : i + 1], cache, [0], [slots[i]]
                 )
             return cache
 

--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -14,6 +14,7 @@
 
 from typing import Optional, Sequence
 import torch
+import torch._dynamo
 from torch._inductor.fx_passes.reinplace import inplaceable_ops, InplaceableOp
 from torch_spyre.ops.fallbacks import warn_fallback
 from torch_spyre.ops.eager import compile_once
@@ -320,7 +321,19 @@ def overwrite(
     offsets: Sequence[int],
     compiled,
 ) -> None:
-    return compiled(input, output, dims, offsets)
+    # specialize_int=True installs int-equality guards on the int-list
+    # args so each unique (dims, offsets) triggers a fresh trace and a
+    # fresh SDSC binary; without this dynamo's default specialize_int=
+    # False reuses one baked binary across all values and scatters all
+    # writes to the first call's offset (see test_overwrite.py).
+    # Patch is call-scoped to leave process-wide dynamo behavior alone.
+    # Note: this gives one compiled binary per unique (input shape, dims,
+    # offsets) tuple. dynamo's cache_size_limit is bumped to 1024 in
+    # torch_spyre/__init__.py — long-running workloads that scatter into
+    # many distinct slots can blow past that. Symbolic offsets (one
+    # binary, any value) are tracked in issues #220 / #1371-3.
+    with torch._dynamo.config.patch(specialize_int=True):
+        return compiled(input, output, dims, offsets)
 
 
 @overwrite.register_fake


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

A Python loop of `torch.ops.spyre.overwrite(input, output, dims, offsets)` calls with varying `offsets` silently scatters every write to the first call's offset. This breaks the paged-KV-cache scatter pattern in spyre-inference, where the slot index changes on every decode step. Because `@compile_once` uses `torch._dynamo.config.specialize_int = False` by default, the first compiled SDSC binary is reused for every subsequent call regardless of the actual offsets, producing the wrong output.

This PR sets `specialize_int=True`, which causes int-equality guards on `dims` and `offsets` to fail on new unique values, triggering a recompilation. This is slower, but correct. My understanding is that we can't compile this dynamically today due to #220, but in the future we should be able to.

#### Which issue(s) this PR is related to:

Seems to fix #1765 - I've added the issue's original repro as a test, confirming it passes with this fix and fails without it:
```
AssertionError: 5.296875 not less than 0.01 : max_diff=5.296875
```

Additionally I ran @raghukiran1224's stronger repro from [this comment](https://github.com/torch-spyre/torch-spyre/issues/1765#issuecomment-4314956083), it now yields:

```
written row max diff: 0.0048828125
untouched max diff: 0.001953125
```

on my machine with this change, instead of

```
written row max diff: ~2.89
untouched max diff: ~0.002
```


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

I don't think it should. The interface to the `overwrite` op is unchanged, only the recompilation behavior.

#### Additional note:

Dynamo's `cache_size_limit` is set to 1024 in `torch_spyre/__init__.py`, but the number of recompiles that this could cause might just blow way past that, so I'm not sure if this is the correct direction for this change. Feel free to close if so.