### PR TITLE
First-fit and best-fit layout solvers

### DIFF
--- a/tests/inductor/test_scratchpad_patterns.py
+++ b/tests/inductor/test_scratchpad_patterns.py
@@ -16,11 +16,10 @@
 from collections import defaultdict
 import copy
 from dataclasses import dataclass
-from typing import Callable, Optional, Iterable, override
+from typing import Callable, ClassVar, Optional, Iterable, override
 from unittest import TestCase, expectedFailure
 from enum import Enum
 import os
-from functools import wraps
 
 import torch
 from torch.utils._ordered_set import OrderedSet
@@ -30,24 +29,21 @@ from torch_spyre._inductor.scratchpad.allocator import (
     DefaultAllocator,
     LifetimeBoundBuffer,
 )
+from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
+    BestFitLayoutSolver,
+    FirstFitLayoutSolver,
+)
 from torch_spyre._inductor.scratchpad.passes import CloneInputNodesPass
-from torch_spyre._inductor.scratchpad.plan_solver import GreedyLayoutSolver
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    MemoryPlanSolver,
+    GreedyLayoutSolver,
+)
 from torch_spyre._inductor import config
 
 # From scratchpad.py
 AVAILABLE_LX_SIZE = int((2 << 20) * (1.0 - config.dxp_lx_frac_avail))
 
-if os.environ.get("SCRATCHPAD_PATTERN_BYPASS_XFAIL", "0") == "1":
-    # Define usuallyExpectedFailure as a no-op. This should show failures indicating that the
-    # current allocation uses more HBM than the good allocation, not anything else.
-    def usuallyExpectedFailure(test_item: Callable) -> Callable:
-        @wraps(test_item)
-        def wrapper(*args, **kwargs):
-            return test_item(*args, **kwargs)
-
-        return wrapper
-else:
-    usuallyExpectedFailure = expectedFailure
+BYPASS_XFAIL = os.environ.get("SCRATCHPAD_PATTERN_BYPASS_XFAIL", "0") == "1"
 
 
 class BufferDeviceLayout:
@@ -148,7 +144,7 @@ class Allocation:
     component: Component = Component.LX
     # If the component is LX, then the address must be an integer. If the component is HBM, we don't
     # care about the address; this is encoded by the address being None. (This is enforced in
-    # TestExamplePattern.verify_pattern.)
+    # PatternTests.verify_pattern.)
     address: Optional[int] = None
 
 
@@ -241,15 +237,14 @@ class MockGraphLowering:
 
 
 class InstrumentedAllocator(DefaultAllocator):
-    def __init__(self, pattern: Pattern, lowering: MockGraphLowering):
+    def __init__(
+        self, solver: MemoryPlanSolver, pattern: Pattern, lowering: MockGraphLowering
+    ):
         self.buffers = pattern.buffers
         self.operations = pattern.operations
-        layout_planning = GreedyLayoutSolver(AVAILABLE_LX_SIZE)
         super().__init__(
-            layout_planning,
-            pre_optimization_passes=[
-                MockCloneInputNodesPass(layout_planning.limit, self)
-            ],
+            solver,
+            pre_optimization_passes=[MockCloneInputNodesPass(solver.limit, self)],
         )
         self.allocations: dict[str, int] = {}
         self.graph_lowering = lowering
@@ -275,8 +270,8 @@ class InstrumentedAllocator(DefaultAllocator):
                 # can't record at what point in time the allocation happens. This is okay as long as we
                 # every buffer name can be uniquely allocated with a single address. In order to change
                 # this, we need to store allocations differently, and then modify the logic for
-                # measuring HBM usage in TestExamplePattern.hbm_usage_for_actual_run to account for
-                # this. Also update TestExamplePattern.verify_actual_run to account for this.
+                # measuring HBM usage in PatternTests.hbm_usage_for_actual_run to account for
+                # this. Also update PatternTests.verify_actual_run to account for this.
                 assert self.allocations[tensor_name] == addr, (
                     f"Buffer {tensor_name} was already allocated at address "
                     f"{self.allocations[tensor_name]}, but is being allocated again at address {addr}."
@@ -341,8 +336,58 @@ class MockCloneInputNodesPass(CloneInputNodesPass):
             ]
 
 
