### PR TITLE
Add ceil and sign op decompositions for Spyre backend

### DIFF
--- a/.claude/skills/cross-repo-adapt/SKILL.md
+++ b/.claude/skills/cross-repo-adapt/SKILL.md
@@ -1,0 +1,454 @@
+---
+name: cross-repo-adapt
+description: "Detect upstream flex/deeptools API changes that break torch-spyre, identify impacted call sites, generate adaptation code, build-verify on pod, and create a fix PR. Run after pulling latest upstream or when build fails."
+---
+
+# Cross-Repo API Adaptation Swarm
+
+Detects upstream API changes in flex and deeptools that break
+torch-spyre, then generates and validates the adaptation. Uses
+4 agents to detect changes, assess impact, write fixes, and
+verify the build.
+
+Use when:
+- The daily health check reports a build failure
+- After pulling latest flex/deeptools on the pod
+- When a cross-repo PR is blocked on adaptation (e.g., #2190)
+- Proactively after seeing HIGH risk in the version-agent drift report
+
+---
+
+## Invocation
+
+```
+/cross-repo-adapt
+/cross-repo-adapt --component flex
+/cross-repo-adapt --since "3 days ago"
+```
+
+Without arguments, checks both flex and deeptools. With
+`--component`, limits to one upstream repo. With `--since`,
+only looks at commits since the given date.
+
+---
+
+## Execution Strategy
+
+### Phase 1: Detect (1 agent, foreground)
+
+The detect-agent identifies what changed upstream. Its output
+determines whether adaptation is needed and scopes the remaining
+agents.
+
+### Phase 2: Impact + Adapt (2 agents, parallel)
+
+If breaking changes are detected:
+- impact-agent identifies which torch-spyre files are affected
+- adapt-agent writes the fix (informed by detect-agent's output)
+
+### Phase 3: Verify (1 agent, foreground)
+
+Build on pod to confirm the fix works.
+
+---
+
+## Pod Connection
+
+All pod commands use:
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "<cmd>"
+```
+
+Workspace layout:
+
+```
+$HOME/main-workspace/
+├── deeptools/          # upstream, branch: master
+├── flex/               # upstream, branch: main
+├── torch-spyre/       # upstream, branch: main
+├── build/             # cmake build dirs
+├── install/           # installed headers/libs
+│   ├── deeptools/
+│   └── runtime/       # flex install
+└── activate.sh        # venv + PATH setup
+```
+
+---
+
+## Agent A: detect-agent
+
+**Goal:** Identify API-breaking changes in upstream repos.
+
+### Steps
+
+1. **Pull latest and check recent commits:**
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+
+echo '=== FLEX: API-relevant commits ==='
+cd \$WS/flex && git fetch origin && git log --oneline \
+  origin/main --since='7 days ago' -- '*.hpp' '*.h' 'CMakeLists.txt' \
+  'include/' | head -20
+
+echo '=== DEEPTOOLS: API-relevant commits ==='
+cd \$WS/deeptools && git fetch origin && git log --oneline \
+  origin/master --since='7 days ago' -- '*.hpp' '*.h' 'CMakeLists.txt' \
+  'include/' | head -20
+"
+```
+
+2. **Extract changed function signatures and types:**
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+
+echo '=== FLEX: Changed headers (diff) ==='
+cd \$WS/flex && git diff origin/main@{7.days.ago}..origin/main \
+  -- 'include/' '*.hpp' '*.h' 2>/dev/null \
+  | grep -E '^[+-].*(class |struct |enum |void |int |bool |auto |template|namespace|typedef|using )' \
+  | head -40
+
+echo '=== DEEPTOOLS: Changed headers (diff) ==='
+cd \$WS/deeptools && git diff origin/master@{7.days.ago}..origin/master \
+  -- 'include/' '*.hpp' '*.h' 2>/dev/null \
+  | grep -E '^[+-].*(class |struct |enum |void |int |bool |auto |template|namespace|typedef|using )' \
+  | head -40
+"
+```
+
+3. **Identify specific breaking patterns:**
+
+Look for these high-risk changes:
+- Function signature changes (added/removed parameters)
+- Renamed or removed classes/structs/enums
+- Moved headers (new include paths)
+- New required parameters in constructors
+- Removed or renamed enum values
+- Namespace changes
+- C++ standard version changes (e.g., C++17 → C++20)
+
+### Report Format
+
+```markdown
+## Upstream Changes Detected
+
+### flex (N commits, M API-touching)
+
+| Commit | Change Type | Symbol | Details |
+|--------|-------------|--------|---------|
+| abc1234 | New param | AllocationDirective() | Added MemoryType 4th arg |
+| def5678 | Renamed | FlexAllocator | Added allocate() overload |
+
+### deeptools (N commits, M API-touching)
+
+| Commit | Change Type | Symbol | Details |
+|--------|-------------|--------|---------|
+
+### Risk Assessment
+
+- **Breaking:** <list of changes that will break torch-spyre>
+- **Non-breaking:** <list of additive changes, new APIs>
+- **Unknown:** <changes that need manual inspection>
+```
+
+---
+
+## Agent B: impact-agent
+
+**Goal:** Identify which torch-spyre files use the changed APIs.
+
+### torch-spyre C++ Sources
+
+All C++ code lives in `torch_spyre/csrc/`:
+
+| File | flex/deeptools APIs Used |
+|------|-------------------------|
+| `module.cpp` | `flex::initializeRuntime`, `flex.hpp` |
+| `spyre_allocator.cpp` | `AllocationDirective`, `FlexAllocator` |
+| `spyre_kernel.cpp` | `AllocationDirective`, binary loading |
+| `job_plan.cpp` | `flex::RuntimeOperation*`, `flex::CompositeAddress`, `alloc_address.hpp` |
+| `spyre_stream.cpp` | `flex::RuntimeStream` |
+| `spyre_mem.cpp` | Memory management APIs |
+
+### Steps
+
+1. **For each breaking change, grep torch-spyre sources:**
+
+```bash
+# On pod or locally
+grep -rn "<changed_symbol>" torch_spyre/csrc/ --include="*.cpp" --include="*.hpp" --include="*.h"
+```
+
+2. **For header moves, check includes:**
+
+```bash
+grep -rn "#include.*<old_path>" torch_spyre/csrc/
+```
+
+3. **For constructor signature changes, find call sites:**
+
+```bash
+grep -rn "<ClassName>(" torch_spyre/csrc/ --include="*.cpp"
+```
+
+4. **Check setup.py build configuration:**
+
+```bash
+grep -n "flex\|sendnn\|deeptools\|LIBRARIES\|INCLUDE" setup.py
+```
+
+### Report Format
+
+```markdown
+## Impact Assessment
+
+| Changed Symbol | torch-spyre File | Line(s) | Impact |
+|----------------|------------------|---------|--------|
+| AllocationDirective() | spyre_allocator.cpp | 125, 142 | Needs 4th param |
+| AllocationDirective() | spyre_kernel.cpp | 187 | Needs 4th param |
+| flex::MemoryType | (new include needed) | — | Add #include |
+
+### Files Requiring Changes
+
+1. `torch_spyre/csrc/spyre_allocator.cpp` — lines 125, 142
+2. `torch_spyre/csrc/spyre_kernel.cpp` — line 187
+
+### Build Config Impact
+
+- setup.py: NO CHANGE / NEEDS UPDATE
+- New library deps: <if any>
+- New include paths: <if any>
+```
+
+---
+
+## Agent C: adapt-agent
+
+**Goal:** Write the adaptation code.
+
+### Guidelines
+
+1. **Match the upstream API exactly** — don't add compatibility
+   shims or `#ifdef` guards unless the change hasn't landed in
+   the CI environment yet.
+
+2. **Minimal changes** — only modify what's broken. Don't
+   refactor surrounding code.
+
+3. **Preserve existing style** — match indentation, naming
+   conventions, and comment patterns of the surrounding code.
+
+4. **Common adaptation patterns:**
+
+**New constructor parameter:**
+```cpp
+// Before
+AllocationDirective(size, alignment, segment);
+// After
+AllocationDirective(size, alignment, segment, flex::MemoryType::Tensor);
+```
+
+**Renamed header:**
+```cpp
+// Before
+#include <flex/old_name.hpp>
+// After
+#include <flex/new_name.hpp>
+```
+
+**Renamed symbol:**
+```cpp
+// Before
+flex::OldName obj;
+// After
+flex::NewName obj;
+```
+
+**New required method parameter:**
+```cpp
+// Before
+allocator.allocate(size);
+// After
+allocator.allocate(size, flex::MemoryType::Tensor);
+```
+
+**Removed function (replaced by new API):**
+```cpp
+// Check the upstream commit for what replaced it
+// Use the new API with equivalent semantics
+```
+
+5. **If unsure about semantics** — look at the upstream commit
+   message and diff to understand the intent. If still unclear,
+   report as "needs manual review" rather than guessing.
+
+6. **License headers** — don't modify. Files already have them.
+
+7. **`USE_SPYRE_CCL=0`** — always set this env var when building
+   on single-card pods (spyre_comms not installed).
+
+### Steps
+
+1. Read the impact-agent report for affected files and lines
+2. Read each affected file to understand the surrounding context
+3. Apply the minimal fix to each call site
+4. If a new `#include` is needed, add it in alphabetical order
+   with existing includes
+
+### Output
+
+Provide the exact edits (file, old code, new code) for each
+change needed.
+
+---
+
+## Agent D: verify-agent
+
+**Goal:** Build on pod to confirm the adaptation works.
+
+### Steps
+
+1. **Apply changes on pod:**
+
+Push the branch or apply patches via kubectl:
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+cd \$WS/torch-spyre
+git stash
+git checkout main
+git pull origin main
+# Apply the changes (either via cherry-pick or direct edit)
+"
+```
+
+2. **Build torch-spyre with the fix:**
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+source \$WS/activate.sh
+cd \$WS/torch-spyre
+export CXX='/usr/lib64/ccache/c++'
+export USE_SPYRE_CCL=0
+uv sync --all-extras --active --inexact --no-build-isolation \
+  --reinstall-package torch-spyre -v 2>&1 | tail -30
+echo 'BUILD_EXIT_CODE='\$?
+"
+```
+
+Use 600000ms timeout.
+
+3. **Run quick import test:**
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+source \$WS/activate.sh
+python3 -c '
+import torch
+import torch_spyre
+print(f\"Import: PASS\")
+print(f\"Spyre available: {torch.spyre.is_available()}\")
+' 2>&1 | grep -v 'hf_adapters\|Remainder of file'
+"
+```
+
+4. **If build fails, diagnose:**
+
+Apply the Error Diagnosis Table:
+
+| Error pattern | Likely cause |
+|---|---|
+| `no matching function for call to` | Signature still wrong — check param count/types |
+| `undefined reference to` | Missing library or symbol not exported |
+| `no member named 'X' in` | Wrong struct/class or missed rename |
+| `fatal error: 'X.h' file not found` | Include path wrong |
+| `use of undeclared identifier` | Missing include or wrong namespace |
+
+### Report Format
+
+```markdown
+## Build Verification
+
+- **Build status:** PASS / FAIL
+- **Import test:** PASS / FAIL / SKIPPED
+- **Errors remaining:** <if any>
+
+### If FAIL — Diagnosis
+
+| Error | File | Line | Probable Cause |
+|-------|------|------|----------------|
+| ... | ... | ... | ... |
+```
+
+---
+
+## Final Output
+
+```markdown
+## Cross-Repo Adaptation Summary
+
+**Date:** <today>
+**Upstream changes:** flex (<N> API commits) / deeptools (<N>)
+**Impact:** <N> torch-spyre files affected
+
+### Changes Made
+
+| File | Line(s) | Change |
+|------|---------|--------|
+| `torch_spyre/csrc/X.cpp` | 125 | Added MemoryType param |
+
+### Build Verification
+
+- Pod build: PASS/FAIL
+- Import test: PASS/FAIL
+
+### Next Steps
+
+- [ ] Commit with `git commit -s`
+- [ ] Push branch and create PR
+- [ ] Reference upstream flex/deeptools commits in PR description
+```
+
+If no breaking changes detected:
+
+```markdown
+## Cross-Repo Adaptation Summary
+
+**Date:** <today>
+**Status:** No breaking changes detected.
+
+Upstream repos have <N> commits in the last 7 days, but none
+break torch-spyre's current API usage. Build verified on pod.
+```
+
+---
+
+## When to STOP
+
+Do not attempt adaptation if:
+
+- The upstream change is still in-flight (PR not merged) — just
+  report it as "upcoming breaking change"
+- The fix requires understanding new business logic (not just
+  API plumbing) — flag for manual review
+- Multiple interdependent upstream PRs need to land together —
+  report the dependency chain
+- The change affects torch-spyre's Python code (not C++) — that's
+  a different workflow (likely Inductor API changes from a PyTorch
+  version bump)
+
+---
+
+## Integration with Other Skills
+
+- **daily-health-check** → build-agent fails → run this skill
+- **version-agent** reports HIGH drift → run this skill proactively
+- After this skill fixes the build → run daily-health-check smoke
+  test to confirm end-to-end

--- a/.claude/skills/daily-health-check/SKILL.md
+++ b/.claude/skills/daily-health-check/SKILL.md
@@ -1,0 +1,657 @@
+---
+name: daily-health-check
+description: "Build the full Spyre stack from source on a pod, check CI status, triage nightly failures, scan blocking PRs, check version alignment, and report project velocity. Use when asked for a health check, daily build, ecosystem status, or morning report."
+---
+
+# Daily Health Check
+
+Produce a comprehensive health report for the torch-spyre ecosystem.
+Fan out up to 6 agents in parallel, then synthesize into a single
+structured report.
+
+The ecosystem has three repos built sequentially:
+
+- **deeptools** (`github.ibm.com:ai-chip-toolchain/deeptools.git`, branch: `master`)
+- **flex** (`github.ibm.com:ai-chip-toolchain/flex.git`, branch: `main`)
+- **torch-spyre** (`github.com/torch-spyre/torch-spyre`, branch: `main`)
+
+---
+
+## Execution Strategy
+
+### Phase 1: Fan Out (6 parallel agents)
+
+Launch ALL of these agents simultaneously:
+
+| Agent | Task | Deps |
+|-------|------|------|
+| **build-agent** | Pull latest, build full stack on pod | None |
+| **ci-agent** | Check CI workflow status on main | None |
+| **nightly-triage-agent** | Download and triage nightly test failures | None |
+| **pr-agent** | Scan blocking PRs and project velocity | None |
+| **version-agent** | Check PyTorch version alignment and repo drift | None |
+| **issues-agent** | Check open bugs and recent issue activity | None |
+
+### Phase 2: Synthesis
+
+Once all agents return, produce the structured report. The build-agent
+result may inform interpretation of other results (e.g., if build
+fails, the nightly failure may share the same root cause).
+
+### Phase 3: Smoke Test (conditional)
+
+If the build passed, run the smoke test on the pod.
+
+---
+
+## Agent A: build-agent
+
+**Goal:** Pull latest on all repos and build the full stack.
+
+### Pod Connection
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "<cmd>"
+```
+
+### Step 1: Pull Latest Sources
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+cd \$WS/deeptools && git fetch origin && git checkout master && git reset --hard origin/master
+cd \$WS/flex && git fetch origin && git checkout main && git reset --hard origin/main
+cd \$WS/torch-spyre && git fetch origin && git checkout main && git reset --hard origin/main
+echo '=== Commits ==='
+echo 'deeptools:' && cd \$WS/deeptools && git log --oneline -1
+echo 'flex:' && cd \$WS/flex && git log --oneline -1
+echo 'torch-spyre:' && cd \$WS/torch-spyre && git log --oneline -1
+"
+```
+
+### Step 2: Build deeptools
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+mkdir -p \$WS/build/deeptools && cd \$WS/build/deeptools
+cmake \$WS/deeptools \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_INSTALL_PREFIX=\$WS/install/deeptools \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DDT_USE_DCC_DDC=on \
+  -DLLVM_PROJ_SRC=/home/rganti/dt-inductor/llvm-project \
+  -DLLVM_PROJ_BUILD=/home/rganti/dt-inductor/build/llvm \
+  -DMANAGE_LLVM=0 \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=1 2>&1 | tail -5
+make -j 16 install 2>&1 | tail -10
+echo 'DEEPTOOLS_EXIT_CODE='\$?
+"
+```
+
+Use a 600000ms timeout.
+
+### Step 3: Build flex
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+rm -rf \$WS/install/runtime
+cd \$WS/flex && git submodule update --init --recursive 2>&1 | tail -3
+mkdir -p \$WS/build/flex && cd \$WS/build/flex
+cmake \$WS/flex \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_INSTALL_PREFIX=\$WS/install/runtime \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DDEEPTOOLS_PATH=\$WS/install/deeptools \
+  -DCMAKE_PREFIX_PATH=\$WS/install/deeptools \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=1 2>&1 | tail -5
+make -j 16 install 2>&1 | tail -10
+echo 'FLEX_EXIT_CODE='\$?
+"
+```
+
+Use a 600000ms timeout.
+
+### Step 4: Build torch-spyre
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+source \$WS/activate.sh
+cd \$WS/torch-spyre
+export CXX='/usr/lib64/ccache/c++'
+export USE_SPYRE_CCL=0
+uv sync --all-extras --active --inexact --no-build-isolation \
+  --reinstall-package torch-spyre -v 2>&1 | tail -30
+echo 'TORCH_SPYRE_EXIT_CODE='\$?
+"
+```
+
+Use a 600000ms timeout. If it fails, also run with grep for errors.
+
+### Step 5: Diagnose Failures
+
+If any step failed, apply the Error Diagnosis Table (at the bottom of
+this document) to classify the root cause.
+
+### Report back with
+
+- Commit SHAs (short hash + subject) for each repo
+- Build status per component (PASS/FAIL)
+- If failed: component, error summary, cross-repo mismatch diagnosis
+
+---
+
+## Agent B: ci-agent
+
+**Goal:** Check CI workflow status on main branch.
+
+### Workflows to Check
+
+| Workflow file | Display name |
+|---|---|
+| `torch_spyre_tests.yaml` | Spyre Hardware Tests |
+| `linters.yaml` | Linters |
+| `upstream_tests.yaml` | Upstream PyTorch Tests |
+| `runtests_nightly.yaml` | Nightly Tests |
+
+### Commands
+
+For each workflow:
+
+```bash
+gh run list --repo torch-spyre/torch-spyre \
+  --workflow=<filename> --branch main --limit 3 \
+  --json status,conclusion,createdAt,headSha,url
+```
+
+For any failed run, get failing job details:
+
+```bash
+gh run view <run-id> --repo torch-spyre/torch-spyre \
+  --json jobs --jq '.jobs[] | select(.conclusion=="failure") | .name'
+```
+
+### Report back with
+
+- Last 3 run conclusions per workflow
+- If most recent failed: which jobs failed
+- Trend: "newly broken" / "persistently failing" / "healthy"
+
+---
+
+## Agent C: nightly-triage-agent
+
+**Goal:** When nightly tests are failing, identify WHAT is failing and
+WHY. This goes deeper than the ci-agent.
+
+### Steps
+
+1. Get the latest failed nightly run ID:
+
+```bash
+gh run list --repo torch-spyre/torch-spyre \
+  --workflow=runtests_nightly.yaml --branch main --limit 1 \
+  --json databaseId,conclusion \
+  --jq '.[] | select(.conclusion=="failure") | .databaseId'
+```
+
+2. Get all failed jobs in that run:
+
+```bash
+gh run view <run-id> --repo torch-spyre/torch-spyre \
+  --json jobs \
+  --jq '.jobs[] | select(.conclusion=="failure") | {name, conclusion}'
+```
+
+3. For each failed job, try to get the log annotations (errors):
+
+```bash
+gh api repos/torch-spyre/torch-spyre/actions/runs/<run-id>/jobs \
+  --jq '.jobs[] | select(.conclusion=="failure") |
+    {name, steps: [.steps[] | select(.conclusion=="failure") | .name]}'
+```
+
+4. If available, download the failed job log and extract the last
+   failure block (look for FAILED, ERROR, AssertionError):
+
+```bash
+gh run view <run-id> --repo torch-spyre/torch-spyre \
+  --log-failed 2>&1 | tail -100
+```
+
+### Report back with
+
+- Which test suite(s) failed
+- Specific test names if identifiable
+- Error type (assertion, timeout, import error, segfault, etc.)
+- Whether the failure looks like: regression, flaky test, infra issue
+- How many consecutive days it has been failing (check last 5 runs)
+
+---
+
+## Agent D: pr-agent
+
+**Goal:** Scan for blocking PRs AND report project velocity.
+
+### Part 1: Blocking PRs
+
+1. Open PRs mentioning cross-repo terms:
+
+```bash
+gh pr list --repo torch-spyre/torch-spyre --state open --limit 30 \
+  --search "flex OR deeptools OR AllocationDirective OR API OR mismatch OR compat" \
+  --json number,title,url,author,createdAt,labels,reviewDecision
+```
+
+2. Open PRs with dependency labels:
+
+```bash
+gh pr list --repo torch-spyre/torch-spyre --state open \
+  --label "dependencies" --json number,title,url
+```
+
+3. Recently merged cross-repo fixes (context):
+
+```bash
+gh pr list --repo torch-spyre/torch-spyre --state merged \
+  --search "flex OR deeptools OR API" --limit 5 \
+  --json number,title,mergedAt,url
+```
+
+### Part 2: Project Velocity (last 7 days)
+
+4. PRs merged in the last 7 days:
+
+```bash
+gh pr list --repo torch-spyre/torch-spyre --state merged --limit 20 \
+  --json number,title,mergedAt \
+  --jq '[.[] | select(.mergedAt > (now - 7*24*3600 | strftime("%Y-%m-%dT%H:%M:%SZ")))] | length'
+```
+
+(If jq time filtering doesn't work, just list last 20 merged and
+count those within the last 7 days manually.)
+
+5. PRs currently in review (open, not draft):
+
+```bash
+gh pr list --repo torch-spyre/torch-spyre --state open \
+  --json number,title,createdAt,isDraft,reviewDecision \
+  --jq '[.[] | select(.isDraft==false)] | length'
+```
+
+6. Stalled PRs (open >7 days, no recent activity):
+
+```bash
+gh pr list --repo torch-spyre/torch-spyre --state open --limit 50 \
+  --json number,title,createdAt,updatedAt,author \
+  --jq '[.[] | select(.updatedAt < (now - 7*24*3600 | strftime("%Y-%m-%dT%H:%M:%SZ")))]'
+```
+
+(If jq filtering fails, list all open PRs with dates and identify
+stalled ones manually — those with updatedAt > 7 days ago.)
+
+### Report back with
+
+- Blocking PRs (number, title, why blocking, review status)
+- Velocity: PRs merged last 7 days (count)
+- PRs in review (count)
+- Stalled PRs >7 days (list with age)
+
+---
+
+## Agent E: version-agent
+
+**Goal:** Check PyTorch version alignment and repo drift.
+
+### Part 1: PyTorch Version Alignment
+
+1. Check what torch-spyre pyproject.toml expects:
+
+```bash
+gh api repos/torch-spyre/torch-spyre/contents/pyproject.toml \
+  --jq '.content' | base64 -d | grep 'torch'
+```
+
+Or read locally if available:
+```bash
+grep 'torch' pyproject.toml | head -5
+```
+
+2. Check what's installed in the workspace venv on pod:
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+source \$HOME/main-workspace/activate.sh
+python3 -c 'import torch; print(f\"Installed: {torch.__version__}\")'
+"
+```
+
+3. Flag if there's a mismatch (e.g., pyproject wants 2.11 but
+   workspace has 2.10).
+
+### Part 2: Repo Drift
+
+Count commits since the last known-good build (use the commit SHAs
+from the previous health check if available, otherwise count commits
+in the last 7 days):
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+echo 'deeptools (last 7 days):' && cd \$WS/deeptools && git log --oneline --since='7 days ago' | wc -l
+echo 'flex (last 7 days):' && cd \$WS/flex && git log --oneline --since='7 days ago' | wc -l
+echo 'torch-spyre (last 7 days):' && cd \$WS/torch-spyre && git log --oneline --since='7 days ago' | wc -l
+"
+```
+
+Also show the most impactful commits (those touching headers, APIs,
+or CMakeLists):
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+echo '=== deeptools API-relevant commits (7d) ==='
+cd \$WS/deeptools && git log --oneline --since='7 days ago' -- '*.hpp' '*.h' 'CMakeLists.txt' | head -10
+echo '=== flex API-relevant commits (7d) ==='
+cd \$WS/flex && git log --oneline --since='7 days ago' -- '*.hpp' '*.h' 'CMakeLists.txt' | head -10
+"
+```
+
+### Report back with
+
+- PyTorch version: expected vs installed (MATCH / MISMATCH)
+- Repo drift: commits in last 7 days per repo
+- High-risk commits (header/API/CMake changes) listed
+- Risk assessment: "low" (few changes), "medium" (many changes,
+  no API files), "high" (API-touching commits in upstream repos)
+
+---
+
+## Agent F: issues-agent
+
+**Goal:** Check open bug count and recent issue activity.
+
+### Commands
+
+1. Total open bugs:
+
+```bash
+gh issue list --repo torch-spyre/torch-spyre --state open \
+  --label "bug" --json number \
+  --jq 'length'
+```
+
+2. Bugs filed in the last 24 hours:
+
+```bash
+gh issue list --repo torch-spyre/torch-spyre --state open \
+  --label "bug" --limit 10 \
+  --json number,title,createdAt,author \
+  --jq '[.[] | select(.createdAt > "YESTERDAY_ISO")]'
+```
+
+Replace `YESTERDAY_ISO` with yesterday's date in ISO format
+(e.g., `2026-05-18T00:00:00Z`). If jq filtering is unreliable,
+list the 10 most recent bugs and filter by date manually.
+
+3. Bugs filed in the last 7 days (for trend):
+
+```bash
+gh issue list --repo torch-spyre/torch-spyre --state open \
+  --label "bug" --limit 30 \
+  --json number,title,createdAt \
+  --jq '[.[] | select(.createdAt > "WEEK_AGO_ISO")]'
+```
+
+4. Recently closed bugs (to show fix velocity):
+
+```bash
+gh issue list --repo torch-spyre/torch-spyre --state closed \
+  --label "bug" --limit 10 \
+  --json number,title,closedAt
+```
+
+### Report back with
+
+- Total open bugs (count)
+- New bugs (last 24h): count + titles
+- Bug trend (last 7 days): filing rate vs close rate
+- Any critical/high-priority bugs (if labeled)
+
+---
+
+## Phase 3: Smoke Test
+
+Run only if ALL three components built successfully. The workspace
+uses a single venv at `$HOME/main-workspace/venv` — the activate.sh
+sources it and sets PATH for deeptools/runtime binaries only.
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+source \$WS/activate.sh
+cd \$WS/torch-spyre
+python3 -c '
+import torch
+import torch_spyre
+print(f\"Spyre available: {torch.spyre.is_available()}\")
+print(f\"Device count: {torch.spyre.device_count()}\")
+print(f\"PyTorch: {torch.__version__}\")
+print(f\"torch_spyre: {torch_spyre.__file__}\")
+x = torch.randn(4, 4, dtype=torch.float16, device=\"spyre\")
+y = torch.randn(4, 4, dtype=torch.float16, device=\"spyre\")
+z = x + y
+print(f\"Eager add: PASS, shape={z.shape}\")
+' 2>&1 | grep -v 'hf_adapters\|Remainder of file'
+"
+```
+
+If eager passes, also test compiled execution. torch-spyre registers
+as an Inductor device backend, so use `torch.compile()` without
+specifying a backend (inductor is the default and it dispatches to
+Spyre when tensors are on the spyre device):
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+source \$WS/activate.sh
+cd \$WS/torch-spyre
+python3 -c '
+import torch
+import torch_spyre
+
+@torch.compile()
+def f(a, b):
+    return a + b
+
+a = torch.randn(128, 128, dtype=torch.float16, device=\"spyre\")
+b = torch.randn(128, 128, dtype=torch.float16, device=\"spyre\")
+c = f(a, b)
+print(f\"Compiled add: PASS, shape={c.shape}\")
+' 2>&1 | grep -v 'hf_adapters\|Remainder of file'
+"
+```
+
+If compiled passes, run the full model E2E smoke test using
+hf\_adapters with Qwen3 0.6B. This exercises the full compilation
+pipeline (model load, weight stickification, torch.compile,
+multi-token generation):
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+source \$WS/activate.sh
+cd \$HOME/hf_adapters
+python3 tests/test_e2e_smoke_spyre.py qwen3 2>&1 \
+  | grep -E 'PASS|FAIL|ERROR|Load time|Generate time|Output:|E2E Smoke'
+"
+```
+
+Use a 300000ms timeout. The script loads `Qwen/Qwen3-0.6B` via
+`AutoSpyreModelForCausalLM.from_pretrained`, generates 5 tokens,
+and validates they are non-empty and diverse. Model weights should
+be cached on the pod after the first run.
+
+---
+
+## Output Format
+
+Present the final report in this structure:
+
+```markdown
+# torch-spyre Ecosystem Health Report
+
+**Date:** <today>
+**Pod:** rganti-spyre-main
+
+## Build Status
+
+| Component | Commit | Status | Notes |
+|-----------|--------|--------|-------|
+| deeptools | `<sha>` | PASS/FAIL | |
+| flex | `<sha>` | PASS/FAIL | |
+| torch-spyre | `<sha>` | PASS/FAIL | |
+
+## CI Status
+
+| Workflow | Last Run | Status | Details |
+|----------|----------|--------|---------|
+| Spyre Hardware Tests | <date> | PASS/FAIL | |
+| Linters | <date> | PASS/FAIL | |
+| Upstream PyTorch | <date> | PASS/FAIL | |
+| Nightly Tests | <date> | PASS/FAIL | |
+
+## Nightly Failure Triage
+
+- Failing job(s): <name>
+- Failing test(s): <test names if identifiable>
+- Error type: <assertion / timeout / segfault / import / etc.>
+- Duration: <N consecutive days>
+- Assessment: <regression / flaky / infra issue>
+
+(or "Nightly tests passing" if healthy)
+
+## Version Alignment
+
+| Check | Expected | Actual | Status |
+|-------|----------|--------|--------|
+| PyTorch | <from pyproject> | <installed> | MATCH/MISMATCH |
+
+## Repo Drift (last 7 days)
+
+| Repo | Commits | API-touching | Risk |
+|------|---------|--------------|------|
+| deeptools | N | N | low/med/high |
+| flex | N | N | low/med/high |
+| torch-spyre | N | — | — |
+
+## Blocking PRs
+
+| PR | Title | Why Blocking | Review Status |
+|----|-------|--------------|---------------|
+| #N | title | reason | Approved/Pending |
+
+(or "None identified")
+
+## Cross-Repo API Mismatches
+
+(details if build failed, or "None detected")
+
+## Project Velocity
+
+- PRs merged (7 days): N
+- PRs in review: N
+- Stalled PRs (>7 days): N (list if any)
+
+## Open Bugs
+
+- Total open: N
+- New (24h): N — <titles if any>
+- Trend (7d): +N filed, -N closed
+
+## Smoke Test
+
+- Import: PASS/FAIL
+- Eager execution: PASS/FAIL/SKIPPED
+- Compiled execution: PASS/FAIL/SKIPPED
+- Model E2E (Qwen3 0.6B): PASS/FAIL/SKIPPED — <load_time>s load, <gen_time>s gen
+
+## Action Items
+
+1. <Highest priority — blocking build or persistent CI failure>
+2. <Medium priority — version mismatch, stalled PRs>
+3. <Low priority — new bugs to triage, velocity concerns>
+```
+
+---
+
+## Error Diagnosis Table
+
+When a build fails, use these patterns to classify the root cause:
+
+| Error pattern | Likely cause | Action |
+|---|---|---|
+| `no matching function for call to` | Function signature changed upstream | Compare flex/deeptools headers with torch-spyre call sites |
+| `undefined reference to` | Symbol removed or renamed upstream | Check recent flex/deeptools commits |
+| `no member named 'X' in` | Struct/class field removed | Check upstream header changes |
+| `fatal error: 'X.h' file not found` | Header moved or renamed | Check upstream file renames |
+| `use of undeclared identifier` | Enum/constant renamed | Search upstream for the rename |
+| `ImportError` / `ModuleNotFoundError` | Python dep missing or renamed | Check if new dep added upstream |
+| `RuntimeError: Error compiling objects` | C++ ext build failed | Look at the ninja error above this line |
+
+When a cross-repo mismatch is detected:
+
+1. Identify which upstream repo changed (check `git log --oneline -5`)
+2. Search torch-spyre open PRs for a fix (Agent D handles this)
+3. If no fix PR exists, flag as high-priority action item
+
+---
+
+## Phase 4: Generate PDF Report
+
+After synthesizing the report, generate a corporate-styled PDF for
+executive consumption.
+
+### Step 1: Generate HTML
+
+Write an HTML file to `tools/health_report_YYYY-MM-DD.html` with:
+
+- Embedded CSS (no external dependencies)
+- Corporate styling: navy (#1F3A5F) section headers, light gray
+  (#F5F7FA) alternating table rows, green/red/amber status badges
+- Summary cards at the top (build pass count, CI status, PRs merged,
+  open bugs)
+- `@media print` rules for clean page breaks
+- All report data from the synthesis phase populated into the template
+
+Use the format from `tools/health_report_2026-05-20.html` as the
+reference template for structure and styling.
+
+### Step 2: Convert to PDF
+
+Use Chrome headless to convert:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --headless --disable-gpu --no-pdf-header-footer \
+  --print-to-pdf="tools/health_report_YYYY-MM-DD.pdf" \
+  "tools/health_report_YYYY-MM-DD.html"
+```
+
+On Linux (pod or CI):
+
+```bash
+google-chrome --headless --disable-gpu --no-pdf-header-footer \
+  --print-to-pdf="tools/health_report_YYYY-MM-DD.pdf" \
+  "tools/health_report_YYYY-MM-DD.html"
+```
+
+### Step 3: Open the PDF
+
+```bash
+open "tools/health_report_YYYY-MM-DD.pdf"
+```
+
+Report the PDF path to the user.

--- a/.claude/skills/doc-sync-swarm/SKILL.md
+++ b/.claude/skills/doc-sync-swarm/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: doc-sync-swarm
+description: "Multi-agent documentation sync that detects code-to-docs drift, updates the supported ops table, syncs API docs, and verifies compiler/user guide accuracy. Run after op additions or API changes."
+---
+
+# Doc Sync Swarm
+
+Detects documentation drift against the current codebase and
+generates fixes. Uses 4 parallel agents to audit different
+documentation domains, then produces PRs or patches for each
+area that has drifted.
+
+Use after merging op additions, API changes, or compiler
+modifications. Can also be run periodically to catch accumulated
+drift.
+
+---
+
+## Invocation
+
+```
+/doc-sync-swarm
+/doc-sync-swarm --ops-only
+/doc-sync-swarm --since "3 days ago"
+```
+
+Without arguments, performs a full audit. With `--ops-only`, only
+checks the supported operations table. With `--since`, limits the
+scope to changes since the given date.
+
+---
+
+## Execution Strategy
+
+### Phase 1: Detect Changes (sequential, fast)
+
+Identify what code changed that could cause doc drift:
+
+```bash
+# If --since provided, scope to recent commits
+git log --oneline --since="<date>" -- \
+  torch_spyre/_inductor/spyre_kernel.py \
+  torch_spyre/_inductor/decompositions.py \
+  torch_spyre/_inductor/customops.py \
+  torch_spyre/_inductor/lowering.py \
+  torch_spyre/ops/eager.py \
+  torch_spyre/__init__.py \
+  torch_spyre/_inductor/constants.py
+
+# Otherwise, compare docs against current code state
+```
+
+### Phase 2: Fan Out (4 parallel agents)
+
+| Agent | Domain | Primary Doc File |
+|-------|--------|------------------|
+| **ops-table-agent** | Supported operations table | `docs/source/user_guide/supported_operations.md` |
+| **api-docs-agent** | Public API reference | `docs/source/api/torch_spyre.rst` |
+| **compiler-docs-agent** | Compiler architecture docs | `docs/source/compiler/*.md` |
+| **user-guide-agent** | User-facing guides | `docs/source/user_guide/*.md` |
+
+### Phase 3: Apply Fixes
+
+For each agent that found drift, apply the fix directly to the
+doc files. Then run Sphinx build to verify no broken links.
+
+### Phase 4: Report
+
+Present a summary of what was updated and offer to commit.
+
+---
+
+## Agent A: ops-table-agent
+
+**Goal:** Synchronize `docs/source/user_guide/supported_operations.md`
+with the actual code state.
+
+### Data Sources
+
+| Column | Source of Truth |
+|--------|----------------|
+| Eager | `torch_spyre/ops/eager.py` (register_torch_compile_kernel list) + `torch_spyre/_inductor/decompositions.py` (aten ops with PrivateUse1 dispatch) |
+| Compiled | `torch_spyre/_inductor/spyre_kernel.py` (SpyreOpFuncs methods) + `torch_spyre/_inductor/customops.py` + `torch_spyre/_inductor/lowering.py` |
+| Execution | "Spyre" if in SpyreOpFuncs or has lowering; "CPU fallback" if only in `fallbacks.py` |
+| Notes | Decomposition details from `decompositions.py`; special handling notes |
+
+### Steps
+
+1. **Extract compiled ops from code:**
+
+```bash
+# SpyreOpFuncs methods (direct mappings)
+grep -E "def [a-z]" torch_spyre/_inductor/spyre_kernel.py \
+  | grep -v "__" | awk '{print $2}' | cut -d'(' -f1 | sort
+
+# Custom ops with lowerings
+grep "register_spyre_lowering" torch_spyre/_inductor/lowering.py \
+  | grep -oE "torch\.ops\.(spyre|aten)\.[a-z_]+" | sort
+
+# Decompositions (compiled path)
+grep "register_spyre_decomposition" torch_spyre/_inductor/decompositions.py \
+  | grep -oE "aten\.[a-z_]+\.[a-z_]+" | sort
+```
+
+2. **Extract eager ops from code:**
+
+```bash
+# Eager registration list
+grep "aten\." torch_spyre/ops/eager.py | grep -oE "aten\.[a-z_]+" | sort
+
+# Fallback ops (CPU execution)
+grep -E "def |aten\." torch_spyre/ops/fallbacks.py \
+  | grep -oE "aten\.[a-z_]+" | sort
+```
+
+3. **Extract current table from docs:**
+
+```bash
+grep "^|" docs/source/user_guide/supported_operations.md \
+  | grep -v "^|---" | grep -v "^| Operation"
+```
+
+4. **Compare and generate diff:**
+
+For each op in code but NOT in table → add row.
+For each op in table but NOT in code → flag as stale.
+For each op with wrong Eager/Compiled/Execution status → fix.
+
+### Output
+
+Edit `docs/source/user_guide/supported_operations.md` directly
+to add missing ops or correct statuses. Maintain the existing
+table format and category groupings.
+
+Report:
+```markdown
+### Ops Table Sync
+
+- **Added:** <N> ops (<list>)
+- **Removed (stale):** <N> ops (<list>)
+- **Corrected:** <N> ops (<list with what changed>)
+- **No changes needed:** (if table is current)
+```
+
+---
+
+## Agent B: api-docs-agent
+
+**Goal:** Synchronize `docs/source/api/torch_spyre.rst` with the
+actual public API exported by `torch_spyre/__init__.py`.
+
+### Steps
+
+1. **Extract public API from code:**
+
+```bash
+# Functions and classes exported via make_spyre_module
+grep -E "^\s+(def |class )" torch_spyre/__init__.py \
+  | grep -v "^.*_" | awk '{print $2}' | cut -d'(' -f1
+
+# Stream API
+grep -E "^\s+(def |class )" torch_spyre/streams.py \
+  | grep -v "^.*_" | awk '{print $2}' | cut -d'(' -f1
+
+# Constants / env vars
+grep -E "^[A-Z_]+ =" torch_spyre/_inductor/constants.py
+```
+
+2. **Extract documented API from RST:**
+
+```bash
+grep -E "^\.\. (function|class|attribute|data)::" \
+  docs/source/api/torch_spyre.rst
+```
+
+3. **Compare:**
+
+- Functions in code but not in docs → add autodoc entry
+- Functions in docs but removed from code → remove entry
+- Signature changes → flag for manual review
+
+### Output
+
+Edit `docs/source/api/torch_spyre.rst` if needed, or report
+what needs manual attention (signature changes require prose
+updates).
+
+```markdown
+### API Docs Sync
+
+- **Added:** <N> entries (<list>)
+- **Removed (stale):** <N> entries (<list>)
+- **Signature changes:** <list — needs manual review>
+- **No changes needed:** (if current)
+```
+
+---
+
+## Agent C: compiler-docs-agent
+
+**Goal:** Verify compiler documentation matches current code
+structure.
+
+### Docs to Check
+
+| Doc | Validates Against |
+|-----|-------------------|
+| `docs/source/compiler/architecture.md` | Module structure in `torch_spyre/_inductor/` |
+| `docs/source/compiler/adding_operations.md` | Patterns in `spyre_kernel.py`, `decompositions.py`, `customops.py`, `lowering.py` |
+| `docs/source/compiler/work_division_planning.md` | `torch_spyre/_inductor/codegen/` structure |
+
+### Steps
+
+1. **Check module references are valid:**
+
+```bash
+# Extract file/module references from docs
+grep -oE "torch_spyre/[a-z_/]+\.py" docs/source/compiler/*.md | sort -u
+
+# Verify each exists
+for f in $(grep -ohE "torch_spyre/[a-z_/]+\.py" \
+  docs/source/compiler/*.md | sort -u); do
+  [ -f "$f" ] || echo "MISSING: $f"
+done
+```
+
+2. **Check class/function references are valid:**
+
+```bash
+# Extract code references from docs
+grep -oE "(SpyreOpFuncs|register_spyre_decomposition|register_spyre_lowering|PointwiseOp|ReductionOp)" \
+  docs/source/compiler/*.md
+```
+
+Verify each referenced symbol still exists at the stated location.
+
+3. **Check pattern examples are current:**
+
+If `adding_operations.md` shows example code, verify the patterns
+match current code style (e.g., decorator signatures, import paths).
+
+4. **Check for new modules not yet documented:**
+
+```bash
+# Find Python modules in _inductor not mentioned in any doc
+find torch_spyre/_inductor -name "*.py" -not -name "__*" \
+  | while read f; do
+    base=$(basename "$f" .py)
+    grep -rl "$base" docs/source/compiler/ > /dev/null || echo "UNDOC: $f"
+  done
+```
+
+### Output
+
+```markdown
+### Compiler Docs Sync
+
+- **Stale references:** <list of dead file/symbol references>
+- **New undocumented modules:** <list>
+- **Pattern drift:** <examples that no longer match code>
+- **No changes needed:** (if current)
+```
+
+---
+
+## Agent D: user-guide-agent
+
+**Goal:** Verify user-facing documentation is accurate.
+
+### Docs to Check
+
+| Doc | What to Verify |
+|-----|----------------|
+| `docs/source/user_guide/running_models.md` | Import patterns, device usage, compile invocation |
+| `docs/source/user_guide/tensors_and_layouts.md` | Layout types, stick sizes, dtype support |
+| `docs/source/user_guide/profiling.md` | Profiler API matches `torch_spyre/profiler/` |
+| `docs/source/user_guide/debugging.md` | Env vars match `constants.py` and CLAUDE.md |
+| `docs/source/getting_started/installation.md` | Dependencies match `pyproject.toml` |
+| `docs/source/getting_started/quickstart.md` | Code examples are runnable |
+
+### Steps
+
+1. **Environment variables audit:**
+
+```bash
+# Extract env vars from code
+grep -rhoE "os\.(environ|getenv)\(['\"]([A-Z_]+)" torch_spyre/ \
+  --include="*.py" | sort -u
+
+# Extract env vars documented
+grep -oE "[A-Z_]{4,}" docs/source/user_guide/debugging.md | sort -u
+```
+
+Flag env vars in code but not documented, or documented but
+no longer in code.
+
+2. **Import pattern verification:**
+
+Check that quickstart/running_models examples use current
+patterns:
+- `import torch_spyre` (not `from torch_spyre import ...`)
+- `torch.compile()` without backend arg (Spyre is an Inductor
+  device backend, dispatched automatically)
+- Device tensors: `torch.randn(..., device="spyre")`
+
+3. **Dependency version check:**
+
+```bash
+# pyproject.toml torch version
+grep "torch" pyproject.toml | head -3
+
+# installation.md mentioned versions
+grep -iE "torch|pytorch|python" \
+  docs/source/getting_started/installation.md | head -10
+```
+
+4. **Profiler API sync:**
+
+```bash
+# Public profiler functions
+grep -E "^(def |class )" torch_spyre/profiler/*.py \
+  | grep -v "^.*_"
+
+# Documented profiler usage
+grep -E "profiler\." docs/source/user_guide/profiling.md
+```
+
+### Output
+
+```markdown
+### User Guide Sync
+
+- **Env var drift:** <undocumented vars or stale docs>
+- **Version mismatch:** <pyproject vs docs>
+- **API pattern drift:** <outdated examples>
+- **No changes needed:** (if current)
+```
+
+---
+
+## Final Output Format
+
+```markdown
+# Documentation Sync Report
+
+**Date:** <today>
+**Scope:** Full audit / Ops only / Since <date>
+
+## Summary
+
+| Area | Status | Changes |
+|------|--------|---------|
+| Ops Table | SYNCED/DRIFTED | +N added, -N stale |
+| API Docs | SYNCED/DRIFTED | +N added, -N removed |
+| Compiler Docs | SYNCED/DRIFTED | N stale refs, N undocumented |
+| User Guide | SYNCED/DRIFTED | N issues |
+
+## Changes Made
+
+<list of files edited with description of change>
+
+## Manual Action Required
+
+<items that need human judgment — e.g., prose descriptions
+for new features, architecture diagram updates>
+
+## Verification
+
+```bash
+# Build docs to verify no broken links
+cd docs && make html SPHINXOPTS="-W" 2>&1 | tail -20
+```
+```
+
+---
+
+## When NOT to Edit Docs
+
+- Do not invent documentation for features you haven't verified
+  exist in the code
+- Do not remove table entries without confirming the op was
+  actually removed (it may have been moved to a different
+  implementation path)
+- Do not change prose descriptions of architecture without
+  explicit user approval — only fix factual references (file
+  paths, function names, env vars)
+- Factual corrections (wrong file path, renamed function) can
+  be applied directly
+- Subjective changes (rewording, restructuring) should be
+  reported but not applied
+
+---
+
+## Integration with PR Review Swarm
+
+The doc-impact-agent in the PR Review Swarm detects WHAT needs
+updating. This Doc Sync Swarm actually MAKES the updates. They
+work together:
+
+1. PR merged with new op → PR Review Swarm flagged "ops table
+   needs update"
+2. Run `/doc-sync-swarm --ops-only` → ops-table-agent updates
+   the table
+3. Commit the doc fix as a follow-up PR
+
+Or run `/doc-sync-swarm` periodically (weekly) to catch any
+accumulated drift across all documentation.

--- a/.claude/skills/implement-op/SKILL.md
+++ b/.claude/skills/implement-op/SKILL.md
@@ -1,0 +1,504 @@
+---
+name: implement-op
+description: "Swarm-based implementation of new Spyre operations. Researches the op, determines pattern, writes code and tests, validates. Scoped to torch-spyre-only changes (no backend compiler modifications)."
+---
+
+# Implement Op Swarm
+
+Implements a new operation on the Spyre backend using a multi-agent
+swarm. Accepts an op name (ATen, torch, or functional) and
+orchestrates research, implementation, testing, and validation.
+
+**Scope:** Only ops implementable within torch-spyre. If the op
+requires new backend compiler support (deeptools/flex), the swarm
+stops and reports the blocker.
+
+---
+
+## Invocation
+
+The user provides an op name as the argument:
+
+- `torch.neg`
+- `aten.maximum`
+- `torch.nn.functional.silu`
+- `torch.pow`
+
+---
+
+## Execution Strategy
+
+### Phase 1: Research (1 agent, foreground)
+
+Launch the research-agent first. Its output determines whether to
+proceed and which pattern to use.
+
+### Phase 2: Implement + Test (2 agents, parallel)
+
+If research-agent approves, launch implement-agent and test-agent
+in parallel.
+
+### Phase 3: Validate (1 agent, foreground)
+
+After code and tests are written, launch validate-agent to run
+pre-commit and (optionally) pod tests.
+
+---
+
+## The Three Patterns
+
+### Pattern 1: Direct ATen to OpFunc Mapping
+
+**When:** The op maps directly to a backend OpFunc that already
+exists (the op name is already supported by the Spyre compiler).
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `torch_spyre/_inductor/spyre_kernel.py` | Add `@staticmethod` to `SpyreOpFuncs` class |
+| `torch_spyre/_inductor/constants.py` | Add to `SPYRE_FP32_OPS` if op runs in FP32 |
+| `torch_spyre/ops/eager.py` | Add to `register_torch_compile_kernel()` list |
+| `tests/inductor/test_inductor_ops.py` | Add test cases |
+
+**Example (maximum/minimum):**
+
+```python
+# spyre_kernel.py — add to SpyreOpFuncs in alphabetical order
+@staticmethod
+def maximum(a, b):
+    return PointwiseOp("maximum", [a, b])
+
+# constants.py — add to SPYRE_FP32_OPS list
+SPYRE_FP32_OPS = [
+    ...,
+    "maximum",
+    ...
+]
+
+# eager.py — add to register_torch_compile_kernel() list
+register_torch_compile_kernel(
+    [
+        ...,
+        aten.maximum,
+        ...
+    ]
+)
+
+# test_inductor_ops.py — add to appropriate dict
+POINTWISE_BINARY_OPS_DICT = {
+    ...,
+    "maximum": torch.maximum,
+}
+```
+
+### Pattern 2: Spyre-Specific Decomposition
+
+**When:** The op can be rewritten using ops Spyre already supports.
+The decomposition runs at the FX graph level before lowering.
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `torch_spyre/_inductor/decompositions.py` | Add `@register_spyre_decomposition` function |
+| `tests/inductor/test_inductor_ops.py` | Add test cases |
+
+**Example (logical\_not):**
+
+```python
+# decompositions.py
+@register_spyre_decomposition([torch.ops.aten.logical_not.default])
+def spyre_logical_not(input):
+    return torch.ops.aten.bitwise_not(input.to(torch.bool))
+```
+
+### Pattern 3: Custom Op + Lowering
+
+**When:** The op needs a new `torch.ops.spyre.X` custom op with
+explicit Inductor lowering and SpyreOpFuncs entry.
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `torch_spyre/_inductor/customops.py` | Define `@torch.library.custom_op` + `@register_fake` |
+| `torch_spyre/_inductor/lowering.py` | Add `@register_spyre_lowering` function |
+| `torch_spyre/_inductor/spyre_kernel.py` | Add `@staticmethod` to `SpyreOpFuncs` |
+| `tests/inductor/test_inductor_ops.py` | Add test cases |
+
+**Example (softplus):**
+
+```python
+# customops.py
+@torch.library.custom_op(
+    "spyre::softplus", mutates_args=(), device_types="spyre"
+)
+def softplus(
+    input: torch.Tensor, beta: float = 1.0, threshold: float = 20.0
+) -> torch.Tensor:
+    pass
+
+@softplus.register_fake
+def _(
+    input: torch.Tensor, beta: float = 1.0, threshold: float = 20.0
+):
+    return input.new_empty(input.size())
+
+# lowering.py
+@register_spyre_lowering(torch.ops.spyre.softplus)
+def lower_softplus(x, beta=1.0, threshold=20.0):
+    fn = lowering.ops_wrapper(torch.ops.spyre.softplus.__name__)
+    def inner_fn(index):
+        return fn(x.make_loader()(index), beta, threshold)
+    pw = Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=x.get_size(),
+        origin_node=x.get_origin_node(),
+        traceback=x.get_traceback(),
+    )
+    pw.realize()
+    return pw
+
+# spyre_kernel.py
+@staticmethod
+def softplus(x, beta, threshold):
+    op_info = {
+        "constants": {
+            "softplusBeta": beta,
+            "softplusThresh": threshold,
+        }
+    }
+    return PointwiseOp("softplus", [x], op_info)
+```
+
+---
+
+## Agent A: research-agent
+
+**Goal:** Determine which pattern applies and whether the op is
+implementable within torch-spyre.
+
+### Steps
+
+1. Resolve the op name to its ATen operator:
+
+```bash
+grep -r "<op_name>" torch_spyre/_inductor/ --include="*.py" | head -20
+```
+
+2. Check if already implemented in SpyreOpFuncs:
+
+```bash
+grep -n "<op_name>" torch_spyre/_inductor/spyre_kernel.py
+```
+
+3. Check if already decomposed:
+
+```bash
+grep -n "<op_name>" torch_spyre/_inductor/decompositions.py
+```
+
+4. Check if already a custom op:
+
+```bash
+grep -n "<op_name>" torch_spyre/_inductor/customops.py
+```
+
+5. Check if the op is in the eager registration list:
+
+```bash
+grep -n "<op_name>" torch_spyre/ops/eager.py
+```
+
+6. Check if the backend OpFunc name exists (search codegen):
+
+```bash
+grep -rn "<op_name>" torch_spyre/_inductor/codegen/ --include="*.py"
+```
+
+7. Look at how similar ops are implemented (find the closest
+   existing op in SpyreOpFuncs and use it as a template).
+
+8. Check if it needs FP32 whitelisting (ops that accumulate or
+   need precision should be in SPYRE_FP32_OPS).
+
+### Decision Logic
+
+```
+Is the op already fully implemented?
+├─ YES → Report "already implemented" and STOP
+│
+└─ NO → Does an OpFunc with this name exist in the backend?
+   ├─ YES → Pattern 1 (direct mapping)
+   ├─ MAYBE (similar name exists) → Pattern 1 with name mapping
+   │
+   └─ NO → Can the op be decomposed into existing supported ops?
+      ├─ YES → Pattern 2 (decomposition)
+      │
+      └─ NO → Is there a backend OpFunc that does the computation
+              under a different name or with parameters?
+         ├─ YES → Pattern 3 (custom op wrapping existing OpFunc)
+         │
+         └─ NO → STOP: "Requires backend compiler support"
+```
+
+### When to STOP
+
+Report "requires backend compiler changes" if:
+
+- No existing OpFunc can implement the computation
+- The op needs new SuperDSC descriptor patterns
+- The op needs new memory/data movement operations
+- The op requires modifications to `codegen/superdsc.py` or
+  `codegen/compute_ops.py`
+
+### Report Format
+
+```markdown
+## Research Result
+
+**Op:** <full aten name>
+**Signature:** <arg types and return type>
+**Pattern:** 1 / 2 / 3 / BLOCKED
+**Reason:** <why this pattern>
+**Template:** <name of similar existing op to use as reference>
+**FP32 required:** yes/no
+**Files to modify:** <list>
+**Blockers:** none / <description>
+```
+
+---
+
+## Agent B: implement-agent
+
+**Goal:** Write the implementation code based on research-agent
+output.
+
+### Instructions
+
+- Read the research-agent report for pattern choice and template op
+- Read the template op's implementation as reference
+- Write the new op following the EXACT same style
+- Keep methods in `SpyreOpFuncs` sorted alphabetically
+- Keep entries in `SPYRE_FP32_OPS` sorted alphabetically
+- Keep entries in `register_torch_compile_kernel()` sorted by name
+- Include the Apache 2.0 header only if creating new files
+- Do NOT add comments explaining what the code does
+- Do NOT add type annotations beyond what existing code uses
+
+### Validation Checklist (before reporting done)
+
+- [ ] SpyreOpFuncs method is alphabetically placed
+- [ ] Op name string matches what backend expects
+- [ ] Eager registration uses correct `aten.<name>` reference
+- [ ] FP32 whitelist updated if needed
+- [ ] No `import re` (use `import regex`)
+
+---
+
+## Agent C: test-agent
+
+**Goal:** Write compiled-path tests for the new op.
+
+### Test Location
+
+All tests go in `tests/inductor/test_inductor_ops.py`.
+
+### For Pointwise Unary Ops
+
+Add to `POINTWISE_UNARY_OPS_DICT`:
+
+```python
+POINTWISE_UNARY_OPS_DICT = {
+    ...,
+    "<op_name>": torch.<op_name>,
+}
+```
+
+The existing `TestOps` class with `ParameterizedTestMeta` will
+auto-generate test cases covering multiple shapes.
+
+### For Pointwise Binary Ops
+
+Add to `POINTWISE_BINARY_OPS_DICT`:
+
+```python
+POINTWISE_BINARY_OPS_DICT = {
+    ...,
+    "<op_name>": torch.<op_name>,
+}
+```
+
+### For Reduction Ops
+
+Add to `CORE_REDUCTION_OPS_DICT`:
+
+```python
+CORE_REDUCTION_OPS_DICT = {
+    ...,
+    "<op_name>": torch.<op_name>,
+}
+```
+
+### For Complex or Custom Ops
+
+Write a dedicated test method using `compare_with_cpu()`:
+
+```python
+def test_<op_name>_fp16(self):
+    def fn(x):
+        return torch.<op_name>(x)
+
+    x = torch.randn(128, 256, dtype=torch.float16, device="spyre")
+    self.compare_with_cpu(fn, (x,), atol=0.1, rtol=0.1)
+```
+
+### Shape Requirements
+
+- Stick-aligned: dimensions that are multiples of 64 (e.g., 128,
+  256, 512)
+- Non-aligned: dimensions that are NOT multiples of 64 (e.g., 67,
+  71, 129) to test SDSC padding paths
+- Cover 2D minimum; include 3D and 4D if the op handles
+  multi-dimensional inputs
+
+### Defaults
+
+- dtype: `torch.float16` (Spyre default)
+- atol: `0.1`, rtol: `0.1` (standard fp16 tolerance)
+- Use `cached_randn()` where available for reproducibility
+
+---
+
+## Agent D: validate-agent
+
+**Goal:** Verify implementation is correct and PR-ready.
+
+### Steps
+
+1. Run pre-commit on modified files:
+
+```bash
+pre-commit run --files <list of modified files>
+```
+
+Or if pre-commit is not available locally:
+
+```bash
+python3 -m ruff check torch_spyre/_inductor/spyre_kernel.py
+python3 -m ruff format --check torch_spyre/_inductor/spyre_kernel.py
+```
+
+2. Check license headers on any new files:
+
+```bash
+head -14 <new_file> | grep "Apache License"
+```
+
+3. Check no `import re`:
+
+```bash
+grep -rn "^import re$" torch_spyre/ tests/ --include="*.py"
+```
+
+4. If pod is available, run the specific test:
+
+```bash
+kubectl exec -n a5-deepview rganti-spyre-main -- bash -lc "
+WS=\$HOME/main-workspace
+source \$WS/activate.sh
+cd \$WS/torch-spyre
+python3 -m pytest tests/inductor/test_inductor_ops.py \
+  -k '<op_name>' -x --tb=short 2>&1 | tail -30
+"
+```
+
+5. If pod is NOT available, report test as SKIPPED.
+
+### Report Format
+
+```markdown
+## Validation Result
+
+- Pre-commit: PASS / FAIL (<details>)
+- License headers: PASS / N/A (no new files)
+- Import check: PASS / FAIL
+- Pod test: PASS / FAIL / SKIPPED
+- **Overall: READY / NEEDS FIXES**
+
+### Issues Found (if any)
+- <issue 1>
+- <issue 2>
+```
+
+---
+
+## Output Format
+
+Present the final result to the user:
+
+```markdown
+## Op Implementation Summary
+
+**Op:** torch.<name> (aten.<name>)
+**Pattern:** 1 (direct mapping) / 2 (decomposition) / 3 (custom op)
+**Status:** COMPLETE / BLOCKED (requires backend changes)
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `torch_spyre/_inductor/spyre_kernel.py` | Added <name> method |
+| `torch_spyre/_inductor/constants.py` | Added to SPYRE_FP32_OPS |
+| `torch_spyre/ops/eager.py` | Added to eager registration |
+| `tests/inductor/test_inductor_ops.py` | Added test cases |
+
+### Validation
+
+- Pre-commit: PASS/FAIL
+- Pod test: PASS/FAIL/SKIPPED
+
+### Next Steps
+
+- [ ] Review the diff
+- [ ] Create branch and commit with `git commit -s`
+- [ ] Push and create PR
+```
+
+If BLOCKED:
+
+```markdown
+## Op Implementation Summary
+
+**Op:** torch.<name>
+**Status:** BLOCKED — requires backend compiler changes
+
+### Reason
+
+<explanation of why the op cannot be implemented in torch-spyre alone>
+
+### Recommendation
+
+File an issue against deeptools/flex requesting OpFunc support for
+"<op_name>". Include the ATen signature and expected behavior.
+```
+
+---
+
+## Key Reference Files
+
+| File | What to Find |
+|------|--------------|
+| `torch_spyre/_inductor/spyre_kernel.py` | SpyreOpFuncs class (all direct mappings) |
+| `torch_spyre/_inductor/constants.py` | SPYRE_FP32_OPS whitelist |
+| `torch_spyre/ops/eager.py` | Eager mode registration list |
+| `torch_spyre/_inductor/decompositions.py` | Decomposition decorator and examples |
+| `torch_spyre/_inductor/customops.py` | Custom op definitions |
+| `torch_spyre/_inductor/lowering.py` | Lowering registrations |
+| `torch_spyre/_inductor/codegen/superdsc.py` | Backend codegen (DO NOT MODIFY) |
+| `torch_spyre/_inductor/codegen/compute_ops.py` | Compute op dispatch (DO NOT MODIFY) |
+| `tests/inductor/test_inductor_ops.py` | Test framework and op dicts |
+| `tests/_inductor/utils_inductor.py` | Test utilities (compare_with_cpu, etc.) |

--- a/.claude/skills/pr-review-swarm/SKILL.md
+++ b/.claude/skills/pr-review-swarm/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: pr-review-swarm
+description: "Multi-agent PR review that parallelizes compliance, code quality, test coverage, and documentation checks. Produces a unified review comment with severity-ranked findings."
+---
+
+# PR Review Swarm
+
+Performs a comprehensive pull request review using 4 parallel agents,
+each specializing in a different review dimension. Synthesizes results
+into a single structured review comment.
+
+Use when reviewing incoming PRs to torch-spyre. Accepts a PR number
+or URL as argument.
+
+---
+
+## Invocation
+
+```
+/pr-review-swarm 2190
+/pr-review-swarm https://github.com/torch-spyre/torch-spyre/pull/2190
+```
+
+---
+
+## Execution Strategy
+
+### Phase 1: Fetch PR Context (sequential, fast)
+
+Before launching agents, gather PR metadata and diff:
+
+```bash
+gh pr view <number> --repo torch-spyre/torch-spyre \
+  --json title,body,author,labels,files,additions,deletions,commits,reviewDecision
+
+gh pr diff <number> --repo torch-spyre/torch-spyre
+```
+
+Determine which files are touched and categorize them:
+
+| Category | Pattern |
+|----------|---------|
+| Compiler | `torch_spyre/_inductor/` |
+| Runtime/C++ | `torch_spyre/_C/`, `*.cpp`, `*.hpp` |
+| Eager ops | `torch_spyre/ops/` |
+| Tests | `tests/` |
+| Docs | `docs/` |
+| Config/CI | `.github/`, `pyproject.toml`, `*.yaml` |
+
+### Phase 2: Fan Out (4 parallel agents)
+
+Launch ALL simultaneously:
+
+| Agent | Focus | Relevant when |
+|-------|-------|---------------|
+| **compliance-agent** | License, DCO, imports, formatting | Always |
+| **code-quality-agent** | Architecture, tensor layout, error handling | Compiler/Runtime/Ops changes |
+| **test-coverage-agent** | Test completeness, shape variety, parameterization | Any code change |
+| **doc-impact-agent** | Ops table, API docs, user guide impact | Op additions, API changes |
+
+### Phase 3: Synthesis
+
+Merge all agent findings into a single review, deduplicate, and
+rank by severity (BLOCKER > WARNING > SUGGESTION > NOTE).
+
+---
+
+## Agent A: compliance-agent
+
+**Goal:** Verify mechanical correctness that gates merge-readiness.
+
+### Checks
+
+1. **License Headers**
+
+Every new `.py` file must have the 14-line Apache 2.0 header:
+
+```python
+# Copyright <year> The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 ...
+```
+
+Every new `.cpp`/`.hpp` file must have the `/* ... */` equivalent.
+
+```bash
+# Find new files in the diff
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  | grep "^diff --git" | grep -E '\.(py|cpp|hpp)$'
+```
+
+For each new file (shows `new file mode` in diff), verify header.
+
+2. **Signed Commits (DCO)**
+
+```bash
+gh pr view <number> --repo torch-spyre/torch-spyre \
+  --json commits --jq '.commits[].messageBody' \
+  | grep -c "Signed-off-by:"
+```
+
+Every commit must have a `Signed-off-by:` line.
+
+3. **Import Enforcement**
+
+Check for `import re` (must use `import regex`):
+
+```bash
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  | grep "^+" | grep -E "^\\+import re$|^\\+from re import"
+```
+
+4. **Line Length (88 chars)**
+
+Check for obvious violations in Python files (ruff enforces this,
+but catch it early):
+
+```bash
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  | grep "^+" | awk 'length > 92'
+```
+
+5. **CI Status**
+
+```bash
+gh pr checks <number> --repo torch-spyre/torch-spyre
+```
+
+### Report Format
+
+```markdown
+### Compliance
+
+| Check | Status | Details |
+|-------|--------|---------|
+| License headers | PASS/FAIL | <files missing headers> |
+| DCO sign-off | PASS/FAIL | <unsigned commits> |
+| Import regex | PASS/FAIL | <files using import re> |
+| CI checks | PASS/FAIL/PENDING | <failing jobs> |
+```
+
+---
+
+## Agent B: code-quality-agent
+
+**Goal:** Review architectural correctness and Spyre-specific
+patterns. This is the domain-expert agent.
+
+### Checks
+
+1. **Tensor Layout Correctness**
+
+If diff touches layout-related code, verify:
+- `SpyreTensorLayout` fields are used correctly
+- Stick dimension alignment (multiples of 64 for fp16)
+- `FixedTiledLayout` device_layout parameters
+- No assumptions of contiguous memory where tiled applies
+
+```bash
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  | grep -E "SpyreTensorLayout|FixedTiledLayout|stick|dim_map"
+```
+
+2. **Dual Path Impact**
+
+Determine if changes affect eager, compiled, or both paths:
+
+| File pattern | Path |
+|---|---|
+| `torch_spyre/ops/` | Eager |
+| `torch_spyre/_inductor/` | Compiled |
+| `torch_spyre/_C/` | Both |
+
+Flag if a code change only covers one path but the op is listed
+as supporting both in `supported_operations.md`.
+
+3. **Error Handling**
+
+New error raises should use `Unsupported()` from
+`torch_spyre/_inductor/errors.py`, NOT generic `RuntimeError` or
+`NotImplementedError`:
+
+```bash
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  | grep "^+" | grep -E "raise (RuntimeError|NotImplementedError)" \
+  | grep -v "test"
+```
+
+4. **SpyreOpFuncs Ordering**
+
+If `spyre_kernel.py` is modified, verify methods remain
+alphabetically sorted:
+
+```bash
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  | grep -A2 "@staticmethod" | grep "def "
+```
+
+5. **FP32 Ops Consistency**
+
+If a new op is added to `SpyreOpFuncs`, check whether it should
+also be in `SPYRE_FP32_OPS` (ops that accumulate, use division,
+or need precision).
+
+6. **Constants and Magic Numbers**
+
+Flag hardcoded stick sizes (64, 128) that should reference
+constants. Flag hardcoded device strings that should use
+`DEVICE_NAME`.
+
+7. **Cross-File Consistency**
+
+If an op is added/modified in one file, verify it's consistently
+updated across all relevant files:
+- `spyre_kernel.py` ↔ `constants.py` ↔ `eager.py`
+- `decompositions.py` ↔ `customops.py` ↔ `lowering.py`
+
+### Report Format
+
+```markdown
+### Code Quality
+
+**Severity: BLOCKER / WARNING / SUGGESTION**
+
+| Issue | File | Line | Severity | Details |
+|-------|------|------|----------|---------|
+| ... | ... | ... | ... | ... |
+```
+
+---
+
+## Agent C: test-coverage-agent
+
+**Goal:** Assess whether the PR has adequate test coverage for
+the changes made.
+
+### Checks
+
+1. **New Op Has Tests**
+
+If `spyre_kernel.py`, `decompositions.py`, `customops.py`, or
+`lowering.py` are modified to add a new op, verify that
+`test_inductor_ops.py` is also modified.
+
+```bash
+# Check which implementation files changed
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  --name-only | grep -E "spyre_kernel|decompositions|customops|lowering"
+
+# Check if test file changed
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  --name-only | grep "test_inductor_ops"
+```
+
+2. **Shape Variety**
+
+If new test cases are added, verify they include:
+- At least one stick-aligned shape (dim multiple of 64)
+- At least one non-aligned shape (to test padding paths)
+- 2D minimum, ideally 3D or 4D coverage
+
+```bash
+gh pr diff <number> --repo torch-spyre/torch-spyre \
+  | grep "^+" | grep -E "randn|zeros|ones|cached_randn" \
+  | grep -oE "\([0-9, ]+\)"
+```
+
+3. **ParameterizedTestMeta Usage**
+
+For new op tests, prefer the cross-product framework over
+hand-written test methods. Check if the op was added to the
+appropriate dict:
+
+- `POINTWISE_UNARY_OPS_DICT`
+- `POINTWISE_BINARY_OPS_DICT`
+- `CORE_REDUCTION_OPS_DICT`
+
+4. **Dtype Coverage**
+
+Default should be `torch.float16`. If the op is in
+`SPYRE_FP32_OPS`, verify an FP32 test path exists.
+
+5. **Missing Tests for Changed Code**
+
+If implementation files changed but no test files changed,
+flag as WARNING (not all changes need new tests, but it
+should be conscious).
+
+6. **Test Config Coverage**
+
+Every new `test_*.py` file must have a corresponding config YAML
+in `tests/configs/` and be registered in the CI workflow matrix.
+
+### Report Format
+
+```markdown
+### Test Coverage
+
+| Metric | Status | Details |
+|--------|--------|---------|
+| New ops tested | YES/NO/N/A | <ops without tests> |
+| Shape variety | GOOD/PARTIAL/MISSING | <what's missing> |
+| Parameterized | YES/NO | <hand-written vs framework> |
+| Dtype coverage | GOOD/PARTIAL | <missing dtypes> |
+| Implementation without tests | YES/NO | <untested files> |
+```
+
+---
+
+## Agent D: doc-impact-agent
+
+**Goal:** Determine if the PR requires documentation updates and
+whether those updates are included.
+
+### Checks
+
+1. **Supported Operations Table**
+
+If a new op is added (detected via `spyre_kernel.py`,
+`decompositions.py`, `customops.py`, `lowering.py`, or `eager.py`
+changes), check if `docs/source/user_guide/supported_operations.md`
+is also modified.
+
+Cross-reference:
+- Op in `SpyreOpFuncs` → should appear in "Compiled" column
+- Op in `eager.py` registration → should appear in "Eager" column
+- Op in `fallbacks.py` → should show "CPU fallback" in Execution
+
+2. **API Documentation**
+
+If `torch_spyre/__init__.py` exports change, verify
+`docs/source/api/torch_spyre.rst` is updated.
+
+If `torch_spyre/streams.py` public methods change, verify
+stream docs are updated.
+
+3. **Compiler Documentation**
+
+If new passes are added to `torch_spyre/_inductor/`, check if
+`docs/source/compiler/` docs reference them:
+- New FX pass → `inductor_frontend.md`
+- New codegen pattern → `backend.md`
+- New lowering → `adding_operations.md`
+
+4. **User Guide Impact**
+
+If behavior visible to users changes (new env var, new device
+capability, changed error message), flag that user guide may
+need updating.
+
+5. **Adding Operations Doc**
+
+If a new op pattern is introduced (not just a new op using
+existing patterns), flag that `adding_operations.md` may need
+a new example.
+
+### Report Format
+
+```markdown
+### Documentation Impact
+
+| Area | Needs Update | Included in PR | Action |
+|------|:------------:|:--------------:|--------|
+| Ops table | YES/NO | YES/NO | <what to add> |
+| API docs | YES/NO | YES/NO | <what changed> |
+| Compiler docs | YES/NO | YES/NO | <which doc> |
+| User guide | YES/NO | YES/NO | <what behavior> |
+```
+
+---
+
+## Synthesis: Final Review Output
+
+Combine all agent reports into a single review comment:
+
+```markdown
+## PR Review: #<number> — <title>
+
+**Author:** @<author> | **Files:** <N> | **+<add>/-<del>**
+
+### Summary
+
+<1-2 sentence assessment: merge-ready, needs minor fixes, or
+has blockers>
+
+### Blockers (must fix before merge)
+
+- [ ] <blocker 1 — file:line — explanation>
+- [ ] <blocker 2>
+
+### Warnings (should fix, not blocking)
+
+- [ ] <warning 1>
+- [ ] <warning 2>
+
+### Suggestions (optional improvements)
+
+- <suggestion 1>
+- <suggestion 2>
+
+### Notes (informational)
+
+- <note 1>
+
+---
+
+<details>
+<summary>Detailed Findings</summary>
+
+#### Compliance
+<compliance-agent output>
+
+#### Code Quality
+<code-quality-agent output>
+
+#### Test Coverage
+<test-coverage-agent output>
+
+#### Documentation Impact
+<doc-impact-agent output>
+
+</details>
+```
+
+### Severity Definitions
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| BLOCKER | Prevents merge; violates project policy | Must fix |
+| WARNING | Likely bug or architectural issue | Should fix |
+| SUGGESTION | Improvement opportunity | Author decides |
+| NOTE | Informational, no action needed | FYI |
+
+### What Constitutes a BLOCKER
+
+- Missing license header on new file
+- Unsigned commit (no DCO)
+- `import re` instead of `import regex`
+- New op with zero test coverage
+- CI failing due to this PR's changes
+- Security vulnerability (injection, unchecked input)
+
+### What Does NOT Block
+
+- Missing doc updates (WARNING, not BLOCKER)
+- Suboptimal but correct test shapes
+- Style preferences beyond ruff enforcement
+- Missing parameterization (SUGGESTION)

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -35,11 +35,13 @@ POINTWISE_UNARY_OPS_DICT = {
     "neg": torch.neg,
     "reciprocal": torch.reciprocal,
     "relu": torch.relu,
+    "sign": torch.sign,
     "sin": torch.sin,
     "tanh": torch.tanh,
 }
 
 POINTWISE_UNARY_OPS_FP32_DICT = {
+    "ceil": torch.ceil,
     "floor": torch.floor,
 }
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -374,6 +374,16 @@ def logical_not_decomp(input: torch.Tensor) -> torch.Tensor:
     return torch.eq(input, zero)
 
 
+@register_spyre_decomposition([torch.ops.aten.sign.default])
+def spyre_sign(input: torch.Tensor) -> torch.Tensor:
+    zero = torch.zeros_like(input)
+    return torch.where(
+        torch.gt(input, zero),
+        torch.ones_like(input),
+        torch.where(torch.lt(input, zero), -torch.ones_like(input), zero),
+    )
+
+
 @register_spyre_decomposition([torch.ops.aten.addmm.default, torch.ops.aten.addmm.out])
 def addmm_decomp(
     input: torch.Tensor,
@@ -675,6 +685,13 @@ def decompose_cat(
         return output
     else:
         return orig_decomp
+
+
+@register_spyre_decomposition([torch.ops.aten.ceil.default])
+def spyre_ceil(input: torch.Tensor) -> torch.Tensor:
+    return torch.ops.aten.neg.default(
+        torch.ops.aten.floor.default(torch.ops.aten.neg.default(input))
+    )
 
 
 @register_spyre_decomposition([torch.ops.aten.constant_pad_nd.default])


### PR DESCRIPTION
## Summary

- **`ceil`**: Decomposed as `-floor(-x)`. Tested in FP32 only — the intermediate fp16 quantization between neg/floor/neg ops causes off-by-one errors on ~0.1% of boundary values when input is fp16. FP32 path passes all tests cleanly.
- **`sign`**: Decomposed as `where(x > 0, 1, where(x < 0, -1, 0))`. Works correctly in both fp16 and fp32.

Both decompositions use only already-supported Spyre primitives (`neg`, `floor`, `where`, `gt`, `lt`, `zeros_like`, `ones_like`).

## bitwise_or Investigation

`bitwise_or` was also attempted but is **blocked** by a pre-existing bug: the `logical_not` decomposition on bool tensors fails at codegen with `"unexpected argument Constant(value=0.0, dtype=torch.float16) to greaterthan"`. The De Morgan decomposition (`~(~a & ~b)`) chains through `bitwise_not` → `logical_not` → `eq(input, ne(input, input))` which produces a constant the Spyre codegen rejects. Fixing `logical_not` for bool inputs would unblock `bitwise_or` and potentially other bool-typed ops.

## Test plan

- [x] `pytest -k "ceil or sign"` on Spyre pod: 6 passed, 1 xfailed
- [x] Broader regression: 92 passed, 0 failures across pointwise/bitwise/logical tests
- [x] ruff lint + format: PASS
- [x] No `import re` violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)