### PR TITLE
feat(test):print tags side by side to live test execution without -s flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,38 @@ import pytest
 
 
 import shared_config
+from spyre_test_utilities import _RUNTIME_TAGS
+
+
+# Attaches per-test tags to the pytest report object after each test call.
+# Tags come from _RUNTIME_TAGS (set by print_test_tags_oot during test execution,
+# includes per-occurrence op tags) with fallback to _spyre_method_tags
+# (set at collection time, includes test-level + dynamic op__/dtype__ markers).
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    if call.when == "call":
+        method_name = getattr(item, "originalname", None) or item.name
+        tags = _RUNTIME_TAGS.get(method_name, [])
+        if not tags:
+            fn = getattr(item, "function", None) or getattr(item, "obj", None)
+            tags = getattr(fn, "_spyre_method_tags", [])
+        if tags:
+            # Store on report for use in logreport hook
+            rep._spyre_tags = tags
+
+
+# Prints [TAGS = ...] for every test alongside the result line.
+# Uses os.write(1, ...) to write directly to stdout fd, bypassing pytest's output
+# capture visible without -s. Fires after pytest_runtest_makereport so tags
+# are already attached to the report.
+def pytest_runtest_logreport(report):
+    if report.when == "call":
+        tags = getattr(report, "_spyre_tags", None)
+        if tags:
+            # Write directly to terminal
+            os.write(1, f"  [TAGS = {' '.join(tags)}]\n".encode())
 
 
 def _get_case_marks(case: dict) -> set[str]:

--- a/tests/spyre_test_utilities.py
+++ b/tests/spyre_test_utilities.py
@@ -27,6 +27,9 @@ except ImportError as _yaml_err:  # pragma: no cover
 Utility for printing per-test tags at run time alongside PASS/FAIL output.
 """
 
+# To store method_name -> full tag list set during test execution
+_RUNTIME_TAGS: Dict[str, List[str]] = {}
+
 
 def print_test_tags_oot(test_instance, op_tags: List[str] = []) -> None:
     """Print [TAGS = ...] for a test method at run time.
@@ -43,6 +46,9 @@ def print_test_tags_oot(test_instance, op_tags: List[str] = []) -> None:
     _method_tags = getattr(_method_fn, "_spyre_method_tags", [])
     _per_op_tags = [t for t in op_tags if t not in set(_method_tags)]
     _all_tags = _method_tags + _per_op_tags
+    # Store for pytest_runtest_makereport hook to work without -s
+    _RUNTIME_TAGS[method_name] = _all_tags
+    # Also write directly to stderr (visible with -s)
     os.write(2, f"[TAGS = {' '.join(_all_tags)}]\n".encode())
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds [TAGS = ...] output for every test result without requiring -s. 
Tags are collected from two sources:  
- `_RUNTIME_TAGS` (populated at run time by print_test_tags_oot, incldes per-occurrence op tags like torch.add.4)
- `_spyre_method_tags` (set at collection time, includes test-level and dynamic op__/dtype__ markers). Uses os.write(1, ...) via `pytest_runtest_logreport` to bypass pytest's output capture.

#### Running example:

```bash
 bash run_test.sh configs/model_ops_tests/gpt_oss_20b_spyre.yaml -v
```

##### Output:
<img width="3456" height="1786" alt="image" src="https://github.com/user-attachments/assets/84c991ab-8935-457f-994c-665f4751d1a1" />
