### PR TITLE
chore(testing framework): refactor spyre test framework to be device generic, remove hardcoded `spyre` from framework

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ import pytest
 
 
 import shared_config
-from spyre_test_utilities import _RUNTIME_TAGS
+from oot_test_utilities import _RUNTIME_TAGS
 
 
 # Attaches per-test tags to the pytest report object after each test call.

--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -31,17 +31,17 @@ from torch.testing._internal.common_utils import TestCase
 
 import shared_config
 from op_registry import OP_REGISTRY, OpAdapter
-from spyre_test_constants import ENV_TEST_CONFIG
-from spyre_test_config_models import (
+
+from oot_test_constants import ENV_TEST_CONFIG
+from oot_test_config_models import (
     InputArgTensor,
     InputArgTensorList,
     OOTTestConfig,
     OpsNamedItem,
     TestEntry,
 )
-from spyre_test_parsing import load_yaml_config, resolve_current_file
-from spyre_test_utilities import print_test_tags_oot
-
+from oot_test_parsing import load_yaml_config, resolve_current_file
+from oot_test_utilities import print_test_tags_oot
 
 # ---------------------------------------------------------------------------
 # ModelOpInfo
@@ -391,14 +391,14 @@ class TestSpyreModelOps(TestCase):
             SampleInput=SampleInput,
         )
 
-        def _to_spyre(x: Any) -> Any:
+        def _to_target_device(x: Any) -> Any:
             if torch.is_tensor(x):
                 return x.to(test_device)
             if isinstance(x, list):
                 return [t.to(test_device) if torch.is_tensor(t) else t for t in x]
             return x
 
-        test_sample: SampleInput = cpu_sample.transform(_to_spyre)
+        test_sample: SampleInput = cpu_sample.transform(_to_target_device)
 
         # Adapter pre-hook (e.g. dropout sets training=False)
         if adapter.pre is not None:

--- a/tests/oot_test_base_common.py
+++ b/tests/oot_test_base_common.py
@@ -1,5 +1,6 @@
 """
 Shared class and methods for all OOT PyTorch test overrides.
+# Copyright Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
 
 """
 
@@ -12,7 +13,7 @@ import regex as re
 import pytest  # type: ignore
 import torch
 
