### PR TITLE
Fix aten.cat lowering crash with zero-sized tensor inputs

### DIFF
--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -649,16 +649,27 @@ def decompose_cat(
     tensors: list[torch.Tensor],
     dim: int = 0,
 ) -> torch.Tensor:
-    orig_decomp = torch._inductor.decomposition.cat(tensors, dim)
+    # Filter out zero-element tensors: they contribute nothing to the output
+    # and may have collapsed shapes (e.g. 1D [0]) that cause dimension
+    # validation failures when dim exceeds their ndim.
+    non_empty = [t for t in tensors if t.numel() > 0]
+    if len(non_empty) == 0:
+        # All inputs are empty — fall through with originals so upstream
+        # handling produces the correct empty output.
+        non_empty = tensors
+    elif len(non_empty) == 1:
+        return non_empty[0]
+
+    orig_decomp = torch._inductor.decomposition.cat(non_empty, dim)
     if orig_decomp == NotImplemented:
         expanded_size = 0
-        for t in tensors:
+        for t in non_empty:
             expanded_size += t.size(dim)
-        output_size = list(tensors[0].size())
+        output_size = list(non_empty[0].size())
         output_size[dim] = expanded_size
-        output = tensors[0].new_empty(output_size)
+        output = non_empty[0].new_empty(output_size)
         offset = 0
-        for input in tensors:
+        for input in non_empty:
             output = torch.ops.spyre.overwrite_f(
                 input=input, output=output, dims=[dim], offsets=[offset]
             )

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -649,13 +649,16 @@ def decompose_cat(
     tensors: list[torch.Tensor],
     dim: int = 0,
 ) -> torch.Tensor:
-    # Filter out zero-element tensors: they contribute nothing to the output
-    # and may have collapsed shapes (e.g. 1D [0]) that cause dimension
-    # validation failures when dim exceeds their ndim.
+    # Spyre replaces the upstream cat decomposition because the upstream
+    # lowering (ConcatKernel/pointwise_cat) emits CPU/CUDA IR that Spyre
+    # cannot execute. Instead we lower to spyre::overwrite_f.
+    #
+    # Because this decomposition fully replaces upstream, we must also
+    # replicate the zero-element filtering that upstream does in
+    # torch/_inductor/decomposition.py:390-413. Without it, collapsed
+    # 1D [0] tensors cause _validate_dim assertions in the fallback path.
     non_empty = [t for t in tensors if t.numel() > 0]
-    if len(non_empty) == 0:
-        # All inputs are empty — fall through with originals so upstream
-        # handling produces the correct empty output.
+    if not non_empty:
         non_empty = tensors
     elif len(non_empty) == 1:
         return non_empty[0]
@@ -669,14 +672,13 @@ def decompose_cat(
         output_size[dim] = expanded_size
         output = non_empty[0].new_empty(output_size)
         offset = 0
-        for input in non_empty:
+        for t in non_empty:
             output = torch.ops.spyre.overwrite_f(
-                input=input, output=output, dims=[dim], offsets=[offset]
+                input=t, output=output, dims=[dim], offsets=[offset]
             )
-            offset += input.size(dim)
+            offset += t.size(dim)
         return output
-    else:
-        return orig_decomp
+    return orig_decomp
 
 
 @register_spyre_decomposition([torch.ops.aten.ceil.default])


### PR DESCRIPTION
## Summary

- Filter out zero-element tensors in `decompose_cat` before dimension validation and the `overwrite_f` fallback path
- Fixes nightly failures: `test_cat_4d_dim2_zero`, `test_cat_4d_dim_m2_empty_first`

## Root Cause

Spyre replaces the upstream `aten.cat` decomposition because the upstream Inductor lowering (`ConcatKernel`/`pointwise_cat`) emits CPU/CUDA IR that Spyre cannot execute — Spyre needs `spyre::overwrite_f` instead.

However, by replacing the upstream decomposition, Spyre also bypasses the zero-element tensor filtering that upstream performs (`torch/_inductor/decomposition.py:390-413`). After PR #2089 changed zero-sized tensor layout to a collapsed 1D `[0]` representation, tensors like `torch.randn(0)` arrive at `decompose_cat` with `ndim=1`. When `dim=2` is passed, the downstream `_validate_dim` assertion (`assert 0 <= dim < ndim`) fails.

On standard CPU Inductor this never happens because:
1. The upstream `cat` decomposition filters zero-sized tensors during `aot_autograd` tracing
2. The `aten.cat` node is eliminated from the graph before lowering

On Spyre, the node survives to the decomposition/lowering phase because Spyre's `decompose_cat` replaces upstream's. The fix replicates upstream's filtering logic.

## Changes

- Filter `numel() == 0` tensors before processing (they contribute nothing to concatenation)
- If all inputs are empty, fall through with originals for correct empty output shape
- If one non-empty input remains, return it directly (identity)
- Renamed loop variable from `input` (shadows builtin) to `t`
- Added comment explaining why Spyre owns the cat decomposition path

## Test plan

- [x] `pytest tests/inductor/test_inductor_ops.py::TestOps::test_cat_4d_dim2_zero` — PASSED on Spyre hardware
- [x] `pytest tests/inductor/test_inductor_ops.py::TestOps::test_cat_4d_dim_m2_empty_first` — PASSED on Spyre hardware
- [x] No new tests needed — existing tests cover this regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)