### PR TITLE
fix(test): per-variant tag resolution for multi-config merged runs using the OOT test framework

### DIFF
--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -330,6 +330,7 @@ class TestSpyreModelOps(TestCase):
                 op_name,
                 repr(ops_item.sample_inputs_func.args),
                 repr(ops_item.sample_inputs_func.kwargs),
+                dtype,  # variants with different runtime dtypes are distinct test cases
             )
             if dedup_key in seen_case_keys:
                 pytest.skip(

--- a/tests/spyre_test_base_common.py
+++ b/tests/spyre_test_base_common.py
@@ -112,26 +112,97 @@ def remove_builtin_privateuse1_test_base():
 remove_builtin_privateuse1_test_base()
 
 
-def _build_test_entry_map(file_entry: FileEntry) -> Dict[str, TestEntry]:
-    """Build {method_name -> TestEntry} from file_entry.tests.
+# ---------------------------------------------------------------------------
+# Multi-entry test map helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_test_entry_map(file_entry: FileEntry) -> Dict[str, List["TestEntry"]]:
+    """Build {method_name -> [TestEntry, ...]} from file_entry.tests.
 
     A single TestEntry can cover multiple test ids via name: [list].
-    Each method_name in the list gets its own entry in the map pointing
-    to the same TestEntry object so _should_run() can look up by method_name.
+    Each method_name in the list gets its own entry in the map.
+
+    This supports multiple TestEntry objects per method_name.
+    This is needed when two configs target the same test name with different tags/dtypes
+    (e.g. the same op tested for two different models).
+    The correct entry for a given variant is resolved later by ``_select_entry_for_variant``
+    once the dtype is known from the instantiated method name.
     """
-    result: Dict[str, TestEntry] = {}
+    result: Dict[str, List[TestEntry]] = {}
     for entry in file_entry.tests:
         for method_name in entry.method_names():
-            if method_name in result:
-                import warnings
-
-                warnings.warn(
-                    f"test method {method_name!r} appears in multiple TestEntry "
-                    f"blocks in the YAML. The last entry will take precedence.",
-                    stacklevel=2,
-                )
-            result[method_name] = entry
+            result.setdefault(method_name, []).append(entry)
     return result
+
+
+def _entry_dtype_set(
+    entry: "TestEntry",
+    global_supported_dtypes: Optional[Set[torch.dtype]],
+) -> Optional[Set[torch.dtype]]:
+    """Return the effective dtype set for *entry*.
+
+    Priority (highest to lowest):
+      1. entry.edits.dtypes.include  -- explicit per-entry dtype list
+      2. global_supported_dtypes     -- global filter from the YAML global section
+      3. None                        -- no filtering; all dtypes match
+
+    Returns None when neither the entry nor the global config restricts dtypes,
+    meaning the entry is considered compatible with any dtype.
+    """
+    included = entry.edits.dtypes.resolved_include()
+    if included:
+        return included
+    return global_supported_dtypes  # may itself be None
+
+
+def _select_entry_for_variant(
+    entries: List["TestEntry"],
+    method_name: str,
+    global_supported_dtypes: Optional[Set[torch.dtype]],
+) -> "TestEntry":
+    """Pick the best-matching TestEntry for a concrete variant method name.
+
+    When only one entry exists the choice is trivial.  When multiple entries
+    share the same base test name merged from different configs we select
+    by matching the dtype embedded in *method_name* against each entry's
+    effective dtype set.
+
+    Selection rules:
+      1. Entry whose effective dtype set contains the variant's dtype.
+      2. Entry with no dtype restriction (effective set is None) acts as
+         a wildcard / fallback.
+      3. First entry in the list (last-resort fallback to old behaviour).
+
+    The list order reflects YAML insertion order so config-A entries take
+    precedence over config-B entries for identical dtype sets.
+    """
+    if len(entries) == 1:
+        return entries[0]
+
+    dtype_str = extract_dtype_from_name(method_name)
+    variant_dtype: Optional[torch.dtype] = None
+    if dtype_str:
+        try:
+            variant_dtype = parse_dtype(dtype_str)
+        except ValueError:
+            pass
+
+    # Pass 1 - strict dtype match
+    if variant_dtype is not None:
+        for entry in entries:
+            eset = _entry_dtype_set(entry, global_supported_dtypes)
+            if eset is not None and variant_dtype in eset:
+                return entry
+
+    # Pass 2 - wildcard entry (no dtype restriction)
+    for entry in entries:
+        eset = _entry_dtype_set(entry, global_supported_dtypes)
+        if eset is None:
+            return entry
+
+    # Pass 3 - fallback: return first entry
+    return entries[0]
 
 
 def _extract_op_name_from_method(
@@ -172,7 +243,8 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
     device_type: str = "privateuse1"
     precision: float = DEFAULT_FLOATING_PRECISION
 
-    TEST_ENTRIES: Dict[str, "TestEntry"] = {}  # {method_name -> TestEntry}
+    # multiple configs targeting the same test name with different tags/dtypes.
+    TEST_ENTRIES: Dict[str, List["TestEntry"]] = {}  # {method_name -> [TestEntry, ...]}
     UNLISTED_TEST_MODE: str = UNLISTED_MODE_XFAIL  # file-level default
     SUPPORTED_OPS_CONFIG: Dict[str, "SupportedOpConfig"] = {}  # {op_name -> config}
     SUPPORTED_MODULES_CONFIG: Dict[
@@ -232,6 +304,8 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
 
         file_entry: FileEntry = resolve_current_file(config, path)
 
+        # Build multi-entry map: same method_name can have multiple TestEntry
+        # objects when configs differ in tags/dtypes for the same test.
         cls.TEST_ENTRIES = _build_test_entry_map(file_entry)
         cls.UNLISTED_TEST_MODE = file_entry.unlisted_test_mode
 
@@ -366,13 +440,26 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         method_name: str,
         base_test_name: str,
         generic_cls_name: str,
+        entry: Optional["TestEntry"] = None,
     ) -> tuple:
         """Decide the behaviour of test variant based on config modes.
 
+        The ``entry`` parameter is the already-resolved TestEntry for this
+        specific variant (selected by ``_select_entry_for_variant`` in
+        ``instantiate_test``).  Passing it in avoids a second map lookup and
+        ensures the correct entry is used when multiple entries share the same
+        base test name.
+
         Returns (enabled: bool, reason: Optional[str], xfail: bool, strict: bool)
         """
-        # look up the test entry by base_test_name (method name without op/dtype suffix)
-        entry: Optional[TestEntry] = cls.TEST_ENTRIES.get(base_test_name)
+        # If entry was not pre-resolved by the caller, fall back to the old
+        # single-entry lookup for backward compatibility.
+        if entry is None:
+            entries = cls.TEST_ENTRIES.get(base_test_name)
+            if entries:
+                entry = _select_entry_for_variant(
+                    entries, method_name, cls.GLOBAL_SUPPORTED_DTYPES
+                )
 
         # unlisted_test_mode only applies to tests NOT in TEST_ENTRIES
         if entry is not None:
@@ -443,24 +530,37 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
     def instantiate_test(cls, name, test, *, generic_cls=None):
         _OOTOnlyOnPatcher(test, _SPYRE_DEVICE_TYPE).patch()
         cls._load_test_suite_config()
-        # print tags to stderr
-        entry = cls.TEST_ENTRIES.get(name)
-        tags = entry.tags if entry is not None else []
-        # test-level tags only — used for method_tags assembly
-        all_tags = tags
+
+        # Retrieve all entries for this base test name.
+        # There may be multiple when different configs target the same test
+        # name with different tags/dtypes (e.g. same op, different models).
+        all_entries_for_name: List[TestEntry] = cls.TEST_ENTRIES.get(name, [])
+
+        # ------------------------------------------------------------------
+        # Collect the union of all tags across all entries for collection-time
+        # summary logging.  The per-variant tag selection happens later in the
+        # new_methods loop where the dtype is known from method_name.
+        # ------------------------------------------------------------------
+        all_tags_union: List[str] = []
+        _seen_union: set = set()
+        for _e in all_entries_for_name:
+            for _t in _e.tags or []:
+                if _t not in _seen_union:
+                    _seen_union.add(_t)
+                    all_tags_union.append(_t)
 
         # Collect op-level tags for collection-time summary print ONLY
         op_tags: List[str] = []
-        if entry is not None:
-            seen_op_tags: set = set()
-            for ops_item in entry.edits.ops.include:
+        seen_op_tags: set = set()
+        for _e in all_entries_for_name:
+            for ops_item in _e.edits.ops.include:
                 for t in ops_item.tags:
                     if t not in seen_op_tags:
                         seen_op_tags.add(t)
                         op_tags.append(t)
 
-        # Print summary at collection time
-        summary_tags = tags + [t for t in op_tags if t not in set(tags)]
+        # Print summary at collection time -- union of all tags
+        summary_tags = all_tags_union + [t for t in op_tags if t not in _seen_union]
         if summary_tags:
             if generic_cls is not None:
                 os.write(
@@ -474,8 +574,8 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                     f"cannot print tag information"
                 )
 
-        # Store test-level tags only — op-level tags added per-occurrence at run time
-        cls._TEST_LEVEL_TAGS = list(tags)
+        # Store union of test-level tags for backward compat (used by print_test_tags_oot)
+        cls._TEST_LEVEL_TAGS = all_tags_union
 
         # op list filtering
         supported_ops = cls._get_supported_ops()
@@ -492,13 +592,13 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         included_modules = getattr(cls, "_FILE_LEVEL_INCLUDED_MODULES", None) or set()
         excluded_modules = getattr(cls, "_FILE_LEVEL_EXCLUDED_MODULES", None) or set()
 
-        # Also merge in test-specific includes/excludes if present
-        if entry is not None:
+        # Merge in includes/excludes from ALL entries for this test name
+        for _e in all_entries_for_name:
             included_modules = (
-                included_modules | entry.edits.modules.included_module_names()
+                included_modules | _e.edits.modules.included_module_names()
             )
             excluded_modules = (
-                excluded_modules | entry.edits.modules.excluded_module_names()
+                excluded_modules | _e.edits.modules.excluded_module_names()
             )
 
         if supported_modules is not None or included_modules or excluded_modules:
@@ -509,6 +609,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                 excluded_modules=excluded_modules,
             ).patch()
 
+        # Collect dtype union across all entries for patching
         op_level_dtypes: Set[torch.dtype] = set()
         if cls.SUPPORTED_OPS_CONFIG:
             from torch.testing._internal.common_device_type import ops as _ops_cls
@@ -555,20 +656,21 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         if module_level_dtypes:
             _OOTModuleDtypePatcher(test, module_level_dtypes).patch()
 
-        if entry is not None:
-            extra_dtypes = entry.edits.dtypes.resolved_include()
-            if extra_dtypes:
-                _OOTDtypePatcher(test, extra_dtypes).patch()
-                _OOTOpDtypeExpander(test, extra_dtypes).patch()
+        # Collect extra dtypes from ALL entries for this test name (union)
+        all_extra_dtypes: Set[torch.dtype] = set()
+        for _e in all_entries_for_name:
+            all_extra_dtypes |= _e.edits.dtypes.resolved_include()
 
+        if all_extra_dtypes:
+            _OOTDtypePatcher(test, all_extra_dtypes).patch()
+            _OOTOpDtypeExpander(test, all_extra_dtypes).patch()
+
+        # Collect precision overrides: merge global + union across all entries.
+        # Per-variant selection happens below in new_methods loop.
         _OOTPrecisionOverridePatcher(
             test,
             global_dtype_precision=cls.GLOBAL_DTYPE_PRECISION,
-            include_dtype_precision=(
-                entry.edits.dtypes.resolved_include_precision()
-                if entry is not None
-                else {}
-            ),
+            include_dtype_precision={},  # handled per-variant below
         ).patch()
 
         # Dynamically adds pytest marker to each of ops and dtype passed to @ops
@@ -583,12 +685,31 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
 
         _tags_to_write: Dict[str, List[str]] = {}
         for method_name in new_methods:
+            # ------------------------------------------------------------------
+            # Select the correct TestEntry for THIS variant using dtype matching.
+            # Instead of using a single shared entry for
+            # all variants, we pick the entry whose dtype set covers the dtype
+            # embedded in method_name (e.g. bfloat16 -> bfloat16 entry,
+            # float16 -> float16 entry).
+            # ------------------------------------------------------------------
+            resolved_entry: Optional[TestEntry] = None
+            if all_entries_for_name:
+                resolved_entry = _select_entry_for_variant(
+                    all_entries_for_name, method_name, cls.GLOBAL_SUPPORTED_DTYPES
+                )
+
+            # Tags for this specific variant = tags from the resolved entry only
+            variant_tags: List[str] = (
+                list(resolved_entry.tags) if resolved_entry else []
+            )
+
             enabled, reason, is_xfail, is_strict = cls._should_run(
                 method_name=method_name,
                 base_test_name=name,
                 generic_cls_name=generic_cls.__name__
                 if generic_cls is not None
                 else "",
+                entry=resolved_entry,
             )
 
             if not enabled:
@@ -618,7 +739,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
 
             # Collect dynamic markers (op__, dtype__, module__) that the
             # patchers attached to this specific instantiated method, and
-            # union them with the YAML-declared tags so _XML_INJECT_PY
+            # union them with the variant-specific tags so _XML_INJECT_PY
             # only needs to handle one flat tag list per method.
             _DYNAMIC_PREFIXES = ("op__", "dtype__", "module__")
             existing_fn = cls.__dict__.get(method_name)
@@ -632,14 +753,14 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                     }
                 )
 
-            seen = set(all_tags)
-            method_tags = list(all_tags)
+            seen = set(variant_tags)
+            method_tags = list(variant_tags)
             for t in dynamic_tags:
                 if t not in seen:
                     seen.add(t)
                     method_tags.append(t)
 
-            # apply all tags (YAML + dynamic) as marks
+            # apply all tags (variant-specific YAML + dynamic) as marks
             if method_tags:
                 existing_fn = cls.__dict__.get(method_name)
                 if existing_fn is not None:

--- a/tests/spyre_test_utilities.py
+++ b/tests/spyre_test_utilities.py
@@ -134,11 +134,16 @@ def _merge_file_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Merge per-file entries from all configs into a deduplicated list.
 
     Two entries with the same ``path`` value are merged: their ``tests``
-    lists are concatenated (with deduplication by name) and their
-    ``unlisted_test_mode`` is kept from the first occurrence (a warning is
-    emitted if configs disagree).
+    lists are combined and their ``unlisted_test_mode`` is kept from the
+    first occurrence.
 
-    Entries with distinct paths are appended in the order they appear.
+    Test block deduplication within a path:
+    - A block is a TRUE duplicate and dropped only when its ``names``,
+      ``tags``, AND ``edits`` all match an already-seen block exactly.
+    - Blocks that share the same ``names`` but differ in ``tags`` or
+      ``edits`` (e.g. the same test op run for different models/dtypes)
+      are kept as SEPARATE entries so each produces its own tagged variant.
+    - Entries with distinct paths are appended in the order they appear.
     """
     # Preserve insertion order; key = resolved path string.
     merged: Dict[str, Dict[str, Any]] = {}
@@ -165,20 +170,28 @@ def _merge_file_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     file=sys.stderr,
                 )
 
