### PR TITLE
Pad only y's K dimension; defer K→K_padded to SDSC codegen

### DIFF
--- a/tests/inductor/test_padding.py
+++ b/tests/inductor/test_padding.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""IR-level unit tests for insert_padding_ir.
+"""IR-level unit tests for insert_bmm_padding.
 
-Tests hook into CustomPreSchedulingPasses after insert_padding_ir runs to inspect
+Tests hook into CustomPreSchedulingPasses after insert_bmm_padding runs to inspect
 the operations list directly, without requiring end-to-end compilation to succeed.
 """
 
@@ -49,7 +49,7 @@ Ts = TypeVarTuple("Ts")
 
 class CustomPreSchedulingPassesWithCapture(CustomPreSchedulingPasses):
     """Subclass of CustomPreSchedulingPasses that captures the operations list
-    after all built-in passes (including insert_padding_ir) have run."""
+    after all built-in passes (including insert_bmm_padding) have run."""
 
     test_instance: Optional["TestInsertPaddingIR"] = None
 
@@ -70,10 +70,10 @@ class CustomPreSchedulingPassesWithCapture(CustomPreSchedulingPasses):
 
 
 class TestInsertPaddingIR(unittest.TestCase):
-    """IR-level structural tests for insert_padding_ir.
+    """IR-level structural tests for insert_bmm_padding.
 
     Each test compiles a small matmul function, captures the operations list
-    after CustomPreSchedulingPasses finishes (which includes insert_padding_ir),
+    after CustomPreSchedulingPasses finishes (which includes insert_bmm_padding),
     and asserts structural properties of the resulting operation sequence.
     """
 
