### PR TITLE
Allow int64→int32 type conversion during device copy operations

### DIFF
--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -435,7 +435,7 @@ at::Tensor spyre_empty(c10::IntArrayRef size,
   c10::Device device = device_opt.value_or(
       c10::impl::VirtualGuardImpl{c10::DeviceType::PrivateUse1}.getDevice());
   DEBUGINFO("shape=", size, " on Spyre ", device);
-  const auto dtype = c10::dtype_or_default(dtype_opt);
+  auto dtype = c10::dtype_or_default(dtype_opt);
   TORCH_CHECK(device.is_privateuseone());
   TORCH_CHECK(c10::layout_or_default(layout_opt) == c10::Layout::Strided,
               "Non strided layout not supported");
@@ -445,7 +445,10 @@ at::Tensor spyre_empty(c10::IntArrayRef size,
               "Spyre backend does not support dtype ", dtype);
   const c10::DeviceGuard device_guard(device);
 
-  auto device_layout = SpyreTensorLayout(size.vec(), dtype);
+  // Get the actual device scalar type (handles conversions like int64->int32)
+  auto device_dtype = getDeviceScalarType(dtype);
+
+  auto device_layout = SpyreTensorLayout(size.vec(), device_dtype);
   size_t size_bytes = get_device_size_in_bytes(device_layout);
   constexpr c10::DispatchKeySet pu1_dks(c10::DispatchKey::PrivateUse1);
   auto tensor = at::detail::make_tensor_base<SpyreTensorImpl>(
@@ -453,7 +456,7 @@ at::Tensor spyre_empty(c10::IntArrayRef size,
           c10::StorageImpl::use_byte_size_t(), size_bytes,
           &SpyreAllocator::instance(),
           /*resizeable=*/true)),
-      pu1_dks, c10::scalarTypeToTypeMeta(dtype));
+      pu1_dks, c10::scalarTypeToTypeMeta(device_dtype));
 
   auto spyre_tensor_impl =
       static_cast<SpyreTensorImpl*>(tensor.unsafeGetTensorImpl());
