### PR TITLE
Add aten.ne.Scalar_out comparison test

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1181,6 +1181,20 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             },
         },
+        ("test_cmp_scalar_int64", "test_cmp_scalar_int64_cpu"): {
+            "ops_dict": {
+                "ne": torch.ne,
+            },
+            "param_sets": {
+                # [1, 64] int64 non-contiguous (stride (64,1)) != scalar
+                "ne_1x64_int64_noncontig_eager": (
+                    torch.randint(0, 100, (1, 64), dtype=torch.int64).as_strided(
+                        (1, 64), (64, 1)
+                    ),
+                    0,
+                ),
+            },
+        },
         (
             "test_where",
             "test_where_cpu",
@@ -3539,6 +3553,10 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         # - torch.matmul: numerical divergence (close=False) in eager 2d case
         eager_supported = op in (torch.eq, torch.ge, torch.gt, torch.lt, torch.ne)
         self.compare_with_cpu(op, x, y, run_eager=eager_supported)
+
+    def test_cmp_scalar_int64_cpu(self, op, x, scalar):
+        # Test comparison ops with int64 tensors and scalar values.
+        self.compare_with_cpu(op, x, scalar, run_eager=True, run_compile=False)
 
     def test_linear_fn(self, x, weight, bias):
         # NOTE: relaxing atol from 2e-1 to 3e-1 for multi-dim work division, single element fails without


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds the aten.ne.Scalar_out to the fallbacks list. It is a small addition.

#### Which issue(s) this PR is related to:

Fix issue #1680 

#### Special notes for your reviewer:
This script:
```python
#!/usr/bin/env python3
"""
Test script matching user's requirement - must work without explicit torch_spyre import.
"""

# User's script - should work as-is
import torch

# Set device to Spyre
device = torch.device("spyre")

# Create test tensor
x = torch.randint(0, 100, (1, 64), dtype=torch.int64).to(device)

print(f"Created tensor: shape={x.shape}, dtype={x.dtype}, device={x.device}")

# Compare with scalar 0
result = torch.ne(x, 0)

print(f"Result: shape={result.shape}, dtype={result.dtype}, device={result.device}")
print(f"Expected behavior: Returns boolean tensor of shape (1, 64) with True where elements ≠ 0")

# Verify correctness
x_cpu = x.cpu()
expected = torch.ne(x_cpu, 0)
matches = torch.equal(result.cpu(), expected)

print(f"\n✅ SUCCESS! Result matches expected behavior: {matches}")
print(f"Sample values from x: {x_cpu[0, :10]}")
print(f"Sample results: {result.cpu()[0, :10]}")

# Made with Bob
```
Is outputing:
```bash
home/flaviabeodebayser/dt-inductor/torch-spyre/test_user_script.py:13: UserWarning: Backend Spyre does not support int64; downcasting to int32 may change values outside the 32-bit range. You can silence this via warnings.filterwarnings(...) or spyre.set_downcast_warning(False) or TORCH_SPYRE_DOWNCAST_WARN env. variable. (Triggered internally at /home/flaviabeodebayser/dt-inductor/torch-spyre/torch_spyre/csrc/types_mapping.h:96.)
  x = torch.randint(0, 100, (1, 64), dtype=torch.int64).to(device)
Created tensor: shape=torch.Size([1, 64]), dtype=torch.int64, device=spyre:0
/home/flaviabeodebayser/dt-inductor/torch-spyre/test_user_script.py:18: FallbackWarning: aten.ne.Scalar_out is falling back to cpu
  result = torch.ne(x, 0)
Result: shape=torch.Size([1, 64]), dtype=torch.bool, device=spyre:0
Expected behavior: Returns boolean tensor of shape (1, 64) with True where elements ≠ 0

✅ SUCCESS! Result matches expected behavior: True
Sample values from x: tensor([86, 72, 11, 65,  0, 40, 54, 85, 81, 66])
Sample results: tensor([ True,  True,  True,  True, False,  True,  True,  True,  True,  True])
```

And the test described in the issue:
```bash
pytest test_llama_3_8b_instruct.py::TestNe::test_torch_ne_pattern_000_ne_1x64_int64_noncontig_eager -v
```
Outputs:
```bash

tests/models/test_llama_3_8b_instruct.py:4628
  /home/flaviabeodebayser/dt-inductor/torch-spyre/tests/models/test_llama_3_8b_instruct.py:4628: PytestUnknownMarkWarning: Unknown pytest.mark.torch_sdpa - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = pytest.mark.torch_sdpa

tests/models/test_llama_3_8b_instruct.py::TestNe::test_torch_ne_pattern_000_ne_1x64_int64_noncontig_eager
  /home/flaviabeodebayser/dt-inductor/torch-spyre/tests/models/utils_llama_3_8b_instruct.py:475: UserWarning: Backend Spyre does not support int64; downcasting to int32 may change values outside the 32-bit range. You can silence this via warnings.filterwarnings(...) or spyre.set_downcast_warning(False) or TORCH_SPYRE_DOWNCAST_WARN env. variable. (Triggered internally at /home/flaviabeodebayser/dt-inductor/torch-spyre/torch_spyre/csrc/types_mapping.h:96.)
    device_args = [a.to(device) if isinstance(a, torch.Tensor) else a for a in args]

tests/models/test_llama_3_8b_instruct.py::TestNe::test_torch_ne_pattern_000_ne_1x64_int64_noncontig_eager
  /home/flaviabeodebayser/dt-inductor/torch-spyre/tests/models/test_llama_3_8b_instruct.py:744: FallbackWarning: aten.ne.Scalar_out is falling back to cpu
    lambda x: torch.ne(x, scalar),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 1 passed, 32 warnings in 36.77s ====================================================
```
#### Does this PR introduce a user-facing change?

#### Additional note:

Test added to inductor ops:

```bash
==================================================== 1 passed, 2 warnings in 41.42s =====================================================
(dt-inductor) [flaviabeodebayser@flaviabeodebayser-spyre-dev-pf torch-spyre]$ pytest tests/inductor/test_inductor_ops.py
========================================================== test session starts ==========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/flaviabeodebayser/dt-inductor/torch-spyre
configfile: pyproject.toml
plugins: xdist-3.8.0, hypothesis-6.152.7
collected 1479 items                                                                                                                    

tests/inductor/test_inductor_ops.py .......................x............................................x...x.................... [  6%]
..........................................................................xxxxx...................x...........x.................. [ 15%]
..................x.........x.x.....................xxxxx.....................xxxxxxxx....................xxxxxxxxx.............x [ 23%]
xxx....xxxxxxxx..x..............xxxxxxxxxxxxxxxx......................xxxxxxxxxxxxxxxxxx........x..x....xxxxx.................... [ 32%]
..........................................................x......x............................................................... [ 41%]
................................................................................................................................. [ 49%]
................................................................................................................................. [ 58%]
................................................................................................................................. [ 67%]
...............................................x..x.............................................................................. [ 76%]
................................................................................................................................. [ 84%]
............................................................xx........xxxxxxxx............xxxxxxxxxxxx........x.......xxxxxx..... [ 93%]
..............................x..x...x............................xx............................                 [100%]

=================================================== warnings summary ===================================================
tests/inductor/test_inductor_ops.py::TestOps::test_cmp_scalar_int64_ne_llama3_attn_mask
  /home/flaviabeodebayser/dt-inductor/torch-spyre/tests/inductor/utils_inductor.py:549: FallbackWarning: aten.ne.Scalar_out is falling back to cpu
    result = fn(*device_args, **device_kwargs)

tests/inductor/test_inductor_ops.py: 46 warnings
  /home/flaviabeodebayser/dt-inductor/torch-spyre/torch_spyre/_inductor/customops.py:220: FallbackWarning: torch.ops.spyre.full is falling back to cpu
    warn_fallback("torch.ops.spyre.full")

tests/inductor/test_inductor_ops.py::TestOps::test_isin_scalar_tensor_out_cpu
  /home/flaviabeodebayser/dt-inductor/torch-spyre/tests/inductor/test_inductor_ops.py:4342: UserWarning: An output with one or more elements was resized since it had shape [], which does not match the required output shape [0]. This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (Triggered internally at /pytorch/aten/src/ATen/native/Resize.cpp:31.)
    torch.isin(3, test_elements_spyre, out=out_spyre)

tests/inductor/test_inductor_ops.py: 23 warnings
  /home/flaviabeodebayser/dt-inductor/torch-spyre/torch_spyre/_inductor/decompositions.py:615: FallbackWarning: aten.argmax.default is falling back to cpu
    @register_spyre_decomposition([torch.ops.aten.max.dim])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================== 1352 passed, 127 xfailed, 71 warnings in 759.32s (0:12:39) ==============================
```