@@ -164,7 +164,11 @@ class TestInsertPaddingIR(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_mm_unaligned_k_pads(self) -> None:
-        """2D mm with K=67 (unaligned) — x and y are both padded before the matmul."""
+        """2D mm with K=67 (unaligned) — only y is padded before the matmul.
+
+        x is untouched; reduction_ranges stays at K=67.
+        y gets 2 overwrites (fill + copy).
+        """
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         # 67 is not a multiple of stick_size (64), so padding should occur.
@@ -181,23 +185,22 @@ class TestInsertPaddingIR(unittest.TestCase):
         self.assertEqual(len(matmuls), 1, "Expected exactly one matmul op")
         mm = matmuls[0]
 
-        # reduction_ranges is updated to K_padded so the hardware iterates
-        # r_K = 0..K_padded-1; the pad region of x and y is zero-filled.
-        k_padded = ((67 + stick_size - 1) // stick_size) * stick_size
+        # reduction_ranges stays at K (not K_padded): the K→K_padded extension
+        # happens at SDSC codegen time, not in the IR.
         reduction = mm.data
         assert isinstance(reduction, Reduction)
         k_actual = int(reduction.reduction_ranges[0])
         self.assertEqual(
             k_actual,
-            k_padded,
-            f"reduction_ranges should be K_padded={k_padded}, got {k_actual}",
+            67,
+            f"reduction_ranges should stay at K=67, got {k_actual}",
         )
 
-        # 4 overwrite ops before the matmul: fill + copy for x, fill + copy for y.
+        # 2 overwrite ops before the matmul: fill + copy for y only (x untouched).
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
         self.assertGreaterEqual(
-            len(overwrites), 4, "Expected at least 4 overwrite ops before matmul"
+            len(overwrites), 2, "Expected at least 2 overwrite ops before matmul"
         )
 
     def test_mm_aligned_k_no_padding(self) -> None:
@@ -229,7 +232,7 @@ class TestInsertPaddingIR(unittest.TestCase):
         self.assertEqual(len(overwrites), 0, "Expected no overwrite ops for aligned K")
 
     def test_bmm_3d_unaligned_k_pads(self) -> None:
-        """3D bmm (B,M,K)×(B,K,N) with K=67 — both x and y are padded before bmm."""
+        """3D bmm (B,M,K)×(B,K,N) with K=67 — only y is padded before bmm."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -245,18 +248,17 @@ class TestInsertPaddingIR(unittest.TestCase):
         self.assertEqual(len(matmuls), 1, "Expected exactly one batched matmul op")
         mm = matmuls[0]
 
-        k_padded = ((67 + stick_size - 1) // stick_size) * stick_size
+        # reduction_ranges stays at K.
         reduction = mm.data
         assert isinstance(reduction, Reduction)
-        # reduction_ranges is updated to K_padded.
-        self.assertEqual(int(reduction.reduction_ranges[0]), k_padded)
+        self.assertEqual(int(reduction.reduction_ranges[0]), 67)
 
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
-        self.assertGreaterEqual(len(overwrites), 4)
+        self.assertGreaterEqual(len(overwrites), 2)
 
     def test_bmm_3d_2d_unaligned_k_pads(self) -> None:
-        """3D×2D bmm: (B,M,K)×(K,N) with K=67 — both x and y are padded."""
+        """3D×2D bmm: (B,M,K)×(K,N) with K=67 — only y is padded."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -272,19 +274,18 @@ class TestInsertPaddingIR(unittest.TestCase):
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
 
-        k_padded = ((67 + stick_size - 1) // stick_size) * stick_size
+        # reduction_ranges stays at K.
         reduction = mm.data
         assert isinstance(reduction, Reduction)
-        # reduction_ranges is updated to K_padded.
-        self.assertEqual(int(reduction.reduction_ranges[0]), k_padded)
+        self.assertEqual(int(reduction.reduction_ranges[0]), 67)
 
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
-        # 4 overwrites: fill + copy for x, fill + copy for y.
-        self.assertGreaterEqual(len(overwrites), 4)
+        # 2 overwrites: fill + copy for y only.
+        self.assertGreaterEqual(len(overwrites), 2)
 
     def test_matmul_4d_unaligned_k_pads(self) -> None:
-        """4D matmul (B,H,M,K)×(B,H,K,N) with K=67 — both x and y are padded."""
+        """4D matmul (B,H,M,K)×(B,H,K,N) with K=67 — only y is padded."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -300,17 +301,17 @@ class TestInsertPaddingIR(unittest.TestCase):
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
 
-        k_padded = ((67 + stick_size - 1) // stick_size) * stick_size
+        # reduction_ranges stays at K.
         reduction = mm.data
         assert isinstance(reduction, Reduction)
-        self.assertEqual(int(reduction.reduction_ranges[0]), k_padded)
+        self.assertEqual(int(reduction.reduction_ranges[0]), 67)
 
         ops_before = self._ops_before(ops, mm)
         overwrites = self._overwrite_ops(ops_before)
-        self.assertGreaterEqual(len(overwrites), 4)
+        self.assertGreaterEqual(len(overwrites), 2)
 
     def test_einsum_mk_kn_mn_pads(self) -> None:
-        """einsum('mk,kn->mn') with K=67 — both x and y are padded to K_padded."""
+        """einsum('mk,kn->mn') with K=67 — y is padded; reduction_ranges stays at K."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
@@ -326,17 +327,16 @@ class TestInsertPaddingIR(unittest.TestCase):
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
 
-        k_padded = ((67 + stick_size - 1) // stick_size) * stick_size
+        # reduction_ranges stays at K=67.
         reduction = mm.data
         assert isinstance(reduction, Reduction)
-        # reduction_ranges is updated to K_padded.
-        self.assertEqual(int(reduction.reduction_ranges[0]), k_padded)
+        self.assertEqual(int(reduction.reduction_ranges[0]), 67)
 
     def test_padding_constants_deduped(self) -> None:
         """Two matmuls with the same shapes yield exactly one spyre.constant after dedup.
 
-        Both matmuls pad x and y with fill_value=0.0 at the same dtype, so four
-        spyre.constant FX nodes are created (one per pad sequence) and lowered to four
+        Both matmuls pad only y with fill_value=0.0 at the same dtype, so two
+        spyre.constant FX nodes are created (one per pad sequence) and lowered to two
         SpyreConstantFallback IR ops.  dedup_and_promote_constants then merges them into
         one canonical constant and moves it to the head of operations.
         """
@@ -396,13 +396,17 @@ class TestInsertPaddingIR(unittest.TestCase):
             "origin_node should not be None after _rebuild_matmul",
         )
 
-    def test_padded_buffer_sizes_x_and_y(self) -> None:
-        """Both x and y are padded; host K-dims are extended to k_padded.
+    def test_padded_buffer_sizes_y_only(self) -> None:
+        """Only y is padded; x is untouched.  y_padded has host size [B, K_padded, N].
 
-        spyre.empty lowers to SpyreEmptyFallback.  Two SpyreEmptyFallback ops
-        appear before the matmul: one for x_padded with host size [B, M, K_padded]
-        and one for y_padded with host size [B, K_padded, N].
+        For the 3D bmm shape [B=2, K=67, N=128]: SpyreTensorLayout for
+        [B, K_padded, N] sticked on N lays out device dims as
+        [K_padded, N_sticks, B, stick_size], so device_size[-4] == K_padded.
+
+        spyre.empty lowers to SpyreEmptyFallback.  Exactly one SpyreEmptyFallback op
+        appears before the matmul.
         """
+        from torch_spyre._inductor.ir import FixedTiledLayout
 
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
@@ -425,49 +429,54 @@ class TestInsertPaddingIR(unittest.TestCase):
         ops_before = self._ops_before(ops, mm)
 
         padded_empties = [op for op in ops_before if isinstance(op, SpyreEmptyFallback)]
-        # Both x and y are padded — exactly two SpyreEmptyFallback ops.
+        # Only y is padded — exactly one SpyreEmptyFallback op.
         self.assertEqual(
             len(padded_empties),
-            2,
-            f"Expected 2 padded buffers (x and y), found {len(padded_empties)}: "
+            1,
+            f"Expected 1 padded buffer (y only), found {len(padded_empties)}: "
             f"{[[int(s) for s in op.get_size()] for op in padded_empties]}",
         )
 
-        host_sizes = sorted([int(s) for s in op.get_size()] for op in padded_empties)
-        # x_padded: [B, M, K_padded]; y_padded: [B, K_padded, N].
-        self.assertIn(
-            [B, M, k_padded],
-            host_sizes,
-            f"x_padded size [B,M,K_padded]=[{B},{M},{k_padded}] not found in {host_sizes}",
-        )
-        self.assertIn(
+        y_empty = padded_empties[0]
+
+        # y_padded's host size is [B, K_padded, N]: lower_pad_sequence builds it at the
+        # padded shape and no host-downgrade is applied.  The IR iteration space (via
+        # reduction_ranges) stays at K; only the buffer allocation is K_padded.
+        host_size = [int(s) for s in y_empty.get_size()]
+        self.assertEqual(
+            host_size,
             [B, k_padded, N],
-            host_sizes,
-            f"y_padded size [B,K_padded,N]=[{B},{k_padded},{N}] not found in {host_sizes}",
+            f"y_padded host size should be [B,k_padded,N]=[{B},{k_padded},{N}], "
+            f"got {host_size}",
         )
 
-        # Each padded buffer's host K-dim must equal K_padded.
-        for empty in padded_empties:
-            host_size = [int(s) for s in empty.get_size()]
-            self.assertIn(
-                k_padded,
-                host_size,
-                f"k_padded={k_padded} not found in host_size={host_size}",
-            )
+        # y's device_layout.device_size must reflect K_padded in the K-row device dim.
+        # For [B, K_padded, N] sticked on N: device_size = [K_padded, N_sticks, B, stick_size].
+        # K_padded sits at device_size[-4] (index -stride_idx-2 with stride_idx=2 for K).
+        layout = y_empty.get_layout()
+        self.assertIsInstance(layout, FixedTiledLayout)
+        assert isinstance(layout, FixedTiledLayout)
+        dev_size = list(layout.device_layout.device_size)
+        self.assertEqual(
+            dev_size[-4],
+            k_padded,
+            f"y device_size[-4] should be K_padded={k_padded}, "
+            f"got {dev_size[-4]}; full device_size={dev_size}",
+        )
 
     def test_padded_buffer_preserves_stick_dimension(self) -> None:
-        """Both padded buffers (x and y) preserve the original within-stick stride.
+        """y's padded buffer preserves the original within-stick stride.
 
-        ``lower_pad_sequence`` constructs each padded buffer's ``SpyreTensorLayout``
+        ``lower_pad_sequence`` constructs the padded buffer's ``SpyreTensorLayout``
         from the padded host size/stride so that ``device_coordinates[-1]`` (the
         stick coordinate expression) is identical for both the original and padded
-        buffers.  Concretely, ``stride_map[-1]`` must be 1 for every padded
+        buffers.  Concretely, ``stride_map[-1]`` must be 1 for the padded
         ``SpyreEmptyFallback``.
 
-        x is sticked on K (the reduction dim), y is sticked on N (the output dim).
-        Both have contiguous within-stick strides, so ``stride_map[-1] == 1``.
-        The test catches a regression that confused the stick dim (e.g. producing
-        ``stride_map[-1] == K_padded`` from a default layout with the wrong dim_order).
+        y is sticked on N (the output dim), which is contiguous, so
+        ``stride_map[-1] == 1``.  The test catches a regression that confused the
+        stick dim (e.g. producing ``stride_map[-1] == K_padded`` from a default
+        layout with the wrong dim_order).
         """
         from torch_spyre._inductor.ir import FixedTiledLayout
 
@@ -517,8 +526,8 @@ class TestInsertPaddingIR(unittest.TestCase):
                 ]
                 self.assertEqual(
                     len(padded_empties),
-                    2,
-                    f"{name}: expected exactly 2 padded buffers (x and y)",
+                    1,
+                    f"{name}: expected exactly 1 padded buffer (y only)",
                 )
 
                 for empty in padded_empties:

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -429,6 +429,85 @@ def _ref_arg(op_spec):
     return op_spec.args[-1]
 
 
+def _extend_matmul_k_to_padded(
+    op_spec: OpSpec,
+    sdsc_iteration_space: dict,
+    symbol_mapping: dict,
+) -> None:
+    """Extend sdsc_iteration_space[K] to K_padded for matmul ops.
+
+    The IR-level padding pass pads y's device_size to K_padded rows but keeps
+    the host iteration space (and op_spec.iteration_space) at K.  This function
+    reads K_padded from y's device_size and updates sdsc_iteration_space[K_sym]
+    before _create_sdsc_tensors runs.
+
+    With sdsc_iteration_space[K_sym] = K_padded:
+    - y's dev_dim_size for K == it_dim_size → backGap branch never fires for y.
+    - Strides are computed against K_padded → correct for K_padded-extended iteration.
+    - _get_padded_iteration_space becomes a no-op for K (already aligned).
+
+    K is identified as the symbol that appears in y's (non-stick) device_coordinates
+    but NOT in the output's device_coordinates.  This is the reduction symbol and is
+    layout-position agnostic: it works regardless of how MATMUL_DIM_LABELS maps the
+    iteration symbols for this particular ndim.
+    """
+    # y is always args[1]; output is always args[-1] for matmul.
+    y_arg = op_spec.args[1]
+    out_arg = op_spec.args[-1]
+
+    # Collect non-stick symbols in y's device_coordinates (after symbol_mapping).
+    y_dim_order, y_stick_dim = _get_device_dim_order(y_arg, symbol_mapping)
+    # y_stick_dim is the within-stick symbol; the remaining dims include K.
+    y_non_stick_syms: set = set(y_dim_order) - ({y_stick_dim} if y_stick_dim else set())
+
+    # Collect all symbols in the output's device_coordinates.
+    out_dim_order, _ = _get_device_dim_order(out_arg, symbol_mapping)
+    out_syms: set = set(out_dim_order)
+
+    # K is in y but not in the output (it's reduced).
+    k_candidates = y_non_stick_syms - out_syms
+    if not k_candidates:
+        logger.warning(
+            "_extend_matmul_k_to_padded: could not identify K symbol "
+            "(y_non_stick=%s, out_syms=%s), skipping",
+            y_non_stick_syms,
+            out_syms,
+        )
+        return
+    k_sym = next(iter(k_candidates))
+
+    if k_sym not in sdsc_iteration_space:
+        logger.warning(
+            "_extend_matmul_k_to_padded: K symbol %s not in sdsc_iteration_space %s, skipping",
+            k_sym,
+            list(sdsc_iteration_space.keys()),
+        )
+        return
+
+    # Find K_padded from y's device_size using the same stride_idx formula as
+    # _create_sdsc_tensors: dev_dim_size = device_size[-stride_idx - 2]
+    # where stride_idx is the position of k_sym in y_dim_order.
+    # y has no reduced dims, so stride_dim_order == y_dim_order, and k_sym is
+    # guaranteed to be present (it was just found in y_non_stick_syms ⊆ y_dim_order).
+    stride_idx = y_dim_order.index(k_sym)
+    dev_dim_idx = -stride_idx - 2
+    k_padded = int(y_arg.device_size[dev_dim_idx])
+
+    k_current = sdsc_iteration_space[k_sym]
+    if k_padded > k_current:
+        logger.debug(
+            "_extend_matmul_k_to_padded: extending K %d -> %d "
+            "(sym=%s, y device_size[%d]=%d, stride_idx=%d)",
+            k_current,
+            k_padded,
+            k_sym,
+            dev_dim_idx,
+            k_padded,
+            stride_idx,
+        )
+        sdsc_iteration_space[k_sym] = k_padded
+
+
 def parse_op_spec(op_spec: OpSpec) -> SDSCSpec:
     is_matmul = _is_matmul(op_spec.op)
     ndim = len(op_spec.iteration_space)
@@ -465,6 +544,9 @@ def parse_op_spec(op_spec: OpSpec) -> SDSCSpec:
         sdsc_iteration_space[stick_sym] = op_spec.args[0].device_dtype.elems_per_stick()
         work_slices[stick_sym] = 1
         dim_splits[stick_sym] = 1
+
+    if is_matmul:
+        _extend_matmul_k_to_padded(op_spec, sdsc_iteration_space, symbol_mapping)
 
     args, layouts, missing_dim = _create_sdsc_tensors(
         op_spec,

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""IR-level pass to pad the K (reduction) dimension to a stick boundary for
+"""IR-level pass to pad y's K (row) dimension to a stick boundary for
 BATCH_MATMUL_OP operations.  Runs in CustomPreSchedulingPasses immediately
 after insert_restickify, when every ComputedBuffer has a FixedTiledLayout.
 
-Both x and y are padded along their K dimension to K_padded = next stick
-boundary.  For each argument:
+Only y is padded; x is left untouched.
+
+For y, the following IR sequence is emitted:
   spyre.empty(padded_size)                         — uninitialised allocation
   spyre.constant(0.0)                              — scalar zero, generated on-device (cached)
   aten.expand(constant, pad_size)                  — broadcast to pad-region shape; free
@@ -30,6 +31,16 @@ This ensures the fill overwrite is stick-aligned; any elements between
 fill_offset and original_size[dim] that are over-zeroed are restored by the
 data overwrite, which always runs after the fill overwrite.
 
+y's padded buffer is built at the full K_padded host size by lower_pad_sequence.
+reduction_ranges stays at K; the K→K_padded extension happens at SDSC codegen
+time: _extend_matmul_k_to_padded in superdsc.py reads K_padded from y's
+device_size and widens sdsc_iteration_space[K] to K_padded before
+_create_sdsc_tensors runs.
+
+x is left physically untouched.  The hardware masks within-stick elements of x
+beyond the true K to zero, so extending the SDSC iteration to K_padded does not
+introduce numerical error from x.
+
 spyre.constant is cached across all matmuls with the same (fill_value, device,
 dtype) key so it is lowered at most once per unique fill value and dtype,
 regardless of tensor shape or which dimension is padded.
@@ -37,16 +48,8 @@ regardless of tensor shape or which dimension is padded.
 x and y are identified via device_coordinates: x is the input sticked on the
 reduction coord, y is the other.  This avoids positional assumptions and handles
 square matrices (M==K==N) correctly.
-
-x's effective size is derived from the output ranges ([batch..., M, K]) rather
-than from the underlying buffer's shape.  This handles cases where mm_to_bmm_pass
-adds a batch dimension to the output ranges while leaving the input buffers 2D
-(e.g. torch.einsum("mk,kn->mn")).
-
-reduction_ranges is updated to K_padded so the hardware iterates r=0..K_padded-1.
 """
 
-import sympy
 import torch
 from torch._inductor.ir import (
     Buffer,
@@ -136,25 +139,26 @@ def _find_arg_fx_node(
 
 def _rebuild_matmul(
     op: ComputedBuffer,
-    x_padded_buf: Buffer,
+    x_ir: object,
     y_padded_buf: Buffer,
-    k_padded: int,
     operations: list[Operation],
 ) -> ComputedBuffer:
-    """Rebuild the matmul ComputedBuffer with padded loaders and updated reduction_ranges.
+    """Rebuild the matmul ComputedBuffer so y's loader reads from the padded buffer.
 
-    Patches the Reduction's inner_fn to load from the padded buffers and updates
-    reduction_ranges to k_padded, then delegates the ComputedBuffer reconstruction
-    and operations-list swap to replace_computed_buffer_body.
+    Patches the Reduction's inner_fn to load x from its original IR node and y
+    from the padded buffer.  reduction_ranges is left unchanged (stays at K);
+    the K→K_padded extension happens at SDSC codegen time via
+    _extend_matmul_k_to_padded in superdsc.py.
 
-    x_padded_buf must have ndim matching len(output_ranges) (all output dims
-    except N plus K_padded) so indices [batch..., M, r_K] are valid.
+    x_ir must support make_loader() and its get_size() must have ndim matching
+    len(output_ranges) (all output dims except N plus K) so indices
+    [batch..., M, r_K] are valid.
     y_padded_buf must have the same ndim as the original y buffer.
     """
     reduction = op.data
     assert isinstance(reduction, Reduction)
 
-    x_padded_loader = x_padded_buf.make_loader()
+    x_loader = x_ir.make_loader()
     y_padded_loader = y_padded_buf.make_loader()
     # y's batch dims: y_ndim - 2 batch dims come first in y_index.
     y_ndim = len(y_padded_buf.get_size())
@@ -163,7 +167,7 @@ def _rebuild_matmul(
     def new_inner_fn(
         index,
         reduction_index,
-        _x_loader=x_padded_loader,
+        _x_loader=x_loader,
         _y_loader=y_padded_loader,
         _y_batch_ndim=y_batch_ndim,
     ):
@@ -180,17 +184,21 @@ def _rebuild_matmul(
         return (_x_loader(x_index), _y_loader(y_index))
 
     object.__setattr__(reduction, "inner_fn", new_inner_fn)
-    object.__setattr__(reduction, "reduction_ranges", [sympy.Integer(k_padded)])
+    # reduction_ranges stays at K; no extension here.
 
     return replace_computed_buffer_body(op, reduction, operations)
 
 
-def insert_padding_ir(operations: list[Operation]) -> None:
+def insert_bmm_padding(operations: list[Operation]) -> None:
     """
-    Pad the K (reduction) dimension of each BATCH_MATMUL_OP to a stick boundary.
+    Pad y's K (row) dimension for each BATCH_MATMUL_OP to a stick boundary.
 
-    Mutates ``operations`` in place.  All new buffers are inserted immediately
+    Mutates ``operations`` in place.  New buffers for y are inserted immediately
     before the matmul that consumes them to preserve topological order.
+
+    x is left entirely untouched.  y's padded buffer is built at K_padded host
+    size by lower_pad_sequence; reduction_ranges stays at K so the IR iteration
+    space is unchanged.  The K→K_padded widening happens at SDSC codegen time.
 
     x and y are identified via device_coordinates: x is the input sticked on
     the reduction coord, y is the other.  This avoids positional assumptions
@@ -255,7 +263,7 @@ def insert_padding_ir(operations: list[Operation]) -> None:
 
         if x_dep is None or y_dep is None:
             logger.warning(
-                "insert_padding_ir: could not identify x/y for %s, skipping",
+                "insert_bmm_padding: could not identify x/y for %s, skipping",
                 op.get_name(),
             )
             continue
@@ -281,10 +289,17 @@ def insert_padding_ir(operations: list[Operation]) -> None:
         if pad == 0:
             continue
 
+        # Find the FX node/TensorBox that presents x at x_size dimensionality.
+        # mm_to_bmm_pass may wrap a 2D x buffer with a 3D view; we need the
+        # loader to accept x_size-dimensional indices (len(output_ranges) dims).
+        x_view_fx = _find_arg_fx_node(x_name, expected_size=x_size)
+        _patch_env(V.graph)
+        x_view_buf = V.graph.env[x_view_fx]
+
         k_padded = k_val + pad
 
         logger.debug(
-            "insert_padding_ir: padding %s K=%d -> K=%d (pad=%d)",
+            "insert_bmm_padding: padding %s K=%d -> K=%d (pad=%d)",
             op.get_name(),
             k_val,
             k_padded,
@@ -296,27 +311,14 @@ def insert_padding_ir(operations: list[Operation]) -> None:
         # minimising their live range.
         matmul_fx_node = next(iter(op.origins))
 
-        # --- Pad x: size=[batch..., M, K_padded] ---
-        # Look for the FX node with the expected pre-padded x size so that the
-        # padded clone has the right dimensionality for the inner_fn's loaders.
-        x_padded_size = x_size[:-1] + [k_padded]
-        x_fx_node = _find_arg_fx_node(x_name, expected_size=x_size)
-
-        x_orig_stl = x_buf.get_layout().device_layout
-        x_padded_buf, x_new_ops = lower_pad_sequence(
-            x_fx_node,
-            padded_size=x_padded_size,
-            device=device,
-            dtype=dtype,
-            dim=len(x_padded_size) - 1,
-            insert_before=matmul_fx_node,
-            orig_stl=x_orig_stl,
-        )
-
-        # --- Pad y: size=[batch..., K_padded, N] ---
+        # --- Pad y only ---
         # y's K dimension is y's row (mb) dimension.  Padding it to K_padded
-        # ensures the matmul reduction does not read uninitialised rows of y
-        # when reduction_ranges is extended to k_padded.
+        # ensures rows K..K_padded-1 of y are zero-filled so the hardware
+        # accumulates no contribution from those rows.
+        # lower_pad_sequence builds the padded buffer at K_padded host size;
+        # reduction_ranges is NOT changed.  superdsc._extend_matmul_k_to_padded
+        # widens sdsc_iteration_space[K] to K_padded at SDSC codegen time,
+        # reading K_padded from y's device_layout.device_size.
         y_size = [concretize_expr(s) for s in y_buf.get_size()]
         if y_host_k_dim is None:
             y_k_dim = len(y_size) - 2
@@ -339,18 +341,18 @@ def insert_padding_ir(operations: list[Operation]) -> None:
 
         # --- Relocate new ops before the matmul ---
         # run_node appended them at the end of operations; move before op.
-        all_new_ops = x_new_ops + y_new_ops
-        for new_op in all_new_ops:
+        for new_op in y_new_ops:
             operations.remove(new_op)
         op_idx = operations.index(op)
-        for i, new_op in enumerate(all_new_ops):
+        for i, new_op in enumerate(y_new_ops):
             operations.insert(op_idx + i, new_op)
 
-        # --- Rebuild matmul inner_fn and reduction_ranges ---
+        # --- Rebuild matmul inner_fn to load y from the padded buffer ---
+        # x keeps its original loader (via x_view_buf which presents x at the
+        # x_size dimensionality the inner_fn expects); reduction_ranges stays at K.
         _rebuild_matmul(
             op,
-            x_padded_buf,
+            x_view_buf,
             y_padded_buf,
-            k_padded,
             operations,
         )

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -29,7 +29,7 @@ from torch._inductor.scheduler import BaseSchedulerNode
 
 from .logging_utils import get_inductor_logger
 
-from .padding import insert_padding_ir
+from .padding import insert_bmm_padding
 from .temp_passes import (
     bmm_unflatten_pass,
     mm_to_bmm_pass,
@@ -228,7 +228,7 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         optimize_restickify_locations(operations)
         finalize_layouts(operations)
         insert_restickify(operations)
-        insert_padding_ir(operations)
+        insert_bmm_padding(operations)
         dedup_and_promote_constants(operations)
         span_reduction(operations)
         k_fast_ops = (
@@ -248,7 +248,7 @@ class CustomPreSchedulingPasses(CustomGraphPass):
             inspect.getfile(propagate_spyre_tensor_layouts),
             inspect.getfile(optimize_restickify_locations),
             inspect.getfile(insert_restickify),
-            inspect.getfile(insert_padding_ir),
+            inspect.getfile(insert_bmm_padding),
             inspect.getfile(span_reduction),
             inspect.getfile(work_distribution),
             inspect.getfile(k_fast_division),


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
##### Problem

For matmuls with an unaligned K dimension (K not a multiple of the stick size,
64 at fp16), the compiler must pad K to K_padded = next stick boundary before
lowering to SDSC.  The previous implementation padded **both** x and y:

- **x side**: allocated a new K_padded buffer, zero-filled the pad region,
  copied x's data into it, and rewired x's loader to the padded copy.
- **y side**: same sequence, plus set `reduction_ranges = [K_padded]` so the
  hardware iterates the full K_padded reduction.

Padding x is pure overhead.  The hardware masks within-stick elements of x that
lie beyond the true K to zero, so the reduction over `r_K = K..K_padded-1`
contributes nothing for x regardless of what those bytes contain.  The x
allocation, zero-fill, and data copy exist solely to make the copy safe to read,
not because the hardware needs the zeros there.

Additionally, extending `reduction_ranges` to K_padded made `K_padded` visible
to `compute_coordinates` in `views.py`.  When K_padded exceeded a stride in
y's `stride_map`, `normalize_coordinates` produced fractional coefficients
(e.g. `67*c0/128`) and raised an assertion error in certain non-square shapes.

##### Approach

###### IR pass (`padding.py` → `insert_bmm_padding`)

**x**: dropped entirely.  No padded allocation, no copy, no loader rewrite.
x's original buffer and loader are used as-is.

**y**: the existing `lower_pad_sequence` sequence (empty + constant + expand +
clone + 2 overwrites) is still emitted, building y_padded at K_padded host
size.  `reduction_ranges` is **not** changed; it stays at K.

Because `reduction_ranges = K`, `compute_coordinates` always sees K as the
iteration limit and the fractional-coefficient bug cannot occur.

###### SDSC codegen (`superdsc.py` → `_extend_matmul_k_to_padded`)

The backend compiler requires K to be a stick multiple in the SDSC descriptor.
A new function `_extend_matmul_k_to_padded` is called in `parse_op_spec`
after `sdsc_iteration_space` is built from `op_spec.iteration_space` (which
carries K) but before `_create_sdsc_tensors` runs.

The function:

1. Identifies the K symbol structurally — it is the symbol that appears in
   y's non-stick device_coordinates but **not** in the output's
   device_coordinates.  This is layout-position agnostic: it does not assume
   any fixed position in `MATMUL_DIM_LABELS` and works for all matmul ndims.
2. Reads K_padded from `y_arg.device_size` using the same `device_size[-stride_idx-2]`
   formula that `_create_sdsc_tensors` uses for the same dimension.
3. Sets `sdsc_iteration_space[K_sym] = K_padded`.

With `sdsc_iteration_space[K] = K_padded`:

- y's `dev_dim_size == it_dim_size` → the `backGap` branch in
  `_create_sdsc_tensors` does not fire for y's K dim.
- Strides are computed against K_padded → correct descriptor for the
  K_padded-extended hardware iteration.
- `_get_padded_iteration_space` becomes a no-op for K (already aligned).

x's SDSC descriptor is unchanged.  The hardware's within-stick masking
zeroes the `r_K = K..K_padded-1` elements of x, so the extended reduction
produces the same numerical result as a K-length reduction.

##### Files changed

| File | Change |
|---|---|
| `torch_spyre/_inductor/padding.py` | Drop x padding; rename to `insert_bmm_padding`; keep y padding at K_padded host size; leave `reduction_ranges` at K |
| `torch_spyre/_inductor/codegen/superdsc.py` | Add `_extend_matmul_k_to_padded`; call it in `parse_op_spec` for matmul ops |
| `torch_spyre/_inductor/passes.py` | Update import and call sites for the rename |
| `tests/inductor/test_padding.py` | Update all assertions: 1 empty (y only), 2 overwrites, `reduction_ranges == K`; rename and update `test_padded_buffer_sizes_y_only`; verify `device_size[-4] == K
_padded` for 3D bmm y |

##### Testing

```
python -m pytest tests/inductor/test_padding.py -v          # 10/10 pass
python -m pytest tests/inductor/test_inductor_ops.py \
    -k "matmul or bmm or einsum" -v                         # 28/28 pass
pre-commit run --files \
    torch_spyre/_inductor/padding.py \
    torch_spyre/_inductor/codegen/superdsc.py \
    tests/inductor/test_padding.py                          # all hooks pass
```


#### Which issue(s) this PR is related to:

Fixes #1502. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
