### PR TITLE
chore(dashboard): use clickhouse temp instance 

### DIFF
--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -61,7 +61,7 @@ jobs:
       # CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS_DEV }}
       # CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB_DEV }}
 
-      # TRIAL INSTANCE PUBLIC
+      # PROD INSTANCE
       CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
       CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
       CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
@@ -174,7 +174,7 @@ jobs:
             --triggered-at "${TRIGGERING_AT}" \
             --pr-number    "${{ steps.resolve-pr.outputs.pr_number }}"
         env:
-          # TRIAL INSTANCE PUBLIC
+          # PROD INSTANCE
           CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
           CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
           CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}

--- a/.github/workflows/push-to-clickhouse.yaml
+++ b/.github/workflows/push-to-clickhouse.yaml
@@ -53,11 +53,20 @@ jobs:
       #   CLICKHOUSE_PASS   the password
       #   CLICKHOUSE_DB     e.g. spyre
       # ---------------------------------------------------------------------------
-      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST_DEV }}
-      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT_DEV }}
-      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER_DEV }}
-      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS_DEV }}
-      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB_DEV }}
+
+      # DEV INSTANCE
+      # CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST_DEV }}
+      # CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT_DEV }}
+      # CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER_DEV }}
+      # CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS_DEV }}
+      # CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB_DEV }}
+
+      # TRIAL INSTANCE PUBLIC
+      CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+      CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
+      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
 
       # Metadata about the triggering run
       TRIGGERING_RUN_ID: ${{ github.event.workflow_run.id || inputs.gha_run_id }}
@@ -165,11 +174,12 @@ jobs:
             --triggered-at "${TRIGGERING_AT}" \
             --pr-number    "${{ steps.resolve-pr.outputs.pr_number }}"
         env:
-          CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST_DEV }}
-          CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT_DEV }}
-          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER_DEV }}
-          CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS_DEV }}
-          CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB_DEV }}
+          # TRIAL INSTANCE PUBLIC
+          CLICKHOUSE_HOST: ${{ secrets.CLICKHOUSE_HOST }}
+          CLICKHOUSE_PORT: ${{ secrets.CLICKHOUSE_PORT }}
+          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+          CLICKHOUSE_PASS: ${{ secrets.CLICKHOUSE_PASS }}
+          CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
 
       - name: Summary
         if: always()


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

Worked from local spyre pod:

```bash
CLICKHOUSE_HOST='sm73y6g9e8.ap-south-1.aws.clickhouse.cloud' \
CLICKHOUSE_PORT='8443' \
CLICKHOUSE_USER='default' \
CLICKHOUSE_PASS='****' \
CLICKHOUSE_DB='spyre' \
python3 ingest_xml.py \
  --xml-dir xml_artifacts \
  --workflow "model-module-tests" \
  --branch   "main" \
  --sha      "7074c80c356c" \
  --run-id   "26460401994" \
  --triggered-at "2026-05-26T04:28:54Z" \
  --pr-number "2301"
Connecting to ClickHouse at <host>:8443 ...
Connected.

Processing: granite_3_3_8b_instruct_spyre.xml
  run_id=19535e65-59ac-4eb0-8ae7-0d83282d89ea  tests=36  passed=36  failed=0  xpass=0  xfail=0  skipped=0
  Inserted 36 test cases + 132 properties

Done. 1 file(s), 36 total cases ingested.
```