### PR TITLE
minor fix for _C import in eager.py 

### DIFF
--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -227,7 +227,6 @@ def _patch_tensor_for_spyre():
                 or x.device_tensor_layout() == expected_layout
             ),
             [f"SpyreTensorLayout({guard.name}) == {expected_layout}"],
-            guard.user_stack,
         )
 
     GuardBuilder.TENSOR_MATCH = _spyre_TENSOR_MATCH

--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -227,6 +227,7 @@ def _patch_tensor_for_spyre():
                 or x.device_tensor_layout() == expected_layout
             ),
             [f"SpyreTensorLayout({guard.name}) == {expected_layout}"],
+            guard.user_stack,
         )
 
     GuardBuilder.TENSOR_MATCH = _spyre_TENSOR_MATCH

--- a/torch_spyre/ops/eager.py
+++ b/torch_spyre/ops/eager.py
@@ -15,7 +15,6 @@
 import torch
 import torch_spyre.ops.fallbacks  # noqa: F401
 from .fallbacks import _get_op_overloads
-import torch_spyre._C as _C
 import warnings
 import functools
 import inspect
@@ -193,7 +192,7 @@ def spyre__copy_from(self, dst, non_blocking=False):
     if (self.device.type == "cpu" and dst.device.type == "spyre") or (
         self.device.type == "spyre" and dst.device.type == "cpu"
     ):
-        _C.copy_tensor(self, dst, non_blocking)
+        torch_spyre._C.copy_tensor(self, dst, non_blocking)
         return dst
     elif self.device.type == "spyre" and self.device == dst.device:
         torch.ops.spyre.copy_from_d2d(self, dst)


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

Remove the module level import of _C in eager.py since it causes issues when _C.so file is incompatible with changes in runtime

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

These tests should pass:
```
pytest tests/test_spyre.py -s -v
pytest tests/tensor/test_tensor_layout.py -s -v
```

#### Does this PR introduce a user-facing change? yes

#### Additional note:
