### PR TITLE
[TESTING GHA] feat:enable tests in module-tests workflow to be pushed to ClickHouse V2

### DIFF
--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -5,7 +5,7 @@ name: push-to-clickhouse
 on:
   workflow_run:
     workflows:
-      # - module-tests
+      - module-tests
       - upstream-pytorch-tests
       # to add more workflows
     types: [completed]


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR enables tests in module-tests workflow to be pushed to ClickHouse for dashboard injestion.