### PR TITLE
[TESTING GHA] fix: dorny negative pattern not working for glob patterns

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -41,7 +41,7 @@ jobs:
     name: Detect changed files
     runs-on: ubuntu-latest
     outputs:
-      should-run: ${{ steps.filter.outputs.src }}
+      docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,12 +51,9 @@ jobs:
         id: filter
         with:
           filters: |
-            src:
-              # Trigger tests for any file change in the repo except
-              # pure documentation under tests/docs/.
-              - '**'
-              - '!tests/docs/**'
-              # - '!**.md'        # optionally exclude all markdown files
+            docs_only:
+              - 'tests/docs/**'
+              - 'docs/**'
   # ---------------------------------------------------------------------------
   # Job 2: test matrix
   #
@@ -74,7 +71,7 @@ jobs:
     # Skip this job entirely if no test-relevant files were modified.
     # The fan-in job below handles the skipped case and still reports green
     # to satisfy the branch protection required check.
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.docs_only == 'false'
     runs-on:
       - x86_64
       - spyre_pf_x1

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -56,7 +56,7 @@ jobs:
               # pure documentation under tests/docs/.
               - '**'
               - '!tests/docs/**'
-              - '!**.md'        # optionally exclude all markdown files
+              # - '!**.md'        # optionally exclude all markdown files
   # ---------------------------------------------------------------------------
   # Job 2: test matrix
   #

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -32,10 +32,11 @@ jobs:
   # and does not use spyre cards.
   #
   # Filter rules:
-  #   src -- matches any file that should cause tests to run:
-  #     -- any file in the repo ('**')
-  #     -- except tests/docs/**  (pure documentation)
-  #     -- except **.md          (markdown files anywhere in the repo)
+  #   docs_only -- matches changes that should NOT trigger tests:
+  #     -- tests/docs/**  (test suite documentation)
+  #     -- docs/**        (repo-level documentation)
+  # Tests are skipped only when docs_only == 'true'.
+  # For every other change in the repo, tests run.
   # ---------------------------------------------------------------------------
   changes:
     name: Detect changed files
@@ -57,8 +58,9 @@ jobs:
   # ---------------------------------------------------------------------------
   # Job 2: test matrix
   #
-  # Only runs when `changes.should-run == 'true'`, i.e. when a relevant file
-  # was modified. For docs-only PRs this job is skipped entirely -- no hardware
+  # Only runs when `changes.docs_only == 'false'`, i.e. when something
+  # other than documentation was modified.
+  # For docs-only PRs this job is skipped entirely -- no hardware
   # runners are consumed.
   #
   # To add a new test suite, append an entry to the matrix below:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fix dorny/paths-filter approach by inverting the logic -- instead of negating ** to exclude tests/docs/ (which dorny does not support reliably), detect `docs_only` changes explicitly and skip the test matrix only when that filter matches.