### PR TITLE
Restrict test_modules_custom.py to float32 only

### DIFF
--- a/tests/test_modules_custom.py
+++ b/tests/test_modules_custom.py
@@ -48,7 +48,7 @@ class TestModuleCustom(TestCase):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
-    @modules(module_db)
+    @modules(module_db, allowed_dtypes=[torch.float32])
     def test_eager_vs_compile(self, device, dtype, module_info, training):
         """Test eager mode vs compile mode, comparing CPU and Spyre outputs.
 
@@ -144,7 +144,7 @@ class TestModuleCustom(TestCase):
                     msg=f"{module_info.name}: Spyre eager vs Spyre compile mismatch (tensor {i})",
                 )
 
-    @modules(module_db)
+    @modules(module_db, allowed_dtypes=[torch.float32])
     def test_layout_stride(self, device, dtype, module_info, training):
         """Test module with real YAML-specified layouts and strides.
 


### PR DESCRIPTION
## Summary

Restrict `test_modules_custom.py` to `allowed_dtypes=[torch.float32]`, eliminating ~500 nightly test failures from unsupported float64 dtype on Spyre.

## Changes

Add `allowed_dtypes=[torch.float32]` to both `@modules(module_db)` decorators. The `module_db` declares float32 and float64 for the `privateuse1` device type, but Spyre does not support float64 — every float64 test hits `RuntimeError: Spyre backend does not support dtype Double`.

This is a 2-line change that cuts the nightly failure count from ~640 to ~140 (the remaining ~140 are unimplemented ops on float32, which should be addressed separately with xfail markers).

## Test plan

- [x] Verified on pod: test collection drops from 500 to 250 tests (float64 tests eliminated)
- [ ] Full nightly CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)