### PR TITLE
Fix symbolic shape conversion error in index_copy operations

### DIFF
--- a/tests/inductor/test_inductor_fx_passes.py
+++ b/tests/inductor/test_inductor_fx_passes.py
@@ -190,6 +190,35 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
         )
         assert spyre_1 != cpu_1, "SPYRE graph should differ from CPU graph"
 
+    def test_concretize_index_with_symbolic_shapes(self):
+        """
+        Test that concretize_index handles unconvertible symbolic expressions.
+
+        Regression test for: "TypeError: Cannot convert symbols to int"
+        that occurred in index_copy operations with symbolic shapes.
+        """
+        from unittest.mock import patch
+        import sympy
+        from torch_spyre._inductor.pass_utils import concretize_index
+
+        # Create symbolic variables
+        x = sympy.Symbol("x")  # Loop variable
+        tmp0 = sympy.Symbol("tmp0")  # Unconvertible symbol
+
+        # Create expression: x + tmp0
+        index = x + tmp0
+        loop_vars = {x}
+
+        # Mock size_hint to raise TypeError for tmp0
+        with patch("torch_spyre._inductor.pass_utils.V") as mock_v:
+            mock_v.graph.sizevars.size_hint.side_effect = TypeError(
+                "Cannot convert symbols to int"
+            )
+
+            # Should NOT raise, should return original index
+            result = concretize_index(index, loop_vars)
+            assert result == index, f"Expected {index}, got {result}"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -88,7 +88,18 @@ def concretize_index(index: sympy.Expr, loop_vars: set) -> sympy.Expr:
     size_syms = index.free_symbols - loop_vars
     if not size_syms:
         return index
-    subs = {s: V.graph.sizevars.size_hint(s) for s in size_syms}
+    # Try each symbol individually
+    subs = {}
+    for s in size_syms:
+        try:
+            hint = V.graph.sizevars.size_hint(s)
+            subs[s] = hint  # Successfully concretized
+        except (TypeError, ValueError):
+            # Can't concretize this symbol, skip it
+            pass
+
+    if not subs:
+        return index  # No symbols concretized, return original
     result = index.subs(subs)
     return result
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR fixes the `TypeError: Cannot convert symbols to int` error encountered during compilation of `torch.index_copy_` operations when symbolic shape expressions cannot be concretized to integers. The fix allows compilation to proceed by preserving unresolved symbolic expressions while still concretizing those that can be resolved.

The Spyre compiler was failing to compile models using index_copy operations (e.g., granite-4.1-8b) with the following error:
```TypeError: Cannot convert symbols to int
  File "torch_spyre/_inductor/pass_utils.py", line 91, in concretize_index
    subs = {s: V.graph.sizevars.size_hint(s) for s in size_syms}
  File "torch/_inductor/sizevars.py", line 651, in size_hint
    return int(out)
  File "sympy/core/expr.py", line 342, in __int__
    raise TypeError("Cannot convert symbols to int")
```

#### Which issue(s) this PR is related to:
[#1942](https://github.com/torch-spyre/torch-spyre/issues/1942)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

Affected Tests (No longer showing this error):
test_model_ops_db_torch_index_copy__1__granite-4_1-8b_yaml__spyre_float16
test_model_ops_db_torch_index_copy__2__granite-4_1-8b_yaml__spyre_float16
test_model_ops_db_torch_index_copy__3__granite-4_1-8b_yaml__spyre_float16

**Test Reproduction Command**:
```pytest -vv -s -rA models/test_model_ops.py::TestSpyreModelOpsPRIVATEUSE1::test_model_ops_db_torch_index_copy__3__granite-4_1-8b_yaml__spyre_float16 --model granite-4.1-8b -n1 ```


