### PR TITLE
fix(testing cicd): set REPORT_PATH/NAME env vars before `bash run_test.sh` so upload step has them on failure

### DIFF
--- a/.github/workflows/model_ops_tests.yaml
+++ b/.github/workflows/model_ops_tests.yaml
@@ -106,13 +106,14 @@ jobs:
           REPORT_NAME="${CONFIG%.yaml}.xml"
           REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
 
+          # Expose report path/name to subsequent steps via GITHUB_ENV
+          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
+          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+
           echo "Running ${{ matrix.suite.name }} model ops tests..."
           bash tests/run_test.sh "tests/configs/model_ops_tests/${CONFIG}" -v --junit-xml="${REPORT_PATH}"
           echo "${{ matrix.suite.name }} model ops tests done"
 
-          # Expose report path/name to subsequent steps via GITHUB_ENV
-          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
-          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
 
       # ---------------------------------------------------------------------------
       # Upload the JUnit XML as a GHA artifact so it can be downloaded and

--- a/.github/workflows/module_tests.yaml
+++ b/.github/workflows/module_tests.yaml
@@ -96,13 +96,15 @@ jobs:
           REPORT_NAME="${CONFIG%.yaml}.xml"
           REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
 
+          # Expose report path/name to subsequent steps via GITHUB_ENV
+          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
+          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+
           echo "Running ${{ matrix.suite.name }} module tests..."
           bash tests/run_test.sh "tests/configs/module_tests/${CONFIG}" -v --junit-xml="${REPORT_PATH}"
           echo "${{ matrix.suite.name }} module tests done"
 
-          # Expose report path/name to subsequent steps via GITHUB_ENV
-          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
-          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+
 
       # ---------------------------------------------------------------------------
       # Upload the JUnit XML as a GHA artifact so it can be downloaded and

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -99,13 +99,14 @@ jobs:
           REPORT_NAME="${CONFIG%.yaml}.xml"
           REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
 
+          # Expose report path/name to subsequent steps via GITHUB_ENV
+          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
+          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+
           echo "Running ${{ matrix.suite.name }} upstream tests..."
           bash tests/run_test.sh "tests/configs/upstream_tests/${CONFIG}" --capture=sys -v --junit-xml="${REPORT_PATH}"
           echo "${{ matrix.suite.name }} upstream tests done"
 
-          # Expose report path/name to subsequent steps via GITHUB_ENV
-          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
-          echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
 
       # ---------------------------------------------------------------------------
       # Upload the JUnit XML as a GHA artifact so it can be downloaded and


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR moves REPORT_PATH/NAME env vars setting before running `run_test.sh` run so that upload step runs successfully even on failure

#### Working Output: 
<img width="2632" height="1348" alt="image" src="https://github.com/user-attachments/assets/7cdd6340-7ddf-4803-a16e-ca00e61a8c36" />
