### PR TITLE
Finding reduction dimension in matmul/exx2/layernorm/topk 

### DIFF
--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -281,6 +281,69 @@ def _layernormnorm_layout(
     return [out_stl]
 
 
+def _matmul_find_req_stl(
+    arg: "PropArg",
+    arg_coords,
+    target_coord,
+    reduction_type: str,
+    label: str,
+) -> "SpyreTensorLayout":
+    """Find the required STL for a matmul input by iterating all candidate layouts.
+
+    1. Return the first layout whose stick is already on target_coord (zero cost).
+    2. Else return the first layout that can be restickified to target_coord.
+    3. Else raise Unsupported.
+    """
+    arg_dev_coords = [device_coordinates(stl, arg.dep) for stl in arg.layouts]
+    target_dim = matching_dim(arg_coords, target_coord)
+
+    # Pass 1: already stick-compatible
+    for stl, dev_coords in zip(arg.layouts, arg_dev_coords):
+        if matching_dim(arg_coords, dev_coords[-1]) == target_dim:
+            return stl
+
+    # Pass 2: can be restickified
+    for stl, dev_coords in zip(arg.layouts, arg_dev_coords):
+        result = compute_restickify_target_layout(
+            stl, arg.layout, target_coord, arg_coords, dev_coords
+        )
+        if result is not None:
+            return result
+
+    raise Unsupported(
+        f"{reduction_type}: cannot restickify {label} to {label}_coord={target_coord}"
+    )
+
+
+def _matmul_reduction_coord(x_coords, out_coords):
+    """K dim: resolvable x coord whose loop variable does not appear in output."""
+    x_syms = {s for c in x_coords for s in c.free_symbols}
+    out_syms = {s for c in out_coords for s in c.free_symbols}
+    reduction_syms = x_syms - out_syms
+    if len(reduction_syms) != 1:
+        raise Unsupported(f"matmul: expected 1 reduction symbol, got {reduction_syms}")
+    sym = next(iter(reduction_syms))
+    return next(
+        c for c in x_coords
+        if sym in c.free_symbols and matching_dim(x_coords, c) is not None
+    )
+
+
+def _matmul_generated_coord(y_coords, x_coords, out_coords):
+    """N dim: resolvable y coord whose loop variable appears in output but not in x."""
+    y_syms = {s for c in y_coords for s in c.free_symbols}
+    x_syms = {s for c in x_coords for s in c.free_symbols}
+    out_syms = {s for c in out_coords for s in c.free_symbols}
+    generated_syms = (y_syms & out_syms) - x_syms
+    if len(generated_syms) != 1:
+        raise Unsupported(f"matmul: expected 1 generated symbol, got {generated_syms}")
+    sym = next(iter(generated_syms))
+    return next(
+        c for c in y_coords
+        if sym in c.free_symbols and matching_dim(y_coords, c) is not None
+    )
+
+
 def _matmul_layouts(
     op: Operation,
     output: FixedLayout,
@@ -290,79 +353,27 @@ def _matmul_layouts(
     """
     Matmul has fixed in/out stick requirements so handled specially.
     Algorithm is
-       1. For both input args, compuate a layout that is representative
-       2. For output arg, compute the output layout
-       3. Construct the FixdInOutNode cost function
+       1. Compute reduction_coord (K) and generated_coord (N) from host geometry
+       2. For both input args, find a required STL with the correct stick
+       3. Compute the output STL and construct the FixedInOutNode cost function
     """
     data = op.data
     out_coords = host_coordinates(output, output_dep)
 
     x = args[0]
     y = args[1]
-    x_stl = next(iter(x.layouts))
-    y_stl = next(iter(y.layouts))
     x_coords = host_coordinates(x.layout, x.dep)
-    x_dev_coords = device_coordinates(x_stl, x.dep)
     y_coords = host_coordinates(y.layout, y.dep)
-    y_dev_coords = device_coordinates(y_stl, y.dep)
-
-    x_stick_expr = x_dev_coords[-1]
-    y_stick_expr = y_dev_coords[-1]
-    if (
-        matching_dim(x_coords, x_stick_expr) is None
-        or matching_dim(y_coords, y_stick_expr) is None
-    ):
-        raise Unsupported(
-            f"{data.reduction_type}: failed to map stick_dims to host coords"
-        )
 
     # Hardware stick constraints (DF16):
     #   Input1 (x): stick on reduction_dim (the x coord that does NOT appear in output)
     #   Input2 (y): stick on generated_dim (the y coord that appears in output)
     #   Output:     stick on generated_dim
-    if matching_dim(out_coords, x_stick_expr) is not None:
-        reduction_coord = next(
-            c
-            for c in x_coords
-            if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is None
-        )
-    else:
-        reduction_coord = x_stick_expr
+    reduction_coord = _matmul_reduction_coord(x_coords, out_coords)
+    generated_coord = _matmul_generated_coord(y_coords, x_coords, out_coords)
 
-    if matching_dim(out_coords, y_stick_expr) is None:
-        generated_coord = next(
-            c
-            for c in y_coords
-            if len(c.free_symbols) > 0
-            and matching_dim(out_coords, c) is not None
-            and matching_dim(x_coords, c) is None
-        )
-    else:
-        generated_coord = y_stick_expr
-
-    if reduction_coord == x_dev_coords[-1]:
-        x_req_stl = x_stl
-    else:
-        _x = compute_restickify_target_layout(
-            x_stl, x.layout, reduction_coord, x_coords, x_dev_coords
-        )
-        if _x is None:
-            raise Unsupported(
-                f"{data.reduction_type}: cannot restickify x to reduction_coord={reduction_coord}"
-            )
-        x_req_stl = _x
-
-    if generated_coord == y_dev_coords[-1]:
-        y_req_stl = y_stl
-    else:
-        _y = compute_restickify_target_layout(
-            y_stl, y.layout, generated_coord, y_coords, y_dev_coords
-        )
-        if _y is None:
-            raise Unsupported(
-                f"{data.reduction_type}: cannot restickify y to generated_coord={generated_coord}"
-            )
-        y_req_stl = _y
+    x_req_stl = _matmul_find_req_stl(x, x_coords, reduction_coord, data.reduction_type, "x")
+    y_req_stl = _matmul_find_req_stl(y, y_coords, generated_coord, data.reduction_type, "y")
 
     out_stick_dim = matching_dim(out_coords, generated_coord)
     if out_stick_dim is None:

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -222,27 +222,6 @@ def _single_arg_op_layout(
                 return SpyreTensorLayout(c_size, c_stride, output.dtype, dim_order)
 
 
-def _stick_on_last_dim_req_stl(
-    arg: PropArg,
-) -> SpyreTensorLayout:
-    """Build the required-input STL with stick on arg's last logical dim."""
-    x_coords = host_coordinates(arg.layout, arg.dep)
-    last_dim_coord = x_coords[-1]
-    candidate = next(iter(arg.layouts))
-    cand_dev_coords = device_coordinates(candidate, arg.dep)
-    # Compare iter var ids: stick exprs may be wrapped (e.g. Mod(d1, 64)).
-    if iter_var_id(cand_dev_coords[-1]) == iter_var_id(last_dim_coord):
-        return candidate
-    req = compute_restickify_target_layout(
-        candidate, arg.layout, last_dim_coord, x_coords, cand_dev_coords
-    )
-    if req is None:
-        raise Unsupported(
-            f"cannot restickify to last logical dim (host_size={list(arg.layout.size)})"
-        )
-    return req
-
-
 def _exx2_layout(
     op: Operation,
     output: FixedLayout,
@@ -253,11 +232,14 @@ def _exx2_layout(
     Use FixedInOutNode to schedule a restickify if the input stick is elsewhere.
     """
     x = args[0]
+    x_coords = host_coordinates(x.layout, x.dep)
     out_dim_order = list(range(len(output.size))) + [-1]
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
     out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
-    req_in_stl = _stick_on_last_dim_req_stl(x)
+    req_in_stl = find_stick_compatible_input_layout(
+        x, x_coords, x_coords[-1], "exx2", "x"
+    )
     op.restick_cost_fn = FixedInOutNode.from_args(args, out_stl, [req_in_stl])
     return [out_stl]
 
@@ -272,16 +254,19 @@ def _layernormnorm_layout(
     Use FixedInOutNode to schedule a restickify if x's stick is elsewhere.
     """
     x = args[0]
+    x_coords = host_coordinates(x.layout, x.dep)
     out_dim_order = list(range(len(output.size)))
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
     out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
-    req_in_stl = _stick_on_last_dim_req_stl(x)
+    req_in_stl = find_stick_compatible_input_layout(
+        x, x_coords, x_coords[-1], "layernormnorm", "x"
+    )
     op.restick_cost_fn = FixedInOutNode.from_args(args[:1], out_stl, [req_in_stl])
     return [out_stl]
 
 
-def _matmul_find_req_stl(
+def find_stick_compatible_input_layout(
     arg: "PropArg",
     arg_coords,
     target_coord,
@@ -311,36 +296,30 @@ def _matmul_find_req_stl(
             return result
 
     raise Unsupported(
-        f"{reduction_type}: cannot restickify {label} to {label}_coord={target_coord}"
+        f"{reduction_type}: cannot restickify any input layout of {label} to {label}_coord={target_coord}"
     )
 
 
-def _matmul_reduction_coord(x_coords, out_coords):
-    """K dim: resolvable x coord whose loop variable does not appear in output."""
-    x_syms = {s for c in x_coords for s in c.free_symbols}
-    out_syms = {s for c in out_coords for s in c.free_symbols}
-    reduction_syms = x_syms - out_syms
-    if len(reduction_syms) != 1:
-        raise Unsupported(f"matmul: expected 1 reduction symbol, got {reduction_syms}")
-    sym = next(iter(reduction_syms))
+def _find_reduction_coord(x_coords, out_coords):
+    """Reduction coord: x coord absent from output and resolvable in x."""
     return next(
-        c for c in x_coords
-        if sym in c.free_symbols and matching_dim(x_coords, c) is not None
+        c
+        for c in x_coords
+        if len(c.free_symbols) > 0
+        and matching_dim(out_coords, c) is None
+        and matching_dim(x_coords, c) is not None
     )
 
 
 def _matmul_generated_coord(y_coords, x_coords, out_coords):
-    """N dim: resolvable y coord whose loop variable appears in output but not in x."""
-    y_syms = {s for c in y_coords for s in c.free_symbols}
-    x_syms = {s for c in x_coords for s in c.free_symbols}
-    out_syms = {s for c in out_coords for s in c.free_symbols}
-    generated_syms = (y_syms & out_syms) - x_syms
-    if len(generated_syms) != 1:
-        raise Unsupported(f"matmul: expected 1 generated symbol, got {generated_syms}")
-    sym = next(iter(generated_syms))
+    """N dim: y coord present in output, absent from x, and resolvable in y."""
     return next(
-        c for c in y_coords
-        if sym in c.free_symbols and matching_dim(y_coords, c) is not None
+        c
+        for c in y_coords
+        if len(c.free_symbols) > 0
+        and matching_dim(out_coords, c) is not None
+        and matching_dim(x_coords, c) is None
+        and matching_dim(y_coords, c) is not None
     )
 
 
@@ -369,11 +348,15 @@ def _matmul_layouts(
     #   Input1 (x): stick on reduction_dim (the x coord that does NOT appear in output)
     #   Input2 (y): stick on generated_dim (the y coord that appears in output)
     #   Output:     stick on generated_dim
-    reduction_coord = _matmul_reduction_coord(x_coords, out_coords)
+    reduction_coord = _find_reduction_coord(x_coords, out_coords)
     generated_coord = _matmul_generated_coord(y_coords, x_coords, out_coords)
 
-    x_req_stl = _matmul_find_req_stl(x, x_coords, reduction_coord, data.reduction_type, "x")
-    y_req_stl = _matmul_find_req_stl(y, y_coords, generated_coord, data.reduction_type, "y")
+    x_req_stl = find_stick_compatible_input_layout(
+        x, x_coords, reduction_coord, data.reduction_type, "x"
+    )
+    y_req_stl = find_stick_compatible_input_layout(
+        y, y_coords, generated_coord, data.reduction_type, "y"
+    )
 
     out_stick_dim = matching_dim(out_coords, generated_coord)
     if out_stick_dim is None:
@@ -487,11 +470,7 @@ def _topk_layouts(
     out_coords = host_coordinates(output, output_dep)
 
     # Reduction coordinate: in x's host coords but absent from output's host coords.
-    reduction_coord = next(
-        c
-        for c in x_coords
-        if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is None
-    )
+    reduction_coord = _find_reduction_coord(x_coords, out_coords)
     reduction_dim = matching_dim(x_coords, reduction_coord)
 
     # Coords that survive the reduction into the output.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Matmul/exx2/layernorm/topk all have code that tries to find a fixed dimension (reduction, generation, etc).  Nearly all shared multiple problems:

1. They found the reduction dim in different ways, and each had different bugs.  Most would fail on some granite examples with host-dimension tiling.   matmul was  a strange implementation to avoid that granite failure.
2. They considered only the first of the input STLs to try to find a representative target STL.  If the first STL could not be restickified to the desired target, they would fail, rather than consider the next input STL

This PR creates some common helpers to bring the implementations in line and remove the latent bugs from all of them

Granite runs properly 

#### Which issue(s) this PR is related to:
#843
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

I'm worried about our heavy reliance on `matching_dim` throughout many of these cases. But it pre-existed this PR and I think we can address it in a future pass