### PR TITLE
ops: register aten.ne for Spyre backend in eager mode

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -3339,9 +3339,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     def test_binary_op_cpu(self, op, x, y):
         # Eager mode support varies by op:
         # - torch.eq, torch.ge, torch.gt, torch.lt: work eagerly
-        # - torch.ne, torch.le: aten::ne.Tensor_out / aten::le.Tensor_out not registered
+        # - torch.le: aten::le.Tensor_out not registered
         # - torch.matmul: numerical divergence (close=False) in eager 2d case
-        eager_supported = op in (torch.eq, torch.ge, torch.gt, torch.lt)
+        eager_supported = op in (torch.eq, torch.ge, torch.gt, torch.lt, torch.ne)
         self.compare_with_cpu(op, x, y, run_eager=eager_supported)
 
     def test_linear_fn(self, x, weight, bias):

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -106,6 +106,7 @@ register_torch_compile_kernel(
         aten.sub,
         aten.addmm,
         aten.eq,
+        aten.ne,
         aten.ge,
         aten.gt,
         aten.lt,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds aten.ne to register_torch_compile_kernel in eager.py to fix
NotImplementedError in eager mode. aten.eq is already registered
and works correctly, this PR brings aten.ne to the same level of support.

#### Which issue(s) this PR is related to:
#2087 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