-class TestExamplePattern(TestCase):
-    def setUp(self):
+class PatternTests:
+    """Mixin providing pattern definitions and test infrastructure.
+
+    Concrete subclasses are created with a ``role`` keyword:
+    - ``role="verify"``  — generates ``test_verify_{name}_pattern`` methods that validate the
+      good allocation defined in the pattern
+    - ``role="solver"``  — generates ``test_{name}_pattern`` methods that run the solver and
+      check it meets the good allocation; names in ``expected_failures`` are wrapped with
+      ``@expectedFailure``
+    """
+
+    PATTERNS: ClassVar[list[str]] = [
+        "simple_fragmentation",
+        "staircase",
+        "downward_staircase",
+        "simple_eviction",
+        "eviction_reallocation",
+        "gqattention",
+        "moe_mlp",
+    ]
+    INPLACE_PATTERNS: ClassVar[frozenset[str]] = frozenset(
+        {"simple_eviction", "eviction_reallocation", "moe_mlp"}
+    )
+
+    def __init_subclass__(cls, role: str = "", **kwargs: object) -> None:
+        # This creates tests like test_verify_moe_mlp_pattern
+        # and test_moe_mlp_pattern
+        super().__init_subclass__(**kwargs)  # type: ignore[misc]
+        if role == "verify":
+            for name in PatternTests.PATTERNS:
+                inplace = name in PatternTests.INPLACE_PATTERNS
+
+                def _test_verify(self, _n: str = name, _ip: bool = inplace) -> None:
+                    self.verify_pattern(
+                        getattr(self, f"make_{_n}_pattern")(), inplace=_ip
+                    )
+
+                setattr(cls, f"test_verify_{name}_pattern", _test_verify)
+        elif role == "solver":
+            xfails: frozenset[str] = getattr(cls, "expected_failures", frozenset())
+            for name in PatternTests.PATTERNS:
+
+                def _test_solve(self, _n: str = name) -> None:
+                    self.run_pattern(
+                        self.solver_type, getattr(self, f"make_{_n}_pattern")()
+                    )
+
+                if name in xfails and not BYPASS_XFAIL:
+                    _test_solve = expectedFailure(_test_solve)
+                setattr(cls, f"test_{name}_pattern", _test_solve)
+
+    def setUp(self) -> None:
         super().setUp()
         torch.manual_seed(0xAFFE)
 
@@ -548,12 +593,14 @@ class TestExamplePattern(TestCase):
 
         return hbm_usage
 
-    def run_pattern(self, pattern: Pattern):
+    def run_pattern(self, solver_type: type[MemoryPlanSolver], pattern: Pattern):
         # The scratchpad_planning operation may modify the pattern (adding operations), and then
         # examining the "good" allocation will run into trouble.
         pattern_copy = copy.deepcopy(pattern)
         lowering = MockGraphLowering(pattern_copy)
-        alloc = InstrumentedAllocator(pattern_copy, lowering)
+        alloc = InstrumentedAllocator(
+            solver_type(AVAILABLE_LX_SIZE), pattern_copy, lowering
+        )
 
         scratchpad_planning(lowering, alloc)
 
@@ -614,13 +661,6 @@ class TestExamplePattern(TestCase):
         )
         return Pattern(buffers, ops, good_allocation=good_allocation)
 
-    def test_verify_simple_fragmentation_pattern(self):
-        self.verify_pattern(self.make_simple_fragmentation_pattern())
-
-    @usuallyExpectedFailure
-    def test_simple_fragmentation_pattern(self):
-        self.run_pattern(self.make_simple_fragmentation_pattern())
-
     def make_staircase_pattern(self) -> Pattern:
         """Allocate N*2 buffers of sizes k, k, 2*k, 2*k, 3*k, 3*k, ..., N*k, N*k. After an
         even-numbered buffer is allocated, free the previous odd-numbered buffer. This creates a
@@ -631,7 +671,7 @@ class TestExamplePattern(TestCase):
 
         The greedy allocator will always allocate the next buffer just after all other buffers,
         because no gap is big enough for the current size. So it uses
-        2 * (k + 2*k + ... + N*k) = k * N * (N + 1) or roughly 2/3 times more."""
+        2 * (k + 2*k + ... + N*k) = k * N * (N + 1) or roughly 2 times more."""
         N = 7
         k = (2 * AVAILABLE_LX_SIZE) // (N * (N + 3))
         k = (k // 128) * 128  # round down to a multiple of the stick size
@@ -668,13 +708,6 @@ class TestExamplePattern(TestCase):
 
         pattern = Pattern(buffers, ops, good_allocation=good_allocation)
         return pattern
-
-    def test_verify_staircase_pattern(self):
-        self.verify_pattern(self.make_staircase_pattern())
-
-    @usuallyExpectedFailure
-    def test_staircase_pattern(self):
-        self.run_pattern(self.make_staircase_pattern())
 
     def make_downward_staircase_pattern(self) -> Pattern:
         """Allocate 1+N*2 buffers of sizes k, N*k, N*k, (N-1)*k, (N-1)*k, ..., 2*k, 2*k, k, k.
