### PR TITLE
fix: accept size keyword in spyre empty

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -98,6 +98,15 @@ class TestSpyre(TestCase):
         a_cpu = a.cpu()
         self.assertTrue(a_cpu.eq(3.5).all())
 
+    def test_empty_factory_accepts_size_keyword(self):
+        self.assertTrue(getattr(torch.Tensor, "_spyre_tensor_patched", False))
+
+        a = torch.empty(size=(2, 3), device="cpu", dtype=torch.float16)
+
+        self.assertEqual(tuple(a.shape), (2, 3))
+        self.assertEqual(a.device.type, "cpu")
+        self.assertEqual(a.dtype, torch.float16)
+
     def test_ones_factory(self):
         a = torch.ones(50, device="spyre", dtype=torch.float16)
         self.assertEqual(a.device.type, "spyre")

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -122,6 +122,7 @@ def _patch_tensor_for_spyre():
 
     def spyre_empty(
         *args,
+        size=None,
         device_layout=None,
         out=None,
         dtype=None,
@@ -131,6 +132,14 @@ def _patch_tensor_for_spyre():
         pin_memory=False,
         memory_format=torch.contiguous_format,
     ):
+        if size is not None:
+            if args:
+                raise TypeError(
+                    "torch.empty() received both positional size arguments "
+                    "and a 'size' keyword"
+                )
+            args = (size,)
+
         if (
             device_layout is None
         ):  # use original implementation if no layout is provided


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

## Summary
- Adds `size=` keyword support to the `torch.empty` monkey patch by normalizing it into the positional size argument before dispatch.
- Adds regression coverage for `torch.empty(size=(...), device="cpu")` while the Spyre tensor patch is active.

## Related Issues / Closes
Closes #1729

## Testing
- `python3 -m py_compile torch_spyre/_monkey_patch.py tests/test_spyre.py` — passed
- `git diff --check` — passed
- Source assertion script checked that `spyre_empty` accepts `size=None`, normalizes `size` into `args`, and the regression test calls `torch.empty(size=(2, 3), device="cpu", dtype=torch.float16)` — passed
- Not run: `python3 -m pytest tests/test_spyre.py::TestSpyre::test_empty_factory_accepts_size_keyword` because this cron runner does not have `torch` installed (`ModuleNotFoundError: No module named 'torch'`).

#### Which issue(s) this PR is related to:

Fixes #1729

#### Special notes for your reviewer:

Opened as a draft because the local runner lacks the PyTorch/torch-spyre test environment; CI should exercise the new regression with the project toolchain.

#### Does this PR introduce a user-facing change?

Yes. The Spyre `torch.empty` monkey patch now preserves PyTorch's `size=` keyword calling convention.

#### Additional note:

## AI assistance disclosure
This draft PR was prepared by Hermes Agent as an automated maintainer-assist change. I inspected the issue, duplicate PRs, contribution notes, made the minimal code/test change, and recorded the local validation caveat above.
