### PR TITLE
testing only float32 and float16 (not float64), reverting #2160

### DIFF
--- a/tests/configs/module_tests/granite_3_3_8b_instruct_spyre.yaml
+++ b/tests/configs/module_tests/granite_3_3_8b_instruct_spyre.yaml
@@ -319,6 +319,9 @@ test_suite_config:
           edits:
             modules:
               include: *id001
+            dtypes:
+              include:
+                - name: float32
   global:
     supported_dtypes:
       - name: float16

--- a/tests/module_discovery/auto_generate_module_config.py
+++ b/tests/module_discovery/auto_generate_module_config.py
@@ -712,7 +712,12 @@ def generate_unified_yaml_config(
                             ],
                             "mode": "mandatory_success",
                             "tags": [f"model__{model_name}", "custom_tests"],
-                            "edits": {"modules": {"include": module_entries}},
+                            "edits": {
+                                "modules": {"include": module_entries},
+                                "dtypes": {
+                                    "include": [{"name": "float32"}],
+                                },
+                            },
                         }
                     ],
                 },

--- a/tests/test_modules_custom.py
+++ b/tests/test_modules_custom.py
@@ -48,7 +48,7 @@ class TestModuleCustom(TestCase):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
-    @modules(module_db, allowed_dtypes=[torch.float32])
+    @modules(module_db)
     def test_eager_vs_compile(self, device, dtype, module_info, training):
         """Test eager mode vs compile mode, comparing CPU and Spyre outputs.
 
@@ -144,7 +144,7 @@ class TestModuleCustom(TestCase):
                     msg=f"{module_info.name}: Spyre eager vs Spyre compile mismatch (tensor {i})",
                 )
 
-    @modules(module_db, allowed_dtypes=[torch.float32])
+    @modules(module_db)
     def test_layout_stride(self, device, dtype, module_info, training):
         """Test module with real YAML-specified layouts and strides.
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Restricts test_modules_custom.py tests to float32 dtype via YAML config and reverting #2160 

#### Which issue(s) this PR is related to:

#2161 
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