@@ -732,13 +765,6 @@ class TestExamplePattern(TestCase):
 
         pattern = Pattern(buffers, ops, good_allocation=good_allocation)
         return pattern
-
-    def test_verify_downward_staircase_pattern(self):
-        self.verify_pattern(self.make_downward_staircase_pattern())
-
-    @usuallyExpectedFailure
-    def test_downward_staircase_pattern(self):
-        self.run_pattern(self.make_downward_staircase_pattern())
 
     def make_simple_eviction_pattern(self) -> Pattern:
         """This pattern requires allocating a buffer, evicting it, and then reallocating it later.
@@ -812,13 +838,6 @@ class TestExamplePattern(TestCase):
             good_allocation=make_general_allocation_result(good_allocation),
         )
         return pattern
-
-    def test_verify_simple_eviction_pattern(self):
-        self.verify_pattern(self.make_simple_eviction_pattern(), inplace=True)
-
-    @usuallyExpectedFailure
-    def test_simple_eviction_pattern(self):
-        self.run_pattern(self.make_simple_eviction_pattern())
 
     def make_eviction_reallocation_pattern(self) -> Pattern:
         """This pattern requires allocating a buffer, evicting it, and then reallocating it later
@@ -896,13 +915,6 @@ class TestExamplePattern(TestCase):
             good_allocation=make_general_allocation_result(good_allocations),
         )
         return pattern
-
-    def test_verify_eviction_reallocation_pattern(self):
-        self.verify_pattern(self.make_eviction_reallocation_pattern(), inplace=True)
-
-    @usuallyExpectedFailure
-    def test_eviction_reallocation_pattern(self):
-        self.run_pattern(self.make_eviction_reallocation_pattern())
 
     def make_gqattention_pattern(self) -> Pattern:
         """We describe the GQA attention pattern. The "input" are three tensors, Q, K, and V. The
@@ -1006,13 +1018,6 @@ class TestExamplePattern(TestCase):
 
         pattern = Pattern(buffers, ops, good_allocation=good_allocation)
         return pattern
-
-    def test_verify_gqattention_pattern(self):
-        self.verify_pattern(self.make_gqattention_pattern())
-
-    @usuallyExpectedFailure
-    def test_gqattention_pattern(self):
-        self.run_pattern(self.make_gqattention_pattern())
 
     def make_moe_mlp_pattern(self) -> Pattern:
         """This pattern is a (simplified) mixture of experts multi-layer perceptron.
@@ -1193,11 +1198,37 @@ class TestExamplePattern(TestCase):
         pattern = Pattern(buffers, ops, good_allocation=good_allocation)
         return pattern
 
-    def test_verify_moe_mlp_pattern(self):
-        self.verify_pattern(self.make_moe_mlp_pattern(), inplace=True)
 
-    def test_moe_mlp_pattern(self):
-        self.run_pattern(self.make_moe_mlp_pattern())
+class TestVerifyPatterns(PatternTests, TestCase, role="verify"):
+    pass
+
+
+class TestGreedyPatterns(PatternTests, TestCase, role="solver"):
+    solver_type = GreedyLayoutSolver
+    expected_failures: ClassVar[frozenset[str]] = frozenset(
+        {
+            "simple_fragmentation",
+            "staircase",
+            "downward_staircase",
+            "simple_eviction",
+            "eviction_reallocation",
+            "gqattention",
+        }
+    )
+
+
+class TestBestFitPatterns(PatternTests, TestCase, role="solver"):
+    solver_type = BestFitLayoutSolver
+    expected_failures: ClassVar[frozenset[str]] = frozenset(
+        {"eviction_reallocation", "gqattention", "simple_eviction"}
+    )
+
+
+class TestFirstFitPatterns(PatternTests, TestCase, role="solver"):
+    solver_type = FirstFitLayoutSolver
+    expected_failures: ClassVar[frozenset[str]] = frozenset(
+        {"eviction_reallocation", "gqattention", "simple_eviction"}
+    )
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -19,23 +19,58 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     GreedyLayoutSolver,
     LifetimeBoundBuffer,
 )
+from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
+    BestFitLayoutSolver,
+    FirstFitLayoutSolver,
+    _assert_in_place_relationships,
+)
 
 LARGE_SIZE = 512
 SMALL_SIZE = 10
 ALIGNMENT = 128
 
 