-            # Merge tests: deduplicate by the set of names in each test block.
-            existing_test_names: set = set()
-            for t in existing["tests"]:
-                for n in t.get("names") or []:
-                    existing_test_names.add(n.strip())
-
             for test_block in entry.get("tests") or []:
-                block_names = {n.strip() for n in (test_block.get("names") or [])}
-                # Append the whole block if ANY of its names is new.
-                # (Partial overlaps are very unlikely in practice but if they
-                # occur the block is still added so no test is silently lost.)
-                if not block_names.issubset(existing_test_names):
+                block_names = frozenset(
+                    n.strip() for n in (test_block.get("names") or [])
+                )
+
+                # A block is a TRUE duplicate only when names + tags + edits
+                # all match an already-present block exactly.  Blocks with
+                # the same names but different tags/edits represent distinct
+                # configurations (e.g. same op for different models) and must
+                # be kept as separate entries.
+                is_true_duplicate = any(
+                    frozenset(n.strip() for n in (t.get("names") or [])) == block_names
+                    and t.get("tags") == test_block.get("tags")
+                    and t.get("edits") == test_block.get("edits")
+                    for t in existing["tests"]
+                )
+
+                if not is_true_duplicate:
                     existing["tests"].append(test_block)
-                    existing_test_names.update(block_names)
+                    # Note: we intentionally do NOT track block_names in a
+                    # global "seen names" set here, because the same name is
+                    # reused across configs with different tags.
 
     return list(merged.values())
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

