### PR TITLE
Fix runtime error in test_model_ops.py

### DIFF
--- a/tests/models/runner.py
+++ b/tests/models/runner.py
@@ -21,7 +21,7 @@ from torch.testing._internal.opinfo.core import (  # noqa: F401
     SampleInput,
 )
 
-from op_registry import OP_REGISTRY
+from .op_registry import OP_REGISTRY
 
 DTYPE_MAP = {
     "fp16": torch.float16,

--- a/tests/models/test_model_ops.py
+++ b/tests/models/test_model_ops.py
@@ -18,9 +18,11 @@ import sys
 import pytest
 import torch
 
-from model_cases_loader import LoadedCase, case_key, load_all_cases
-from runner import run_test, parse_dtype, make_SampleInput
 import shared_config
+
+from .model_cases_loader import LoadedCase, case_key, load_all_cases
+from .runner import run_test, parse_dtype, make_SampleInput
+from .op_registry import OP_REGISTRY, OpAdapter
 
 from typing import Any, Dict, List
 
@@ -32,7 +34,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
 )
 from torch.testing._internal.common_utils import TestCase
-from op_registry import OP_REGISTRY, OpAdapter
 
 
 class ModelOpInfo(OpInfo):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This PR allows `test_model_ops.py` to use relative import to avoid runtime error.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Fixes #2282

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Execution logs for v1 and v2.

