### PR TITLE
[test] Fix incorrect behavior of model op-level tests with multple yaml files and show tags in short summary info

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -391,6 +391,26 @@ def pytest_collection_modifyitems(config, items):
         items[:] = keep
 
 
+def pytest_report_teststatus(report, config):
+    if report.when != "call":
+        return
+
+    tags = getattr(report, "_spyre_tags", [])
+    if len(tags) > 0:
+        tags_str = " ".join(map(str, tags))
+        tags_msg = f" [TAGS = {tags_str}]"
+    else:
+        tags_msg = ""
+
+    if report.failed:
+        return "failed", "F", f"FAILED{tags_msg}"
+    if report.passed:
+        return "passed", ".", f"PASSED{tags_msg}"
+    if report.skipped:
+        return "skipped", "s", "SKIPPED"
+    return None
+
+
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if not config.getoption("--show-skipped"):
         return

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -15,7 +15,7 @@
 
 import os
 import sys
-from typing import Any, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 import regex as re
 import torch
@@ -155,11 +155,16 @@ def _build_model_ops_db() -> List[ModelOpInfo]:
                     seed=seed,
                 )
             )
+            model_ops_entry_by_unique_name[unique_name] = test_entry
 
     return db
 
 
 model_ops_db: List[ModelOpInfo] = []
+# unique_name (e.g. "torch_add__2") -> originating TestEntry. Used by the
+# variant resolver in spyre_test_base_common; dtype heuristics alone can
+# pick the wrong entry when merged YAML configs overlap in dtypes.
+model_ops_entry_by_unique_name: Dict[str, TestEntry] = {}
 
 
 def _init_model_ops_db() -> None:

