### PR TITLE
Fix spurious `insert_bmm_padding` warning during decode-phase attention

### DIFF
--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -221,6 +221,23 @@ def insert_bmm_padding(operations: list[Operation]) -> None:
         if len(reads) != 2:  # noqa: PLR2004
             continue
 
+        # Skip aligned-K matmuls early before any x/y identification.
+        # Aligned-K matmuls need no padding regardless of input layout, and
+        # skipping here avoids a spurious warning for e.g. decode-phase SDPA
+        # attention where out_coords has a constant-folded M dimension that
+        # makes reduction_coord detection fail for both inputs.
+        k_val = concretize_expr(reduction.reduction_ranges[0])
+        first_buf = next(
+            (V.graph.get_buffer(d.name) for d in reads if V.graph.get_buffer(d.name)),
+            None,
+        )
+        assert first_buf is not None, (
+            f"insert_bmm_padding: no input buffer found for matmul {op.get_name()}"
+        )
+        dtype = first_buf.get_dtype()
+        if compute_padding(k_val, dtype) == 0:
+            continue
+
         # Identify x and y via device_coordinates.
         # x is the input sticked on the reduction coord (hardware masks within-stick
         # padding for x).  y is the other input; its K host dim is derived from the
@@ -280,14 +297,9 @@ def insert_bmm_padding(operations: list[Operation]) -> None:
         # the inner_fn accesses x through a view with more dims than x_buf
         # (e.g. when mm_to_bmm_pass wraps a 2D mm into a 3D bmm).
         output_ranges = [concretize_expr(s) for s in reduction.ranges]
-        k_val = concretize_expr(reduction.reduction_ranges[0])
         x_size = output_ranges[:-1] + [k_val]  # [batch..., M, K]
-        dtype = x_buf.get_dtype()
         device = x_buf.get_device()
-
         pad = compute_padding(k_val, dtype)
-        if pad == 0:
-            continue
 
         # Find the FX node/TensorBox that presents x at x_size dimensionality.
         # mm_to_bmm_pass may wrap a 2D x buffer with a 3D view; we need the


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

##### Problem

When running inference with a model that uses decode-phase attention (e.g.
granite-3.3-8b-instruct), `insert_bmm_padding` emits a spurious warning for
every generated token:

```
[WARNING] [padding] insert_bmm_padding: could not identify x/y for buf33, skipping
```

The warning fires because the x/y identification logic can fail for
decode-phase SDPA attention matmuls even though they need no padding.

###### Root cause

The x/y identification loop in `insert_bmm_padding` works by finding the
reduction symbol (K) in each input's `host_coordinates` — specifically, the
first coordinate with free symbols that does not appear in `out_coords`.

For decode-phase attention, Q has shape `[B, H, 1, D]` with sequence length
`M=1`. Inductor constant-folds M to `0` in the index expressions, so the
matmul's output coordinates become `[0, d_H, 0, d_N]` (two constant zeros)
rather than containing a variable M symbol. With M absent from `out_coords`,
the K symbol in Q's coordinates (`h_coords = [0, d_H, 0, d_K]`) is
indistinguishable from an output coordinate by the `matching_dim` check —
`reduction_coord` resolves to `None` for both inputs, neither `x_dep` nor
`y_dep` is set, and the warning fires.

This is entirely harmless in practice: these matmuls have K=D (e.g. 128 for
granite), which is already stick-aligned, so no padding is needed and the pass
would have skipped them via `pad == 0` anyway. The warning only fired because
the `pad == 0` check was placed *after* the x/y identification loop rather
than before it.

##### Fix

Move the `k_val` / `dtype` / `pad == 0` computation to the top of the
per-matmul loop body, before any x/y identification is attempted. Aligned-K
matmuls now exit immediately and silently via `continue`.

As a secondary improvement, the `first_buf is None` fallback is changed from a
silent `continue` to an `assert`. `V.graph.get_buffer` returning `None` for
both inputs of a `BATCH_MATMUL_OP` that survived dead-code elimination would
indicate a graph invariant violation; asserting surfaces the problem instead of
hiding it.

The duplicate `k_val`, `dtype`, and `pad == 0` check that formerly appeared
later in the function body are removed since they are now redundant.

##### Testing

- `tests/inductor/test_padding.py` — all 10 existing tests pass unchanged.
  The aligned-K path (`test_mm_aligned_k_no_padding`) exercises the new
  early-exit; no new tests are needed since the bug was a noisy log line, not
  incorrect behaviour.
- Manually reproduced the warning with a decode-phase SDPA attention
  (`[B, H, 1, D] × [B, H, D, S]` with K=128) and confirmed it is suppressed
  after this fix.
- Manually ran `run_granite_fms.sh ` and verified correct execution and no spurious warning message.

#### Which issue(s) this PR is related to:

#843 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
