### PR TITLE
Eliminate x buffer allocation and copy in K-padding pass

### DIFF
--- a/tests/inductor/test_padding.py
+++ b/tests/inductor/test_padding.py
@@ -164,7 +164,7 @@ class TestInsertPaddingIR(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_mm_unaligned_k_pads(self) -> None:
-        """2D mm with K=67 (unaligned) — x and y are both padded before the matmul."""
+        """2D mm with K=67 (unaligned) — y is padded before the matmul; x is not."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         # 67 is not a multiple of stick_size (64), so padding should occur.
@@ -182,7 +182,7 @@ class TestInsertPaddingIR(unittest.TestCase):
         mm = matmuls[0]
 
         # reduction_ranges is updated to K_padded so the hardware iterates
-        # r_K = 0..K_padded-1; the pad region of x and y is zero-filled.
+        # r_K = 0..K_padded-1; x's tail is handled by pt hardware masking.
         k_padded = ((67 + stick_size - 1) // stick_size) * stick_size
         reduction = mm.data
         assert isinstance(reduction, Reduction)
@@ -193,11 +193,11 @@ class TestInsertPaddingIR(unittest.TestCase):
             f"reduction_ranges should be K_padded={k_padded}, got {k_actual}",
         )
 
-        # 4 overwrite ops before the matmul: fill + copy for x, fill + copy for y.
+        # 2 overwrite ops before the matmul: fill + copy for y only.
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
         self.assertGreaterEqual(
-            len(overwrites), 4, "Expected at least 4 overwrite ops before matmul"
+            len(overwrites), 2, "Expected at least 2 overwrite ops before matmul"
         )
 
     def test_mm_aligned_k_no_padding(self) -> None:
@@ -229,7 +229,7 @@ class TestInsertPaddingIR(unittest.TestCase):
         self.assertEqual(len(overwrites), 0, "Expected no overwrite ops for aligned K")
 
     def test_bmm_3d_unaligned_k_pads(self) -> None:
-        """3D bmm (B,M,K)×(B,K,N) with K=67 — both x and y are padded before bmm."""
+        """3D bmm (B,M,K)×(B,K,N) with K=67 — y is padded before bmm; x is not."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -253,10 +253,10 @@ class TestInsertPaddingIR(unittest.TestCase):
 
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
-        self.assertGreaterEqual(len(overwrites), 4)
+        self.assertGreaterEqual(len(overwrites), 2)
 
     def test_bmm_3d_2d_unaligned_k_pads(self) -> None:
-        """3D×2D bmm: (B,M,K)×(K,N) with K=67 — both x and y are padded."""
+        """3D×2D bmm: (B,M,K)×(K,N) with K=67 — y is padded; x is not."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -280,11 +280,11 @@ class TestInsertPaddingIR(unittest.TestCase):
 
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
-        # 4 overwrites: fill + copy for x, fill + copy for y.
-        self.assertGreaterEqual(len(overwrites), 4)
+        # 2 overwrites: fill + copy for y only.
+        self.assertGreaterEqual(len(overwrites), 2)
 
     def test_matmul_4d_unaligned_k_pads(self) -> None:
-        """4D matmul (B,H,M,K)×(B,H,K,N) with K=67 — both x and y are padded."""
+        """4D matmul (B,H,M,K)×(B,H,K,N) with K=67 — y is padded; x is not."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -307,10 +307,10 @@ class TestInsertPaddingIR(unittest.TestCase):
 
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
-        self.assertGreaterEqual(len(overwrites), 4)
+        self.assertGreaterEqual(len(overwrites), 2)
 
     def test_einsum_mk_kn_mn_pads(self) -> None:
-        """einsum('mk,kn->mn') with K=67 — both x and y are padded to K_padded."""
+        """einsum('mk,kn->mn') with K=67 — y is padded to K_padded; x is not."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -389,12 +389,13 @@ class TestInsertPaddingIR(unittest.TestCase):
             "origin_node should not be None after _rebuild_matmul",
         )
 
-    def test_padded_buffer_sizes_x_and_y(self) -> None:
-        """Both x and y are padded; host K-dims are extended to k_padded.
+    def test_padded_buffer_sizes_y_only(self) -> None:
+        """Only y is padded; its host K-dim is extended to k_padded.
 
-        spyre.empty lowers to SpyreEmptyFallback.  Two SpyreEmptyFallback ops
-        appear before the matmul: one for x_padded with host size [B, M, K_padded]
-        and one for y_padded with host size [B, K_padded, N].
+        spyre.empty lowers to SpyreEmptyFallback.  Exactly one SpyreEmptyFallback
+        op appears before the matmul: y_padded with host size [B, K_padded, N].
+        x is not padded — neither allocated nor copied; it is consumed via its
+        original TensorBox and the pt hardware is intended to mask its K tail.
         """
 
         dtype = torch.float16
@@ -418,49 +419,91 @@ class TestInsertPaddingIR(unittest.TestCase):
         ops_before = self._ops_before(ops, mm)
 
         padded_empties = [op for op in ops_before if isinstance(op, SpyreEmptyFallback)]
-        # Both x and y are padded — exactly two SpyreEmptyFallback ops.
+        # Only y is padded — exactly one SpyreEmptyFallback op.
         self.assertEqual(
             len(padded_empties),
-            2,
-            f"Expected 2 padded buffers (x and y), found {len(padded_empties)}: "
+            1,
+            f"Expected 1 padded buffer (y only), found {len(padded_empties)}: "
             f"{[[int(s) for s in op.get_size()] for op in padded_empties]}",
         )
 
-        host_sizes = sorted([int(s) for s in op.get_size()] for op in padded_empties)
-        # x_padded: [B, M, K_padded]; y_padded: [B, K_padded, N].
-        self.assertIn(
-            [B, M, k_padded],
-            host_sizes,
-            f"x_padded size [B,M,K_padded]=[{B},{M},{k_padded}] not found in {host_sizes}",
-        )
-        self.assertIn(
+        # y_padded: [B, K_padded, N].
+        host_size = [int(s) for s in padded_empties[0].get_size()]
+        self.assertEqual(
+            host_size,
             [B, k_padded, N],
-            host_sizes,
-            f"y_padded size [B,K_padded,N]=[{B},{k_padded},{N}] not found in {host_sizes}",
+            f"y_padded size should be [{B},{k_padded},{N}], got {host_size}",
         )
 
-        # Each padded buffer's host K-dim must equal K_padded.
-        for empty in padded_empties:
-            host_size = [int(s) for s in empty.get_size()]
-            self.assertIn(
-                k_padded,
-                host_size,
-                f"k_padded={k_padded} not found in host_size={host_size}",
-            )
+    def test_x_layout_override_stride_map(self) -> None:
+        """The matmul's op_info carries an x_layout_override with K_padded as the M-row stride.
+
+        insert_padding_ir stores a (x_name, FixedTiledLayout) pair on the matmul's
+        op_info under "x_layout_override".  The FixedTiledLayout has K_padded as the
+        M-row host stride and an overlay SpyreTensorLayout (stride_map[M_dim]=K_padded).
+        SpyreKernel.load() uses this override so the index expression and stride_map
+        are consistent, preventing the spurious r_K//K overflow term.
+        """
+        from torch_spyre._inductor.ir import FixedTiledLayout
+
+        dtype = torch.float16
+        stick_size = get_elem_in_stick(dtype)
+        K = 67
+        assert K % stick_size != 0
+        k_padded = ((K + stick_size - 1) // stick_size) * stick_size
+
+        x = torch.randn(55, K, dtype=dtype, device="spyre")
+        w = torch.randn(K, 128, dtype=dtype, device="spyre")
+
+        def fn(x, w):
+            return x @ w
+
+        ops = self.compile_and_capture(fn, (x, w))
+        matmuls = self._matmul_ops(ops)
+        self.assertEqual(len(matmuls), 1)
+        mm = matmuls[0]
+
+        reduction = mm.data
+        assert isinstance(reduction, Reduction)
+        op_info = getattr(reduction, "op_info", None)
+        self.assertIsNotNone(op_info, "matmul op_info should not be None after padding")
+        override = op_info.get("x_layout_override")
+        self.assertIsNotNone(override, "op_info should contain 'x_layout_override'")
+        override_name, override_layout = override
+        self.assertIsInstance(override_name, str)
+        self.assertIsInstance(override_layout, FixedTiledLayout)
+
+        # stride_map should contain K_padded (the M-row stride).
+        stride_map = list(override_layout.device_layout.stride_map)
+        self.assertIn(
+            k_padded,
+            stride_map,
+            f"x_layout_override.device_layout.stride_map should contain K_padded={k_padded}; "
+            f"got {stride_map}",
+        )
+
+        # Host strides should use K_padded as the M-row stride.
+        host_stride = [int(s) for s in override_layout.stride]
+        self.assertIn(
+            k_padded,
+            host_stride,
+            f"x_layout_override.stride should contain K_padded={k_padded}; "
+            f"got {host_stride}",
+        )
 
     def test_padded_buffer_preserves_stick_dimension(self) -> None:
-        """Both padded buffers (x and y) preserve the original within-stick stride.
+        """y's padded buffer preserves the original within-stick stride.
 
-        ``lower_pad_sequence`` constructs each padded buffer's ``SpyreTensorLayout``
+        ``lower_pad_sequence`` constructs the padded buffer's ``SpyreTensorLayout``
         from the padded host size/stride so that ``device_coordinates[-1]`` (the
         stick coordinate expression) is identical for both the original and padded
-        buffers.  Concretely, ``stride_map[-1]`` must be 1 for every padded
+        buffers.  Concretely, ``stride_map[-1]`` must be 1 for the padded
         ``SpyreEmptyFallback``.
 
-        x is sticked on K (the reduction dim), y is sticked on N (the output dim).
-        Both have contiguous within-stick strides, so ``stride_map[-1] == 1``.
-        The test catches a regression that confused the stick dim (e.g. producing
-        ``stride_map[-1] == K_padded`` from a default layout with the wrong dim_order).
+        y is sticked on N (the output dim) with a contiguous within-stick stride,
+        so ``stride_map[-1] == 1``.  The test catches a regression that confused
+        the stick dim (e.g. producing ``stride_map[-1] == K_padded`` from a default
+        layout with the wrong dim_order).
         """
         from torch_spyre._inductor.ir import FixedTiledLayout
 
@@ -510,8 +553,8 @@ class TestInsertPaddingIR(unittest.TestCase):
                 ]
                 self.assertEqual(
                     len(padded_empties),
-                    2,
-                    f"{name}: expected exactly 2 padded buffers (x and y)",
+                    1,
+                    f"{name}: expected exactly 1 padded buffer (y only)",
                 )
 
                 for empty in padded_empties:

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -16,8 +16,23 @@
 BATCH_MATMUL_OP operations.  Runs in CustomPreSchedulingPasses immediately
 after insert_restickify, when every ComputedBuffer has a FixedTiledLayout.
 
-Both x and y are padded along their K dimension to K_padded = next stick
-boundary.  For each argument:
+Only y is padded via a new allocation.  x uses its original buffer without
+any allocation or copy — the pt hardware unit masks within-stick K reads
+beyond the true K size.  reduction_ranges is set to K_padded so the hardware
+iterates r_K = 0..K_padded-1.
+
+x's inner_fn computes the flat index into x's original buffer using K_padded
+as the M-row stride (c_M*K_padded + c_K), then calls ops.load directly.
+SpyreKernel.load() detects a per-op layout override stored in
+op_info["x_layout_override"] and substitutes a FixedTiledLayout whose
+stride_map uses K_padded instead of K.  This makes the index expression and
+stride_map consistent, preventing the spurious r_K//K overflow term in the M
+coordinate that compute_coordinates would otherwise emit when r_K's range
+(K_padded) exceeds x's original M-row stride (K).  x's original buffer is
+untouched; no other consumer sees the padded strides.
+
+For y, the K (row/mb) dimension is not within-stick, so the hardware has no
+implicit masking.  y is padded to K_padded = next stick boundary:
   spyre.empty(padded_size)                         — uninitialised allocation
   spyre.constant(0.0)                              — scalar zero, generated on-device (cached)
   aten.expand(constant, pad_size)                  — broadcast to pad-region shape; free
@@ -55,12 +70,13 @@ from torch._inductor.ir import (
     Reduction,
     TensorBox,
 )
-from torch._inductor.virtualized import V
+from torch._inductor.virtualized import V, ops
 
 from .constants import BATCH_MATMUL_OP
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
 from .pass_utils import (
+    _build_padded_stl,
     concretize_expr,
     device_coordinates,
     host_coordinates,
@@ -136,25 +152,30 @@ def _find_arg_fx_node(
 
 def _rebuild_matmul(
     op: ComputedBuffer,
-    x_padded_buf: Buffer,
+    x_name: str,
+    x_padded_host_stride: list[int],
     y_padded_buf: Buffer,
     k_padded: int,
     operations: list[Operation],
 ) -> ComputedBuffer:
     """Rebuild the matmul ComputedBuffer with padded loaders and updated reduction_ranges.
 
-    Patches the Reduction's inner_fn to load from the padded buffers and updates
-    reduction_ranges to k_padded, then delegates the ComputedBuffer reconstruction
-    and operations-list swap to replace_computed_buffer_body.
+    x is NOT padded — its original buffer is used directly.  The flat index for the
+    x load is computed using x_padded_host_stride (K_padded as the M-row stride) so
+    that SpyreKernel.load() receives a K_padded-based index.  SpyreKernel.load() reads
+    op_info["x_layout_override"] and uses the padded FixedTiledLayout for the
+    TensorAccess, ensuring compute_coordinates sees stride_map[M_dim]=K_padded —
+    consistent with the index — and produces clean device coordinates.
 
-    x_padded_buf must have ndim matching len(output_ranges) (all output dims
-    except N plus K_padded) so indices [batch..., M, r_K] are valid.
-    y_padded_buf must have the same ndim as the original y buffer.
+    reduction_ranges is set to K_padded so the hardware iterates r_K = 0..K_padded-1.
+    x's within-stick K tail (uninitialised storage past element K-1) is masked by
+    the pt hardware unit.
+
+    y_padded_buf is fully zero-filled in the K pad region.
     """
     reduction = op.data
     assert isinstance(reduction, Reduction)
 
-    x_padded_loader = x_padded_buf.make_loader()
     y_padded_loader = y_padded_buf.make_loader()
     # y's batch dims: y_ndim - 2 batch dims come first in y_index.
     y_ndim = len(y_padded_buf.get_size())
@@ -163,21 +184,25 @@ def _rebuild_matmul(
     def new_inner_fn(
         index,
         reduction_index,
-        _x_loader=x_padded_loader,
+        _x_name=x_name,
+        _x_stride=x_padded_host_stride,
         _y_loader=y_padded_loader,
         _y_batch_ndim=y_batch_ndim,
     ):
         # x: all output dims except the last (N), plus the reduction dim.
         # y: first y_batch_ndim batch dims, then reduction dim, then N (index[-1]).
         # Matches the lowering pattern for all mm/bmm variants:
-        #   mm (2D×2D):   x_loader([i_M, r_K]),       y_loader([r_K, i_N])
-        #   bmm (3D×3D):  x_loader([i_B, i_M, r_K]),  y_loader([i_B, r_K, i_N])
-        #   bmm (4D×4D):  x_loader([i_B,i_H,i_M,r_K]),y_loader([i_B,i_H,r_K,i_N])
-        #   bmm (3D×2D):  x_loader([i_B, i_M, r_K]),  y_loader([r_K, i_N])
-        #   einsum→bmm:   x_loader([i_B, i_M, r_K]),  y_loader([r_K, i_N])  (y 2D)
+        #   mm (2D×2D):   x_load([i_M, r_K]),       y_loader([r_K, i_N])
+        #   bmm (3D×3D):  x_load([i_B, i_M, r_K]),  y_loader([i_B, r_K, i_N])
+        #   bmm (4D×4D):  x_load([i_B,i_H,i_M,r_K]),y_loader([i_B,i_H,r_K,i_N])
+        #   bmm (3D×2D):  x_load([i_B, i_M, r_K]),  y_loader([r_K, i_N])
+        #   einsum→bmm:   x_load([i_B, i_M, r_K]),  y_loader([r_K, i_N])  (y 2D)
         x_index = list(index[:-1]) + list(reduction_index)
+        # Compute flat index using K_padded as M-row stride so the index is consistent
+        # with the op_info x_layout_override (stride_map[M_dim]=K_padded).
+        x_flat = sum(i * s for i, s in zip(x_index, _x_stride))
         y_index = list(index[:_y_batch_ndim]) + list(reduction_index) + [index[-1]]
-        return (_x_loader(x_index), _y_loader(y_index))
+        return (ops.load(_x_name, x_flat), _y_loader(y_index))
 
     object.__setattr__(reduction, "inner_fn", new_inner_fn)
     object.__setattr__(reduction, "reduction_ranges", [sympy.Integer(k_padded)])
@@ -187,9 +212,14 @@ def _rebuild_matmul(
 
 def insert_padding_ir(operations: list[Operation]) -> None:
     """
-    Pad the K (reduction) dimension of each BATCH_MATMUL_OP to a stick boundary.
+    Pad y's K dimension for each BATCH_MATMUL_OP to a stick boundary.
 
-    Mutates ``operations`` in place.  All new buffers are inserted immediately
+    x is not padded — the pt hardware masks x's within-stick K tail.
+    y's K is a row dimension with no hardware masking, so it is explicitly
+    zero-filled.  reduction_ranges is updated to K_padded so the hardware
+    iterates r_K = 0..K_padded-1.
+
+    Mutates ``operations`` in place.  New y-padding ops are inserted immediately
     before the matmul that consumes them to preserve topological order.
 
     x and y are identified via device_coordinates: x is the input sticked on
@@ -197,8 +227,7 @@ def insert_padding_ir(operations: list[Operation]) -> None:
     and handles square matrices (M==K==N) correctly.
 
     A fill_cache is shared across all matmuls so that spyre.constant is lowered
-    only once per unique (fill_value, device, dtype) combination.  All pad
-    operations with the same fill value and dtype reuse the same constant node.
+    only once per unique (fill_value, device, dtype) combination.
     """
     fill_cache: dict[tuple, torch.fx.Node] = {}
     for op in list(operations):
@@ -298,28 +327,53 @@ def insert_padding_ir(operations: list[Operation]) -> None:
         # minimising their live range.
         matmul_fx_node = next(iter(op.origins))
 
-        # --- Pad x: size=[batch..., M, K_padded] ---
-        # Look for the FX node with the expected pre-padded x size so that the
-        # padded clone has the right dimensionality for the inner_fn's loaders.
-        x_padded_size = x_size[:-1] + [k_padded]
+        # --- x: no allocation, no copy — layout override via op_info ---
+        # The pt hardware unit masks within-stick K reads beyond the true K size,
+        # so x's underlying storage is used as-is.  A FixedTiledLayout with
+        # K_padded as the M-row host stride is built and stored on the matmul's
+        # op_info under "x_layout_override".  SpyreKernel.load() reads this
+        # override so that (a) the index expression uses K_padded as the M-row
+        # stride, and (b) compute_coordinates sees stride_map[M_dim]=K_padded.
+        # Both are consistent, preventing the spurious r_K//K overflow term that
+        # would appear when r_K's range (K_padded) exceeds x's original M-row
+        # stride (K).
         x_fx_node = _find_arg_fx_node(x_name, expected_size=x_size)
 
         x_orig_stl = x_buf.get_layout().device_layout
-        x_padded_buf, x_new_ops = lower_pad_sequence(
+        x_overlay_host_size = list(x_size)
+        x_overlay_host_size[-1] = k_padded  # K is the last dim of x_size
+        x_overlay_stl = _build_padded_stl(
             x_fx_node,
-            padded_size=x_padded_size,
-            device=device,
-            dtype=dtype,
-            dim=len(x_padded_size) - 1,
-            insert_before=matmul_fx_node,
+            padded_size=x_overlay_host_size,
             orig_stl=x_orig_stl,
-            fill_cache=fill_cache,
+            dtype=dtype,
         )
 
+        # Row-major host strides for the padded x shape.
+        n = len(x_overlay_host_size)
+        x_padded_host_stride = [1] * n
+        for i in range(n - 2, -1, -1):
+            x_padded_host_stride[i] = (
+                x_padded_host_stride[i + 1] * x_overlay_host_size[i + 1]
+            )
+
+        x_padded_layout = FixedTiledLayout(
+            device,
+            dtype,
+            [sympy.Integer(s) for s in x_overlay_host_size],
+            [sympy.Integer(s) for s in x_padded_host_stride],
+            x_overlay_stl,
+        )
+        op_info = getattr(reduction, "op_info", None)
+        if op_info is None:
+            op_info = {}
+            object.__setattr__(reduction, "op_info", op_info)
+        op_info["x_layout_override"] = (x_name, x_padded_layout)
+
         # --- Pad y: size=[batch..., K_padded, N] ---
-        # y's K dimension is y's row (mb) dimension.  Padding it to K_padded
-        # ensures the matmul reduction does not read uninitialised rows of y
-        # when reduction_ranges is extended to k_padded.
+        # y's K is a row (mb) dimension, not the within-stick dim, so the hardware
+        # does not mask it.  Explicitly zero-fill rows K..K_padded-1 so the
+        # reduction over r_K = 0..K_padded-1 reads zero in the pad region.
         y_size = [concretize_expr(s) for s in y_buf.get_size()]
         if y_host_k_dim is None:
             y_k_dim = len(y_size) - 2
@@ -343,17 +397,17 @@ def insert_padding_ir(operations: list[Operation]) -> None:
 
         # --- Relocate new ops before the matmul ---
         # run_node appended them at the end of operations; move before op.
-        all_new_ops = x_new_ops + y_new_ops
-        for new_op in all_new_ops:
+        for new_op in y_new_ops:
             operations.remove(new_op)
         op_idx = operations.index(op)
-        for i, new_op in enumerate(all_new_ops):
+        for i, new_op in enumerate(y_new_ops):
             operations.insert(op_idx + i, new_op)
 
         # --- Rebuild matmul inner_fn and reduction_ranges ---
         _rebuild_matmul(
             op,
-            x_padded_buf,
+            x_name,
+            x_padded_host_stride,
             y_padded_buf,
             k_padded,
             operations,

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -438,6 +438,56 @@ def replace_computed_buffer_body(
     return new_buf
 
 
+def _build_padded_stl(
+    arg_fx_node: torch.fx.Node,
+    padded_size: list[int],
+    orig_stl: SpyreTensorLayout,
+    dtype: torch.dtype,
+) -> SpyreTensorLayout:
+    """Build a SpyreTensorLayout for a buffer whose host shape is ``padded_size``.
+
+    The within-stick dimension is preserved from ``orig_stl``.  Phantom leading
+    dimensions (e.g. a batch=1 dim added by mm_to_bmm_pass that is absent from
+    the underlying buffer) are stripped before constructing the STL so that the
+    device layout matches the physical buffer rank.
+
+    Used by ``lower_pad_sequence`` (for y's padded allocation) and by
+    ``insert_padding_ir`` (to build x's codegen-time layout overlay without
+    allocating a new buffer).
+    """
+    # Strip phantom batch dims to get the core host shape.
+    orig_host_ndim = len(list(orig_stl.stride_map)) - 1
+    n_phantom = len(padded_size) - orig_host_ndim
+    padded_core = padded_size[n_phantom:]
+
+    # Identify the within-stick host dim by matching the within-stick element stride.
+    sm_last = int(list(orig_stl.stride_map)[-1])
+    orig_host_stride = list(arg_fx_node.meta["val"].stride())
+    within_stick_dim_view = next(
+        (i for i, s in enumerate(orig_host_stride) if int(s) == sm_last), None
+    )
+    if within_stick_dim_view is None:
+        raise RuntimeError(
+            f"_build_padded_stl: cannot determine within-stick host dimension for "
+            f"buffer {arg_fx_node.name!r}: orig_stl.stride_map[-1]={sm_last} not found "
+            f"in view strides {orig_host_stride}.  orig_stl={list(orig_stl.device_size)} "
+            f"stride_map={list(orig_stl.stride_map)}, padded_size={padded_size}"
+        )
+    within_stick_dim_core = within_stick_dim_view - n_phantom
+
+    # Build dim_order: all non-stick dims in natural order, then the stick dim last.
+    dim_order_core = [
+        i for i in range(len(padded_core)) if i != within_stick_dim_core
+    ] + [within_stick_dim_core]
+
+    # Row-major host strides for the padded core shape.
+    core_stride = [1] * len(padded_core)
+    for i in range(len(padded_core) - 2, -1, -1):
+        core_stride[i] = core_stride[i + 1] * padded_core[i + 1]
+
+    return SpyreTensorLayout(padded_core, core_stride, dtype, dim_order_core)
+
+
 def lower_pad_sequence(
     arg_fx_node: torch.fx.Node,
     padded_size: list[int],
@@ -611,66 +661,7 @@ def lower_pad_sequence(
     assert isinstance(padded_buf, SpyreEmptyFallback)
 
     # --- Build the device layout (SpyreTensorLayout) for the padded buffer. ---
-    #
-    # We need to know two things to construct the padded STL:
-    #   1. The "core" host shape — the dimensions that orig_stl was actually
-    #      built from.  mm_to_bmm_pass sometimes adds a leading batch=1 dim to
-    #      padded_size (the view the matmul inner_fn uses) while leaving the
-    #      underlying buffer 2D.  Passing that phantom dim to SpyreTensorLayout
-    #      would produce a degenerate 4D device layout with a -1 sentinel stride
-    #      for the size-1 device dim, which causes compute_coordinates to emit a
-    #      constant nonzero stick offset and normalize_coordinates to assert.
-    #      We strip phantom dims by comparing padded_size rank against the host
-    #      rank implied by orig_stl: stride_map has one entry per device dim, and
-    #      device dims = host dims + 1 (the extra entry is the within-stick dim),
-    #      so orig_host_ndim = len(stride_map) - 1.
-    #   2. Which host dimension is the within-stick dimension.  SpyreTensorLayout
-    #      takes an explicit dim_order whose last element names the within-stick
-    #      host dim; we must carry this over from the original buffer so that the
-    #      padded buffer's device coordinates use the same stick dimension.  We
-    #      identify it by matching orig_stl.stride_map[-1] (the within-stick
-    #      element stride, always 1 for contiguous layouts) against the original
-    #      buffer's host strides.
-
-    # Step 1 — strip phantom batch dims to get the core host shape.
-    orig_host_ndim = len(list(orig_stl.stride_map)) - 1
-    n_phantom = len(padded_size) - orig_host_ndim
-    padded_core = padded_size[n_phantom:]
-
-    # Step 2 — identify the within-stick host dim in the view (which may include
-    # phantom leading dims) by matching the within-stick element stride.
-    sm_last = int(list(orig_stl.stride_map)[-1])
-    orig_host_stride = list(arg_fx_node.meta["val"].stride())
-    within_stick_dim_view = next(
-        (i for i, s in enumerate(orig_host_stride) if int(s) == sm_last), None
-    )
-    if within_stick_dim_view is None:
-        raise RuntimeError(
-            f"lower_pad_sequence: cannot determine within-stick host dimension for "
-            f"buffer {arg_fx_node.name!r}: orig_stl.stride_map[-1]={sm_last} not found "
-            f"in view strides {orig_host_stride}.  orig_stl={list(orig_stl.device_size)} "
-            f"stride_map={list(orig_stl.stride_map)}, padded_size={padded_size}"
-        )
-
-    # Step 3 — translate the within-stick dim index from view space to core space
-    # (subtract the number of phantom dims that were stripped in step 1).
-    within_stick_dim_core = within_stick_dim_view - n_phantom
-
-    # Step 4 — build dim_order for SpyreTensorLayout: all non-stick dims in their
-    # natural order, followed by the within-stick dim last.  This tells the STL
-    # constructor which host dim maps to the innermost device (within-stick) axis.
-    dim_order_core = [
-        i for i in range(len(padded_core)) if i != within_stick_dim_core
-    ] + [within_stick_dim_core]
-
-    # Step 5 — compute row-major strides for the padded core shape.  These are
-    # host strides, not device strides; SpyreTensorLayout derives the device
-    # layout (sticks, rows, …) from the host shape + dim_order.
-    core_stride = [1] * len(padded_core)
-    for i in range(len(padded_core) - 2, -1, -1):
-        core_stride[i] = core_stride[i + 1] * padded_core[i + 1]
-
-    padded_stl = SpyreTensorLayout(padded_core, core_stride, dtype, dim_order_core)
+    padded_stl = _build_padded_stl(arg_fx_node, padded_size, orig_stl, dtype)
     host_layout = padded_buf.layout
     padded_buf.layout = FixedTiledLayout(
         host_layout.device,
@@ -722,10 +713,10 @@ def lower_pad_sequence(
     object.__setattr__(graph_lowering.operations[-1], "origin_node", overwrite_data_fx)
 
     # Collect all newly added operations (appended at the end of graph.operations).
-    # Fresh path: spyre.empty(1) + spyre.constant(1) + clone(1) + overwrite×2(2) = 5.
-    # Cache-hit path: spyre.constant is reused, so spyre.empty(1) + clone(1) + overwrite×2(2) = 4.
+    # fresh constant:  empty(1) + constant(1) + clone(1) + overwrite×2(2) = 5
+    # cached constant: empty(1) + clone(1) + overwrite×2(2) = 4
     new_ops = graph_lowering.operations[ops_before:]
-    expected = 4 if not const_is_new else 5
+    expected = 5 if const_is_new else 4
     assert len(new_ops) >= expected, (
         f"Expected at least {expected} new ops, got {len(new_ops)}"
     )

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -451,6 +451,17 @@ class SpyreKernel(Kernel[CSEVariable]):
         if not isinstance(layout, FixedTiledLayout):
             raise Unsupported(f"{name} does not have FixedTiledLayout")
         index = sympy_subs(index, V.graph.sizevars.precomputed_replacements)
+
+        # If the current reduction op carries a layout override for this buffer,
+        # use it so that both the index expression and stride_map use K_padded.
+        node_data = getattr(self.current_node.node, "data", None)
+        op_info = getattr(node_data, "op_info", {}) or {}
+        override = op_info.get("x_layout_override")
+        if override is not None:
+            override_name, override_layout = override
+            if override_name == name:
+                layout = override_layout
+
         if not layout.allocation:
             _ = self.args.input(name)
 
@@ -544,6 +555,9 @@ class SpyreKernel(Kernel[CSEVariable]):
         op_info = {}
         if hasattr(self.current_node.node.data, "op_info"):  # type: ignore[union-attr]
             op_info.update(self.current_node.node.data.op_info)  # type: ignore[union-attr]
+        # x_layout_override is consumed by load() at codegen time; exclude from
+        # the serialized op_info so it doesn't appear in the generated kernel code.
+        op_info.pop("x_layout_override", None)
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:


## Problem

The K-padding pass (`insert_padding_ir`) runs in `CustomPreSchedulingPasses` and pads
the K (reduction) dimension of each `BATCH_MATMUL_OP` to the next stick boundary
(64 fp16 elements) so that `reduction_ranges = K_padded` and the hardware iterates
`r_K = 0..K_padded-1`.

Previously, both x and y were padded symmetrically:

1. Allocate a `SpyreEmptyFallback` of padded size.
2. Zero-fill the pad region via `spyre.constant` → `aten.expand` → `aten.clone` →
   `spyre.overwrite`.
3. Copy the original data at offset 0 via a second `spyre.overwrite`.
4. Rebuild the matmul's `inner_fn` to load from the padded buffers.

This was correct but wasteful for x. x is a K-major tensor: its K dimension is the
within-stick dimension. The pt hardware unit masks within-stick reads beyond the true
K size, so uninitialised elements in x's K tail are never visible — the hardware never
reads them. x's original PyTorch allocation already covers `ceil(K/64)` full sticks,
so no memory access out of bounds occurs either.

The allocation and both overwrites for x were therefore pure overhead.

## Root cause of the previous fix attempt

A naive fix — drop the allocation and load directly from x's original buffer — hit a
backend compiler exception from `L3DlOpsScheduler.cpp:927`. The root cause was in
`compute_coordinates` (views.py): when `reduction_ranges = K_padded = 128` and
x's original M-row stride is `K = 67`, the algorithm infers that the reduction index
`r_K` can overflow into the M dimension and emits a spurious `r_K // 67` term in the
M coordinate. This corrupts x's SDSC descriptor (a spurious size-1 device dim with
`backGap=54`, the K-stick layout pushed onto the N dim), causing the crash.

The fix requires that `compute_coordinates` sees `stride_map[M_dim] = K_padded`
(not `K`) so the overflow check passes cleanly.

## Solution

**Codegen-time layout override for x**, with no IR allocation or copy.

Two pieces work together:

### 1. `op_info["x_layout_override"]` on the matmul's `Reduction`

`insert_padding_ir` builds a `FixedTiledLayout` for x with `K_padded` as the
M-row host stride (using the new `_build_padded_stl` helper) and stores a
`(x_name, padded_layout)` pair on the matmul's `op_info`. No new buffer is
allocated; x's original storage is unchanged.

### 2. `new_inner_fn` computes the flat x index with K_padded stride

The rebuilt `inner_fn` calls `ops.load(x_name, x_flat)` directly, where `x_flat`
is computed using the K_padded M-row stride: `x_flat = c_M * K_padded + c_K`.
This makes the index consistent with the layout override below.

### 3. `SpyreKernel.load()` applies the override

Before calling `compute_coordinates`, `SpyreKernel.load()` checks whether the
current reduction node's `op_info` carries an `x_layout_override` whose name
matches the buffer being loaded. If so, the override `FixedTiledLayout` is used
instead of `buf.get_layout()`. `compute_coordinates` then sees
`stride_map[M_dim] = K_padded`, which is consistent with `r_K`'s range, and
produces clean device coordinates with no spurious overflow term.

The override is stripped from `op_info` before `create_op_spec` serialises it to
generated Python, so it never appears in the emitted kernel code.

### `_build_padded_stl` helper (factored from `lower_pad_sequence`)

The STL-construction logic that was previously inline in `lower_pad_sequence` is
now a standalone `_build_padded_stl(arg_fx_node, padded_size, orig_stl, dtype)`
helper in `pass_utils.py`. Both `lower_pad_sequence` (y's padded allocation) and
`insert_padding_ir` (x's codegen overlay) call it.

## Effect

For each padded matmul:

| | Before | After |
|---|---|---|
| `SpyreEmptyFallback` ops | 2 (x and y) | 1 (y only) |
| `spyre.overwrite` ops | ≥ 4 (x: fill+copy, y: fill+copy) | ≥ 2 (y: fill+copy) |
| x buffer allocation | yes | no |
| x data copy | yes | no |
| y buffer allocation | yes | yes |
| y zero-fill | yes | yes |
| `reduction_ranges` | K_padded | K_padded |

## Files changed

- **`torch_spyre/_inductor/pass_utils.py`**: Factor inline STL construction into
  `_build_padded_stl`. Simplify `lower_pad_sequence` (no more `add_fill` branching;
  function is always fill+copy).
- **`torch_spyre/_inductor/padding.py`**: Drop x allocation/copy path. Build
  `x_layout_override` and store on `op_info`. Update `_rebuild_matmul` signature
  (`x_padded_host_stride` replaces `x_padded_buf`); `new_inner_fn` calls
  `ops.load` with flat K_padded-based index.
- **`torch_spyre/_inductor/spyre_kernel.py`**: `load()` checks `op_info` for
  `x_layout_override` and substitutes the padded layout. `store_reduction()` pops
  `x_layout_override` before serialising `op_info`.
- **`tests/inductor/test_padding.py`**: Rename `test_padded_buffer_sizes_x_and_y`
  → `test_padded_buffer_sizes_y_only`; expect 1 `SpyreEmptyFallback` and 2
  overwrites. Add `test_x_layout_override_stride_map` to assert the override
  carries K_padded in `stride_map` and `stride`.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
