### PR TITLE
propagate_layouts: handle ComputedBuffer with no inputs

### DIFF
--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -556,7 +556,10 @@ def propagate_spyre_tensor_layouts(
             output_dep = next(iter(rw.writes))
             args = _get_prop_args(rw.reads)
             output = op.get_layout()
-            if isinstance(op.data, (Pointwise, Reduction)):
+            if not args:
+                op.layouts = [generic_layout(op)]
+                op.restick_cost_fn = AnyInNode.from_args()
+            elif isinstance(op.data, (Pointwise, Reduction)):
                 op.layouts = compute_layouts(op, output, output_dep, args)
             else:
                 logger.warning(f"Warning: unhandled node type {type(op.data)}")


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:


Fixes the crash reported in #98 showing a stack trace [here](https://github.com/torch-spyre/torch-spyre/issues/98#issuecomment-4482109937).

The error was not torch.where itself, but the 0-d `aten.full([], scalar)` that PyTorch generates when promoting a scalar argument to a tensor before lowering where. This produced a ComputedBuffer with no inputs, causing propagate_layouts to crash with an IndexError on args[0]. Fix: treat any no-input op as generic_layout / AnyInNode.
#### Which issue(s) this PR is related to:
#98

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
