### PR TITLE
Additional tests for matmul with 1D-viewed inputs

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -3542,6 +3542,28 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         y = torch.rand(B, C, dtype=torch.float16) * 0.01
         self.compare_with_cpu(fn, x, y, atol=0.5, rtol=0.1)
 
+    def test_matmul_1d_view_y(self):
+        # y is a 1D buffer viewed as 2D: same compound-index case but on y.
+        A, B, C = 64, 128, 256
+
+        def fn(x, y):
+            return x @ y.view(B, C)
+
+        x = torch.rand(A, B, dtype=torch.float16) * 0.01
+        y = torch.rand(B * C, dtype=torch.float16) * 0.01
+        self.compare_with_cpu(fn, x, y, atol=0.5, rtol=0.1)
+
+    def test_matmul_1d_view_xy(self):
+        # Both x and y are 1D buffers viewed as 2D.
+        A, B, C = 64, 128, 256
+
+        def fn(x, y):
+            return x.view(A, B) @ y.view(B, C)
+
+        x = torch.rand(A * B, dtype=torch.float16) * 0.01
+        y = torch.rand(B * C, dtype=torch.float16) * 0.01
+        self.compare_with_cpu(fn, x, y, atol=0.5, rtol=0.1)
+
     @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
     @pytest.mark.filterwarnings("ignore:Backend Spyre does not support int64")
     def test_reduce_cpu(self, op, x):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Two additional tests for matmuls operating on views that are fixed by the `red_coord2` branch that is already merged, but were not included in that PR.   Tests cover inputs x and y as 1D buffers viewed as 2D, and require using loop vars to find reduction and generated dimensions rather than dimensions.

#### Which issue(s) this PR is related to:
Part of #843 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
