### PR TITLE
Updated test_synchronize_callable() in test_spyre_profiler.py

### DIFF
--- a/tests/profiler/test_spyre_profiler.py
+++ b/tests/profiler/test_spyre_profiler.py
@@ -63,8 +63,13 @@ def test_synchronize_callable():
     assert hasattr(torch, "spyre"), "torch.spyre namespace is missing"
     assert hasattr(torch.spyre, "synchronize"), "torch.spyre.synchronize() is missing"
 
-    x = torch.randn(64, 64, device="spyre")
-    y = torch.randn(64, 64, device="spyre")
+    cpu_x = torch.randn(64, 64)
+    cpu_y = torch.randn(64, 64)
+
+    ref = torch.matmul(cpu_x, cpu_y)
+
+    x = cpu_x.to("spyre")
+    y = cpu_y.to("spyre")
 
     z = torch.matmul(x, y)
 
@@ -72,5 +77,4 @@ def test_synchronize_callable():
 
     result = z.cpu()
 
-    assert result.numel() == 64 * 64
-    assert torch.isfinite(result).all()
+    assert torch.allclose(result, ref)


### PR DESCRIPTION
Signed-off-by:  <>

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ x ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Based on a previous comment made on a PR:
"test_synchronize_callable now runs a real matmul on Spyre before calling synchronize(), which is a great improvement. But since .cpu() implicitly forces a sync, the current numel / isfinite assertions would still pass even if synchronize() were a no-op. Could you open a follow-up PR to add a numerical correctness check (e.g., compare z.cpu() against a CPU-computed reference with torch.allclose) so the test actually exercises synchronize()'s contract?"

#### Which issue(s) this PR is related to:

This PR originates from Issue #933 and PR #1721 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
