### PR TITLE
[TESTING GHA]  Fix intermittent CI hangs: switch pytest capture mode to `--capture=sys` in torch_spyre_tests GHA

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -243,7 +243,7 @@ jobs:
           CONFIG="${{ matrix.suite.config }}"
 
           echo "Running ${{ matrix.suite.name }} tests..."
-          bash tests/run_test.sh "tests/configs/${CONFIG}" -v
+          bash tests/run_test.sh "tests/configs/${CONFIG}" -v --capture=sys
           echo "${{ matrix.suite.name }} tests done"
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -145,7 +145,7 @@ jobs:
           REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
 
           echo "Running ${{ matrix.suite.name }} upstream tests..."
-          bash tests/run_test.sh "tests/configs/upstream_tests/${CONFIG}" -v --junit-xml="${REPORT_PATH}"
+          bash tests/run_test.sh "tests/configs/upstream_tests/${CONFIG}" --capture=sys -v --junit-xml="${REPORT_PATH}"
           echo "${{ matrix.suite.name }} upstream tests done"
 
           # Expose report path/name to subsequent steps via GITHUB_ENV


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

CI jobs intermittently hang forever mid-test-run on Spyre hardware runners. The hang is non-deterministic across nodes, pods, and test suites i.e. the process never crashes, it just silently blocks until `timeout-minutes: 720` is hit or is restarted manually by admin.

### Hypothesis

pytest's default `--capture=fd` mode replaces fd 1/fd 2 with a pipe it owns, then blocks on `read()` at test teardown waiting for EOF. EOF only arrives when every holder of the pipe's write-end has closed it.

I suspect that the torch-spyre runtime spawns internal background threads (dispatch monitors, completion handlers etc) the first time the device is touched. These threads inherit the captured fds, long-lived across test boundaries, and are never explicitly shut down between tests. When one of these threads is still alive at teardown, pytest's `read()` blocks forever. 

### Change

`--capture=sys` redirects only Python-level `sys.stdout`/`sys.stderr` --  it does not touch the underlying OS fds. Background threads inheriting the real fds no longer block pytest teardown.

#### Note: 
`--capture=no` also fixes the hang but disables output capture entirely,  all test output streams to the GHA log unconditionally, making failures harder to diagnose across these many parallel test jobs. `--capture=sys` eliminates the fd-level hang while keeping per-test output attached to failure reports.


#### Special notes for your reviewer:

This needs to be monitored for successive runs and see if stalls still occur. If it still occurrs, this might need to be rolled back.