-class TestGreedySolver(TestCase):
+def _two_gap_buffers():
+    """Buffers that leave two free gaps for x in a 120-byte scratchpad.
+
+    Processing order by ascending lifetime: b_mid(2), b_left(4), b_right(5), x(5).
+    b_right and x tie on lifetime; stable sort keeps b_right first.
+
+    Placements: b_mid@0, b_left@40, b_right@70.
+    b_mid lives [2,4) and x lives [4,9) — they do not overlap, so b_mid's
+    address range (0,40) is not subtracted from x's gaps. After removing
+    b_left(40,70) and b_right(70,100), x sees two gaps:
+      (0,40)   waste = 30
+      (100,120) waste = 10
+    FirstFit picks (0,40) → addr=0; BestFit picks (100,120) → addr=100.
+    """
+    return [
+        LifetimeBoundBuffer("b_mid", 40, 2, 4),
+        LifetimeBoundBuffer("b_left", 30, 1, 5),
+        LifetimeBoundBuffer("b_right", 30, 3, 8),
+        LifetimeBoundBuffer("x", 10, 4, 9),
+    ]
+
+
+class BaseLayoutSolverTests:
+    solver_class: type[FirstFitLayoutSolver] = None  # type: ignore[assignment]
+
+    def solve(self, buffers, size=LARGE_SIZE, alignment=1):
+        return self.solver_class(size, alignment).plan_layout(buffers)
+
     def verify_layout(
         self,
         buffers: list[LifetimeBoundBuffer],
-        expected_addresses: list[int | None],
+        expected_addresses: set[tuple[int | None]] | list[int | None],
         size=SMALL_SIZE,
         alignment=1,
     ):
-        result = GreedyLayoutSolver(size, alignment).plan_layout(buffers)
-        for planned, expected_addr in zip(result, expected_addresses, strict=True):
-            self.assertEqual(planned.address, expected_addr)
+        result = self.solve(buffers, size, alignment)
+        result_addresses = [p.address for p in result]
+        if isinstance(expected_addresses, set):
+            self.assertIn(tuple(result_addresses), expected_addresses)
+        else:
+            self.assertEqual(result_addresses, expected_addresses)
 
     def test_simple_layout(self):
         # Three non-overlapping buffers fill memory sequentially.
@@ -89,7 +124,7 @@ class TestGreedySolver(TestCase):
             LifetimeBoundBuffer("buffer2", 3, 2, 4),
             LifetimeBoundBuffer("buffer3", 3, 3, 4),
         ]
-        self.verify_layout(buffers, [0, 3, 6, 3])
+        self.verify_layout(buffers, {(0, 3, 6, 3), (6, 0, 3, 0)})
 
     def test_realloc_between_with_alignment(self):
         # Same reuse pattern as test_realloc_between, but with alignment padding applied.
@@ -99,7 +134,11 @@ class TestGreedySolver(TestCase):
             LifetimeBoundBuffer("buffer2", 100, 2, 4),
             LifetimeBoundBuffer("buffer3", 100, 3, 4),
         ]
-        self.verify_layout(buffers, [0, 256, 384, 256], LARGE_SIZE, ALIGNMENT)
+        if self.solver_class == GreedyLayoutSolver:
+            self.verify_layout(buffers, [0, 256, 384, 256], LARGE_SIZE, ALIGNMENT)
+        else:
+            # Other solvers are smarter than greedy
+            self.verify_layout(buffers, [256, 0, 128, 0], LARGE_SIZE, ALIGNMENT)
 
     def test_inplace_allocation(self):
         # Test that adding inplace options allows for more efficient peak usage
@@ -109,7 +148,7 @@ class TestGreedySolver(TestCase):
                 "buffer1", LARGE_SIZE, 3, 4, in_place_parents=["buffer0"]
             ),
         ]
-        self.verify_layout(buffers, [0, 0], LARGE_SIZE, ALIGNMENT)
+        self.verify_layout(buffers, [0, 0], LARGE_SIZE + 1, ALIGNMENT)
 
     def test_without_inplace_allocation(self):
         # Test that buffer gets evicted without in_place
@@ -117,7 +156,7 @@ class TestGreedySolver(TestCase):
             LifetimeBoundBuffer("buffer0", LARGE_SIZE, 0, 4),
             LifetimeBoundBuffer("buffer1", LARGE_SIZE, 3, 4),
         ]
-        self.verify_layout(buffers, [0, None], LARGE_SIZE, ALIGNMENT)
+        self.verify_layout(buffers, {(0, None), (None, 0)}, LARGE_SIZE, ALIGNMENT)
 
     def test_multiple_evictions_do_not_corrupt_allocation(self):
         # buffer0 fills the entire scratchpad; buffer1 and buffer2 are evicted.
@@ -138,6 +177,127 @@ class TestGreedySolver(TestCase):
             LifetimeBoundBuffer("buffer0", SMALL_SIZE + 1, 0, 2),
         ]
         self.verify_layout(buffers, [None], size=SMALL_SIZE)