@@ -480,10 +483,14 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
                                std::optional<bool> pin_memory_opt) {
   // SETUP FOR Spyre TENSOR
   at::detail::check_size_nonnegative(size);
-  const auto scalar_type = c10::dtype_or_default(dtype_opt);
+  auto scalar_type = c10::dtype_or_default(dtype_opt);
   TORCH_CHECK(spyre::is_supported_dtype(scalar_type),
               "Spyre backend does not support dtype ", scalar_type);
-  caffe2::TypeMeta dtype = c10::scalarTypeToTypeMeta(scalar_type);
+
+  // Get the actual device scalar type (handles conversions like int64->int32)
+  auto device_scalar_type = getDeviceScalarType(scalar_type);
+
+  caffe2::TypeMeta dtype = c10::scalarTypeToTypeMeta(device_scalar_type);
   c10::Device device = device_opt.value_or(
       c10::impl::VirtualGuardImpl{c10::DeviceType::PrivateUse1}.getDevice());
   DEBUGINFO("Tensor info on CPU (Size:", size, ", Stride: ", stride,
@@ -523,6 +530,10 @@ at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
   at::detail::check_size_nonnegative(size);
   c10::Device device =
       c10::impl::VirtualGuardImpl{c10::DeviceType::PrivateUse1}.getDevice();
+
+  // Get the actual device scalar type (handles conversions like int64->int32)
+  auto device_dtype = getDeviceScalarType(dtype);
+
   size_t size_bytes = get_device_size_in_bytes(device_layout);
   auto spyre_storage_impl = c10::make_intrusive<SpyreStorageImpl>(
       c10::StorageImpl::use_byte_size_t(), size_bytes,
@@ -534,7 +545,8 @@ at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,
   const c10::DeviceGuard device_guard(device);
   constexpr c10::DispatchKeySet pu1_dks(c10::DispatchKey::PrivateUse1);
   auto tensor = at::detail::make_tensor_base<SpyreTensorImpl>(
-      std::move(spyre_storage), pu1_dks, c10::scalarTypeToTypeMeta(dtype));
+      std::move(spyre_storage), pu1_dks,
+      c10::scalarTypeToTypeMeta(device_dtype));
 
   auto spyre_tensor_impl =
       static_cast<SpyreTensorImpl*>(tensor.unsafeGetTensorImpl());
@@ -627,7 +639,7 @@ at::Tensor empty_with_layout(
   c10::Device device = device_opt.value_or(
       c10::impl::VirtualGuardImpl{c10::DeviceType::PrivateUse1}.getDevice());
   DEBUGINFO("shape=", size, " on Spyre ", device);
-  const auto dtype = c10::dtype_or_default(dtype_opt);
+  auto dtype = c10::dtype_or_default(dtype_opt);
   TORCH_CHECK(device.is_privateuseone());
   TORCH_CHECK(c10::layout_or_default(layout_opt) == c10::Layout::Strided,
               "Non strided layout not supported");
@@ -637,6 +649,9 @@ at::Tensor empty_with_layout(
               "Spyre backend does not support dtype ", dtype);
   const c10::DeviceGuard device_guard(device);
 
+  // Get the actual device scalar type (handles conversions like int64->int32)
+  auto device_dtype = getDeviceScalarType(dtype);
+
   size_t size_bytes = get_device_size_in_bytes(device_layout);
   constexpr c10::DispatchKeySet pu1_dks(c10::DispatchKey::PrivateUse1);
   auto tensor = at::detail::make_tensor_base<SpyreTensorImpl>(
@@ -644,7 +659,7 @@ at::Tensor empty_with_layout(
           c10::StorageImpl::use_byte_size_t(), size_bytes,
           &SpyreAllocator::instance(),
           /*resizeable=*/true)),
-      pu1_dks, c10::scalarTypeToTypeMeta(dtype));
+      pu1_dks, c10::scalarTypeToTypeMeta(device_dtype));
 
   auto spyre_tensor_impl =
       static_cast<SpyreTensorImpl*>(tensor.unsafeGetTensorImpl());

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -33,6 +33,7 @@
 #include "spyre_guard.h"
 #include "spyre_mem.h"
 #include "spyre_tensor_impl.h"
+#include "types_mapping.h"
 
 namespace spyre {
 namespace {
@@ -144,10 +145,23 @@ void SpyreStream::copyAsync(const at::Tensor& src,
   DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
 
   // TODO(tmhoangt): add type conversion node
-  // Type checking - no type conversion support yet
+  // Type checking - allow conversions where CPU type maps to different Spyre type
+  bool is_valid_conversion = false;
+  if (src.scalar_type() != dst.scalar_type()) {
+    // Check if this is a valid CPU<->Spyre type conversion
+    auto src_device_type = getDeviceScalarType(src.scalar_type());
+    auto dst_device_type = getDeviceScalarType(dst.scalar_type());
+    
+    // Valid if: src's device type == dst OR dst's device type == src
+    // This handles both CPU->Spyre and Spyre->CPU conversions
+    is_valid_conversion = (src_device_type == dst.scalar_type()) ||
+                         (dst_device_type == src.scalar_type());
+  }
+  
   TORCH_CHECK(
-      src.scalar_type() == dst.scalar_type(),
-      "Spyre backend does not support type conversion yet during copy.");
+      src.scalar_type() == dst.scalar_type() || is_valid_conversion,
+      "Spyre backend does not support type conversion during copy for types: ",
+      src.scalar_type(), " -> ", dst.scalar_type());
 
   // Determine copy direction
   bool host2device = src.is_cpu() && dst.is_privateuseone();

--- a/torch_spyre/csrc/types_mapping.h
+++ b/torch_spyre/csrc/types_mapping.h
@@ -347,6 +347,24 @@ stringToSenDatatypePair(const std::string& type_name) {
   return {sendnn::sen_datatype_enum::dt_undef,
           sendnn::sen_datatype_enum::dt_undef};
 }
+inline c10::ScalarType getDeviceScalarType(const c10::ScalarType& cpu_dtype) {
+  /* Returns the actual scalar type to use on Spyre device.
+   * For types that need conversion (e.g., int64 -> int32), returns the device
+   * type. For types that don't need conversion, returns the same type.
+   */
+  static const std::unordered_map<c10::ScalarType, c10::ScalarType>
+      dtype_conversion_map = {
+          {c10::kLong, c10::kInt},  // int64 -> int32 on Spyre
+          // Add more conversions here if needed in the future
+      };
+
+  auto it = dtype_conversion_map.find(cpu_dtype);
+  if (it != dtype_conversion_map.end()) {
+    return it->second;  // Return converted type
+  }
+  return cpu_dtype;  // No conversion needed, return same type
+}
+
 inline std::pair<size_t, size_t> elementSize(const c10::ScalarType& dtype) {
   /* return size (bytes) on CPU and on Spyre*/
   static const std::unordered_map<c10::ScalarType, std::pair<size_t, size_t>>
@@ -357,6 +375,15 @@ inline std::pair<size_t, size_t> elementSize(const c10::ScalarType& dtype) {
   if (it != itemsize_map.end()) {
     return it->second;
   }
+
+  // For types that undergo conversion, compute sizes dynamically
+  auto device_dtype = getDeviceScalarType(dtype);
+  if (device_dtype != dtype) {
+    // Type conversion occurs: return CPU size and device size
+    return {c10::elementSize(dtype), c10::elementSize(device_dtype)};
+  }
+
+  // No conversion: same size on both CPU and device
   auto val = c10::elementSize(dtype);
   return {val, val};
 }


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

### What this PR does:
Resolves RuntimeError when copying int64 tensors between CPU and Spyre device. The Spyre backend intentionally downcasts int64 to int32 due to hardware limitations, but the copy validation was rejecting this valid conversion.

**Error observed:**
```
[ERROR] prefill_position_ids shape=(1,38) int64 -> unsqueeze(0): Spyre backend does not support type conversion yet during copy.
```
**Root Cause:**
The copyAsync() function in spyre_stream.cpp was rejecting all type conversions during copy operations. However, int64→int32 is a valid, intentional conversion that the Spyre backend supports through automatic downcasting.

**Solution:**
Update the copy validation logic to allow valid type conversions that are defined in the device's type conversion map. This uses the same getDeviceScalarType() helper function introduced for the storage bounds fix.

**Implementation**
Modified copyAsync() in spyre_stream.cpp to:

- Check if source and destination types differ
- If they differ, verify it's a valid conversion using getDeviceScalarType()
- Allow the copy if the conversion is valid (e.g., int64→int32)

### Which issue(s) this PR is related to: [#2164](https://github.com/torch-spyre/torch-spyre/issues/2164)

What this fixes:
- Copying int64 tensors from CPU to Spyre device (.to('spyre'))
- Copying int64 tensors from Spyre to CPU device (.to('cpu'))
- Any copy operation involving valid type conversions
- Enables future type conversions by simply updating the conversion map

What this doesn't Change:

- The underlying int64→int32 downcast behavior - This is intentional and hardware-limited
-  Invalid type conversions - Still properly rejected (e.g., float→int without explicit conversion)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

### Additional note:
**This PR depends on the getDeviceScalarType() helper function in types_mapping.h. If that hasn't been merged yet, this PR should be merged after the storage bounds fix PR [#2163](https://github.com/torch-spyre/torch-spyre/pull/2163)**

