### PR TITLE
fix(dashboard) Fix dev clickhouse port

### DIFF
--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -291,39 +291,6 @@ def insert_run(client, run_id: str, run: dict, args):
     )
 
 
-# def insert_run(client, run_id: str, run: dict, args):
-#     client.insert(
-#         """
-#         INSERT INTO test_runs
-#             (run_id, workflow, suite_name, filename, branch, commit_sha,
-#              pr_number, gha_run_id, triggered_at, total_tests, passed, failed,
-#              skipped, xfail, errors, xpass, duration_s)
-#         VALUES
-#         """,
-#         [
-#             {
-#                 "run_id": run_id,
-#                 "workflow": args.workflow,
-#                 "suite_name": run["suite_name"],
-#                 "filename": run["filename"],
-#                 "branch": args.branch,
-#                 "commit_sha": (args.sha or "").ljust(40)[:40],
-#                 "pr_number": int(args.pr_number) if args.pr_number.strip() else 0,
-#                 "gha_run_id": int(args.run_id or 0),
-#                 "triggered_at": run["triggered_at"].replace(tzinfo=None),
-#                 "total_tests": run["total_tests"],
-#                 "passed": run["passed"],
-#                 "failed": run["failed"],
-#                 "skipped": run["skipped"],
-#                 "xfail": run["xfail"],
-#                 "errors": run["errors"],
-#                 "xpass": run["xpass"],
-#                 "duration_s": run["duration_s"],
-#             }
-#         ],
-#     )
-
-
 def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
     if not cases:
         return

--- a/.github/scripts/ingest_xml.py
+++ b/.github/scripts/ingest_xml.py
@@ -21,7 +21,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from lxml import etree
-import clickhouse_driver
+import clickhouse_connect
 
 # ---------------------------------------------------------------------------
 # Status classification — uses the logic in dashboard.html parseXML()
@@ -234,10 +234,10 @@ def parse_xml(xml_path: Path):
 
 
 def get_client():
-    return clickhouse_driver.Client(
+    return clickhouse_connect.get_client(
         host=os.environ["CLICKHOUSE_HOST"],
-        # port=int(os.environ.get("CLICKHOUSE_PORT", 9440)),
-        port=9440,  # native TCP+TLS port, always 9440 on ClickHouse Cloud
+        # port=9440,  # native TCP+TLS port, always 9440 on ClickHouse Cloud
+        port=int(os.environ.get("CLICKHOUSE_PORT", 443)),
         user=os.environ.get("CLICKHOUSE_USER", "default"),
         password=os.environ["CLICKHOUSE_PASS"],
         database=os.environ.get("CLICKHOUSE_DB", "spyre"),
@@ -246,58 +246,119 @@ def get_client():
 
 
 def insert_run(client, run_id: str, run: dict, args):
-    client.execute(
-        """
-        INSERT INTO test_runs
-            (run_id, workflow, suite_name, filename, branch, commit_sha,
-             pr_number, gha_run_id, triggered_at, total_tests, passed, failed,
-             skipped, xfail, errors, xpass, duration_s)
-        VALUES
-        """,
+    client.insert(
+        "test_runs",
         [
-            {
-                "run_id": run_id,
-                "workflow": args.workflow,
-                "suite_name": run["suite_name"],
-                "filename": run["filename"],
-                "branch": args.branch,
-                "commit_sha": (args.sha or "").ljust(40)[:40],
-                "pr_number": int(args.pr_number) if args.pr_number.strip() else 0,
-                "gha_run_id": int(args.run_id or 0),
-                "triggered_at": run["triggered_at"].replace(tzinfo=None),
-                "total_tests": run["total_tests"],
-                "passed": run["passed"],
-                "failed": run["failed"],
-                "skipped": run["skipped"],
-                "xfail": run["xfail"],
-                "errors": run["errors"],
-                "xpass": run["xpass"],
-                "duration_s": run["duration_s"],
-            }
+            [
+                run_id,
+                args.workflow,
+                run["suite_name"],
+                run["filename"],
+                args.branch,
+                (args.sha or "").ljust(40)[:40],
+                int(args.pr_number) if args.pr_number.strip() else 0,
+                int(args.run_id or 0),
+                run["triggered_at"].replace(tzinfo=None),
+                run["total_tests"],
+                run["passed"],
+                run["failed"],
+                run["skipped"],
+                run["xfail"],
+                run["errors"],
+                run["xpass"],
+                run["duration_s"],
+            ]
+        ],
+        column_names=[
+            "run_id",
+            "workflow",
+            "suite_name",
+            "filename",
+            "branch",
+            "commit_sha",
+            "pr_number",
+            "gha_run_id",
+            "triggered_at",
+            "total_tests",
+            "passed",
+            "failed",
+            "skipped",
+            "xfail",
+            "errors",
+            "xpass",
+            "duration_s",
         ],
     )
+
+
+# def insert_run(client, run_id: str, run: dict, args):
+#     client.insert(
+#         """
+#         INSERT INTO test_runs
+#             (run_id, workflow, suite_name, filename, branch, commit_sha,
+#              pr_number, gha_run_id, triggered_at, total_tests, passed, failed,
+#              skipped, xfail, errors, xpass, duration_s)
+#         VALUES
+#         """,
+#         [
+#             {
+#                 "run_id": run_id,
+#                 "workflow": args.workflow,
+#                 "suite_name": run["suite_name"],
+#                 "filename": run["filename"],
+#                 "branch": args.branch,
+#                 "commit_sha": (args.sha or "").ljust(40)[:40],
+#                 "pr_number": int(args.pr_number) if args.pr_number.strip() else 0,
+#                 "gha_run_id": int(args.run_id or 0),
+#                 "triggered_at": run["triggered_at"].replace(tzinfo=None),
+#                 "total_tests": run["total_tests"],
+#                 "passed": run["passed"],
+#                 "failed": run["failed"],
+#                 "skipped": run["skipped"],
+#                 "xfail": run["xfail"],
+#                 "errors": run["errors"],
+#                 "xpass": run["xpass"],
+#                 "duration_s": run["duration_s"],
+#             }
+#         ],
+#     )
 
 
 def insert_cases(client, run_id: str, cases: list[dict], workflow: str = ""):
     if not cases:
         return
-    rows = [
-        {
-            "run_id": run_id,
-            "case_id": c["case_id"],
-            "classname": c["classname"],
-            "name": c["name"],
-            "op_name": c["op_name"],
-            "dtype": c["dtype"],
-            "status": c["status"],
-            "duration_s": c["duration_s"],
-            "fail_message": c["fail_message"][:8192],  # cap very long traces
-            "triggered_at": c["triggered_at"].replace(tzinfo=None),
-            "workflow": workflow,
-        }
-        for c in cases
-    ]
-    client.execute("INSERT INTO test_cases VALUES", rows)
+    client.insert(
+        "test_cases",
+        [
+            [
+                run_id,
+                c["case_id"],
+                c["classname"],
+                c["name"],
+                c["op_name"],
+                c["dtype"],
+                c["status"],
+                c["duration_s"],
+                c["fail_message"][:8192],
+                c["triggered_at"].replace(tzinfo=None),
+                workflow,
+            ]
+            for c in cases
+        ],
+        column_names=[
+            "run_id",
+            "case_id",
+            "classname",
+            "name",
+            "op_name",
+            "dtype",
+            "status",
+            "duration_s",
+            "fail_message",
+            "triggered_at",
+            "workflow",
+        ],
+    )
 
 
 def insert_properties(client, run_id: str, cases: list[dict]):
@@ -314,7 +375,26 @@ def insert_properties(client, run_id: str, cases: list[dict]):
                 }
             )
     if rows:
-        client.execute("INSERT INTO run_properties VALUES", rows)
+        client.insert(
+            "run_properties",
+            [
+                [
+                    r["run_id"],
+                    r["case_id"],
+                    r["prop_name"],
+                    r["prop_value"],
+                    r["triggered_at"].replace(tzinfo=None),
+                ]
+                for r in rows
+            ],
+            column_names=[
+                "run_id",
+                "case_id",
+                "prop_name",
+                "prop_value",
+                "triggered_at",
+            ],
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -344,7 +424,7 @@ def main():
         f"Connecting to ClickHouse at {os.environ['CLICKHOUSE_HOST']}:{os.environ.get('CLICKHOUSE_PORT', 9000)} ..."
     )
     client = get_client()
-    client.execute("SELECT 1")  # connectivity check
+    client.command("SELECT 1")  # connectivity check
     print("Connected.")
 
     total_cases = 0
@@ -356,18 +436,14 @@ def main():
 
         # Deduplication check — skip if this exact GHA run + filename
         # has already been ingested
-        existing = client.execute(
-            """
-            SELECT count() FROM test_runs
-            WHERE gha_run_id = %(gha_run_id)s
-            AND   filename   = %(filename)s
-            """,
-            {
+        existing = client.query(
+            "SELECT count() FROM test_runs WHERE gha_run_id = {gha_run_id:UInt64} AND filename = {filename:String}",
+            parameters={
                 "gha_run_id": int(args.run_id or 0),
                 "filename": run["filename"],
             },
         )
-        if existing[0][0] > 0:
+        if existing.result_rows[0][0] > 0:
             print(f"  Already ingested — skipping {run['filename']}")
             continue
 
@@ -380,27 +456,22 @@ def main():
 
         insert_run(client, run_id, run, args)
 
-        existing_cases_after_run = client.execute(
-            """
-            SELECT count() FROM test_cases tc
-            INNER JOIN test_runs tr ON tc.run_id = tr.run_id
-            WHERE tr.gha_run_id = %(gha_run_id)s
-            AND   tr.filename   = %(filename)s
-            """,
-            {
+        existing_cases_after_run = client.query(
+            "SELECT count() FROM test_cases tc INNER JOIN test_runs tr ON tc.run_id = tr.run_id WHERE tr.gha_run_id = {gha_run_id:UInt64} AND tr.filename = {filename:String}",
+            parameters={
                 "gha_run_id": int(args.run_id or 0),
                 "filename": run["filename"],
             },
         )
-        if existing_cases_after_run[0][0] > 0:
+        if existing_cases_after_run.result_rows[0][0] > 0:
             print("  Cases already exist — skipping case+property inserts")
         else:
             insert_cases(client, run_id, cases, workflow=args.workflow)
-            existing_props = client.execute(
-                "SELECT count() FROM run_properties WHERE run_id = %(run_id)s",
-                {"run_id": run_id},
+            existing_props = client.query(
+                "SELECT count() FROM run_properties WHERE run_id = {run_id:String}",
+                parameters={"run_id": run_id},
             )
-            if existing_props[0][0] > 0:
+            if existing_props.result_rows[0][0] > 0:
                 print("  Properties already exist — skipping property insert")
             else:
                 insert_properties(client, run_id, cases)

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -81,7 +81,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python dependencies
-        run: pip install requests clickhouse-driver lxml
+        run: pip install requests clickhouse-driver clickhouse-connect lxml
 
       - name: Resolve PR number
         id: resolve-pr


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

Because of the port/protocol mismatch, we now shift to `clickhouse-connect`:

- `clickhouse-driver` uses the native TCP protocol on port 9440
-  our dev instance only exposes HTTPS on port 443
- `clickhouse-connect` uses HTTP/HTTPS, so it works with port 443

 execute(SELECT) -> query(...).result_rows,
 execute(INSERT) -> insert(table, rows, column_names)

#### Locally working snapshot after push


```bash
CLICKHOUSE_HOST='spyre-dashboard-clickhouse-spyre-cdev.apps.fmaas-devstage-backend.fmaas.res.ibm.com' \
CLICKHOUSE_PORT='443' \
CLICKHOUSE_USER='default' \
CLICKHOUSE_PASS='*****' \
CLICKHOUSE_DB='spyre' \
python3 ingest_xml.py \
  --xml-dir xml_artifacts \
  --workflow "model-module-tests" \
  --branch   "main" \
  --sha      "7074c80c356c" \
  --run-id   "26460401994" \
  --triggered-at "2026-05-26T04:28:54Z" \
  --pr-number "2301"
Connecting to ClickHouse at spyre-dashboard-clickhouse-spyre-cdev.apps.fmaas-devstage-backend.fmaas.res.ibm.com:443 ...
Connected.

Processing: granite_3_3_8b_instruct_spyre.xml
  run_id=5f10b02e-b727-43f5-9289-1df4c2270a20  tests=36  passed=36  failed=0  xpass=0  xfail=0  skipped=0
  Inserted 36 test cases + 132 properties

Done. 1 file(s), 36 total cases ingested.

```
<img width="1542" height="1400" alt="image" src="https://github.com/user-attachments/assets/ac3667a7-2fd6-4e09-b9e3-14ae887bc803" />
