### PR TITLE
Fix MRO test for PT 2.11 device naming

### DIFF
--- a/tests/test_modules_custom.py
+++ b/tests/test_modules_custom.py
@@ -48,7 +48,7 @@ class TestModuleCustom(TestCase):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
-    @modules(module_db, allowed_dtypes=[torch.float32])
+    @modules(module_db)
     def test_eager_vs_compile(self, device, dtype, module_info, training):
         """Test eager mode vs compile mode, comparing CPU and Spyre outputs.
 
@@ -144,7 +144,7 @@ class TestModuleCustom(TestCase):
                     msg=f"{module_info.name}: Spyre eager vs Spyre compile mismatch (tensor {i})",
                 )
 
-    @modules(module_db, allowed_dtypes=[torch.float32])
+    @modules(module_db)
     def test_layout_stride(self, device, dtype, module_info, training):
         """Test module with real YAML-specified layouts and strides.
 

--- a/tests/test_modules_custom.py
+++ b/tests/test_modules_custom.py
@@ -48,7 +48,7 @@ class TestModuleCustom(TestCase):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
-    @modules(module_db)
+    @modules(module_db, allowed_dtypes=[torch.float32])
     def test_eager_vs_compile(self, device, dtype, module_info, training):
         """Test eager mode vs compile mode, comparing CPU and Spyre outputs.
 
@@ -144,7 +144,7 @@ class TestModuleCustom(TestCase):
                     msg=f"{module_info.name}: Spyre eager vs Spyre compile mismatch (tensor {i})",
                 )
 
-    @modules(module_db)
+    @modules(module_db, allowed_dtypes=[torch.float32])
     def test_layout_stride(self, device, dtype, module_info, training):
         """Test module with real YAML-specified layouts and strides.
 

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -549,14 +549,16 @@ class TestSpyre(TestCase):
         # This must not raise TypeError about MRO
         instantiate_device_type_tests(_TestMROCheck, ns, only_for=("privateuse1",))
 
-        # instantiate_device_type_tests should create a class named
-        # _TestMROCheckPRIVATEUSE1 in the namespace
-        assert "_TestMROCheckPRIVATEUSE1" in ns, (
-            f"Expected _TestMROCheckPRIVATEUSE1 in namespace, got {list(ns)}"
+        # instantiate_device_type_tests creates a class named either
+        # _TestMROCheckPRIVATEUSE1 (PT <=2.10) or _TestMROCheckSPYRE (PT 2.11+)
+        expected_names = ("_TestMROCheckPRIVATEUSE1", "_TestMROCheckSPYRE")
+        found = [n for n in expected_names if n in ns]
+        assert found, (
+            f"Expected one of {expected_names} in namespace, got {list(ns)}"
         )
 
         # The generated class should be instantiable (valid MRO)
-        cls = ns["_TestMROCheckPRIVATEUSE1"]
+        cls = ns[found[0]]
         assert issubclass(cls, TestCase)
 
     def test_device_to_device(self):

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -558,13 +558,14 @@ class TestSpyre(TestCase):
         # This must not raise TypeError about MRO
         instantiate_device_type_tests(_TestMROCheck, ns, only_for=("privateuse1",))
 
-        # instantiate_device_type_tests creates _TestMROCheckSPYRE in the namespace
-        assert "_TestMROCheckSPYRE" in ns, (
-            f"Expected _TestMROCheckSPYRE in namespace, got {list(ns)}"
-        )
+        # instantiate_device_type_tests creates a class named either
+        # _TestMROCheckPRIVATEUSE1 (PT <=2.10) or _TestMROCheckSPYRE (PT 2.11+)
+        expected_names = ("_TestMROCheckPRIVATEUSE1", "_TestMROCheckSPYRE")
+        found = [n for n in expected_names if n in ns]
+        assert found, f"Expected one of {expected_names} in namespace, got {list(ns)}"
 
         # The generated class should be instantiable (valid MRO)
-        cls = ns["_TestMROCheckSPYRE"]
+        cls = ns[found[0]]
         assert issubclass(cls, TestCase)
 
     def test_device_to_device(self):

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -558,14 +558,13 @@ class TestSpyre(TestCase):
         # This must not raise TypeError about MRO
         instantiate_device_type_tests(_TestMROCheck, ns, only_for=("privateuse1",))
 
-        # instantiate_device_type_tests creates a class named either
-        # _TestMROCheckPRIVATEUSE1 (PT <=2.10) or _TestMROCheckSPYRE (PT 2.11+)
-        expected_names = ("_TestMROCheckPRIVATEUSE1", "_TestMROCheckSPYRE")
-        found = [n for n in expected_names if n in ns]
-        assert found, f"Expected one of {expected_names} in namespace, got {list(ns)}"
+        # instantiate_device_type_tests creates _TestMROCheckSPYRE in the namespace
+        assert "_TestMROCheckSPYRE" in ns, (
+            f"Expected _TestMROCheckSPYRE in namespace, got {list(ns)}"
+        )
 
         # The generated class should be instantiable (valid MRO)
-        cls = ns[found[0]]
+        cls = ns["_TestMROCheckSPYRE"]
         assert issubclass(cls, TestCase)
 
     def test_device_to_device(self):

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -553,9 +553,7 @@ class TestSpyre(TestCase):
         # _TestMROCheckPRIVATEUSE1 (PT <=2.10) or _TestMROCheckSPYRE (PT 2.11+)
         expected_names = ("_TestMROCheckPRIVATEUSE1", "_TestMROCheckSPYRE")
         found = [n for n in expected_names if n in ns]
-        assert found, (
-            f"Expected one of {expected_names} in namespace, got {list(ns)}"
-        )
+        assert found, f"Expected one of {expected_names} in namespace, got {list(ns)}"
 
         # The generated class should be instantiable (valid MRO)
         cls = ns[found[0]]


### PR DESCRIPTION
## Summary

PT 2.11 generates test class names using the registered device name (`_TestMROCheckSPYRE`) instead of `_TestMROCheckPRIVATEUSE1`. Update the assertion to accept either name.

## Test plan

- [x] Passes on PT 2.10 (generates PRIVATEUSE1)
- [x] Passes on PT 2.11 (generates SPYRE)
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)