### PR TITLE
[TESTING GHA] fix: use native TCP port 9440 for clickhouse-driver instead of HTTP Port 8443

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -233,7 +233,8 @@ def parse_xml(xml_path: Path):
 def get_client():
     return clickhouse_driver.Client(
         host=os.environ["CLICKHOUSE_HOST"],
-        port=int(os.environ.get("CLICKHOUSE_PORT", 9440)),
+        # port=int(os.environ.get("CLICKHOUSE_PORT", 9440)),
+        port=9440,  # native TCP+TLS port, always 9440 on ClickHouse Cloud
         user=os.environ.get("CLICKHOUSE_USER", "default"),
         password=os.environ["CLICKHOUSE_PASS"],
         database=os.environ.get("CLICKHOUSE_DB", "spyre"),
@@ -272,7 +273,7 @@ def insert_run(client, run_id: str, run: dict, args):
     )
 
 
-def insert_cases(client, run_id: str, cases: list[dict]):
+def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
     if not cases:
         return
     rows = [
@@ -287,6 +288,7 @@ def insert_cases(client, run_id: str, cases: list[dict]):
             "duration_s": c["duration_s"],
             "fail_message": c["fail_message"][:8192],  # cap very long traces
             "triggered_at": c["triggered_at"].replace(tzinfo=None),
+            "workflow": workflow,
         }
         for c in cases
     ]
@@ -354,7 +356,7 @@ def main():
         )
 
         insert_run(client, run_id, run, args)
-        insert_cases(client, run_id, cases)
+        insert_cases(client, run_id, cases, workflow=args.workflow)
         insert_properties(client, run_id, cases)
         total_cases += len(cases)
         print(


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds native TCP port 9440 for clickhouse-driver instead of HTTP Port 8443 to avoid confusion with conflicting port numbers.


Port | Protocol | Used by
-- | -- | --
8443 | HTTPS (HTTP interface) | curl, browser, spyre-clickhouse.js
9440 | Native TCP + TLS | clickhouse-driver Python library


#### Successful push to ClickHouse:
<img width="2422" height="1280" alt="image" src="https://github.com/user-attachments/assets/927df3fc-2324-40fd-82ea-7966ad164e89" />
