### PR TITLE
docs: fix doc drift in supported ops table and RFC index

### DIFF
--- a/docs/source/rfcs/index.md
+++ b/docs/source/rfcs/index.md
@@ -20,6 +20,9 @@ and submit a pull request.
 | [0186](https://github.com/torch-spyre/rfcs/blob/main/0186-TestFrameworks/0186-TestFrameworks.md) | Test Frameworks | Testing |
 | [0601](https://github.com/torch-spyre/rfcs/blob/main/0601-SpyreProfilingToolkit/0601-SpyreProfilingToolkitRFC.md) | Spyre Profiling Toolkit | Profiling |
 | [0682](https://github.com/torch-spyre/rfcs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md) | Kernel Tile Intermediate Representation | Compiler IR |
+| [1287](https://github.com/torch-spyre/rfcs/blob/main/1287-SpyreTestFramework/1287-SpyreTestFrameworkRFC.md) | Test Suite Configuration for Upstream PyTorch Tests on OOT Devices | Testing |
+| [1632](https://github.com/torch-spyre/rfcs/blob/main/1632-ModelEnablement/1632-ModelEnablement.md) | Model Enablement Tracking | Model enablement |
+| [1633](https://github.com/torch-spyre/rfcs/blob/main/1633-E2EModelPerf/1633-E2EModelPerf.md) | End-to-End Model Performance Testing | Performance |
 
 ## Summaries
 
@@ -68,3 +71,31 @@ memory and scratchpad in a hardware-independent form that DeepTools
 then lowers to device-specific code.
 
 See also: [Compiler Backend](../compiler/backend.md)
+
+### RFC 1287 — Test Suite Configuration for Upstream PyTorch Tests on OOT Devices
+
+Defines a YAML-based configuration schema (driven by `PYTORCH_TEST_CONFIG`)
+that lets out-of-tree backends like Spyre reuse PyTorch's upstream test
+suite without drowning in noise. OOT teams declare supported ops, dtypes,
+and devices, and can selectively skip or xfail upstream tests, override
+tolerances, inject custom inputs, and tag variants.
+
+### RFC 1632 — Model Enablement Tracking
+
+Describes how to systematically measure and track progress toward enabling
+models on Spyre. Recommends using vLLM (rather than HuggingFace) model
+definitions when discovering ops and modules, since vLLM definitions match
+what actually ships in production. Proposes a dashboard with two metrics
+per model — percentage of ops covered in `torch-spyre` and percentage of
+modules covered in `vllm-spyre` — supplemented by hybrid end-to-end tests
+where unenabled modules fall back to CPU.
+
+### RFC 1633 — End-to-End Model Performance Testing
+
+Consolidates fragmented performance measurement (PELE, fmwork, OLMES,
+BFCL, etc.) around vLLM as the backend so regressions, output mismatches,
+and quality issues surface systematically. Covers three measurement
+dimensions — correctness against HuggingFace references, benchmarking
+(latency, throughput, TTFT, ITL), and quality evals (GSM8K, MMLU, and
+use-case-specific benchmarks) — leaning on upstream tooling such as
+`HfRunner`, `VLLMRunner`, `vllm bench`, and `lm-evaluation-harness`.

--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -36,22 +36,27 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.rsqrt` | Y | Y | Spyre | |
 | `torch.reciprocal` | Y | Y | Spyre | |
 | `torch.tanh` | Y | Y | Spyre | |
+| `torch.floor` | Y | Y | Spyre | |
+| `torch.ceil` | | Y | Spyre | Custom decomposition |
+| `torch.sign` | | Y | Spyre | Custom decomposition |
 | `torch.logical_not` | Y | Y | Spyre | Custom decomposition |
 | `torch.bitwise_not` | Y | Y | Spyre | Custom decomposition |
-| `torch.clamp` | | Y | Spyre | Custom op + lowering |
+| `torch.clamp` | Y | Y | Spyre | Custom op + lowering |
 | `torch.pow` | Y | Y | Spyre | |
+| `torch.nn.functional.mish` | Y | Y | Spyre | Eager via `aten.mish.out` |
 | **Pointwise Binary** | | | | |
 | `torch.add` | Y | Y | Spyre | |
 | `torch.sub` | Y | Y | Spyre | |
 | `torch.mul` | Y | Y | Spyre | |
 | `torch.div` | Y | Y | Spyre | |
 | `torch.maximum` | Y | Y | Spyre | |
+| `torch.minimum` | Y | Y | Spyre | |
 | `torch.bitwise_and` | | Y | Spyre | Custom decomposition |
 | `torch.where` | | Y | Spyre | Compiled only |
 | **Comparison** | | | | |
 | `torch.eq` | Y | Y | Spyre | |
-| `torch.ne` | | Y | Spyre | |
-| `torch.gt` | | Y | Spyre | |
+| `torch.ne` | Y | Y | Spyre | |
+| `torch.gt` | Y | Y | Spyre | |
 | `torch.lt` | Y | Y | Spyre | |
 | `torch.ge` | Y | Y | Spyre | |
 | `torch.le` | | Y | Spyre | |
@@ -60,7 +65,9 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.mean` | Y | Y | Spyre | |
 | `torch.amax` | | Y | Spyre | Compiled only (no eager dispatch) |
 | `torch.amin` | | Y | Spyre | Compiled only (no eager dispatch) |
-| `torch.max` | | Y | Spyre | Compiled only (no eager dispatch) |
+| `torch.max` | | Y | Spyre | Compiled only; `max.dim` via custom decomposition |
+| `torch.min` | | Y | Spyre | Compiled only; `min.dim` via custom decomposition (fp16) |
+| `torch.topk` | | Y | Spyre | Custom decomposition + custom ops (`spyre::topkvalue`, `spyre::topkindex`) |
 | `torch.linalg.vector_norm` | Y | | Spyre | Eager only; compiled support not validated |
 | **View Ops** [^views] | | | | |
 | `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` lowering |
@@ -71,6 +78,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.contiguous` | | Y | Spyre | Compiled only |
 | `torch.squeeze` | | Y | Spyre | Partial; some shapes trigger internal recompile |
 | `torch.unsqueeze` | | Y | Spyre | Partial; some shapes trigger internal recompile |
+| `torch.flatten` | | Y | Spyre | Compiled only (lowers via `reshape`) |
 | `torch.cat` | Y | Y | Spyre | |
 | `torch.stack` | Y | | Spyre | Eager only |
 | `torch.repeat` | Y | | Spyre | Eager only |
@@ -96,6 +104,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.bitwise_xor` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.bitwise_or` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.argmax` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
+| `torch.argmin` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.cumsum` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 
 > **Column key:**


### PR DESCRIPTION
## Summary

Two doc files had drifted from `main`. This PR fixes both.

### `docs/source/user_guide/supported_operations.md`

A few rows in the table were wrong, and several ops were missing entirely:

- `torch.ne`, `torch.gt`, and `torch.clamp` are all registered as eager kernels in [`torch_spyre/ops/eager.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/ops/eager.py), but the Eager column was blank. Set to Y.
- Added rows for ops that were not in the table at all:
  - `torch.floor`, `torch.minimum`, `torch.nn.functional.mish` — registered eager (`minimum` from #2153).
  - `torch.ceil`, `torch.sign` — custom decompositions from #2223.
  - `torch.min` — `min.dim` decomposition from #2075.
  - `torch.topk` — custom decomposition plus the `spyre::topkvalue` / `spyre::topkindex` custom ops.
  - `torch.flatten` — compiled-path test from #1866.
  - `torch.argmin` — already registered in [`torch_spyre/ops/fallbacks.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/ops/fallbacks.py).
- The `torch.max` note now mentions the `max.dim` custom decomposition.

### `docs/source/rfcs/index.md`

Three RFCs live in [torch-spyre/rfcs](https://github.com/torch-spyre/rfcs) but were not in the index. Added to the table and the Summaries section:

- RFC 1287 — Test Suite Configuration for Upstream PyTorch Tests on OOT Devices
- RFC 1632 — Model Enablement Tracking
- RFC 1633 — End-to-End Model Performance Testing

## Test plan

- [x] `python3 -m sphinx docs/source docs/build/html -W --keep-going` builds with 0 warnings.
- [x] `pre-commit run --files docs/source/rfcs/index.md docs/source/user_guide/supported_operations.md` passes.
- [x] Every table row cross-checked against `main` versions of `torch_spyre/ops/eager.py`, `torch_spyre/ops/fallbacks.py`, `torch_spyre/_inductor/decompositions.py`, `torch_spyre/_inductor/customops.py`, and `tests/inductor/test_inductor_ops.py`.
- [x] RFC links resolve in `torch-spyre/rfcs`.