When two YAML configs targeting the same test name but with different tags/dtypes were merged and run together, all variants incorrectly received the tags from only the first config. 

Example: both `bfloat16` and `float16` variants showed `model__gpt-oss-20b_spyre` instead of each showing their respective model tag.

#### Root cause was a three-layer bug:

1. `spyre_test_utilities.py: _merge_file_entries()` dropped any test block whose names matched an already-seen block, regardless of whether tags or edits differed. The second config's block was silently discarded before the merged YAML was even written. (Since we assumed different test yaml configs will use different test file paths)

2. `spyre_test_base_common.py:_build_test_entry_map used Dict[str, TestEntry]` (last entry won) - so even if both blocks survived merging,     only one entry would be retained per method name.

3. `instantiate_test()` and `_should_run()` resolved tags from a single shared TestEntry for all dtype variants of a test, with no way to select the correct entry once the dtype was known per variant.

#### PR fix: 

- `_merge_file_entries()` now treats a block as a true duplicate only when  names + tags + edits all match exactly. Blocks with the same names but different tags/edits are kept as separate entries.

- `_build_test_entry_map()` return type changed from Dict[str, TestEntry] to Dict[str, List[TestEntry]] so all entries for a name are retained.

- `instantiate_test()` uses the union of dtypes/modules across all entries for upstream patchers (which run before super() generates variants), then in the new_methods loop calls `_select_entry_for_variant()` per variant so each gets tags from its own correctly matched entry.

- `_should_run` accepts the pre-resolved entry as a parameter (None: fallback preserves backward compatibility) so tag emission and mode resolution use the same entry.

#### Output:
<img width="3454" height="426" alt="image" src="https://github.com/user-attachments/assets/7503e163-31c7-40fe-87b3-deebcb65fe6a" />
