### PR TITLE
[TESTING] Add --max-worker-restart option for pytest-xdist to accept many SIGSEGV failures

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -40,10 +40,10 @@
 # Segfault resilience
 # -------------------
 # If a file-level pytest run exits with any signal (exit >= 128, e.g. SIGSEGV/139
-# or C-level abort/255), the file is automatically retried with "-n1" via
-# pytest-xdist.  xdist spawns each test in a worker subprocess; when a worker
-# crashes the xdist controller catches the worker death, records that test as
-# ERROR, and continues with the remaining tests.
+# or C-level abort/255), the file is automatically retried with "-n1" and
+# "--max-worker-restart 999999" via pytest-xdist.  xdist spawns each test in
+# a worker subprocess; when a worker crashes the xdist controller catches the
+# worker death, records that test as ERROR, and continues with the remaining tests.
 #
 # --collect-only is NOT used as the fallback strategy: the process that crashes
 # during test execution often also crashes during collection, yielding zero IDs.
@@ -1346,7 +1346,8 @@ _run_pytest_isolated() {
 # Called when a file-level pytest run exits with a signal (exit >= 128, most
 # commonly SIGSEGV or exit 255 from a C-level abort).
 #
-# Re-runs the same file with "-n1" (pytest-xdist, 1 worker subprocess).
+# Re-runs the same file with "-n1" (pytest-xdist, 1 worker subprocess) and
+# "--max-worker-restart 999999" (pytest-xdist, restart worker up to 999999 times).
 # xdist spawns each test in a worker process; when a worker crashes the
 # xdist controller catches the worker death, marks that test as ERROR, and
 # continues with the remaining tests
@@ -1389,7 +1390,7 @@ _run_xdist_fallback() {
         fi
     fi
 
-    local _xdist_args=("-n1" "${_extra[@]+"${_extra[@]}"}")
+    local _xdist_args=("-n1" "--max-worker-restart 999999" "${_extra[@]+"${_extra[@]}"}")
     [[ -n "$_shard_xml" ]] && _xdist_args+=("--junit-xml=${_shard_xml}")
 
     _run_pytest_isolated "$_dir" "$_base" "$_exit_tmp" "${_xdist_args[@]}"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

If there are many test failures (e.g.,> 512), pytest-xdist stops restarting workers based on [the default value](https://github.com/pytest-dev/pytest-xdist/issues/226) of `--max-worker-restart`. This PR allows us to run all test cases even if there are many test failures (up to 999999).

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
Follow-up of #2019

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