+
+    def test_empty_returns_empty_list(self):
+        self.assertEqual(self.solve([]), [])
+
+    def test_single_buffer_placed_at_zero(self):
+        self.verify_layout([LifetimeBoundBuffer("a", 10, 0, 5)], [0])
+
+    def test_single_buffer_evicted_when_too_large(self):
+        self.verify_layout([LifetimeBoundBuffer("a", 11, 0, 5)], [None], size=10)
+
+    def test_non_overlapping_lifetimes_reuse_address(self):
+        # b1 ends at time 5 (exclusive); b2 starts at time 5 — they never coexist.
+        self.verify_layout(
+            [LifetimeBoundBuffer("b1", 20, 0, 5), LifetimeBoundBuffer("b2", 20, 5, 10)],
+            [0, 0],
+            size=LARGE_SIZE,
+        )
+
+    def test_concurrent_buffers_packed_input_order(self):
+        # Equal lifetimes: stable sort preserves input order, so a(10)@0, b(20)@10, c(30)@30.
+        self.verify_layout(
+            [
+                LifetimeBoundBuffer("a", 10, 0, 4),
+                LifetimeBoundBuffer("b", 20, 0, 4),
+                LifetimeBoundBuffer("c", 30, 0, 4),
+            ],
+            [0, 10, 30],
+            size=60,
+        )
+
+    def test_largest_buffer_evicted_when_full(self):
+        # a(10)@0 and b(20)@10 consume 30 bytes; c(30) needs 30 but only 20 remain → evicted.
+        self.verify_layout(
+            [
+                LifetimeBoundBuffer("a", 10, 0, 4),
+                LifetimeBoundBuffer("b", 20, 0, 4),
+                LifetimeBoundBuffer("c", 30, 0, 4),
+            ],
+            [0, 10, None],
+            size=50,
+        )
+
+    def test_alignment_pads_between_buffers(self):
+        # Two same-size concurrent buffers; the second is placed at the next
+        # alignment boundary after the first.
+        self.verify_layout(
+            [LifetimeBoundBuffer("a", 10, 0, 4), LifetimeBoundBuffer("b", 10, 0, 4)],
+            [0, 128],
+            alignment=128,
+            size=LARGE_SIZE,
+        )
+
+    def test_alignment_can_cause_eviction(self):
+        # a(13)@0 leaves a gap starting at 13; rounding up to alignment=10 gives
+        # addr=20, but 20+12=32 > limit=30, so b is evicted.
+        self.verify_layout(
+            [LifetimeBoundBuffer("a", 13, 0, 5), LifetimeBoundBuffer("b", 12, 0, 5)],
+            [0, None],
+            size=30,
+            alignment=10,
+        )
+
+    def test_child_reuses_parent_address(self):
+        # P ends at 5; C.start_time=4 == P.end_time - 1, so in-place is valid.
+        # Without in-place, P's [0,20) would be subtracted and C would land at 20.
+        p = LifetimeBoundBuffer("P", 20, 0, 5)
+        c = LifetimeBoundBuffer("C", 15, 4, 9, in_place_parents=["P"])
+        result = self.solve([p, c])
+        by_name = {b.name: b.address for b in result}
+        self.assertEqual(by_name["P"], 0)
+        self.assertEqual(by_name["C"], 0)
+
+    def test_child_falls_back_when_parent_evicted(self):
+        # P is too large to fit; C declared as in-place child of P.
+        # P gets evicted (address=None), so C also cannot in-place and
+        # must fall back to normal placement.
+        p = LifetimeBoundBuffer("P", 200, 0, 5)
+        c = LifetimeBoundBuffer("C", 15, 4, 9, in_place_parents=["P"])
+        result = self.solve([p, c], size=100)
+        by_name = {b.name: b.address for b in result}
+        self.assertIsNone(by_name["P"])
+        # C can still be placed independently (no overlap conflict with evicted P).
+        self.assertEqual(by_name["C"], 0)
+
+    def test_assert_rejects_wrong_end_time(self):
+        p = LifetimeBoundBuffer("P", 20, 0, 5)
+        c = LifetimeBoundBuffer(
+            "C", 15, 3, 9, in_place_parents=["P"]
+        )  # start_time=3, need P.end_time==4
+        with self.assertRaises(AssertionError):
+            _assert_in_place_relationships([p, c])
+
+    def test_assert_rejects_oversized_child(self):
+        p = LifetimeBoundBuffer("P", 10, 0, 5)
+        c = LifetimeBoundBuffer(
+            "C", 15, 4, 9, in_place_parents=["P"]
+        )  # child larger than parent
+        with self.assertRaises(AssertionError):
+            _assert_in_place_relationships([p, c])
+
+
+class TestFirstFitLayoutSolver(BaseLayoutSolverTests, TestCase):
+    solver_class = FirstFitLayoutSolver
+
+    def test_picks_first_gap_not_tightest(self):
+        result = self.solver_class(120, 1).plan_layout(_two_gap_buffers())
+        x_addr = next(b.address for b in result if b.name == "x")
+        self.assertEqual(x_addr, 0)
+
+
+class TestBestFitLayoutSolver(BaseLayoutSolverTests, TestCase):
+    solver_class = BestFitLayoutSolver
+
+    def test_picks_tightest_gap(self):
+        result = self.solver_class(120, 1).plan_layout(_two_gap_buffers())
+        x_addr = next(b.address for b in result if b.name == "x")
+        self.assertEqual(x_addr, 100)
+
+
+class TestGreedyLayoutSolver(BaseLayoutSolverTests, TestCase):
+    solver_class = GreedyLayoutSolver
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -14,7 +14,7 @@
 
 import os
 import sys
