### PR TITLE
Extend FxGraphHashDetails to include SpyreTensorLayout in cache key

### DIFF
--- a/tests/inductor/test_cache.py
+++ b/tests/inductor/test_cache.py
@@ -48,3 +48,68 @@ class TestCache(unittest.TestCase):
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 
         self.assertFalse(torch.compiler._cache.CacheArtifactManager.need_serialize())
+
+    def test_cache_key_includes_spyre_layout(self):
+        """
+        Verify that FxGraphHashDetails includes SpyreTensorLayout in the cache key.
+        Different layouts should produce different cache keys, preventing incorrect
+        cache hits across layout changes.
+        """
+        from torch.spyre import SpyreTensorLayout
+
+        x = torch.rand([64, 64], dtype=torch.float16)
+        stl_a = SpyreTensorLayout(
+            list(x.size()), list(x.stride()), torch.float16, [0, 1]
+        )
+        stl_b = SpyreTensorLayout(
+            list(x.size()), list(x.stride()), torch.float16, [1, 0]
+        )
+
+        _ = x.to("spyre")  # wake up spyre
+        tensor_a = x.to(device_layout=stl_a)
+        tensor_b = x.to(device_layout=stl_b)
+
+        fn = torch.compile(lambda a: a + a, dynamic=False)
+
+        # ── Layout A — first compile, cache miss expected ─────────────────────────
+        counters.clear()
+        with fresh_cache():
+            fn(tensor_a)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            artifacts_a = torch.compiler.save_cache_artifacts()
+            self.assertIsNotNone(artifacts_a)
+            artifact_bytes_a, _ = artifacts_a
+
+        # ── Layout B — different layout, should NOT hit Layout A cache ────────────
+        torch._dynamo.reset()
+        counters.clear()
+        with fresh_cache():
+            # load Layout A artifact into cache
+            torch.compiler.load_cache_artifacts(artifact_bytes_a)
+
+            # compile with Layout B — should miss (different layout → different key)
+            fn(tensor_b)
+            self.assertEqual(
+                counters["inductor"]["fxgraph_cache_miss"],
+                1,
+                "Layout B should miss Layout A cache — different SpyreTensorLayout",
+            )
+            self.assertEqual(
+                counters["inductor"]["fxgraph_cache_hit"],
+                0,
+                "Layout B should not hit Layout A cache — SpyreTensorLayout differs",
+            )
+
+        # ── Layout A again — should hit its own cache ─────────────────────────────
+        torch._dynamo.reset()
+        counters.clear()
+        with fresh_cache():
+            torch.compiler.load_cache_artifacts(artifact_bytes_a)
+            fn(tensor_a)
+            self.assertEqual(
+                counters["inductor"]["fxgraph_cache_hit"],
+                1,
+                "Layout A should hit its own cache",
+            )

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -231,3 +231,55 @@ def _patch_tensor_for_spyre():
         )
 
     GuardBuilder.TENSOR_MATCH = _spyre_TENSOR_MATCH
+    # ───────────────────FxGraph Cache Key Extension ───────────────────
+    # Extends FxGraphHashDetails to include SpyreTensorLayout in the cache key
+    # preventing incorrect disk cache hits across process boundaries.
+    # ──────────────────────────────────────────────────────────────────────────
+    _patch_fx_graph_hash()
+
+
+def _patch_fx_graph_hash():
+    """
+    Extends FxGraphHashDetails to include SpyreTensorLayout in the cache key.
+    """
+    import torch
+    from torch._inductor.codecache import FxGraphHashDetails
+    from torch._inductor.virtualized import V
+
+    if getattr(FxGraphHashDetails, "_spyre_hash_patched", False):
+        return
+
+    original_init = FxGraphHashDetails.__init__
+
+    def _spyre_init(self, gm, example_inputs, fx_kwargs, inputs_to_check):
+        # run original first — populates all standard hash fields
+        original_init(self, gm, example_inputs, fx_kwargs, inputs_to_check)
+
+        # V.get_real_inputs() returns real Spyre tensors with SpyreTensorLayout
+        # before they become FakeTensors (which have no layout by design)
+
+        try:
+            real_inputs = V.get_real_inputs()
+        except RuntimeError:
+            return
+
+        # extract layout from real tensors, fallback to example_inputs
+        spyre_layouts = []
+        # Use real_inputs only if it's a valid list/tuple, otherwise use example_inputs
+        inputs_to_use = (
+            real_inputs if isinstance(real_inputs, (list, tuple)) else example_inputs
+        )
+
+        for inp in inputs_to_use:
+            if isinstance(inp, torch.Tensor):
+                layout = inp.device_tensor_layout()
+                spyre_layouts.append(layout)
+            else:
+                spyre_layouts.append(None)
+
+        # self.spyre_layouts added as field on FxGraphHashDetails
+        # PyTorch pickles ALL fields → spyre_layouts automatically in hash
+        self.spyre_layouts = spyre_layouts
+
+    FxGraphHashDetails.__init__ = _spyre_init
+    FxGraphHashDetails._spyre_hash_patched = True


### PR DESCRIPTION

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR extends the FxGraph compilation cache to include SpyreTensorLayout in the cache key, complementing the Dynamo guard fix from #372.

**Problem**
Two Spyre tensors with identical PyTorch metadata (shape, dtype, strides) but different SpyreTensorLayout (device tiling, stride mapping, device dtype) were hashing to the same FxGraphHashDetails cache key. This caused incorrect disk cache hits — a compiled artifact for Layout A would be incorrectly reused for Layout B, producing silently wrong results.



#### Which issue(s) this PR is related to:


Fixes #372 (this PR addresses the FxGraph cache layer; the Dynamo guard layer was addressed in the previous PR)


**changes:**

One change in `torch_spyre/_monkey_patch.py `— patch `FxGraphHashDetails.__init__` to extract `SpyreTensorLayout` from real tensors via `V.get_real_inputs() `and store as `self.spyre_layouts`. PyTorch automatically includes all fields when computing the pickle-based cache key, so spyre_layouts is automatically included in the hash. 

**Result :**
Layout A and Layout B now produce different FxGraphHashDetails hashes  -- >different disk cache entries -- >correct artifact always loaded.

**Special notes for your reviewer:**

FxGraphHashDetails receives FakeTensors during compilation. FakeTensors intentionally carry no SpyreTensorLayout (propagating layout through FakeTensor was explicitly avoided as too invasive and too fragile to maintain out-of-tree — see [torch-spyre architecture docs](https://github.com/torch-spyre/torch-spyre/blob/main/docs/source/getting_started/how_torch_spyre_works.md)).

The Dynamo guard fix (previous PR) handles same-process runtime recompilation. Both are needed for complete correctness.

FakeTensors intentionally return None for device_tensor_layout() — this is by architectural design. 
V.get_real_inputs() — it provides real tensors during compilation . V.get_real_inputs() may return a NullHandler for non-Spyre graphs — handled with an explicit isinstance(real_inputs, (list, tuple)) check before iterating.


**Does this PR introduce a user-facing change?**
No. This is an internal compilation cache correctness fix.

**Additional note:**
Related Previous PR: https://github.com/torch-spyre/torch-spyre/pull/1297