### PR TITLE
feat(test): Add spyre (OOT) utility method for printing per test per op tags alonside PASS/SKIP/XFAIL etc inside test file

### DIFF
--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -38,6 +38,7 @@ from spyre_test_config_models import (
     TestEntry,
 )
 from spyre_test_parsing import load_yaml_config, resolve_current_file
+from spyre_test_utilities import print_test_tags_oot
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +292,8 @@ class TestSpyreModelOps(TestCase):
 
     @ops(model_ops_db)
     def test_model_ops_db(self, device: str, dtype: torch.dtype, op: ModelOpInfo):
+        # Usage: call `print_test_tags()` from our framework to print tags assosiated per method
+        print_test_tags_oot(self, op_tags=op.op_tags)
         pytestconfig = shared_config._PYTEST_CONFIG
         assert pytestconfig is not None, (
             "shared_config._PYTEST_CONFIG is None — "

--- a/tests/spyre_test_base_common.py
+++ b/tests/spyre_test_base_common.py
@@ -8,7 +8,6 @@ import json
 from typing import Dict, List, Optional, Set
 import warnings
 
-
 import pytest  # type: ignore
 import torch
 
@@ -447,8 +446,10 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         # print tags to stderr
         entry = cls.TEST_ENTRIES.get(name)
         tags = entry.tags if entry is not None else []
-        # Collect op-level tags from all OpsNamedItem entries in this TestEntry
-        # and union them with test-level tags so pytest -m works for both levels.
+        # test-level tags only — used for method_tags assembly
+        all_tags = tags
+
+        # Collect op-level tags for collection-time summary print ONLY
         op_tags: List[str] = []
         if entry is not None:
             seen_op_tags: set = set()
@@ -458,20 +459,23 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                         seen_op_tags.add(t)
                         op_tags.append(t)
 
-        # Union: test-level tags + op-level tags (deduplicated)
-        all_tags = tags + [t for t in op_tags if t not in set(tags)]
-        if all_tags:
+        # Print summary at collection time
+        summary_tags = tags + [t for t in op_tags if t not in set(tags)]
+        if summary_tags:
             if generic_cls is not None:
                 os.write(
                     2,
                     f"[OOTDeviceTestBase] {generic_cls.__name__}::{name} "
-                    f"tags: [{', '.join(all_tags)}]\n".encode(),
+                    f"tags: [{', '.join(summary_tags)}]\n".encode(),
                 )
             else:
                 _log_warning(
-                    f"Test '{name}' has tags {all_tags} but generic_cls is None, "
+                    f"Test '{name}' has tags {summary_tags} but generic_cls is None, "
                     f"cannot print tag information"
                 )
+
+        # Store test-level tags only — op-level tags added per-occurrence at run time
+        cls._TEST_LEVEL_TAGS = list(tags)
 
         # op list filtering
         supported_ops = cls._get_supported_ops()
@@ -628,12 +632,19 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                     }
                 )
 
-            method_tags = all_tags + [t for t in dynamic_tags if t not in set(all_tags)]
+            seen = set(all_tags)
+            method_tags = list(all_tags)
+            for t in dynamic_tags:
+                if t not in seen:
+                    seen.add(t)
+                    method_tags.append(t)
 
             # apply all tags (YAML + dynamic) as marks
             if method_tags:
                 existing_fn = cls.__dict__.get(method_name)
                 if existing_fn is not None:
+                    # Store BEFORE marking so the attribute is on the base function
+                    existing_fn._spyre_method_tags = method_tags
                     marked_fn = existing_fn
                     for tag in method_tags:
                         marked_fn = pytest.mark.__getattr__(tag)(marked_fn)

--- a/tests/spyre_test_utilities.py
+++ b/tests/spyre_test_utilities.py
@@ -23,6 +23,29 @@ except ImportError as _yaml_err:  # pragma: no cover
     ) from _yaml_err
 
 
+"""
+Utility for printing per-test tags at run time alongside PASS/FAIL output.
+"""
+
+
+def print_test_tags_oot(test_instance, op_tags: List[str] = []) -> None:
+    """Print [TAGS = ...] for a test method at run time.
+
+    Combines method-level tags (test-level + dynamic op__/dtype__/module__) stored
+    at collection time with per-op tags available only at run time.
+
+    Usage in a test method:
+        from spyre_test_utilities import print_test_tags_oot
+        print_test_tags_oot(self, op_tags=op.op_tags)
+    """
+    method_name = test_instance._testMethodName
+    _method_fn = getattr(test_instance.__class__, method_name, None)
+    _method_tags = getattr(_method_fn, "_spyre_method_tags", [])
+    _per_op_tags = [t for t in op_tags if t not in set(_method_tags)]
+    _all_tags = _method_tags + _per_op_tags
+    os.write(2, f"[TAGS = {' '.join(_all_tags)}]\n".encode())
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR aadds helper method to print per-test tags at run time alongside PASS/FAIL output. 

`spyre_test_base_common.py`

- Stores test-level + dynamic tags on each instantiated method as _spyre_method_tags at collection time
- Keeps a separate summary_tags for the existing collection-time [OOTDeviceTestBase] print (includes all op tags for visibility) `all_tags` for method_tags assembly stays test-level only to avoid merging per-occurrence op tags


`spyre_test_utilities.py`

- Adds print_test_tags_oot(test_instance, op_tags=[]) utility
- Combines _spyre_method_tags (collection-time) with op_tags (run-time per-occurrence) into a single [TAGS = ...] line on   stderr


`test_model_ops_v2.py`

Calls `print_test_tags_oot(self, op_tags=op.op_tags)` at the start of test_model_ops_db


#### Output (Run with `-s` flag to see the print on stdout from pytest) 
```bash
 bash run_test.sh configs/model_ops_tests/gpt_oss_20b_spyre.yaml -v -s
 ```

 ##### Part of the run snippet with the above command:
 
<img width="2846" height="224" alt="image" src="https://github.com/user-attachments/assets/91d54a4c-bc56-4cd6-a345-85caa9bba058" /> <br><br>

 
 or to run with per level op tag
 
 ```bash
 bash run_test.sh configs/model_ops_tests/gpt_oss_20b_spyre.yaml --model torch.add.4
 ```
 
 ```bash
 bash run_test.sh configs/model_ops_tests/gpt_oss_20b_spyre.yaml -v -m "op__torch_add or op__torch_sub" -s
 ```

 
<img width="3450" height="904" alt="image" src="https://github.com/user-attachments/assets/183055fa-c7b1-4825-98da-96ce74918e9b" />