-from typing import Callable, Optional
+from typing import Callable, Literal, Optional
 
 from torch.utils._config_module import install_config_module
 
@@ -69,5 +69,14 @@ unroll_loops: bool = os.environ.get("UNROLL_LOOPS", "1") == "1"
 # until the working set reduction annotation framework is being developed.
 # It will be removed once the full-fledged annotation mechanism is available.
 coarse_tiling_groups_fn: Optional[Callable] = None
+
+# Layout solver class used by default in scratchpad.allocator.DefaultAllocator.
+# Options:
+#  "greedy":   GreedyLayoutSolver (default),
+#  "bestfit":  BestFitLayoutSolver,
+#  "firstfit": FirstFitLayoutSolver.
+
+# TODO(isuruf): Change to firstfit when deeptools PR4298 lands
+layout_solver: Literal["greedy", "bestfit", "firstfit"] = "greedy"
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -31,6 +31,10 @@ from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
     MemoryPlanSolver,
 )
+from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
+    BestFitLayoutSolver,
+    FirstFitLayoutSolver,
+)
 from torch_spyre._inductor.scratchpad.passes import (
     CloneInputNodesPass,
     ScratchpadOptimizationPass,
@@ -199,7 +203,16 @@ class DefaultAllocator(ScratchpadAllocator):
         """
         size = int((2 << 20) * (1.0 - config.dxp_lx_frac_avail))
         if layout_planning is None:
-            layout_planning = GreedyLayoutSolver(size)
+            if config.layout_solver == "greedy":
+                layout_planning = GreedyLayoutSolver(size)
+            elif config.layout_solver == "bestfit":
+                layout_planning = BestFitLayoutSolver(size)
+            elif config.layout_solver == "firstfit":
+                layout_planning = FirstFitLayoutSolver(size)
+            else:
+                raise ValueError(
+                    f"Invalid layout_solver config option '{config.layout_solver}'."
+                )
         if pre_optimization_passes is None:
             pre_optimization_passes = [CloneInputNodesPass(size)]
         if post_optimization_passes is None:

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -1,0 +1,241 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import heapq
+from dataclasses import dataclass, field, replace
+from typing import Optional, Callable
+
+from torch_spyre._inductor.scratchpad.plan_solver import (
+    LifetimeBoundBuffer,
+    MemoryPlanSolver,
+)
+
+
+def round_up_to_alignment(arg: int, alignment: int) -> int:
+    return ((arg + alignment - 1) // alignment) * alignment
+
+
+@dataclass(frozen=True)
+class Gap:
+    start: int
+    end: int
+    in_place_parents: list[str] = field(default_factory=list)
+
+
+def _assert_in_place_relationships(buffers: list[LifetimeBoundBuffer]) -> None:
+    """Assert that all declared in-place parent/child pairs satisfy required invariants."""
+    buf_by_name = {b.name: b for b in buffers}
+    for child in buffers:
+        for parent_name in child.in_place_parents:
+            parent = buf_by_name[parent_name]
+            assert parent.end_time == child.start_time + 1, (
+                f"In-place parent {parent_name}.end_time={parent.end_time} must equal "
+                f"child {child.name}.start_time+1={child.start_time + 1}"
+            )
+            assert child.size <= parent.size, (
+                f"In-place child {child.name}.size={child.size} "
+                f"must be <= parent {parent_name}.size={parent.size}"
+            )
+
+
+def _topological_sort(
+    buffers: list[LifetimeBoundBuffer],
+    f: Callable[[LifetimeBoundBuffer], int] = lambda b: 0,
+) -> list[LifetimeBoundBuffer]:
+    """Topological sort via Kahn's algorithm; ties broken by (f, original_index)."""
+    name_to_idx = {b.name: i for i, b in enumerate(buffers)}
+    in_degree = [0] * len(buffers)
+    children: list[list[int]] = [[] for _ in buffers]
+
+    for i, child in enumerate(buffers):
+        for parent_name in child.in_place_parents:
+            p = name_to_idx[parent_name]
+            children[p].append(i)
+            in_degree[i] += 1
+
+    heap: list[tuple[int, int]] = []
+    for i, buf in enumerate(buffers):
+        if in_degree[i] == 0:
+            heapq.heappush(heap, (f(buf), i))
+
+    result: list[LifetimeBoundBuffer] = []
+    while heap:
+        _, i = heapq.heappop(heap)
+        result.append(buffers[i])
+        for j in children[i]:
+            in_degree[j] -= 1
+            if in_degree[j] == 0:
+                buf = buffers[j]
+                heapq.heappush(heap, (buf.end_time - buf.start_time, j))
+
+    assert len(result) == len(buffers), (
+        "Cycle detected in in-place parent relationships"
+    )
+    return result
+
+
+class FirstFitLayoutSolver(MemoryPlanSolver):
+    """Allocates buffers shortest-lifetime-first, placing each in the first gap that fits.
+
+    Buffers are sorted topologically (parents before children) with ties broken by ascending
+    lifetime, then placed one at a time. For each buffer, free address gaps during its lifetime
+    are computed; the buffer is placed at the start of the first gap large enough to hold it
+    (rounded up to alignment). In-place reuse is attempted first: if a declared parent has already
+    been placed and its address falls within a free gap, the child inherits that address.
+    Buffers that cannot fit within self.limit are evicted (address=None).
+    """
+
+    def _all_minus(
+        self,
+        gaps: list[Gap],
+        interval: tuple[int, int],
+        minimum_size: int,
+    ) -> list[Gap]:
+        """Return gaps with interval subtracted, dropping remainders < minimum_size."""
+        result = []
+        for gap in gaps:
+            a, b = gap.start, gap.end
+            if a < interval[0]:
+                if b < interval[0]:
+                    if b - a >= minimum_size:
+                        result.append(Gap(a, b))
+                else:
+                    if interval[0] - a >= minimum_size:
+                        result.append(Gap(a, interval[0]))
+            if b > interval[1]:
+                if a > interval[1]:
+                    if b - a >= minimum_size:
+                        result.append(Gap(a, b))
+                else:
+                    if b - interval[1] >= minimum_size:
+                        result.append(Gap(interval[1], b))
+        return result
+
+    def _build_gaps(
+        self,
+        buffer: LifetimeBoundBuffer,
+        placed: list[LifetimeBoundBuffer],
+    ) -> list[Gap]:
+        """Build free gaps for buffer, annotated with valid in-place parent addresses.
+
+        Pass 1: subtract address intervals of all already-placed buffers that overlap
+        buffer's lifetime, except declared in-place parents (their slots are candidates
+        for reuse, not conflicts).
+        Pass 2: for each remaining gap, record which declared parents fit entirely within it.
+        """
+        gaps: list[Gap] = [Gap(0, self.limit)]
+        parent_names = set(buffer.in_place_parents)
+
+        for other in placed:
+            if other.address is None:
+                continue
+            if other.name in parent_names:
+                continue
+            if not (
+                other.start_time < buffer.end_time
+                and buffer.start_time < other.end_time
+            ):
+                continue
+            gaps = self._all_minus(
+                gaps, (other.address, other.address + other.size), buffer.size
+            )
+
+        placed_by_name = {b.name: b for b in placed}
+        for i, gap in enumerate(gaps):
+            new_parents = list(gap.in_place_parents)
+            for parent_name in parent_names:
+                parent = placed_by_name.get(parent_name)
+                if parent is None or parent.address is None:
+                    continue
+                addr_p = parent.address
+                if gap.start <= addr_p and addr_p + parent.size <= gap.end:
+                    new_parents.append(parent_name)
+            gaps[i] = replace(gap, in_place_parents=new_parents)
+
+        return gaps
+
+    def _pick_gap(
+        self,
+        gaps: list[Gap],
+        size: int,
+    ) -> Optional[Gap]:
+        """Return the first fitting gap, or None."""
+        for gap in gaps:
+            addr = round_up_to_alignment(gap.start, self.alignment)
+            if addr + size <= gap.end:
+                return gap
+        return None
+
+    def plan_layout(
+        self, buffers: list[LifetimeBoundBuffer]
+    ) -> list[LifetimeBoundBuffer]:
+        if not buffers:
+            return []
+        assert all(buf.address is None for buf in buffers), (
+            "Buffers cannot be previously or partially planned"
+        )
+        _assert_in_place_relationships(buffers)
+
+        buffers_filtered = [
+            buffer for buffer in buffers if buffer.end_time >= buffer.start_time + 1
+        ]
+        buffers_sorted = _topological_sort(
+            buffers_filtered, lambda b: b.end_time - b.start_time
+        )
+
+        names_to_addresses: dict[str, int] = {}
+        for i, buffer in enumerate(buffers_sorted):
+            placed = buffers_sorted[:i]
+            gaps = self._build_gaps(buffer, placed)
+            gap = self._pick_gap(
+                [gap for gap in gaps if gap.in_place_parents],
+                buffer.size,
+            )
+            if gap is not None:
+                parent = gap.in_place_parents[0]
+                buffer.address = names_to_addresses[parent]
+                names_to_addresses[buffer.name] = buffer.address
+            else:
+                gap = self._pick_gap(gaps, buffer.size)
+                if gap is not None:
+                    buffer.address = round_up_to_alignment(gap.start, self.alignment)
+                    names_to_addresses[buffer.name] = buffer.address
+
+        return buffers
+
+
+class BestFitLayoutSolver(FirstFitLayoutSolver):
+    """Like FirstFitLayoutSolver but places each buffer in the tightest fitting gap.
+
+    Inherits all logic from FirstFitLayoutSolver; only the gap-selection policy
+    differs: instead of picking the first gap large enough to hold the buffer,
+    this picks the gap that minimises leftover space after placement.
+    """
+
+    def _pick_gap(
+        self,
+        gaps: list[Gap],
+        size: int,
+    ) -> Optional[Gap]:
+        """Return the tightest fitting gap, or None."""
+        best_gap: Optional[Gap] = None
+        best_waste: int = 0
+        for gap in gaps:
+            addr = round_up_to_alignment(gap.start, self.alignment)
+            if addr + size <= gap.end:
+                waste = gap.end - addr - size
+                if best_gap is None or waste < best_waste:
+                    best_gap = gap
+                    best_waste = waste
+        return best_gap


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This pull request builds on top of #2004 to add two new layout solvers: `FirstFitLayoutSolver` and `BestFitLayoutSolver`. These are two well-known greedy algorithms to solve bin packing; see e.g. the wikipedia pages for [first-fit bin packing](https://en.wikipedia.org/wiki/First-fit_bin_packing) and [best-fit bin packing](https://en.wikipedia.org/wiki/Best-fit_bin_packing). These algorithms are often used to determine the initial state for more complicated solvers, see e.g. [Imanishi & Xu, 2024](https://dl.acm.org/doi/10.1145/3652024.3665508), but they are worthwhile in their own right.

The implementation shares almost all code between the two solvers. In both cases, the buffers are first sorted so that parents of a buffer come before that buffer, and subject to that constraint, putting the buffers with the shortest lifetime first (after omitting single-use buffers). (Ideally, we would want the secondary sorting criterion, after the parent relationships, to be the *density* of operations within its lifetime for a buffer: we "pay" for allocating a buffer in terms of memory used over time, essentially as the buffer size times the number of operations it is alive for; and we benefit in reduced HBM transfers, equal to the buffer size times the number of operations it participates in. As a consequence, we get the best "bang for our buck" if we can maximize the number of operations divided by the lifetime. However, the solver currently does not have access to the number of operations; the closest we can get is the inverse of the lifetime.)

Buffers get processed in this order. Whenever each buffer is processed, the solver finds all memory gaps in the schedule in the time interval where the buffer is alive, taking into account any in-place opportunities. Then, the solver chooses one of the gaps that are large enough, preferring a gap with an in-place opportunity. If multiple in-place opportunities, or no in-place opportunities but multiple gaps of sufficient size, are available, then this is where the two solvers differ: the first-fit solver takes the gap with the lowest address, whereas the best-fit solver takes the gap with the least "slack" (extra space).

Both solvers pass four of the seven memory access patterns introduced in #1704, compared with just one for the pre-existing `GreedyLayoutSolver`.

While the best-fit solver seems intuitively like a better idea, it typically leads to more fragmentation; see e.g. [Robson, 1977](https://doi.org/10.1093/comjnl/20.3.242). For this reason, we set the first-fit algorithm as the default. It is controlled by a config option, `torch_spyre._inductor.config.layout_solver`, or as before by passing an instance of a solver to a `torch_spyre._inductor.scratchpad.allocator.DefaultAllocator` upon construction.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

If a new configuration option counts as a user-facing change, then yes. Otherwise, no.

#### Additional note:
