### PR TITLE
Support view destinations in mutation ops like torch.Tensor.copy_

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1951,6 +1951,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                         ),
                     )
                 ),
+                "copy_": (
+                    lambda dim, index, x: (
+                        y := torch.split(x, x.size()[dim] // 3, dim=dim)[index],
+                        y.copy_(torch.ones_like(y))._base,
+                    )[-1]
+                ),
                 "chunk": (lambda dim, index, x: x.chunk(3, dim=dim)[index].clone()),
             },
             "param_sets": {
@@ -1980,6 +1986,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "add": lambda dim, x: torch.add(x.clone(), x),
                 "sum": lambda dim, x: torch.sum(x, dim=dim, keepdim=True),
                 "amax": lambda dim, x: torch.amax(x, dim=dim, keepdim=False),
+                "copy_": lambda dim, x: x.copy_(torch.ones_like(x))._base,
             },
             "param_sets": {
                 "1d0s0": (0, 0, cached_randn((192,), dtype=torch.float16)),
@@ -4067,7 +4074,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         def fn(x):
             return op(dim, index, x)
 
-        self.compare_with_cpu(fn, x, run_eager=False)
+        self.compare_with_cpu(fn, x, clone_inputs=True, run_eager=False)
 
     def test_slice_cpu(self, op, dim, index, x):
         def fn(x):
@@ -4080,7 +4087,7 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             elif dim == 2:
                 return op(dim, x[:, :, start:end])
 
-        self.compare_with_cpu(fn, x, run_eager=False)
+        self.compare_with_cpu(fn, x, clone_inputs=True, run_eager=False)
 
     def test_rope_cpu(self, q, freqs):
         def fn(q, freqs):

--- a/tests/inductor/utils_inductor.py
+++ b/tests/inductor/utils_inductor.py
@@ -593,6 +593,7 @@ def compare_with_cpu(
     run_eager=True,
     run_compile=True,
     source_check=None,
+    clone_inputs=False,
 ):
     """Compare Spyre execution against CPU for one or both Spyre execution paths.
 
@@ -618,7 +619,12 @@ def compare_with_cpu(
         # if this env var is set at all, it gets marked as true
         cpu_compile = bool(os.getenv("TEST_COMPARE_CPU_COMPILE"))
 
-    cpu_result = fn(*args)
+    def get_args():
+        if not clone_inputs:
+            return args
+        return [arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args]
+
+    cpu_result = fn(*get_args())
 
     # Order: compiled first, then eager (matches prior [True, False] when both on).
     modes = tuple(
@@ -636,7 +642,7 @@ def compare_with_cpu(
             if target is not None
             else _compile_and_run(
                 fn,
-                args,
+                get_args(),
                 DEVICE,
                 needs_device=needs_device,
                 compile=compiled,
@@ -650,7 +656,7 @@ def compare_with_cpu(
 
         if cpu_compile:
             cpu_other_result = _compile_and_run(
-                fn, args, "cpu", needs_device=needs_device, compile=compiled
+                fn, get_args(), "cpu", needs_device=needs_device, compile=compiled
             )
             _assert_results_close(
                 spyre_result,

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -29,6 +29,7 @@ from torch._inductor.ir import (
     InputBuffer,
     MutationLayoutSHOULDREMOVE,
     Operation,
+    ReinterpretView,
     StorageBox,
     TensorBox,
 )
@@ -284,7 +285,10 @@ def finalize_layouts(operations: list) -> None:
     for op in operations:
         if not isinstance(op.layout, MutationLayoutSHOULDREMOVE):
             continue
-        target_layout = op.layout.target.get_layout()
+        target = op.layout.target
+        while isinstance(target, ReinterpretView):
+            target = target.data  # Traverse view chain to underlying buffer
+        target_layout = target.get_layout()
         assert isinstance(target_layout, FixedTiledLayout), (
             f"mutation op {op.get_name()} target has no committed FixedTiledLayout"
         )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR enables view destinations in mutation operations, such as `torch.Tensor.copy_`.

With this change, mutation ops can now operate directly on tensor views. This allows partial updates of destination tensors using sliced or otherwise derived views.

With this PR, we can update the part of the destination tensor using sliced tensors like this.
```python
import torch

def test(dst, src):
    slice = dst.split(1, dim=0)[1]
    slice.copy_(src)
    return dst

dst = torch.zeros(3, 4, dtype=torch.float16)
src = torch.ones(1, 4, dtype=torch.float16)

compiled = torch.compile(test, backend="inductor")
output = compiled(dst.to("spyre"), src.to("spyre"))
print(output.cpu())
```

In this case, only a specific slice of dst is updated via a view using in-place operations.

And, this change is also a prerequisite of removal of the `spyre::overwrite`custom op.

#### Which issue(s) this PR is related to:

Follow-up to: 
- #2008 

Prerequisite for:
- #1792

Umbrella issue:
- #1333 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Enables in-place mutation ops on tensor views

#### Additional note:
