### PR TITLE
Repurpose top-k restickify for stick dim reductions

### DIFF
--- a/tests/inductor/test_reduction_sparse.py
+++ b/tests/inductor/test_reduction_sparse.py
@@ -1,0 +1,57 @@
+import torch
+
+import pytest
+
+DEVICE = torch.device("spyre")
+
+
+def _make_2d_tensor(s1, s2):
+    # A (cpu tensor), B(spyre tensor): shape [s1, s2];
+    A = torch.randn((s1, s2), dtype=torch.float16)
+    B = A.to(device="spyre")
+    return A, B
+
+
+SIZES_2D_FULL = [
+    (256, 128),
+    (128, 256),
+    (128, 128),
+    (64, 128),
+    (128, 64),
+]
+
+
+@pytest.fixture(params=SIZES_2D_FULL, ids=lambda p: f"{p[0]}x{p[1]}")
+def tensors_2arg(request):
+    s1, s2 = request.param
+    return _make_2d_tensor(s1, s2)
+
+
+def _test_reduction_result(tensors_2arg, reduction_fn):
+    torch._dynamo.reset_code_caches()
+    torch._inductor.codecache.FxGraphCache.clear()
+
+    compiled_reduction_fn = torch.compile(reduction_fn)
+
+    cpu_tensor, spyre_tensor = tensors_2arg
+    res_cpu = compiled_reduction_fn(cpu_tensor)
+    res_spyre = compiled_reduction_fn(spyre_tensor)
+
+    cpu_layout = res_cpu.to(device="spyre").device_tensor_layout()
+    spyre_layout = res_spyre.device_tensor_layout()
+    assert cpu_layout == spyre_layout
+    torch.allclose(res_cpu, res_spyre.to("cpu"), atol=0.1)
+
+
+def test_sum_result_sparsity(tensors_2arg):
+    def sum_fn(a):
+        return torch.sum(a, dim=-1)
+
+    _test_reduction_result(tensors_2arg, sum_fn)
+
+
+def test_max_result_sparsity(tensors_2arg):
+    def max_fn(a):
+        return torch.amax(dim=-1)
+
+    _test_reduction_result(tensors_2arg, max_fn)

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -62,6 +62,8 @@ SPYRE_FP32_OPS = [
 ]
 
 TOPK_OPS = {"topkvalue", "topkindex"}
+# TODO(kavya): Ensure all reduction ops are added here
+REDUCTION_STICK_OPS = {"topkvalue", "topkindex", "sum", "mean", "max", "min", "prod"}
 
 LAYOUT_LABELS = ["OUTPUT", "KERNEL", "INPUT", "KERNEL_IDX"]
 MATMUL_LAYOUT_LABELS = ["INPUT", "KERNEL", "OUTPUT", "KERNEL_IDX"]

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -42,7 +42,7 @@ from torch_spyre._C import (
     get_elem_in_stick,
 )
 from .errors import Unsupported
-from .constants import BATCH_MATMUL_OP, TOPK_OPS
+from .constants import BATCH_MATMUL_OP, REDUCTION_STICK_OPS
 from .ir import FixedTiledLayout, SpyreConstantFallback
 from .pass_utils import (
     compute_restickify_target_layout,
@@ -481,12 +481,13 @@ def _multi_arg_pointwise_layouts(
     return results
 
 
-def _topk_layouts(
+def _reduction_stick_layouts(
     op: Operation,
     output: FixedLayout,
     output_dep: MemoryDep,
     args: list[PropArg],
 ) -> list[SpyreTensorLayout]:
+    # TODO(kavya): Fail here for non 64 dimension sizes
     x = args[0]
     x_coords = host_coordinates(x.layout, x.dep)
     out_coords = host_coordinates(output, output_dep)
@@ -553,8 +554,8 @@ def compute_layouts(
     if isinstance(data, Reduction) and data.reduction_type == "exx2":
         return _exx2_layout(op, output, output_dep, args)
 
-    if isinstance(data, Reduction) and data.reduction_type in TOPK_OPS:
-        return _topk_layouts(op, output, output_dep, args)
+    if isinstance(data, Reduction) and data.reduction_type in REDUCTION_STICK_OPS:
+        return _reduction_stick_layouts(op, output, output_dep, args)
 
     aten_op = next(iter(data.origins)).target if data.origins else None
     if aten_op == spyreop.layernormnorm.default:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

Fixes the sparse tensor created by reduction ops by adding a restickify pass.

#### Which issue(s) this PR is related to:

Fixes #1173 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
