### PR TITLE
Fix null byte in debug prints (spyre_stream.cpp)

### DIFF
--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -111,7 +111,7 @@ bool SpyreStream::query() const {
   c10::DeviceGuard guard(stream_.device());
 
   DEBUGINFO("SpyreStream::query() - stream ", id(), " on device ",
-            device().index());
+            static_cast<int>(device().index()));
 
   flex::RuntimeStream* handle = getRuntimeHandle();
   return handle->query();
@@ -121,7 +121,7 @@ void SpyreStream::synchronize() const {
   c10::DeviceGuard guard(stream_.device());
 
   DEBUGINFO("SpyreStream::synchronize() - stream ", id(), " on device ",
-            device().index());
+            static_cast<int>(device().index()));
 
   flex::RuntimeStream* handle = getRuntimeHandle();
   handle->synchronize();


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When debug prints are enabled, we see a null byte character `'\0'` in the debug logs like this:

```
[ synchronize ]  SpyreStream::synchronize() - stream  0  on device  ^@
```

This prevents us from using `grep` to filter the output:
```bash
$ TORCH_SPYRE_DEBUG=1 python example.py 2>&1 | grep Error
grep: (standard input): binary file matches
```

https://github.com/torch-spyre/torch-spyre/blob/f78ff36943ac0fb387f543fde1adb9aca43bd232/torch_spyre/csrc/spyre_stream.cpp#L113-L114

This comes from the code above, where `index()` returns an `int8_t` value, which is printed as a character, not an integer.

https://github.com/pytorch/pytorch/blob/v2.11.0/c10/core/Device.h#L19
```cpp
using DeviceIndex = int8_t;
```

With this PR, we will get the expected output like this:
```
[ synchronize ]  SpyreStream::synchronize() - stream  0  on device  0
```


#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
