### PR TITLE
Support dtype conversion at DCI level for H2D/D2H transfers (#2134)

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -671,10 +671,11 @@ class TestSpyre(TestCase):
 
         Tests roundtrip for each supported dtype conversion: create tensor on
         CPU with src_dtype, transfer to Spyre with dst_dtype (H2D), then back
-        to CPU (D2H).
+        to CPU (D2H). Also tests that unsupported dtype conversions raise errors.
         """
         from torch_spyre._inductor.dtype_ops import DtypeOpTable
 
+        # Test supported conversions
         for src_dtype, dst_dtype in DtypeOpTable.get_table().keys():
             # Create tensor on CPU with src_dtype
             if src_dtype.is_floating_point:
@@ -693,6 +694,24 @@ class TestSpyre(TestCase):
             tensor_back = tensor_on_spyre.to("cpu", dtype=src_dtype)
             self.assertEqual(tensor_back.device.type, "cpu")
             self.assertEqual(tensor_back.dtype, src_dtype)
+
+        # Test unsupported conversions
+        unsupported_pairs = [
+            (torch.int8, torch.float16),
+            (torch.float32, torch.int32),
+            (torch.float16, torch.int64),
+        ]
+
+        for src_dtype, dst_dtype in unsupported_pairs:
+            # Create tensor on CPU with src_dtype
+            if src_dtype.is_floating_point:
+                tensor = torch.randn(2, 2, dtype=src_dtype)
+            else:
+                tensor = torch.randint(0, 10, (2, 2), dtype=src_dtype)
+
+            # H2D: Expect error when moving to Spyre with unsupported dst_dtype
+            with self.assertRaises(RuntimeError):
+                tensor.to("spyre", dtype=dst_dtype)
 
 
 if __name__ == "__main__":

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -701,6 +701,11 @@ class TestSpyre(TestCase):
             else:
                 self.assertEqual(actual, expected, msg=ctx)
 
+        # D2H conversions not yet supported on the D2H path.
+        skip_d2h_conversions = {
+            (torch.float32, torch.float16),
+        }
+
         # Test supported conversions
         for src_dtype, dst_dtype in DtypeOpTable.get_table().keys():
             ctx = f"H2D {src_dtype}->{dst_dtype}"
@@ -712,6 +717,9 @@ class TestSpyre(TestCase):
             _assert_values_equal(
                 h2d_spyre.to("cpu"), h2d_expected, src_dtype, dst_dtype, ctx
             )
+
+            if (dst_dtype, src_dtype) in skip_d2h_conversions:
+                continue
 
             ctx = f"D2H {dst_dtype}->{src_dtype}"
             d2h_src = _make_cpu_tensor(dst_dtype)

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -690,10 +690,10 @@ class TestSpyre(TestCase):
 
         def _assert_values_equal(actual, expected, src_dtype, dst_dtype, ctx):
             if actual.is_floating_point():
-                atol, rtol = max(
-                    float_tols.get(src_dtype, (1e-5, 1e-5)),
-                    float_tols.get(dst_dtype, (1e-5, 1e-5)),
-                )
+                src_atol, src_rtol = float_tols.get(src_dtype, (1e-5, 1e-5))
+                dst_atol, dst_rtol = float_tols.get(dst_dtype, (1e-5, 1e-5))
+                atol = max(src_atol, dst_atol)
+                rtol = max(src_rtol, dst_rtol)
                 self.assertTrue(
                     torch.allclose(actual, expected, atol=atol, rtol=rtol),
                     msg=f"{ctx}: actual={actual}, expected={expected}",

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -675,31 +675,52 @@ class TestSpyre(TestCase):
         """
         from torch_spyre._inductor.dtype_ops import DtypeOpTable
 
+        float_tols = {
+            torch.float16: (1e-3, 1e-3),
+            torch.bfloat16: (1e-2, 1.6e-2),
+            torch.float32: (1e-5, 1e-5),
+        }
+
+        def _make_cpu_tensor(dtype):
+            if dtype.is_floating_point:
+                return torch.randn(2, 2, dtype=dtype)
+            if dtype == torch.bool:
+                return torch.randint(0, 2, (2, 2), dtype=torch.int32).to(torch.bool)
+            return torch.randint(0, 10, (2, 2), dtype=dtype)
+
+        def _assert_values_equal(actual, expected, src_dtype, dst_dtype, ctx):
+            if actual.is_floating_point():
+                atol, rtol = max(
+                    float_tols.get(src_dtype, (1e-5, 1e-5)),
+                    float_tols.get(dst_dtype, (1e-5, 1e-5)),
+                )
+                self.assertTrue(
+                    torch.allclose(actual, expected, atol=atol, rtol=rtol),
+                    msg=f"{ctx}: actual={actual}, expected={expected}",
+                )
+            else:
+                self.assertEqual(actual, expected, msg=ctx)
+
         # Test supported conversions
         for src_dtype, dst_dtype in DtypeOpTable.get_table().keys():
-            # Create tensor on CPU with src_dtype
-            if src_dtype.is_floating_point:
-                tensor = torch.randn(2, 2, dtype=src_dtype)
-            elif src_dtype == torch.bool:
-                tensor = torch.randint(0, 2, (2, 2), dtype=torch.int32).to(torch.bool)
-            else:
-                tensor = torch.randint(0, 10, (2, 2), dtype=src_dtype)
-
-            # H2D: Move to Spyre with dst_dtype
-            h2d_ctx = f"H2D {src_dtype} -> {dst_dtype}"
-            tensor_on_spyre = tensor.to("spyre", dtype=dst_dtype)
-            self.assertEqual(tensor_on_spyre.device.type, "spyre", msg=h2d_ctx)
-            self.assertEqual(tensor_on_spyre.dtype, dst_dtype, msg=h2d_ctx)
-            self.assertEqual(
-                tensor_on_spyre.to("cpu"), tensor.to(dst_dtype), msg=h2d_ctx
+            ctx = f"H2D {src_dtype}->{dst_dtype}"
+            h2d_src = _make_cpu_tensor(src_dtype)
+            h2d_expected = h2d_src.to(dtype=dst_dtype)  # ground truth on CPU
+            h2d_spyre = h2d_src.to("spyre", dtype=dst_dtype)
+            self.assertEqual(h2d_spyre.device.type, "spyre", msg=ctx)
+            self.assertEqual(h2d_spyre.dtype, dst_dtype, msg=ctx)
+            _assert_values_equal(
+                h2d_spyre.to("cpu"), h2d_expected, src_dtype, dst_dtype, ctx
             )
 
-            # D2H: Move back to CPU with src_dtype
-            d2h_ctx = f"D2H {dst_dtype} -> {src_dtype}"
-            tensor_back = tensor_on_spyre.to("cpu", dtype=src_dtype)
-            self.assertEqual(tensor_back.device.type, "cpu", msg=d2h_ctx)
-            self.assertEqual(tensor_back.dtype, src_dtype, msg=d2h_ctx)
-            self.assertEqual(tensor_back, tensor, msg=d2h_ctx)
+            ctx = f"D2H {dst_dtype}->{src_dtype}"
+            d2h_src = _make_cpu_tensor(dst_dtype)
+            d2h_expected = d2h_src.to(dtype=src_dtype)  # ground truth on CPU
+            d2h_spyre = d2h_src.to("spyre")
+            d2h_cpu = d2h_spyre.to("cpu", dtype=src_dtype)
+            self.assertEqual(d2h_cpu.device.type, "cpu", msg=ctx)
+            self.assertEqual(d2h_cpu.dtype, src_dtype, msg=ctx)
+            _assert_values_equal(d2h_cpu, d2h_expected, dst_dtype, src_dtype, ctx)
 
         # Test unsupported conversions
         unsupported_pairs = [

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -666,6 +666,34 @@ class TestSpyre(TestCase):
         scalar = torch.tensor(3.14, dtype=torch.float16, device="spyre")
         assert scalar.dim() == 0
 
+    def test_d2h_h2d_dtype_conversion(self):
+        """Test H2D (CPU -> Spyre) and D2H (Spyre -> CPU) dtype conversions.
+
+        Tests roundtrip for each supported dtype conversion: create tensor on
+        CPU with src_dtype, transfer to Spyre with dst_dtype (H2D), then back
+        to CPU (D2H).
+        """
+        from torch_spyre._inductor.dtype_ops import DtypeOpTable
+
+        for src_dtype, dst_dtype in DtypeOpTable.get_table().keys():
+            # Create tensor on CPU with src_dtype
+            if src_dtype.is_floating_point:
+                tensor = torch.randn(2, 2, dtype=src_dtype)
+            elif src_dtype == torch.bool:
+                tensor = torch.randint(0, 2, (2, 2), dtype=torch.int32).to(torch.bool)
+            else:
+                tensor = torch.randint(0, 10, (2, 2), dtype=src_dtype)
+
+            # H2D: Move to Spyre with dst_dtype
+            tensor_on_spyre = tensor.to("spyre", dtype=dst_dtype)
+            self.assertEqual(tensor_on_spyre.device.type, "spyre")
+            self.assertEqual(tensor_on_spyre.dtype, dst_dtype)
+
+            # D2H: Move back to CPU with src_dtype
+            tensor_back = tensor_on_spyre.to("cpu", dtype=src_dtype)
+            self.assertEqual(tensor_back.device.type, "cpu")
+            self.assertEqual(tensor_back.dtype, src_dtype)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -686,14 +686,20 @@ class TestSpyre(TestCase):
                 tensor = torch.randint(0, 10, (2, 2), dtype=src_dtype)
 
             # H2D: Move to Spyre with dst_dtype
+            h2d_ctx = f"H2D {src_dtype} -> {dst_dtype}"
             tensor_on_spyre = tensor.to("spyre", dtype=dst_dtype)
-            self.assertEqual(tensor_on_spyre.device.type, "spyre")
-            self.assertEqual(tensor_on_spyre.dtype, dst_dtype)
+            self.assertEqual(tensor_on_spyre.device.type, "spyre", msg=h2d_ctx)
+            self.assertEqual(tensor_on_spyre.dtype, dst_dtype, msg=h2d_ctx)
+            self.assertEqual(
+                tensor_on_spyre.to("cpu"), tensor.to(dst_dtype), msg=h2d_ctx
+            )
 
             # D2H: Move back to CPU with src_dtype
+            d2h_ctx = f"D2H {dst_dtype} -> {src_dtype}"
             tensor_back = tensor_on_spyre.to("cpu", dtype=src_dtype)
-            self.assertEqual(tensor_back.device.type, "cpu")
-            self.assertEqual(tensor_back.dtype, src_dtype)
+            self.assertEqual(tensor_back.device.type, "cpu", msg=d2h_ctx)
+            self.assertEqual(tensor_back.dtype, src_dtype, msg=d2h_ctx)
+            self.assertEqual(tensor_back, tensor, msg=d2h_ctx)
 
         # Test unsupported conversions
         unsupported_pairs = [

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -95,12 +95,19 @@ def _patch_tensor_for_spyre():
                 _device is not None
                 and _dtype is not None
                 and self.device.type == DEVICE_NAME
+                and torch.device(_device).type == DEVICE_NAME
             ):
-                # Step 1: plain D2H copy (no dtype change)
-                tmp = orig_to(self, _device)
-                # Step 2: cast dtype on CPU
-                return orig_to(tmp, dtype=_dtype)
+                import warnings
 
+                warnings.warn(
+                    "D2D dtype conversion on Spyre is not directly supported. "
+                    "Using CPU as an intermediate for the cast.",
+                    stacklevel=2,
+                )
+                # Step 1: plain D2H copy (no dtype change)
+                tmp = orig_to(self, "cpu")
+                # Step 2: cast dtype via H2D
+                return orig_to(tmp, _device, dtype=_dtype)
             return orig_to(self, *args, **kwargs)
         else:
             # Check if copy kwarg is explicitly set

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -74,12 +74,8 @@ def _patch_tensor_for_spyre():
 
     def spyre_to(self, *args, device_layout=None, **kwargs):
         if device_layout is None:
-            # If caller is doing a combined device+dtype move on a Spyre tensor
-            # (e.g. tensor.to("spyre", dtype=torch.int64) or
-            #        tensor.to(device="spyre", dtype=torch.int64)),
-            # split into two steps: cast dtype on CPU first, then copy to device.
-            # This avoids "does not support type conversion during copy" in the
-            # DCI (DataConversionInfo) C++ code in spyre_mem.cpp.
+            # Support D2H and H2D dtype casting via DCI (DataConversionInfo) in spyre_mem.cpp.
+            # For D2D data casting, split it into a D2H copy and a H2D dtype conversion.
             _device = kwargs.get("device", None)
             if (
                 _device is None

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -96,10 +96,10 @@ def _patch_tensor_for_spyre():
                 and _dtype is not None
                 and self.device.type == DEVICE_NAME
             ):
-                # Step 1: cast dtype on CPU
-                tmp = orig_to(self, dtype=_dtype)
-                # Step 2: plain H2D copy with no dtype change
-                return orig_to(tmp, _device)
+                # Step 1: plain D2H copy (no dtype change)
+                tmp = orig_to(self, _device)
+                # Step 2: cast dtype on CPU
+                return orig_to(tmp, dtype=_dtype)
 
             return orig_to(self, *args, **kwargs)
         else:

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -369,8 +369,15 @@ auto generate_dci(const at::Tensor* cpu_tensor, const at::Tensor* dev_tensor,
   auto dev_str_type = torchScalarToString[dev_tensor->scalar_type()];
   const auto [cpu_format_host, cpu_format_dev] =
       stringToDTDataFormatPair(cpu_str_type);
+  TORCH_CHECK(cpu_format_host != DataFormats::INVALID &&
+                  cpu_format_dev != DataFormats::INVALID,
+              "Unsupported CPU tensor dtype for DMA transfer: ", cpu_str_type);
   const auto [dev_format_host, dev_format_dev] =
       stringToDTDataFormatPair(dev_str_type);
+  TORCH_CHECK(
+      dev_format_host != DataFormats::INVALID &&
+          dev_format_dev != DataFormats::INVALID,
+      "Unsupported Spyre tensor dtype for DMA transfer: ", dev_str_type);
 
   DataConversionInfo dci{};
   dci.dci_dsName_ = "DCI-Tensor-0";

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -363,14 +363,20 @@ auto get_device_stride_infos(c10::IntArrayRef sizes,
 auto generate_dci(const at::Tensor* cpu_tensor, const at::Tensor* dev_tensor,
                   SpyreTensorLayout stl, int64_t cpu_offset, bool host2device)
     -> DataConversionInfo {
-  auto str_type = torchScalarToString[cpu_tensor->scalar_type()];
-  const auto [dtype_cpu, dtype_dev] = stringToDTDataFormatPair(str_type);
+  // Support dtype conversion: populate DCI with both source and destination
+  // dtype formats
+  auto cpu_str_type = torchScalarToString[cpu_tensor->scalar_type()];
+  auto dev_str_type = torchScalarToString[dev_tensor->scalar_type()];
+  const auto [cpu_format_host, cpu_format_dev] =
+      stringToDTDataFormatPair(cpu_str_type);
+  const auto [dev_format_host, dev_format_dev] =
+      stringToDTDataFormatPair(dev_str_type);
 
   DataConversionInfo dci{};
   dci.dci_dsName_ = "DCI-Tensor-0";
   dci.isHostToSen_ = host2device;
-  dci.dataformat_src_ = host2device ? dtype_cpu : dtype_dev;
-  dci.dataformat_dst_ = host2device ? dtype_dev : dtype_cpu;
+  dci.dataformat_src_ = host2device ? cpu_format_host : dev_format_dev;
+  dci.dataformat_dst_ = host2device ? dev_format_dev : cpu_format_host;
 
   std::vector<int64_t> cpu_shape;
   std::vector<int64_t> dev_shape = stl.device_size;

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -144,10 +144,6 @@ void SpyreStream::copyAsync(const at::Tensor& src,
   DEBUGINFO("src (", src.scalar_type(), ") is on:", src.device());
   DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
 
-  // TODO(tmhoangt): add type conversion node
-  // (yuezhu1) Remove requirement for src.scalar_type() == dst.scalar_type()
-  // and let type conversion validation be delegated to backend
-
   // Determine copy direction
   bool host2device = src.is_cpu() && dst.is_privateuseone();
   bool device2host = src.is_privateuseone() && dst.is_cpu();

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -145,10 +145,8 @@ void SpyreStream::copyAsync(const at::Tensor& src,
   DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
 
   // TODO(tmhoangt): add type conversion node
-  // Type checking - no type conversion support yet
-  TORCH_CHECK(
-      src.scalar_type() == dst.scalar_type(),
-      "Spyre backend does not support type conversion yet during copy.");
+  // (yuezhu1) Remove requirement for src.scalar_type() == dst.scalar_type()
+  // and let type conversion validation be delegated to backend
 
   // Determine copy direction
   bool host2device = src.is_cpu() && dst.is_privateuseone();


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
  This PR enables proper dtype conversion support at the DCI (Device Compiler Interface) level for host-device transfers.

Changes:
  1. Remove dtype check in `spyre_stream.cpp` that blocked conversion
  2. Update `generate_dci()` to extract both tensor dtypes independently and populate `dataformat_src_` and `dataformat_dst_` correctly
  3. fixed bug in `_monkey_patch.py` for D2H dtype casting. 

What this enables:
  - `.to("spyre", dtype=...)` now works for H2D transfers with dtype conversion
  - `.to("cpu", dtype=...)` now works for D2H transfers with dtype conversion
  - Backend compiler handles dtype conversion via DCI layer

  **Resolves:** #2134 for H2D/D2H paths

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
Fixes #2134 

#### Special notes for your reviewer:
D2D transfer with dtype conversion is not included in this PR. current changes mainly focus on [copyAsync()](https://github.com/torch-spyre/torch-spyre/blob/61cbe1c9dc0dad9d20d6081cb13121db76e853d0/torch_spyre/csrc/spyre_stream.cpp#L141-L181) between host and device


#### Does this PR introduce a user-facing change?

#### Additional note:
