### PR TITLE
fix(test framework) @onlyOn patcher skipping tests due to device_type mismatch between "spyre" and "privateuse1"

### DIFF
--- a/tests/oot_upstream_patcher.py
+++ b/tests/oot_upstream_patcher.py
@@ -122,12 +122,25 @@ class _OOTOnlyOnPatcher:
                 if isinstance(val.device_type, list):
                     if self._PRIVATEUSE1 not in val.device_type:
                         val.device_type.append(self._PRIVATEUSE1)
+                    # Also append "privateuse1" because TorchTestBase.device_type is
+                    # reset to "privateuse1" in setUpClass (to preserve correct class
+                    # naming for PYTORCH_TESTING_DEVICE_ONLY_FOR=privateuse1), so the
+                    # @onlyOn check sees "privateuse1" at runtime, not the registered
+                    # backend name.
+                    if "privateuse1" not in val.device_type:
+                        val.device_type.append("privateuse1")
 
                 # Less common scenario: @onlyOn("cuda") -- single string.
                 # Replace with a list containing both the original and ours.
                 elif isinstance(val.device_type, str):
                     if val.device_type != self._PRIVATEUSE1:
-                        val.device_type = [val.device_type, self._PRIVATEUSE1]
+                        val.device_type = [
+                            val.device_type,
+                            self._PRIVATEUSE1,
+                            "privateuse1",
+                        ]
+                    elif val.device_type != "privateuse1":
+                        val.device_type = [val.device_type, "privateuse1"]
                 return
 
             # This layer had no onlyOn instance in its closure.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`OOTOnlyOnPatcher.patch()` was appending only the registered backend name (e.g. "spyre") to the `@onlyOn` allow list. 

However, `TorchTestBase.device_type` is reset to "privateuse1" in `setUpClass` to preserve correct class naming for `PYTORCH_TESTING_DEVICE_ONLY_FOR=privateuse1`. 

Since `@onlyOn` reads `self.device_type` at test runtime, the check "privateuse1" in ["cuda", "spyre"] always failed, causing affected tests to be silently skipped instead of run. 

This PR fixes by appending both the registered backend name and "privateuse1" to the allow-list.

####  Output before the PR (Skipped)
<img width="3454" height="288" alt="image" src="https://github.com/user-attachments/assets/20380e2f-2c08-4d34-a7f0-0e7b49bb0508" />


#### Output after this PR fix (Ran and Passed)
<img width="3456" height="688" alt="image" src="https://github.com/user-attachments/assets/45da4ab1-89e9-4e6d-b6b2-2e5d6eb9a471" />
