### PR TITLE
feat(dashboard): add PR number to ClickHouse ingest pipeline and test_runs schema

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -10,7 +10,8 @@ Usage (called by the GHA workflow):
         --branch   "main" \
         --sha      "abcdef1234..." \
         --run-id   "12345678" \
-        --triggered-at "2026-04-25T14:20:45Z"
+        --triggered-at "2026-04-25T14:20:45Z" \
+        --pr-number 2271
 """
 
 import argparse
@@ -249,7 +250,7 @@ def insert_run(client, run_id: str, run: dict, args):
         """
         INSERT INTO test_runs
             (run_id, workflow, suite_name, filename, branch, commit_sha,
-             gha_run_id, triggered_at, total_tests, passed, failed,
+             pr_number, gha_run_id, triggered_at, total_tests, passed, failed,
              skipped, xfail, errors, xpass, duration_s)
         VALUES
         """,
@@ -261,6 +262,7 @@ def insert_run(client, run_id: str, run: dict, args):
                 "filename": run["filename"],
                 "branch": args.branch,
                 "commit_sha": (args.sha or "").ljust(40)[:40],
+                "pr_number": int(args.pr_number) if args.pr_number.strip() else 0,
                 "gha_run_id": int(args.run_id or 0),
                 "triggered_at": run["triggered_at"].replace(tzinfo=None),
                 "total_tests": run["total_tests"],
@@ -328,6 +330,7 @@ def main():
     parser.add_argument("--sha", default="")
     parser.add_argument("--run-id", default="")
     parser.add_argument("--triggered-at", default="")
+    parser.add_argument("--pr-number", default="")
     args = parser.parse_args()
 
     xml_dir = Path(args.xml_dir)

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -7,6 +7,7 @@ on:
     workflows:
       - model-module-tests
       - upstream-pytorch-tests
+      - model-ops-tests
       # to add more workflows
     types: [completed]
   workflow_dispatch:
@@ -16,7 +17,7 @@ on:
         required: false
         default: ''
       workflow_name:
-        description: Workflow name (model-module-tests | upstream-tests)
+        description: Workflow name (model-module-tests | upstream-tests | model-ops-tests )
         required: false
         default: upstream-pytorch-tests
 
@@ -60,8 +61,15 @@ jobs:
       TRIGGERING_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
       TRIGGERING_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
       TRIGGERING_AT: ${{ github.event.workflow_run.created_at || '' }}
+      TRIGGERING_PR: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
 
     steps:
+      - name: Debug env
+        run: |
+          echo "TRIGGERING_PR=${TRIGGERING_PR}"
+          echo "All TRIGGERING_* vars:"
+          env | grep TRIGGERING_
+
       - name: Checkout (for the ingest script)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -75,6 +83,16 @@ jobs:
 
       - name: Install Python dependencies
         run: pip install requests clickhouse-driver lxml
+
+      - name: Resolve PR number
+        id: resolve-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=$(gh api \
+            "/repos/${{ github.repository }}/commits/${TRIGGERING_SHA}/pulls" \
+            --jq '.[0].number // 0')
+          echo "pr_number=${PR}" >> "$GITHUB_OUTPUT"
 
       # ---------------------------------------------------------------------------
       # Download all XML artifacts produced by the triggering run.
@@ -132,7 +150,8 @@ jobs:
             --branch   "${TRIGGERING_BRANCH}" \
             --sha      "${TRIGGERING_SHA}" \
             --run-id   "${TRIGGERING_RUN_ID}" \
-            --triggered-at "${TRIGGERING_AT}"
+            --triggered-at "${TRIGGERING_AT}" \
+            --pr-number    "${{ steps.resolve-pr.outputs.pr_number }}"
         env:
           CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
           CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
@@ -150,6 +169,8 @@ jobs:
             echo "|---|---|"
             echo "| Triggering workflow | ${TRIGGERING_WORKFLOW} |"
             echo "| Triggering run ID   | ${TRIGGERING_RUN_ID} |"
+            echo "| PR number           | ${{ steps.resolve-pr.outputs.pr_number }} |"
+            echo "| PR number(from env) | ${TRIGGERING_PR} |"
             echo "| Branch              | ${TRIGGERING_BRANCH} |"
             echo "| Commit SHA          | ${TRIGGERING_SHA:0:12} |"
             echo "| XML files ingested  | ${XML_COUNT} |"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- Adds `pr_number` field to the ClickHouse ingest pipeline to track which pull request triggered a test run. 

- Captures it from `github.event.workflow_run.pull_requests[0].number` in the workflow and passes it to the ingest script via a new --pr-number CLI argument. 

- Stores it in `test_runs` as UInt32 (defaulting to 0 for branch pushes and manual dispatches). Requires a one-time ALTER TABLE migration to add the column to the existing test_runs table (if the table is already creared)

```sql
ALTER TABLE spyre.test_runs
    ADD COLUMN IF NOT EXISTS pr_number UInt32 DEFAULT 0;
```

Actual PR number from github action log woiuld be visible only after merge to main.

<img width="2384" height="198" alt="image" src="https://github.com/user-attachments/assets/7d39a59c-6259-41e4-87f5-f50e632dc5bb" />

