### PR TITLE
Add ceil and sign op decompositions for Spyre backend

### DIFF
--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -40,6 +40,8 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.bitwise_not` | Y | Y | Spyre | Custom decomposition |
 | `torch.clamp` | | Y | Spyre | Custom op + lowering |
 | `torch.pow` | Y | Y | Spyre | |
+| `torch.ceil` | | Y | Spyre | Custom decomposition |
+| `torch.sign` | | Y | Spyre | Custom decomposition |
 | **Pointwise Binary** | | | | |
 | `torch.add` | Y | Y | Spyre | |
 | `torch.sub` | Y | Y | Spyre | |

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -38,11 +38,13 @@ POINTWISE_UNARY_OPS_DICT = {
     "neg": torch.neg,
     "reciprocal": torch.reciprocal,
     "relu": torch.relu,
+    "sign": torch.sign,
     "sin": torch.sin,
     "tanh": torch.tanh,
 }
 
 POINTWISE_UNARY_OPS_FP32_DICT = {
+    "ceil": torch.ceil,
     "floor": torch.floor,
 }
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -374,6 +374,16 @@ def logical_not_decomp(input: torch.Tensor) -> torch.Tensor:
     return torch.eq(input, zero)
 
 
+@register_spyre_decomposition([torch.ops.aten.sign.default])
+def spyre_sign(input: torch.Tensor) -> torch.Tensor:
+    zero = torch.zeros_like(input)
+    return torch.where(
+        torch.gt(input, zero),
+        torch.ones_like(input),
+        torch.where(torch.lt(input, zero), -torch.ones_like(input), zero),
+    )
+
+
 @register_spyre_decomposition([torch.ops.aten.addmm.default, torch.ops.aten.addmm.out])
 def addmm_decomp(
     input: torch.Tensor,
@@ -678,6 +688,13 @@ def decompose_cat(
         return output
     else:
         return orig_decomp
+
+
+@register_spyre_decomposition([torch.ops.aten.ceil.default])
+def spyre_ceil(input: torch.Tensor) -> torch.Tensor:
+    return torch.ops.aten.neg.default(
+        torch.ops.aten.floor.default(torch.ops.aten.neg.default(input))
+    )
 
 
 @register_spyre_decomposition([torch.ops.aten.constant_pad_nd.default])


### PR DESCRIPTION
## Summary

- **`ceil`**: Decomposed as `-floor(-x)`. Tested in FP32 only — intermediate fp16 quantization between neg/floor/neg ops causes boundary errors with fp16 inputs.
- **`sign`**: Decomposed as `where(x > 0, 1, where(x < 0, -1, 0))`. Works in both fp16 and fp32.

Both use only already-supported Spyre primitives.

## Docs

- Updated `docs/source/user_guide/supported_operations.md` — added `torch.ceil` and `torch.sign` to the Pointwise Unary section.

## Test plan

- [x] `pytest -k "ceil or sign"` on Spyre pod: 6 passed, 1 xfailed
- [x] Broader regression (92 pointwise/bitwise/logical tests): 0 failures
- [x] ruff lint + format: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)