### PR TITLE
Use constants in RMSNorm and SDPA decompositions

### DIFF
--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -432,8 +432,7 @@ def spyre_rms_norm(
         )
 
     mean = torch.mean(input * input, dim=-1, keepdim=True)
-    eps_tensor = torch.ops.spyre.full((1,), eps, dtype=torch.float16, device="spyre")
-    rsqrt_inp = torch.rsqrt(mean + eps_tensor)
+    rsqrt_inp = torch.rsqrt(mean + eps)
     output = input * rsqrt_inp
     if weight is not None:
         output = output * weight
@@ -537,12 +536,8 @@ def spyre__sdpa_overrideable(
         scaling_factor = 1.0 / math.sqrt(query.shape[-1])
     scaling_factor = math.sqrt(scaling_factor)
 
-    # TODO (aviros): Figure why this broadcast doesn't work
-    scaling_factor_q = torch.full_like(query, scaling_factor)
-    scaling_factor_k = torch.full_like(key, scaling_factor)
-
-    query = query * scaling_factor_q
-    key = key * scaling_factor_k
+    query = query * scaling_factor
+    key = key * scaling_factor
 
     expansion = num_heads // num_kvheads
     if expansion != 1:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR replaces the use of `torch.spyre.ops.full` with a constant in the decomposition for SDPA and RMSNorm. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