-from spyre_test_constants import (
+from oot_test_constants import (
     DEFAULT_FLOATING_PRECISION,
     ENV_TEST_CONFIG,
     MODE_MANDATORY_SUCCESS,
@@ -21,18 +22,18 @@ from spyre_test_constants import (
     MODE_XFAIL_STRICT,
     UNLISTED_MODE_XFAIL,
 )
-from spyre_test_matching import (
+from oot_test_matching import (
     extract_dtype_from_name,
     parse_dtype,
 )
-from spyre_test_parsing import (
+from oot_test_parsing import (
     FileEntry,
     apply_op_config_overrides,
     load_yaml_config,
     resolve_current_file,
 )
 
-from spyre_upstream_patcher import (
+from oot_upstream_patcher import (
     _OOTDtypePatcher,
     _OOTModuleMarkerPatcher,
     _OOTOnlyOnPatcher,
@@ -43,17 +44,18 @@ from spyre_upstream_patcher import (
     _OOTOpMarkerPatcher,
     _OOTPrecisionOverridePatcher,
 )
-from spyre_test_config_models import (
+from oot_test_config_models import (
     OOTTestConfig,
     Precision,
     SupportedOpConfig,
     SupportedModuleConfig,
     TestEntry,
 )
-from spyre_test_common_methods_invocations import (
+from oot_test_common_methods_invocations import (
     create_module_inputs_func_from_yaml,
     create_module_inputs_func_from_config,
 )
+from oot_test_utilities import _get_privateuse1_device_type
 
 warnings.filterwarnings("ignore", category=pytest.PytestUnknownMarkWarning)
 
@@ -76,14 +78,7 @@ def _log_error(msg: str) -> None:
 # Resolve the actual backend name registered for privateuse1.
 # torch._C._get_privateuse1_backend_name() returns e.g. "spyre".
 # This is what slf.device_type will be at test runtime.
-def _get_privateuse1_device_type() -> str:
-    try:
-        return torch._C._get_privateuse1_backend_name()
-    except Exception:
-        return "privateuse1"  # fallback if not registered yet
-
-
-_SPYRE_DEVICE_TYPE: str = _get_privateuse1_device_type()
+_OOT_DEVICE_TYPE: str = _get_privateuse1_device_type()
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +229,7 @@ def _extract_op_name_from_method(
 ) -> Optional[str]:
     """Extract the op name from a parametrized method name.
 
-    method_name: test_scalar_support_add_spyre_float16
+    method_name: test_scalar_support_add_<device>_float16
     base_test_name: test_scalar_support
     returns: "add"
 
@@ -242,11 +237,10 @@ def _extract_op_name_from_method(
     """
     if not method_name.startswith(base_test_name + "_"):
         return None
-    remainder = method_name[len(base_test_name) + 1 :]  # "add_spyre_float16"
+    remainder = method_name[len(base_test_name) + 1 :]  # "add_<device>_float16"
     # op name is the first segment before the device suffix
-    device_type = "spyre"  # or read from _SPYRE_DEVICE_TYPE
-    if f"_{device_type}_" in remainder:
-        return remainder.split(f"_{device_type}_")[0]  # "add"
+    if f"_{_OOT_DEVICE_TYPE}_" in remainder:
+        return remainder.split(f"_{_OOT_DEVICE_TYPE}_")[0]
     return None
 
 
@@ -261,7 +255,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
 
     All configuration is loaded lazily from the YAML file pointed to by
     PYTORCH_TEST_CONFIG.  The YAML is validated by Pydantic on load.
-    See spyre_test_config_schema.json for the full schema.
+    See oot_test_config_schema.json for the full schema.
     """
 
     device_type: str = "privateuse1"
@@ -285,12 +279,11 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # PrivateUse1TestBase.setUpClass sets cls.device_type = "spyre"
-        # (the registered backend name). This mutates the base class's
-        # device_type, causing subsequent instantiate_device_type_tests calls
-        # to generate class names like TestOldViewOpsSPYRE instead of
-        # TestOldViewOpsPRIVATEUSE1, which then get filtered out by
-        # PYTORCH_TESTING_DEVICE_ONLY_FOR=privateuse1.
+        # PrivateUse1TestBase.setUpClass sets cls.device_type to the registered
+        # backend name (e.g. "spyre").  This mutates the base class's device_type,
+        # causing subsequent instantiate_device_type_tests calls to generate class
+        # names like TestOldViewOpsSPYRE instead of TestOldViewOpsPRIVATEUSE1,
+        # which then get filtered out by PYTORCH_TESTING_DEVICE_ONLY_FOR=privateuse1.
         # Reset TorchTestBase.device_type to "privateuse1" so subsequent
         # calls generate the correct class name.
         TorchTestBase.device_type = "privateuse1"
@@ -529,7 +522,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
 
         # resolve final decision
         if effective_mode == MODE_SKIP:
-            return False, "Skipped for Spyre", False, False
+            return False, "Skipped by OOT config", False, False
         elif effective_mode == MODE_XFAIL:
             return True, None, True, False  # run, xfail non-strict
         elif effective_mode == MODE_XFAIL_STRICT:
@@ -552,7 +545,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
     # ------------------------------------------------------------------
     @classmethod
     def instantiate_test(cls, name, test, *, generic_cls=None):
-        _OOTOnlyOnPatcher(test, _SPYRE_DEVICE_TYPE).patch()
+        _OOTOnlyOnPatcher(test, _OOT_DEVICE_TYPE).patch()
         cls._load_test_suite_config()
 
         # Retrieve all entries for this base test name.
@@ -759,7 +752,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
 
             # if not enabled:
             #     @wraps(test)
-            #     def _skip(self, _reason=reason or "Skipped for Spyre"):
+            #     def _skip(self, _reason=reason or "Skipped by OOT config"):
             #         raise unittest.SkipTest(_reason)
 
             #     setattr(cls, method_name, _skip)
@@ -793,7 +786,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                 existing_fn = cls.__dict__.get(method_name)
                 if existing_fn is not None:
                     # Store BEFORE marking so the attribute is on the base function
-                    existing_fn._spyre_method_tags = method_tags
+                    existing_fn._oot_method_tags = method_tags
                     marked_fn = existing_fn
                     for tag in method_tags:
                         marked_fn = pytest.mark.__getattr__(tag)(marked_fn)

--- a/tests/oot_test_common_methods_invocations.py
+++ b/tests/oot_test_common_methods_invocations.py
@@ -1,5 +1,5 @@
 """
-Utility functions for the Spyre test framework.
+Utility functions for the OOT test framework.
 
 This module contains helper functions for creating module input generators
 and other test utilities that are used by TorchTestBase.

--- a/tests/oot_test_config_models.py
+++ b/tests/oot_test_config_models.py
@@ -1,7 +1,9 @@
 """
+# Copyright Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
+
 Pydantic models for the OOT PyTorch test framework YAML config.
 
-Used by spyre_test_parsing.py to validate and parse the YAML config.
+Used by oot_test_parsing.py to validate and parse the YAML config.
 """
 
 import ast
@@ -14,7 +16,7 @@ from typing import Any, Dict, List, Optional, Set, Union
 import torch
 from pydantic import BaseModel, field_validator, model_validator  # type: ignore
 
-from spyre_test_constants import (
+from oot_test_constants import (
     DTYPE_STR_MAP,
     MODE_MANDATORY_SUCCESS,
     MODE_SKIP,
@@ -22,7 +24,7 @@ from spyre_test_constants import (
     MODE_XFAIL_STRICT,
     REL_PATH_TOKENS,
 )
-from spyre_test_matching import parse_dtype
+from oot_test_matching import parse_dtype
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +195,7 @@ class InputTensorSpec(BaseModel):
 
     shape: List[int]
     dtype: str
-    device: str = "spyre"
+    device: str = "privateuse1"
     init: str = "rand"
     init_args: InputInitArgs = InputInitArgs()
     stride: Optional[List[int]] = None

--- a/tests/oot_test_constants.py
+++ b/tests/oot_test_constants.py
@@ -1,5 +1,7 @@
 """
-Constants for the Spyre PyTorch test framework.
+# Copyright Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
+
+Constants for the OOT PyTorch test framework.
 All string literals, default values, and dtype maps are here.
 """
 

--- a/tests/oot_test_matching.py
+++ b/tests/oot_test_matching.py
@@ -1,5 +1,7 @@
 """
-Dtype helpers and MatchSet for the Spyre PyTorch test framework.
+# Copyright Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
+
+Dtype helpers and MatchSet for the OOT PyTorch test framework.
 
 Responsibilities:
   - parse_dtype / extract_dtype_from_name
@@ -12,7 +14,7 @@ from typing import Dict, Optional, Set
 import regex as re
 import torch
 
-from spyre_test_constants import DTYPE_STR_MAP, DTYPE_NAMES_ORDERED
+from oot_test_constants import DTYPE_STR_MAP, DTYPE_NAMES_ORDERED
 
 
 # ----------------

--- a/tests/oot_test_parsing.py
+++ b/tests/oot_test_parsing.py
@@ -1,9 +1,11 @@
 """
+# Copyright Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
+
 YAML config parsing and op_db filtering for the OOT PyTorch test framework.
 
 Responsibilities:
   - load_yaml_config: read YAML and return validated OOTTestConfig
-  - resolve_rel_path: expand ${PYTORCH} / ${TORCH_SPYRE} tokens
+  - resolve_rel_path: expand ${PYTORCH} / ${TORCH_DEVICE_ROOT} tokens
   - resolve_current_file: match a YAML file entry against cwd
   - filter_op_db: monkey-patch pytorch op_db lists to supported_ops subset
 """
@@ -16,8 +18,8 @@ from typing import Dict, Optional
 
 import yaml
 
-from spyre_test_constants import REL_PATH_TOKENS
-from spyre_test_config_models import FileEntry, OOTTestConfig, SupportedOpConfig
+from oot_test_constants import REL_PATH_TOKENS
+from oot_test_config_models import FileEntry, OOTTestConfig, SupportedOpConfig
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +53,7 @@ def load_yaml_config(path: str) -> OOTTestConfig:
 
 
 def resolve_rel_path(path: str) -> str:
-    """Expand ${PYTORCH} and ${TORCH_SPYRE} tokens using env vars."""
+    """Expand ${TORCH_ROOT} and ${TORCH_DEVICE_ROOT} tokens using env vars."""
     for token, env_var in REL_PATH_TOKENS:
         if token in path:
             root = os.environ.get(env_var)
@@ -106,7 +108,7 @@ def _unwrap_oot_path(path: str) -> str:
 # xdist worker processes via inherited environment, unlike sys.argv (empty
 # in workers) and PYTEST_CURRENT_TEST (only set during test *execution*,
 # not during the *collection* phase when resolve_current_file is called).
-_ENV_SPYRE_TEST_FILE = "SPYRE_TEST_FILE"
+_ENV_OOT_TEST_FILE = "OOT_TEST_FILE"
 
 
 def _resolve_candidate(raw: str, cwd: Path) -> Optional[str]:
@@ -121,9 +123,9 @@ def _resolve_candidate(raw: str, cwd: Path) -> Optional[str]:
 
 
 def _find_test_file_from_env(cwd: Path) -> Optional[str]:
-    """Return the original (non-wrapper) test file path from SPYRE_TEST_FILE.
+    """Return the original (non-wrapper) test file path from OOT_TEST_FILE.
 
-    run_test.sh exports SPYRE_TEST_FILE=<absolute path to wrapper or original>
+    run_test.sh exports OOT_TEST_FILE=<absolute path to wrapper or original>
     immediately before each pytest invocation.  Child processes — including
     xdist worker subprocesses — inherit it via the environment, so it is
     present during both *collection* and *execution*.
@@ -133,7 +135,7 @@ def _find_test_file_from_env(cwd: Path) -> Optional[str]:
 
     Returns the resolved absolute path string, or None if unset / not found.
     """
-    value = os.environ.get(_ENV_SPYRE_TEST_FILE, "")
+    value = os.environ.get(_ENV_OOT_TEST_FILE, "")
     if not value:
         return None
     # Unwrap before resolving so the path we check on disk is the original file.
@@ -178,7 +180,7 @@ def _find_test_file_from_pytest_current_test(cwd: Path) -> Optional[str]:
     This env var is only set during test *execution*, not during
     *collection*.  resolve_current_file is called from instantiate_test()
     which runs at collection time, so this is a last-resort fallback for
-    cases where SPYRE_TEST_FILE is not set (e.g. direct pytest invocations
+    cases where OOT_TEST_FILE is not set (e.g. direct pytest invocations
     outside of run_test.sh during an ongoing test run).
 
     Returns the resolved absolute path string, or None if not set / not found.
@@ -198,7 +200,7 @@ def resolve_current_file(config: OOTTestConfig, config_path: str) -> FileEntry:
 
     Source priority for determining the current test file:
 
-    1. SPYRE_TEST_FILE env var — exported by run_test.sh before every pytest
+    1. OOT_TEST_FILE env var — exported by run_test.sh before every pytest
        invocation (normal and xdist fallback alike).  Inherited by all child
        processes including xdist workers.  Available during both collection
        and execution, making it the only source that works reliably in all
@@ -216,10 +218,10 @@ def resolve_current_file(config: OOTTestConfig, config_path: str) -> FileEntry:
 
     cwd = Path(os.getcwd()).resolve()
 
-    # --- Source 1: SPYRE_TEST_FILE (set by run_test.sh ---
+    # --- Source 1: OOT_TEST_FILE (set by run_test.sh) ---
     current_test_file = _find_test_file_from_env(cwd)
     if current_test_file is not None:
-        _debug(f"resolved from {_ENV_SPYRE_TEST_FILE}: {current_test_file!r}")
+        _debug(f"resolved from {_ENV_OOT_TEST_FILE}: {current_test_file!r}")
 
     # --- Source 2: sys.argv ---
     if current_test_file is None:
@@ -234,10 +236,10 @@ def resolve_current_file(config: OOTTestConfig, config_path: str) -> FileEntry:
     if current_test_file is None:
         raise EnvironmentError(
             f"Could not determine the test file being run.\n"
-            f"  {_ENV_SPYRE_TEST_FILE}={os.environ.get(_ENV_SPYRE_TEST_FILE, '')!r}\n"
+            f"  {_ENV_OOT_TEST_FILE}={os.environ.get(_ENV_OOT_TEST_FILE, '')!r}\n"
             f"  sys.argv[1:]={sys.argv[1:]!r}\n"
             f"  PYTEST_CURRENT_TEST={os.environ.get('PYTEST_CURRENT_TEST', '')!r}\n"
-            f"Make sure run_test.sh exports {_ENV_SPYRE_TEST_FILE} before invoking pytest, "
+            f"Make sure run_test.sh exports {_ENV_OOT_TEST_FILE} before invoking pytest, "
             f"or invoke pytest with an explicit test file, e.g. `pytest test_ops.py`."
         )
 

--- a/tests/oot_test_utilities.py
+++ b/tests/oot_test_utilities.py
@@ -1,5 +1,6 @@
 """
-spyre_test_utilities.py -- Utility functions for the torch-spyre OOT test framework.
+oot_test_utilities.py -- Utility functions for the OOT PyTorch test framework.
+# Copyright Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
 
 """
 
@@ -18,9 +19,31 @@ try:
     import yaml
 except ImportError as _yaml_err:  # pragma: no cover
     raise ImportError(
-        "PyYAML is required for spyre_test_utilities. "
-        "Install it with: pip install pyyaml"
+        "PyYAML is required for oot_test_utilities. Install it with: pip install pyyaml"
     ) from _yaml_err
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Device type helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_privateuse1_device_type() -> str:
+    """Return the backend name registered for the privateuse1 device slot.
+
+    torch._C._get_privateuse1_backend_name() returns e.g. "spyre" or whatever
+    name was passed to torch._register_device_module().  This is what
+    cls.device_type will be at test runtime inside PrivateUse1TestBase.
+
+    Falls back to "privateuse1" if no backend has been registered yet (e.g.
+    during import before the backend module is loaded).
+    """
+    try:
+        return torch._C._get_privateuse1_backend_name()
+    except Exception:
+        return "privateuse1"  # fallback if not registered yet
 
 
 """
@@ -38,12 +61,12 @@ def print_test_tags_oot(test_instance, op_tags: List[str] = []) -> None:
     at collection time with per-op tags available only at run time.
 
     Usage in a test method:
-        from spyre_test_utilities import print_test_tags_oot
+        from oot_test_utilities import print_test_tags_oot
         print_test_tags_oot(self, op_tags=op.op_tags)
     """
     method_name = test_instance._testMethodName
     _method_fn = getattr(test_instance.__class__, method_name, None)
-    _method_tags = getattr(_method_fn, "_spyre_method_tags", [])
+    _method_tags = getattr(_method_fn, "_oot_method_tags", [])
     _per_op_tags = [t for t in op_tags if t not in set(_method_tags)]
     _all_tags = _method_tags + _per_op_tags
     # Store for pytest_runtest_makereport hook to work without -s
@@ -59,14 +82,14 @@ def print_test_tags_oot(test_instance, op_tags: List[str] = []) -> None:
 # Provides YAML config merging for multi-config test runs.
 
 # Usage (Python):
-#     from spyre_test_utilities import merge_yaml_configs
+#     from oot_test_utilities import merge_yaml_configs
 
 #     merged_path = merge_yaml_configs(["config_a.yaml", "config_b.yaml"])
 #     # ... run tests ...
 #     os.unlink(merged_path)   # caller is responsible for cleanup
 
 # Usage (bash, via the CLI entry-point at the bottom):
-#     python3 spyre_test_utilities.py config_a.yaml config_b.yaml
+#     python3 oot_test_utilities.py config_a.yaml config_b.yaml
 #     # prints the path of the merged (temp) YAML to stdout
 
 
@@ -164,7 +187,7 @@ def _merge_file_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             incoming_mode = entry.get("unlisted_test_mode", "xfail")
             if existing["unlisted_test_mode"] != incoming_mode:
                 print(
-                    f"[spyre_merge] WARNING: conflicting unlisted_test_mode for "
+                    f"[oot_merge] WARNING: conflicting unlisted_test_mode for "
                     f"path '{path}': keeping '{existing['unlisted_test_mode']}', "
                     f"ignoring '{incoming_mode}'.",
                     file=sys.stderr,
@@ -205,7 +228,7 @@ def merge_yaml_configs(
     config_paths: Sequence[str | os.PathLike],
     *,
     output_dir: Optional[str | os.PathLike] = None,
-    prefix: str = "_spyre_merged_config_",
+    prefix: str = "_oot_merged_config_",
     suffix: str = ".yaml",
 ) -> str:
     """Merge multiple YAML test-suite configs into one temporary file.
@@ -321,9 +344,9 @@ def _cli() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(
-        prog="spyre_test_utilities",
+        prog="oot_test_utilities",
         description=(
-            "Merge multiple torch-spyre YAML test configs into one temporary file.\n"
+            "Merge multiple OOT PyTorch YAML test configs into one temporary file.\n"
             "Prints the merged file path to stdout. The caller must delete it."
         ),
     )
@@ -352,7 +375,7 @@ def _cli() -> None:
     merged = merge_yaml_configs(args.configs, output_dir=args.output_dir)
     # Emit a human-readable note to stderr so it doesn't pollute the path.
     print(
-        f"[spyre_merge] Merged {len(args.configs)} config(s) -> {merged}",
+        f"[oot_merge] Merged {len(args.configs)} config(s) -> {merged}",
         file=sys.stderr,
     )
     # The path goes to stdout for shell capture.

--- a/tests/oot_upstream_patcher.py
+++ b/tests/oot_upstream_patcher.py
@@ -1,9 +1,11 @@
 """
-Upstream PyTorch decorator patchers for the Spyre test framework.
+# Copyright Author: Anubhav Jana (Anubhav.Jana97@ibm.com)
+
+Upstream PyTorch decorator patchers for the OOT test framework.
 
 These patchers modify upstream PyTorch test decorators at instantiation time
-to allow Spyre's privateuse1 backend to run tests that would otherwise be
-restricted to specific devices or dtypes.
+to allow the registered privateuse1 backend to run tests that would otherwise
+be restricted to specific devices or dtypes.
 
 Each patcher follows the same pattern:
   1. Receive the test method as passed to instantiate_test()
@@ -21,6 +23,13 @@ would not affect these copies.
 
 from typing import Set, Optional
 import torch
+
+from oot_test_utilities import _get_privateuse1_device_type
+
+# Resolve the registered backend name once at import time.
+# Used in _OOTModuleListPatcher to strip the device suffix when extracting
+# op names from parametrised method names (e.g. "add_<device>_float16").
+_OOT_DEVICE_TYPE: str = _get_privateuse1_device_type()
 
 
 def _extract_base_module_name(name: str) -> str:
@@ -190,7 +199,7 @@ class _OOTOpListPatcher:
     on self.op_list.
 
     Access the @ops instance directly via test.__func__.parametrize_fn.__self__
-    (the same path _SpyreDtypePatcher uses for allowed_dtypes) and filter
+    (the same path _OOTDtypePatcher uses for allowed_dtypes) and filter
     self.op_list in-place to keep only supported ops.
     """
 
@@ -256,14 +265,14 @@ class _OOTOpDtypeExpander:
 
     If apply_op_config_overrides narrowed op.__dict__["dtypes"] to only
     global.supported_dtypes, a dtype in edits.dtypes.include won't survive
-    this intersection even if _SpyreDtypePatcher added it to allowed_dtypes.
+    this intersection even if _OOTDtypePatcher added it to allowed_dtypes.
 
     Expand op.__dict__["dtypes"] directly on each OpInfo in @ops.op_list
     to include the extra dtypes before super().instantiate_test() runs.
     Writes to __dict__ directly to bypass OpInfo.__setattr__ validation.
 
-    _SpyreDtypePatcher handles @ops.allowed_dtypes (the outer filter).
-    _SpyreOpDtypeExpander handles op.dtypes on each OpInfo (the inner filter).
+    _OOTDtypePatcher handles @ops.allowed_dtypes (the outer filter).
+    _OOTOpDtypeExpander handles op.dtypes on each OpInfo (the inner filter).
     Both must be patched for a variant to be generated.
 
     edits.dtypes.include is intentionally NOT bounded by global.supported_dtypes.

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -11,7 +11,7 @@
 #   bash run_test.sh configs/ extra.yaml -- [extra pytest args...]
 
 # When more than one YAML file is supplied the configs are merged in order via
-# spyre_test_utilities.py
+# oot_test_utilities.py
 #   - `files` entries with the same path are combined (tests deduplicated).
 #   - `global` list keys form a superset; identical items are deduplicated.
 #   - Conflicting scalar globals raise an error.
@@ -96,8 +96,8 @@ for _arg in "$@"; do
         if [[ ${#_dir_yamls[@]} -eq 0 ]]; then
             echo "WARNING: No YAML files found in directory: $_arg" >&2
         else
-            echo "[spyre_run] Expanded directory '$_arg' -> ${#_dir_yamls[@]} config(s):"
-            for _f in "${_dir_yamls[@]}"; do echo "[spyre_run]   $_f"; done
+            echo "[torch_oot_device_tests_run] Expanded directory '$_arg' -> ${#_dir_yamls[@]} config(s):"
+            for _f in "${_dir_yamls[@]}"; do echo "[torch_oot_device_tests_run]   $_f"; done
             YAML_CONFIGS+=("${_dir_yamls[@]}")
         fi
     elif [[ $_parsing_yamls -eq 1 && ( "$_arg" == *.yaml || "$_arg" == *.yml ) && -f "$_arg" ]]; then
@@ -128,30 +128,30 @@ if [[ ${#YAML_CONFIGS[@]} -eq 1 ]]; then
         exit 1
     fi
 
-    echo "[spyre_run] Using YAML config: $YAML_CONFIG"
+    echo "[torch_oot_device_tests_run] Using YAML config: $YAML_CONFIG"
 else
     # -----------------------------------------------------------------------
-    # Multi-config path -- merge via spyre_test_utilities.py
+    # Multi-config path -- merge via oot_test_utilities.py
     # -----------------------------------------------------------------------
-    echo "[spyre_run] Merging ${#YAML_CONFIGS[@]} YAML config(s):"
+    echo "[torch_oot_device_tests_run] Merging ${#YAML_CONFIGS[@]} YAML config(s):"
     for _c in "${YAML_CONFIGS[@]}"; do
-        echo "[spyre_run]   $_c"
+        echo "[torch_oot_device_tests_run]   $_c"
     done
 
     _script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     _UTILITIES_PY=""
-    if [[ -f "${_script_dir}/spyre_test_utilities.py" ]]; then
-        _UTILITIES_PY="${_script_dir}/spyre_test_utilities.py"
+    if [[ -f "${_script_dir}/oot_test_utilities.py" ]]; then
+        _UTILITIES_PY="${_script_dir}/oot_test_utilities.py"
     else
         _first_config_dir="$(dirname "${YAML_CONFIGS[0]}")"
-        if [[ -f "${_first_config_dir}/spyre_test_utilities.py" ]]; then
-            _UTILITIES_PY="${_first_config_dir}/spyre_test_utilities.py"
+        if [[ -f "${_first_config_dir}/oot_test_utilities.py" ]]; then
+            _UTILITIES_PY="${_first_config_dir}/oot_test_utilities.py"
         fi
     fi
 
     if [[ -z "$_UTILITIES_PY" ]]; then
-        echo "ERROR: spyre_test_utilities.py not found beside run_test.sh or beside the first config." >&2
-        echo "       Place spyre_test_utilities.py in the same directory as run_test.sh." >&2
+        echo "ERROR: oot_test_utilities.py not found beside run_test.sh or beside the first config." >&2
+        echo "       Place oot_test_utilities.py in the same directory as run_test.sh." >&2
         exit 1
     fi
 
@@ -270,7 +270,7 @@ try:
         url = data.get('url', '')
         if url.startswith('file://'):
             candidate = url[len('file://'):]
-            if os.path.isfile(os.path.join(candidate, 'tests', 'spyre_test_base_common.py')):
+            if os.path.isfile(os.path.join(candidate, 'tests', 'oot_test_base_common.py')):
                 print(candidate)
 except Exception:
     pass
@@ -280,7 +280,7 @@ except Exception:
     if [[ -z "$TORCH_DEVICE_ROOT" ]]; then
         _found=$(python3 -c "
 import importlib.util, os
-spec = importlib.util.find_spec('spyre_test_base_common')
+spec = importlib.util.find_spec('oot_test_base_common')
 if spec:
     print(os.path.dirname(os.path.dirname(os.path.abspath(spec.origin))))
 " 2>/dev/null) || true
@@ -288,7 +288,7 @@ if spec:
     fi
 
     if [[ -z "$TORCH_DEVICE_ROOT" ]]; then
-        TORCH_DEVICE_ROOT=$(_walk_up_for_sentinel "$YAML_DIR" "tests/spyre_test_base_common.py" 2>/dev/null) || true
+        TORCH_DEVICE_ROOT=$(_walk_up_for_sentinel "$YAML_DIR" "tests/oot_test_base_common.py" 2>/dev/null) || true
     fi
 
     if [[ -z "$TORCH_DEVICE_ROOT" ]]; then
@@ -300,14 +300,14 @@ if spec:
     fi
 fi
 export TORCH_DEVICE_ROOT
-export TORCH_SPYRE_ROOT="$TORCH_DEVICE_ROOT"
-echo "[spyre_run]   TORCH_DEVICE_ROOT=$TORCH_DEVICE_ROOT"
+export TORCH_OOT_ROOT="$TORCH_DEVICE_ROOT"
+echo "[torch_oot_device_tests_run]   TORCH_OOT_ROOT=$TORCH_DEVICE_ROOT"
 
 # ---------------------------------------------------------------------------
 # 4. Export all framework environment variables
 # ---------------------------------------------------------------------------
 export PYTORCH_TESTING_DEVICE_ONLY_FOR="privateuse1"
-export TORCH_TEST_DEVICES="${TORCH_DEVICE_ROOT}/tests/spyre_test_base_common.py"
+export TORCH_TEST_DEVICES="${TORCH_DEVICE_ROOT}/tests/oot_test_base_common.py"
 export PYTORCH_TEST_CONFIG="$YAML_CONFIG"
 
 _spyre_tests_path="${TORCH_DEVICE_ROOT}/tests"
@@ -317,7 +317,7 @@ case ":${PYTHONPATH:-}:" in
 esac
 
 echo ""
-echo "[spyre_run] Environment set:"
+echo "[torch_oot_device_tests_run] Environment set:"
 echo "  TORCH_ROOT                      = $TORCH_ROOT"
 echo "  TORCH_DEVICE_ROOT               = $TORCH_DEVICE_ROOT"
 echo "  PYTORCH_TESTING_DEVICE_ONLY_FOR = $PYTORCH_TESTING_DEVICE_ONLY_FOR"
@@ -336,7 +336,7 @@ _extract_file_paths_from_yaml() {
         | sed '/^[[:space:]]*$/d'
 }
 
-echo "[spyre_run] Parsing YAML for test file paths..."
+echo "[torch_oot_device_tests_run] Parsing YAML for test file paths..."
 RAW_PATHS=()
 while IFS= read -r line; do
     RAW_PATHS+=("$line")
@@ -347,7 +347,7 @@ if [[ ${#RAW_PATHS[@]} -eq 0 ]]; then
     exit 1
 fi
 
-echo "[spyre_run] Found ${#RAW_PATHS[@]} path entry(s):"
+echo "[torch_oot_device_tests_run] Found ${#RAW_PATHS[@]} path entry(s):"
 for p in "${RAW_PATHS[@]}"; do
     echo "  $p"
 done
@@ -396,7 +396,7 @@ if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
 fi
 
 echo ""
-echo "[spyre_run] Resolved test file(s):"
+echo "[torch_oot_device_tests_run] Resolved test file(s):"
 for f in "${TEST_FILES[@]}"; do
     echo "  $f"
 done
@@ -724,12 +724,12 @@ WRAPPER_FILES=()
 _cleanup_wrappers() {
     for wf in "${WRAPPER_FILES[@]+"${WRAPPER_FILES[@]}"}"; do
         [[ -f "$wf" ]] && rm -f "$wf" && \
-            echo "[spyre_run] Cleaned up wrapper: $wf"
+            echo "[torch_oot_device_tests_run] Cleaned up wrapper: $wf"
     done
     # Remove merged config temp file (only if we created it)
     if [[ $MERGED_CONFIG_IS_TEMP -eq 1 && -n "${YAML_CONFIG:-}" && -f "$YAML_CONFIG" ]]; then
         rm -f "$YAML_CONFIG"
-        echo "[spyre_run] Removed merged temp config: $YAML_CONFIG"
+        echo "[torch_oot_device_tests_run] Removed merged temp config: $YAML_CONFIG"
     fi
     # Remove marker sidecar JSON written by TorchTestBase.instantiate_test.
     # Normally deleted by _XML_INJECT_PY after injection, but when --junit-xml
@@ -737,7 +737,7 @@ _cleanup_wrappers() {
     local _sidecar="${YAML_CONFIG}.markers.json"
     if [[ -f "$_sidecar" ]]; then
         rm -f "$_sidecar"
-        echo "[spyre_run] Cleaned up marker sidecar: $_sidecar"
+        echo "[torch_oot_device_tests_run] Cleaned up marker sidecar: $_sidecar"
     fi
 }
 trap _cleanup_wrappers EXIT
@@ -753,7 +753,7 @@ generate_wrapper_if_needed() {
 
     local result
     if ! result=$(python3 -c "$_ANALYZER_PY" "$test_file" 2>/dev/null); then
-        echo "[spyre_run] WARNING: could not analyze $test_file -- running as-is" >&2
+        echo "[torch_oot_device_tests_run] WARNING: could not analyze $test_file -- running as-is" >&2
         return 0
     fi
 
@@ -762,7 +762,7 @@ generate_wrapper_if_needed() {
 import json,sys; d=json.load(sys.stdin); print(d.get('error',''))
 " 2>/dev/null) || true
     if [[ -n "$err" ]]; then
-        echo "[spyre_run] WARNING: parse error in $test_file: $err -- running as-is" >&2
+        echo "[torch_oot_device_tests_run] WARNING: parse error in $test_file: $err -- running as-is" >&2
         return 0
     fi
 
@@ -798,11 +798,11 @@ import json,sys; d=json.load(sys.stdin); print(' '.join(d['needs_cleanup']))
     [[ -n "$cleanup_str" ]] && read -r -a CLEANUP_CLASSES <<< "$cleanup_str"
     # Warn about plain classes -- they are safe only when YAML skips them.
     if [[ ${#PLAIN_CLASSES[@]} -gt 0 ]]; then
-        echo "[spyre_run] NOTE: the following classes have no 'device' arg in their"
-        echo "[spyre_run]       test methods. They are safe under mode:skip but will"
-        echo "[spyre_run]       fail at runtime if listed as mandatory_success/xfail:"
+        echo "[torch_oot_device_tests_run] NOTE: the following classes have no 'device' arg in their"
+        echo "[torch_oot_device_tests_run]       test methods. They are safe under mode:skip but will"
+        echo "[torch_oot_device_tests_run]       fail at runtime if listed as mandatory_success/xfail:"
         for cls in "${PLAIN_CLASSES[@]}"; do
-            echo "[spyre_run]         $cls"
+            echo "[torch_oot_device_tests_run]         $cls"
         done
     fi
 
@@ -813,23 +813,23 @@ import json,sys; d=json.load(sys.stdin); print(' '.join(d['needs_cleanup']))
     wrapper_path="${original_dir}/${original_stem}__oot_wrapper.py"
     # Report uncontrolled classes (never instantiated upstream at all)
     if [[ ${#UNCONTROLLED_CLASSES[@]} -gt 0 ]]; then
-        echo "[spyre_run] Injecting instantiate_device_type_tests for uncontrolled classes in: $(basename "$test_file")"
+        echo "[torch_oot_device_tests_run] Injecting instantiate_device_type_tests for uncontrolled classes in: $(basename "$test_file")"
         for cls in "${UNCONTROLLED_CLASSES[@]}"; do
-            echo "[spyre_run]   -> $cls"
+            echo "[torch_oot_device_tests_run]   -> $cls"
         done
     fi
     # Report restricted classes (instantiated upstream with only_for, excluding spyre)
     if [[ ${#RESTRICTED_CLASSES[@]} -gt 0 ]]; then
-        echo "[spyre_run] Re-injecting instantiate_device_type_tests (dropping only_for) for restricted classes in: $(basename "$test_file")"
+        echo "[torch_oot_device_tests_run] Re-injecting instantiate_device_type_tests (dropping only_for) for restricted classes in: $(basename "$test_file")"
         for cls in "${RESTRICTED_CLASSES[@]}"; do
-            echo "[spyre_run]   -> $cls  (upstream: only_for=... excluded privateuse1)"
+            echo "[torch_oot_device_tests_run]   -> $cls  (upstream: only_for=... excluded privateuse1)"
         done
     fi
 
     local conftest_path
     conftest_path="${original_dir}/__oot_conftest_${original_stem}.py"
 
-    echo "[spyre_run] Generating wrapper: $(basename "$wrapper_path")"
+    echo "[torch_oot_device_tests_run] Generating wrapper: $(basename "$wrapper_path")"
     # Build the per-class injection block first (pure bash, no heredoc nesting issue).
     # All classes use _pre_import_classes which is populated before the star-import.
     local injection_block=""
@@ -894,7 +894,7 @@ _sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
 
 # Ensure the spyre tests directory is on sys.path before any torch imports.
 # torch.testing._internal.common_device_type uses runpy to load
-# TORCH_TEST_DEVICES (spyre_test_base_common.py), which imports spyre_*
+# TORCH_TEST_DEVICES (oot_test_base_common.py), which imports spyre_*
 # modules.  Those modules must be findable on sys.path at that point.
 # PYTHONPATH is set by run_test.sh but Python only applies it at interpreter
 # startup -- subsequent imports don't re-read it, so we inject it explicitly.
@@ -1077,18 +1077,18 @@ CONFTEST_EOF
 # 10. Clean up any stale wrappers from previous crashed/interrupted runs
 #     before generating new ones, so pytest never picks up an old wrapper.
 # ---------------------------------------------------------------------------
-echo "[spyre_run] Cleaning up any stale OOT wrappers from previous runs..."
+echo "[torch_oot_device_tests_run] Cleaning up any stale OOT wrappers from previous runs..."
 for test_file in "${TEST_FILES[@]}"; do
     original_dir="$(dirname "$test_file")"
     original_stem="$(basename "$test_file" .py)"
     stale_wrapper="${original_dir}/${original_stem}__oot_wrapper.py"
     stale_conftest="${original_dir}/__oot_conftest_${original_stem}.py"
     if [[ -f "$stale_wrapper" ]]; then
-        echo "[spyre_run]   Removing stale wrapper: $stale_wrapper"
+        echo "[torch_oot_device_tests_run]   Removing stale wrapper: $stale_wrapper"
         rm -f "$stale_wrapper"
     fi
     if [[ -f "$stale_conftest" ]]; then
-        echo "[spyre_run]   Removing stale conftest: $stale_conftest"
+        echo "[torch_oot_device_tests_run]   Removing stale conftest: $stale_conftest"
         rm -f "$stale_conftest"
     fi
 done
@@ -1096,7 +1096,7 @@ done
 # ---------------------------------------------------------------------------
 # 11. Build the final run list (original or wrapper per file)
 # ---------------------------------------------------------------------------
-echo "[spyre_run] Checking for uncontrolled/restricted TestCase classes..."
+echo "[torch_oot_device_tests_run] Checking for uncontrolled/restricted TestCase classes..."
 echo ""
 
 RUN_FILES=()
@@ -1219,7 +1219,7 @@ try:
 except OSError:
     pass
 
-print(f"[spyre_run] Tags injected into XML: {xml_path}", flush=True)
+print(f"[torch_oot_device_tests_run] Tags injected into XML: {xml_path}", flush=True)
 '
 
 OVERALL_EXIT=0
@@ -1313,7 +1313,7 @@ merged = (
     + "</testsuite></testsuites>"
 )
 Path(out_path).write_text(merged)
-print(f"[spyre_run] Merged {len(shard_paths)} XML shard(s) -> {out_path}", flush=True)
+print(f"[torch_oot_device_tests_run] Merged {len(shard_paths)} XML shard(s) -> {out_path}", flush=True)
 '
 
 # ---------------------------------------------------------------------------
@@ -1343,7 +1343,7 @@ _run_pytest_isolated() {
             fi
             # Use torchrun for distributed tests
             _NPROC="${AIU_WORLD_SIZE}"
-            echo "[spyre_run] Running distributed test with torchrun (nproc=$_NPROC)"
+            echo "[torch_oot_device_tests_run] Running distributed test with torchrun (nproc=$_NPROC)"
 
             # Set environment variables for split_output.sh
             export _LOGDIR=/tmp/pytest-torch-spyre-dist
@@ -1359,7 +1359,7 @@ _run_pytest_isolated() {
             # Clean up log directory
             rm -rf "${_LOGDIR}"
         else
-            echo "[spyre_run] Running serial test"
+            echo "[torch_oot_device_tests_run] Running serial test"
             # Regular pytest for non-distributed tests
             python3 -m pytest "$_base" "${_args[@]}"
             echo $? > "$_exit_tmp"
@@ -1401,17 +1401,17 @@ _run_xdist_fallback() {
     local _extra=("$@")
 
     echo ""
-    echo "[spyre_run] *** SIGNAL EXIT — retrying with -n1 (xdist worker isolation) ***"
-    echo "[spyre_run]     File: $_orig"
-    echo "[spyre_run]     Each test runs in its own worker; crashes are contained."
+    echo "[torch_oot_device_tests_run] *** SIGNAL EXIT — retrying with -n1 (xdist worker isolation) ***"
+    echo "[torch_oot_device_tests_run]     File: $_orig"
+    echo "[torch_oot_device_tests_run]     Each test runs in its own worker; crashes are contained."
     echo ""
 
     # Check pytest-xdist is available before proceeding.
     if ! python3 -m pytest --co -q --no-header -p xdist /dev/null &>/dev/null 2>&1; then
         if ! python3 -c "import xdist" 2>/dev/null; then
-            echo "[spyre_run] WARNING: pytest-xdist not installed — cannot use -n1 fallback." >&2
-            echo "[spyre_run]          Install with: pip install pytest-xdist" >&2
-            echo "[spyre_run]          Skipping remaining tests in: $_orig" >&2
+            echo "[torch_oot_device_tests_run] WARNING: pytest-xdist not installed — cannot use -n1 fallback." >&2
+            echo "[torch_oot_device_tests_run]          Install with: pip install pytest-xdist" >&2
+            echo "[torch_oot_device_tests_run]          Skipping remaining tests in: $_orig" >&2
             [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1
             return
         fi
@@ -1427,7 +1427,7 @@ _run_xdist_fallback() {
         _xexit=$(< "$_exit_tmp")
         rm -f "$_exit_tmp"
     else
-        echo "[spyre_run] WARNING: xdist fallback subshell exited abnormally for $_orig" >&2
+        echo "[torch_oot_device_tests_run] WARNING: xdist fallback subshell exited abnormally for $_orig" >&2
     fi
 
     # Propagate test failures from the xdist fallback run.
@@ -1451,9 +1451,9 @@ for i in "${!RUN_FILES[@]}"; do
 
     echo "========================================================================"
     if [[ "$run_file" != "$original_file" ]]; then
-        echo "[spyre_run] Running (via OOT wrapper): $original_file"
+        echo "[torch_oot_device_tests_run] Running (via OOT wrapper): $original_file"
     else
-        echo "[spyre_run] Running: $run_file"
+        echo "[torch_oot_device_tests_run] Running: $run_file"
     fi
     echo "========================================================================"
 
@@ -1513,7 +1513,7 @@ for i in "${!RUN_FILES[@]}"; do
 
         if [[ $_probe_exit -eq 5 ]]; then
             # 0 tests match this marker in this file — strip -m from args.
-            echo "[spyre_run] -m filter matched 0 tests in $(basename "$original_file"), running without -m" >&2
+            echo "[torch_oot_device_tests_run] -m filter matched 0 tests in $(basename "$original_file"), running without -m" >&2
             _ARGS_NO_M=()
             _skip_m=0
             for _a in "${_FILE_PYTEST_ARGS[@]+"${_FILE_PYTEST_ARGS[@]}"}"; do
@@ -1553,7 +1553,7 @@ for i in "${!RUN_FILES[@]}"; do
     else
         # Subshell died before writing the exit code (segfault, OOM, SIGKILL).
         _exit=139
-        echo "[spyre_run] ERROR: pytest subshell exited abnormally (segfault or signal?) for $original_file" >&2
+        echo "[torch_oot_device_tests_run] ERROR: pytest subshell exited abnormally (segfault or signal?) for $original_file" >&2
     fi
 
     # Post-process XML to inject YAML tags as <properties>.
@@ -1585,14 +1585,14 @@ for i in "${!RUN_FILES[@]}"; do
             ;;
         5)
             # No tests collected — warn but do not fail the overall run.
-            echo "[spyre_run] WARNING: no tests collected for $original_file" >&2
+            echo "[torch_oot_device_tests_run] WARNING: no tests collected for $original_file" >&2
             ;;
         127)
-            echo "[spyre_run] FATAL: python3 or pytest not found (exit 127) for $original_file" >&2
+            echo "[torch_oot_device_tests_run] FATAL: python3 or pytest not found (exit 127) for $original_file" >&2
             OVERALL_EXIT=$_exit
             ;;
         130)
-            echo "[spyre_run] FATAL: interrupted (exit 130) — aborting run." >&2
+            echo "[torch_oot_device_tests_run] FATAL: interrupted (exit 130) — aborting run." >&2
             OVERALL_EXIT=$_exit
             # Propagate immediately; no point continuing after Ctrl-C.
             break
@@ -1604,7 +1604,7 @@ for i in "${!RUN_FILES[@]}"; do
             # worker is caught by the xdist controller and the remaining tests
             # continue.  --collect-only is not used: the same process that crashes
             # during execution often also crashes during collection.
-            echo "[spyre_run] WARNING: pytest exited with signal (code $_exit) for $original_file" >&2
+            echo "[torch_oot_device_tests_run] WARNING: pytest exited with signal (code $_exit) for $original_file" >&2
 
             # Strip --junit-xml from _FILE_PYTEST_ARGS; _run_xdist_fallback
             # re-adds _SHARD_XML itself so it owns the XML output path.
@@ -1641,7 +1641,7 @@ if [[ -n "$_FINAL_XML_PATH" && ${#_XML_SHARDS[@]} -gt 0 ]]; then
     if [[ ${#_existing_shards[@]} -eq 1 ]]; then
         # Single file run: just rename the shard, no merge needed.
         mv "${_existing_shards[0]}" "$_FINAL_XML_PATH"
-        echo "[spyre_run] Single XML shard moved to: $_FINAL_XML_PATH"
+        echo "[torch_oot_device_tests_run] Single XML shard moved to: $_FINAL_XML_PATH"
     elif [[ ${#_existing_shards[@]} -gt 1 ]]; then
         python3 -c "$_XML_MERGE_PY" "$_FINAL_XML_PATH" "${_existing_shards[@]}" || true
         # Clean up shards after successful merge.
@@ -1649,10 +1649,10 @@ if [[ -n "$_FINAL_XML_PATH" && ${#_XML_SHARDS[@]} -gt 0 ]]; then
             rm -f "$_s"
         done
     else
-        echo "[spyre_run] WARNING: No XML shards found to merge." >&2
+        echo "[torch_oot_device_tests_run] WARNING: No XML shards found to merge." >&2
     fi
 fi
 
 echo ""
-echo "[spyre_run] Done. Overall exit code: $OVERALL_EXIT"
+echo "[torch_oot_device_tests_run] Done. Overall exit code: $OVERALL_EXIT"
 exit $OVERALL_EXIT


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR removes all hardcoded spyre references from the OOT PyTorch test framework, making it reusable with any privateuse1 backend.  

All `spyre_*.py` files renamed to `oot_*.py` with all internal imports updated accordingly.

There are no logic changes -- only rename/generalization. Existing test behaviour is unchanged.