### PR TITLE
Add docs code owners for leadership visibility

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,7 +39,7 @@
 /tests/                  @avery-blanchard @moriohara @ashokponkumar @JRosenkranz @dgrove-oss @tardieu @ani300 @pradghos
 
 # Documentation
-/docs/                   @kaoutar55 @dgrove-oss
+/docs/                   @kaoutar55 @dgrove-oss @mudhakar @raghukiran1224 @viji560 @tehbone
 
 # CI/CD
 /.github/                 @ashokponkumar @jabostian


### PR DESCRIPTION
## Summary
- Add @mudhakar, @raghukiran1224, @viji560, and @tehbone as code owners for `/docs/`

## Test plan
- [x] Verify CODEOWNERS syntax is valid
- [x] Confirm PR reviews on docs changes now request the new owners

🤖 Generated with [Claude Code](https://claude.com/claude-code)