### PR TITLE
[TESTING GHA] fix: replace gh api --output flag with stdout capture for artifact download

### DIFF
--- a/.github/workflows/module_tests.yaml
+++ b/.github/workflows/module_tests.yaml
@@ -30,7 +30,7 @@ jobs:
     name: ${{ matrix.suite.name }}
     runs-on:
       - x86_64
-      - spyre_pf
+      - spyre_pf_x1
       - linux
       - image_torch_spyre
     timeout-minutes: 720

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -106,11 +106,12 @@ jobs:
           repo  = os.environ['GITHUB_REPOSITORY']
           for a in artifacts:
               print(f"Downloading: {a['name']} (id={a['id']})")
-              subprocess.run([
-                  "gh", "api",
-                  f"/repos/{repo}/actions/artifacts/{a['id']}/zip",
-                  "--output", f"xml_artifacts/{a['name']}.zip"
-              ], check=True, env={**os.environ})
+              with open(f"xml_artifacts/{a['name']}.zip", "wb") as f:
+                result = subprocess.run([
+                    "gh", "api",
+                    f"/repos/{repo}/actions/artifacts/{a['id']}/zip",
+                ], check=True, env={**os.environ}, capture_output=True)
+                f.write(result.stdout)
               subprocess.run([
                   "unzip", "-o", f"xml_artifacts/{a['name']}.zip",
                   "-d", "xml_artifacts/"


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR replace `gh api --output` flag with stdout capture for artifact download