### PR TITLE
Fix device constructors not working in torch-spyre with TorchFunctionModes

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -102,6 +102,11 @@ class TestSpyre(TestCase):
         a_cpu = a.cpu()
         self.assertTrue(a_cpu.eq(3.5).all())
 
+    def test_empty_factory_in_device_context(self):
+        with torch.device("spyre"):
+            a = torch.empty(50, dtype=torch.float16)
+        self.assertEqual(a.device.type, "spyre")
+
     def test_ones_factory(self):
         a = torch.ones(50, device="spyre", dtype=torch.float16)
         self.assertEqual(a.device.type, "spyre")

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -103,6 +103,10 @@ class TestSpyre(TestCase):
         self.assertTrue(a_cpu.eq(3.5).all())
 
     def test_empty_factory_in_device_context(self):
+        # The error only repros if at least one allocation
+        # has already happened
+        _ = torch.empty(64, dtype=torch.float16, device="spyre")
+
         with torch.device("spyre"):
             a = torch.empty(50, dtype=torch.float16)
         self.assertEqual(a.device.type, "spyre")

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -33,6 +33,10 @@ def _patch_tensor_for_spyre():
     if getattr(torch.Tensor, "_spyre_tensor_patched", False):
         return
 
+    from torch.utils._device import _device_constructors
+
+    _device_constructors()  # warm the cache with the original torch.empty
+
     orig_repr = torch.Tensor.__repr__
     orig_to = torch.Tensor.to
     orig_empty = torch.empty
@@ -134,16 +138,17 @@ def _patch_tensor_for_spyre():
         if (
             device_layout is None
         ):  # use original implementation if no layout is provided
-            return orig_empty(
-                *args,
+            kwargs = dict(
                 out=out,
                 dtype=dtype,
                 layout=layout,
-                device=device,
                 requires_grad=requires_grad,
                 pin_memory=pin_memory,
                 memory_format=memory_format,
             )
+            if device is not None:
+                kwargs["device"] = device
+            return orig_empty(*args, **kwargs)
         else:
             # layout_opt is omitted; c10::Layout has no pybind11 type caster,
             # so py_empty_with_layout drops that parameter and always uses


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When we monkey patch functions like torch.empty to add SpyreTensorLayout support, we end up breaking some internal pytorch machinery like https://github.com/pytorch/pytorch/blob/59a25c45d07c613863008afafbde8e4eac8c4cd7/torch/utils/_device.py#L68, which has a list of function object pointers that our monkey patching breaks. This PR addresses that, which lets code like:

```python
with torch.device("spyre"):
    a = torch.empty((12, 128), dtype=torch.float16)
```

work correctly.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