```
$ pytest -rsapd tests/models/test_model_ops.py --model gpt-oss-20b  -k torch_add
================================================================================================================== test session starts ==================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre
configfile: pyproject.toml
plugins: github-report-0.0.1, timeout-2.4.0, xdist-3.8.0, md-report-0.7.0
collected 4952 items / 4806 deselected / 146 selected                                                                                                                                                                                                   

tests/models/test_model_ops.py ss.ssss.s.sss.s.sss.s.sss..ss.........sss.sssssss.sssss.sssssss.sssss.ssssss.ssss.ssssss.ssss.ssssss.ssss.ssssss.ssss.ssssss.ssss.ssssss.sss.ssss.                                                                 [100%]

================================================================================================================ short test summary info ================================================================================================================
SKIPPED [110] tests/models/test_model_ops.py:146: Filtered out by --model (selected=['gpt-oss-20b'])
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_10__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_10_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_11__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_11_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_12__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_12_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_13__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_13_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_14__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_14_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_15__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_15_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_16__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_16_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_17__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_17_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_18__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_18_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_1__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_1_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_2__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_2_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_3__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_3_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_4__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_4_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_5__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_5_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_6__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_6_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_7__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_7_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_8__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_8_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_9__gpt-oss-20b_yaml__spyre_float16
PASSED tests/models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add_9_spyre__gpt-oss-20b_spyre_yaml__spyre_float16
=================================================================================================== 36 passed, 110 skipped, 4806 deselected in 32.46s ===================================================================================================
% bash tests/run_test.sh tests/configs/model_ops_tests/gpt-oss-20b.yaml  -rsapd -k torch_add
[torch_oot_device_tests_run] Using YAML config: /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre/tests/configs/model_ops_tests/gpt-oss-20b.yaml
[spyre_run]   YAML config does not reference ${TORCH_ROOT} — skipping resolution.
[spyre_run]   TORCH_ROOT=/home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib/python3.12/site-packages/torch
[spyre_run] Resolving TORCH_DEVICE_ROOT...
[torch_oot_device_tests_run]   TORCH_OOT_ROOT=/home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre

[torch_oot_device_tests_run] Environment set:
  TORCH_ROOT                      = /home/ishizaki/aiu-src/dt-opfunc-verify/.venv/lib/python3.12/site-packages/torch
  TORCH_DEVICE_ROOT               = /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre
  PYTORCH_TESTING_DEVICE_ONLY_FOR = privateuse1
  TORCH_TEST_DEVICES              = /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre/tests/oot_test_base_common.py
  PYTORCH_TEST_CONFIG             = /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre/tests/configs/model_ops_tests/gpt-oss-20b.yaml
  PYTHONPATH                      = /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre/tests:/home/ishizaki/aiu-src/dt-opfunc-verify/sentient/runtime/lib

[torch_oot_device_tests_run] Parsing YAML for test file paths...
[torch_oot_device_tests_run] Found 1 path entry(s):
  ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py

[torch_oot_device_tests_run] Resolved test file(s):
  /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre/tests/models/test_model_ops_v2.py

[torch_oot_device_tests_run] Cleaning up any stale OOT wrappers from previous runs...
[torch_oot_device_tests_run] Checking for uncontrolled/restricted TestCase classes...


========================================================================
[torch_oot_device_tests_run] Running: /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre/tests/models/test_model_ops_v2.py
========================================================================
[torch_oot_device_tests_run] Running serial test
================================================================================================================== test session starts ==================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre
configfile: pyproject.toml
plugins: github-report-0.0.1, timeout-2.4.0, xdist-3.8.0, md-report-0.7.0
collected 243 items / 225 deselected / 18 selected                                                                                                                                                                                                      

test_model_ops_v2.py X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.8]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.9]
X  [TAGS = model__gpt-oss-20b dtype__float32 op__torch_add fp32operation constant torch.add.10]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.11]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.12]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.13]
X  [TAGS = model__gpt-oss-20b dtype__float32 op__torch_add fp32operation constant torch.add.1]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.14]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.15]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation constant torch.add.16]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.17]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.18]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.2]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.3]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.4]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.5]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.6]
X  [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation constant torch.add.7]
                                                                                                                                                                                                           [100%]

======================================================================================================================== XPASSES ========================================================================================================================
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__101_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.8]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__119_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.9]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__143_spyre_float32 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__float32 op__torch_add fp32operation constant torch.add.10]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__160_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.11]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__167_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.12]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__173_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.13]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__17_spyre_float32 _______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__float32 op__torch_add fp32operation constant torch.add.1]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__188_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.14]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__209_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.15]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__216_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation constant torch.add.16]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__219_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.17]
_____________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__232_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.18]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__34_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.2]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__41_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.3]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__52_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.4]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__69_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.5]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__91_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.6]
______________________________________________________________________________________ TestSpyreModelOpsPRIVATEUSE1.test_model_ops_db_torch_add__98_spyre_bfloat16 ______________________________________________________________________________________
----------------------------------------------------------------------------------------------------------------- Captured stderr call ------------------------------------------------------------------------------------------------------------------
[TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation constant torch.add.7]
================================================================================================================ short test summary info ================================================================================================================
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.8] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__101_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.9] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__119_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__float32 op__torch_add fp32operation constant torch.add.10] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__143_spyre_float32 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.11] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__160_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.12] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__167_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.13] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__173_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__float32 op__torch_add fp32operation constant torch.add.1] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__17_spyre_float32 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.14] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__188_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.15] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__209_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation constant torch.add.16] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__216_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.17] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__219_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.18] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__232_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.2] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__34_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.3] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__41_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.4] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__52_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.5] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__69_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation torch.add.6] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__91_spyre_bfloat16 - expected failure (OOT xfail)
XPASS [TAGS = model__gpt-oss-20b dtype__bfloat16 op__torch_add bf16operation constant torch.add.7] test_model_ops_v2.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_add__98_spyre_bfloat16 - expected failure (OOT xfail)
========================================================================================================= 225 deselected, 18 xpassed in 22.86s ==========================================================================================================

[torch_oot_device_tests_run] Done. Overall exit code: 0
[torch_oot_device_tests_run] Cleaned up marker sidecar: /home/ishizaki/aiu-src/dt-opfunc-verify/torch-spyre/tests/configs/model_ops_tests/gpt-oss-20b.yaml.markers.json
```