--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -33,6 +33,8 @@ import shared_config
 from op_registry import OP_REGISTRY, OpAdapter
 from spyre_test_constants import ENV_TEST_CONFIG
 from spyre_test_config_models import (
+    InputArgTensor,
+    InputArgTensorList,
     OOTTestConfig,
     OpsNamedItem,
     TestEntry,
@@ -97,43 +99,62 @@ def _build_model_ops_db() -> List[ModelOpInfo]:
         return []
 
     target = "TestSpyreModelOps::test_model_ops_db"
-    test_entry: Optional[TestEntry] = None
-    for entry in file_entry.tests:
-        if target in entry.names:
-            test_entry = entry
-            break
+    matching_entries: List[TestEntry] = [
+        entry for entry in file_entry.tests if target in entry.names
+    ]
 
-    if test_entry is None:
+    if not matching_entries:
         return []
 
     db: List[ModelOpInfo] = []
     seen: Set[str] = set()
+    idx = 0
 
-    for idx, ops_item in enumerate(test_entry.edits.ops.include):
-        op_name = ops_item.name
-        if op_name not in OP_REGISTRY:
-            import warnings
+    for test_entry in matching_entries:
+        for ops_item in test_entry.edits.ops.include:
+            op_name = ops_item.name
+            if op_name not in OP_REGISTRY:
+                import warnings
 
-            warnings.warn(f"test_model_ops: {op_name!r} not in OP_REGISTRY — skipping")
-            continue
+                warnings.warn(
+                    f"test_model_ops: {op_name!r} not in OP_REGISTRY — skipping"
+                )
+                continue
 
-        safe_op = op_name.replace(".", "_")
-        unique_name = f"{safe_op}__{idx}"
+            safe_op = op_name.replace(".", "_")
+            unique_name = f"{safe_op}__{idx}"
 
-        assert unique_name not in seen, f"Duplicate model_ops_db key: {unique_name}"
-        seen.add(unique_name)
+            assert unique_name not in seen, f"Duplicate model_ops_db key: {unique_name}"
+            seen.add(unique_name)
+            idx += 1
 
-        db.append(
-            ModelOpInfo(
-                unique_name,
-                op_name,
-                dtypes=(torch.float16,),
-                adapter=OP_REGISTRY[op_name],
-                ops_item=ops_item,
-                test_entry=test_entry,
-                seed=seed,
+            # choose a representative dtype used as a part of test name
+            args = ops_item.sample_inputs_func.args
+            assert isinstance(args, list)
+            if len(args) == 0:
+                # use float16 as default
+                dtypes = (torch.float16,)
+            elif isinstance(args[0], InputArgTensor):
+                # use dtype of a tensor at the first arg
+                dtypes = (args[0].tensor.resolved_dtype(),)
+            elif isinstance(args[0], InputArgTensorList):
+                # use dtype of the first tensor in a tensor list at the first arg
+                dtypes = (args[0].tensor_list[0].resolved_dtype(),)
+            else:
+                # use float16 as default
+                dtypes = (torch.float16,)
+
+            db.append(
+                ModelOpInfo(
+                    unique_name,
+                    op_name,
+                    dtypes=dtypes,
+                    adapter=OP_REGISTRY[op_name],
+                    ops_item=ops_item,
+                    test_entry=test_entry,
+                    seed=seed,
+                )
             )
-        )
 
     return db
 

--- a/tests/spyre_test_base_common.py
+++ b/tests/spyre_test_base_common.py
@@ -8,6 +8,7 @@ import json
 from typing import Dict, List, Optional, Set
 import warnings
 
+import regex as re
 import pytest  # type: ignore
 import torch
 
@@ -154,6 +155,29 @@ def _entry_dtype_set(
     if included:
         return included
     return global_supported_dtypes  # may itself be None
+
+
+# Matches "test_model_ops_db_<unique>__<idx>_<device>_<dtype>", capturing
+# the op unique_name key into model_ops_entry_by_unique_name.
+_MODEL_OPS_VARIANT_RE = re.compile(
+    r"^test_model_ops_db_(?P<unique>.+?__\d+)_[A-Za-z0-9]+_\w+$"
+)
+
+
+def _select_entry_by_op_index(method_name: str) -> Optional["TestEntry"]:
+    """Resolve the TestEntry for a test_model_ops_db variant via the
+    authoritative unique_name mapping; returns None to let callers fall
+    back to the dtype heuristic."""
+    m = _MODEL_OPS_VARIANT_RE.match(method_name)
+    if not m:
+        return None
+    try:
+        from models.test_model_ops_v2 import (  # type: ignore
+            model_ops_entry_by_unique_name,
+        )
+    except ImportError:
+        return None
+    return model_ops_entry_by_unique_name.get(m.group("unique"))
 
 
 def _select_entry_for_variant(
@@ -694,9 +718,13 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
             # ------------------------------------------------------------------
             resolved_entry: Optional[TestEntry] = None
             if all_entries_for_name:
-                resolved_entry = _select_entry_for_variant(
-                    all_entries_for_name, method_name, cls.GLOBAL_SUPPORTED_DTYPES
-                )
+                resolved_entry = _select_entry_by_op_index(method_name)
+                if resolved_entry is None:
+                    resolved_entry = _select_entry_for_variant(
+                        all_entries_for_name,
+                        method_name,
+                        cls.GLOBAL_SUPPORTED_DTYPES,
+                    )
 
             # Tags for this specific variant = tags from the resolved entry only
             variant_tags: List[str] = (


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This PR consists of two items

1. Surface per-test tags in the pytest result line (tests/conftest.py)

  Adds a pytest_report_teststatus hook that appends `report._spyre_tags`  (already populated by the existing pytest_runtest_makereport hook) to the long-form status shown in verbose mode. Tests now report as e.g. `PASSED [TAGS = op__add dtype__float16]` instead of just `PASSED`, making verbose logs easier to triage.
  
2. Fix _build_model_ops_db() to process all matching test entries (tests/models/test_model_ops_v2.py)

  When multiple YAML configs were loaded and more than one TestEntry matched `TestSpyreModelOps::test_model_ops_db`, the previous code broke out of the loop after the first match and silently dropped every op from the remaining entries. The lookup is now replaced with a list comprehension that collects all matching entries, and the build loop iterates over them with a shared idx counter so generated unique_name keys stay collision-free across entries.
  
#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#2174
#2202
closes #2239 

#### Special notes for your reviewer:

Example of short test summary info 
```
====================================================================================================================================================================================================================== short test summary info =======================================================================================================================================================================================================================
SKIPPED [23] test_model_ops_v2.py:351: Duplicate signature already tested (--no-dedupe to disable)
FAILED [ TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_Tensor_view bf16operation constant torch.Tensor.view.4 ] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_Tensor_view__149_spyre_bfloat16 - TypeError: view() received an invalid combination of arguments - got (list), but expected one of:
FAILED [ TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_Tensor_view bf16operation constant torch.Tensor.view.5 ] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_Tensor_view__152_spyre_bfloat16 - TypeError: view() received an invalid combination of arguments - got (list), but expected one of:
FAILED [ TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_Tensor_view bf16operation constant torch.Tensor.view.1 ] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_Tensor_view__23_spyre_bfloat16 - TypeError: view() received an invalid combination of arguments - got (list), but expected one of:
...
PASSED [ TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_Tensor_contiguous bf16operation torch.Tensor.contiguous.3 ] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_Tensor_contiguous__184_spyre_bfloat16
PASSED [ TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_Tensor_contiguous bf16operation torch.Tensor.contiguous.4 ] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_Tensor_contiguous__186_spyre_bfloat16
...
================================================================================================================================================================================================ 161 failed, 302 passed, 23 skipped, 49 warnings in 498.68s (0:08:18) ================================================================================================================================================================================================
```

Example of short summary info when two yaml files are given
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b_spyre dtype__float16 op__torch_cat torch.cat.1]
====================================================================================================================================================================================================================== short test summary info =======================================================================================================================================================================================================================
FAILED [TAGS = model__gpt-oss-20b_spyre dtype__float16 op__torch_cat torch.cat.1] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_cat__1_spyre_float16 - torch._inductor.exc.InductorError: Unsupported: Spyre backend does not support: Unexpected stick expression d1 + 32: expected Mod(var, 64), a bare variable, or 0
PASSED [TAGS = model__gpt-oss-20b_spyre dtype__float32 op__torch_add torch.add.1] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__0_spyre_float32
PASSED [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add torch.add.1] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__2_spyre_bfloat16
==================================================================================================================================================================================================================== 1 failed, 2 passed in 14.49s ====================================================================================================================================================================================================================
```

#### Does this PR introduce a user-facing change?

#### Additional note:
