### PR TITLE
[TESTING] Add Makefile for running tests using our test framework and keep pytest working as it is

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,3 +46,4 @@
 /.pre-commit-config.yaml  @ashokponkumar @jabostian
 /pytest.ini               @ashokponkumar @jabostian
 /pytest_models.ini        @ashokponkumar @jabostian
+/Makefile                 @ashokponkumar @jabostian

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# HELP
+# This will output the help for each task
+.PHONY: help
+help: ## Show this help message
+	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := help
+
+PYTEST_ARGS ?= -v
+TEST_CONFIGS ?= tests/configs/module_tests tests/configs/torch_spyre_tests
+
+# ---------------------------------------------------------------------------
+# Test suites
+# ---------------------------------------------------------------------------
+
+.PHONY: tests
+tests: ## Run all torch spyre tests + module tests by default. Override with: make tests TEST_CONFIGS="tests/configs/torch_spyre_tests/inductor"
+	@bash tests/run_test.sh $(TEST_CONFIGS) $(PYTEST_ARGS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,18 +315,35 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
+    # Files ignored for plain `pytest` runs (known failures outside `make tests`)
+    # When run via run_test.sh / make tests, PYTORCH_TEST_CONFIG is set so skip the ignore.
+    ignored_files = set()
+    if not os.environ.get("PYTORCH_TEST_CONFIG"):
+        ignored_files = {
+            "tests/test_modules_custom.py",
+        }
+
     selected_models = config.getoption("--model") or []
     if not selected_models:
-        return  # normal behavior
+        # Still deselect ignored files even without --model
+        deselect = [
+            i for i in items if any(i.nodeid.startswith(f) for f in ignored_files)
+        ]
+        if deselect:
+            config.hook.pytest_deselected(items=deselect)
+            items[:] = [i for i in items if i not in deselect]
+        return
 
     # Keep only model-yaml runner tests
     keep = []
     deselect = []
 
     for item in items:
+        if any(item.nodeid.startswith(f) for f in ignored_files):
+            deselect.append(item)
         # item.nodeid includes the file path, e.g. "tests/models/test_model_ops.py::test_model_ops[...]"
         # if "tests/models/test_model_ops.py::" in item.nodeid:
-        if "tests/models/test_model_ops" in item.nodeid:
+        elif "tests/models/test_model_ops" in item.nodeid:
             keep.append(item)
         else:
             deselect.append(item)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

### What this PR does:

Add Makefile for local test execution
Adds a Makefile as a developer convenience wrapper around tests/run_test.sh, which adapts to the CI test suites without requiring users to know internal config paths while removing test_modules_custom.py from pytest collection.

```bash
##### Running tests locally:

# Show all available targets
make help
##### Run all test suites
make tests

##### Run only Inductor tests
make tests TEST_CONFIGS=tests/configs/torch_spyre_tests/inductor

##### Run only Tensor tests
make tests TEST_CONFIGS=tests/configs/torch_spyre_tests/tensors

# Pass custom pytest args (e.g. run a specific test)
make tests PYTEST_ARGS="-v -k test_my_case"
```
<img width="2694" height="126" alt="image" src="https://github.com/user-attachments/assets/09141842-3169-4213-bf1c-9f32b604ac71" />



With this approach, pytest no longer throws major errors from `test_modules_custom.py` added as a part to be supported using config framework 

#### Output of `pytest tests/ -v` (**Please note that this error is because it is run in some random order but if we run these 2 failing tests individually, they PASS**)

<img width="3456" height="184" alt="image" src="https://github.com/user-attachments/assets/fa719329-cf05-4123-b8c1-d5f73fb2480f" />


#### Output of `make tests` (runs both torch-spyre tests + module tests using our framework with no failures)
 
<img width="2262" height="1038" alt="image" src="https://github.com/user-attachments/assets/55362480-9894-4182-8d4b-357499954c28" />

#### Output of `make tests TEST_CONFIGS=tests/configs/torch_spyre_tests/inductor`

<img width="2412" height="624" alt="image" src="https://github.com/user-attachments/assets/a7dd1e5a-6c4b-4989-8b19-4b9b619aab72" />



