### PR TITLE
Drive coarse tiling transformation from spyre hints user annotations

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -46,6 +46,7 @@ from torch._inductor.utils import run_and_get_code
 from torch._inductor.ir import ComputedBuffer, Operation
 
 from torch_spyre._inductor import config
+import torch_spyre._inductor.propagate_named_dims as _pnd
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from utils_inductor import compare_with_cpu  # noqa: E402
@@ -706,6 +707,253 @@ class TestCoarseTileUnrollEndToEnd(InductorTestCase):
             atol=0.1,
             rtol=0.1,
         )
+
+
+# ===========================================================================
+# spyre_hint-driven coarse tiling
+# These tests verify that coarse tiling is driven automatically by
+# spyre_hint(slices=...) annotations, without requiring a
+# coarse_tiling_groups_fn.  Named tensor dimensions must be declared and
+# annotated on device tensors for the hint resolver to map dimension names
+# to loop variables.
+# ===========================================================================
+
+
+_declare_tensor_dim = _pnd.declare_tensor_dim
+_name_tensor_dims = _pnd.name_tensor_dims
+
+
+class TestCoarseTileSpyreHints(InductorTestCase):
+    """Coarse tiling driven by spyre_hint(slices=...) annotations."""
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0xAFFE)
+
+    # ------------------------------------------------------------------
+    # Baseline: no hints -> no tiling
+    # ------------------------------------------------------------------
+
+    def test_hint_no_tiling_baseline(self):
+        """Without spyre_hint annotations, coarse tiling must not fire."""
+        x = torch.randn(256, 128, dtype=torch.float16).to("spyre")
+
+        def fn(x):
+            return torch.abs(x)
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x)
+        self.assertTrue(len(source_codes) > 0)
+        # LoopSpec appears as an import even without tiling; check for a call.
+        self.assertNotIn("LoopSpec(", source_codes[0])
+
+    # ------------------------------------------------------------------
+    # Single pointwise op
+    # ------------------------------------------------------------------
+
+    @config.patch(
+        {"coarse_tiling": True, "bundle_hbm_symbols": True, "unroll_loops": False}
+    )
+    def test_hint_single_group_pointwise(self):
+        """spyre_hint(slices={"A": 4}) tiles a pointwise abs into 4 iterations."""
+        from torch_spyre._inductor import spyre_hint
+
+        # 256 rows × 128 cols.  Tiling the outermost dim by 4 → 64 rows/iter.
+        A, B = 256, 128
+        x = torch.randn(A, B, dtype=torch.float16)
+
+        def fn(x):
+            with spyre_hint(slices={"A": 4}):
+                return torch.abs(x)
+
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("A", A)
+        _declare_tensor_dim("B", B)
+        _name_tensor_dims(x_dev, ["A", "B"])
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec call in generated source")
+        self.assertIn(
+            "sympify('4')",
+            src,
+            "Expected loop count 4 in generated source",
+        )
+
+    # ------------------------------------------------------------------
+    # Softmax-shaped chain (pointwise-reduce-pointwise)
+    # ------------------------------------------------------------------
+
+    @config.patch(
+        {"coarse_tiling": True, "bundle_hbm_symbols": True, "unroll_loops": False}
+    )
+    def test_hint_softmax_shaped(self):
+        """Tile the pointwise-reduce-pointwise stages of a softmax-like kernel.
+
+        softmax(x, dim=-1) lowers to roughly:
+          max_val = x.amax(dim=-1, keepdim=True)   # reduction
+          x_shifted = x - max_val                   # pointwise broadcast sub
+          exp_x = x_shifted.exp()                   # pointwise
+          sum_exp = exp_x.sum(dim=-1, keepdim=True) # reduction
+          out = exp_x / sum_exp                     # pointwise broadcast div
+
+        All stages share the batch (row) dimension B.  Tiling over that
+        dimension by K=4 means each loop iteration processes B/K rows.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 256, 128  # batch = 256 rows, each of length 128
+        x = torch.randn(B, D, dtype=torch.float16)
+
+        def softmax_fn(x):
+            with spyre_hint(slices={"B": 4}):
+                max_val = x.amax(dim=-1, keepdim=True)
+                x_shifted = x - max_val
+                exp_x = x_shifted.exp()
+                sum_exp = exp_x.sum(dim=-1, keepdim=True)
+                return exp_x / sum_exp
+
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(x_dev, ["B", "D"])
+
+        cfn = torch.compile(softmax_fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn(
+            "LoopSpec(",
+            src,
+            "Expected LoopSpec call in generated source for softmax-shaped fn",
+        )
+        self.assertIn(
+            "sympify('4')",
+            src,
+            "Expected loop count 4 in generated softmax source",
+        )
+
+    # ------------------------------------------------------------------
+    # Nested hints: outer K=2, inner M=4 on a single op
+    # ------------------------------------------------------------------
+
+    @config.patch(
+        {"coarse_tiling": True, "bundle_hbm_symbols": True, "unroll_loops": False}
+    )
+    def test_hint_nested_loop_two_dims(self):
+        """Nested spyre_hint scopes produce a two-level tiling loop.
+
+        Input shape [1024, 4096]: outer hint tiles dim A by 2 (512 rows/iter),
+        inner hint tiles dim B by 4 (1024 cols/iter).  Both ops (add and mul)
+        share the nested LoopSpec.  Generated source must contain two LoopSpec
+        entries with counts 2 and 4.
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        A, B = 1024, 4096
+        a = torch.randn(A, B, dtype=torch.float16)
+        b = torch.randn(A, B, dtype=torch.float16)
+        c = torch.randn(A, B, dtype=torch.float16)
+
+        def fn(a, b, c):
+            with spyre_hint(slices={"A": 2}):
+                with spyre_hint(slices={"B": 4}):
+                    y = a + b
+                    z = y * c
+                    return z
+
+        a_dev = a.to("spyre")
+        b_dev = b.to("spyre")
+        c_dev = c.to("spyre")
+        _declare_tensor_dim("A", A)
+        _declare_tensor_dim("B", B)
+        _name_tensor_dims(a_dev, ["A", "B"])
+        _name_tensor_dims(b_dev, ["A", "B"])
+        _name_tensor_dims(c_dev, ["A", "B"])
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, a_dev, b_dev, c_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec in generated source")
+        self.assertIn("sympify('2')", src, "Expected outer loop count 2")
+        self.assertIn("sympify('4')", src, "Expected inner loop count 4")
+        # The nested LoopSpec must appear inside another LoopSpec.
+        self.assertGreaterEqual(
+            src.count("LoopSpec("),
+            2,
+            f"Expected ≥2 LoopSpec entries for nested loops\n\nSource:\n{src}",
+        )
+
+    # ------------------------------------------------------------------
+    # Two ops with different slice counts -> two separate groups
+    # ------------------------------------------------------------------
+
+    @config.patch(
+        {"coarse_tiling": True, "bundle_hbm_symbols": True, "unroll_loops": False}
+    )
+    def test_hint_two_groups(self):
+        """Two separate tiling groups produce two LoopSpec entries in the source."""
+        from torch_spyre._inductor import spyre_hint
+
+        A, B = 256, 128
+        x = torch.randn(A, B, dtype=torch.float16)
+        y = torch.randn(A, B, dtype=torch.float16)
+
+        def fn(x, y):
+            # Two independent pointwise ops: each becomes its own group.
+            with spyre_hint(slices={"A": 4}):
+                out_x = torch.abs(x)
+            with spyre_hint(slices={"A": 8}):
+                out_y = torch.neg(y)
+            return out_x, out_y
+
+        x_dev = x.to("spyre")
+        y_dev = y.to("spyre")
+        _declare_tensor_dim("A", A)
+        _declare_tensor_dim("B", B)
+        _name_tensor_dims(x_dev, ["A", "B"])
+        _name_tensor_dims(y_dev, ["A", "B"])
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x_dev, y_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        loop_spec_count = src.count("LoopSpec(")
+        self.assertGreaterEqual(
+            loop_spec_count,
+            2,
+            f"Expected ≥2 LoopSpec entries, got {loop_spec_count}\n\nSource:\n{src}",
+        )
+
+    # ------------------------------------------------------------------
+    # Softmax with row-tiling: large [NROW, NCOL] tensor
+    # ------------------------------------------------------------------
+
+    @config.patch({"coarse_tiling": True})
+    def test_hint_softmax_row_tiling(self):
+        """spyre_hint(slices={"NROW": 4}) tiles softmax over the row dimension."""
+        from torch_spyre._inductor import spyre_hint
+
+        NROW, NCOL = 16384, 4096
+        x = torch.rand(NROW, NCOL, dtype=torch.float16)
+
+        _declare_tensor_dim("NROW", NROW)
+        _declare_tensor_dim("NCOL", NCOL)
+
+        def fn(x, dim=-1):
+            _name_tensor_dims(x, ["NROW", "NCOL"])
+            with spyre_hint(slices={"NROW": 4}):
+                return torch.softmax(x, dim)
+
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.1, rtol=0.1)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -58,8 +58,9 @@ unroll_loops: bool = os.environ.get("UNROLL_LOOPS", "1") == "1"
 # Signature: (list[Operation]) -> list[tuple[list[Operation], sympy.Expr[, list[int]]]]
 # Each tuple is (ops, loop_count) or (ops, loop_count, tiled_dims).
 # tiled_dims overrides the default per-group (None = tile outermost dim only).
-# When None and coarse_tiling is True, coarse_tile() is called with groups=[]
-# (a no-op useful for testing the pipeline without real group detection).
+# When None and coarse_tiling is True, groups are derived from spyre_hint
+# annotations via hints_to_coarse_tile_groups (a no-op if no hints are present).
+# When set, this callable overrides the hint-derived groups entirely.
 # Must be a module-level named function (not a lambda) for Inductor cache pickling.
 # This is intended to be used for interim testing of the coarse-tiling transformation
 # until the working set reduction annotation framework is being developed.

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -35,7 +35,8 @@ from .temp_passes import (
     bmm_unflatten_pass,
     mm_to_bmm_pass,
     convert_constant_with_graph_node,
-    process_hints,
+    resolve_hints,
+    hints_to_coarse_tile_groups,
 )
 from . import config
 from .propagate_hints import (
@@ -246,7 +247,7 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         deadcode_elimination(operations)
         propagate_spyre_tensor_layouts(operations)
         propagate_named_dims(operations)
-        process_hints(operations)
+        resolve_hints(operations)
         optimize_restickify_locations(operations)
         finalize_layouts(operations)
         insert_restickify(operations)
@@ -255,11 +256,9 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         if config.chunk_large_tensors:
             chunk_large_tensors(operations)
         if config.coarse_tiling:
-            groups = (
-                config.coarse_tiling_groups_fn(operations)
-                if config.coarse_tiling_groups_fn is not None
-                else []
-            )
+            groups = hints_to_coarse_tile_groups(operations)
+            if config.coarse_tiling_groups_fn is not None:
+                groups = config.coarse_tiling_groups_fn(operations)
             coarse_tile(operations, groups=groups)
         span_reduction(operations)
         k_fast_ops = (

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import dataclasses
 from typing import Any
 
 import regex as re
@@ -24,6 +25,30 @@ from torch._inductor.ir import Operation
 from .logging_utils import get_inductor_logger
 
 logger = get_inductor_logger("propagate_hints")
+
+
+@dataclasses.dataclass
+class DimHint:
+    dim_names: list[str]  # e.g. ["A"]
+    range_size: int  # full loop range, e.g. 256
+    split_count: int  # from slices={"A": 4}, e.g. 4
+    dim_index: int  # index into op.loop_var_dims / op.data.ranges
+    is_reduction: bool
+
+
+# op.spyre_hints: list[DimHint]
+#
+# One entry per hinted dimension, ordered outermost hint scope first.
+# Outer hint IDs are smaller than inner hint IDs (guaranteed by spyre_hint
+# counter order), so sorting by hint ID gives outermost-first ordering.
+#
+# Example — two nested hints on one op:
+#   with spyre_hint(slices={"A": 2}):      # outer scope → smaller hint ID
+#       with spyre_hint(slices={"B": 4}):  # inner scope → larger hint ID
+#           y = a + b
+#
+# spyre_hints = [DimHint(dim_names=["A"], split_count=2, dim_index=0, ...),
+#                 DimHint(dim_names=["B"], split_count=4, dim_index=1, ...)]
 
 
 _HINT_RE = re.compile(r"^_hint_(\d+)$")

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -14,8 +14,10 @@
 
 # This file contains inductor passes that are only needed as temp fixes
 
+import logging
+import sympy
 import torch
-from torch._inductor.ir import ComputedBuffer
+from torch._inductor.ir import ComputedBuffer, Operation
 from torch._inductor.pattern_matcher import (
     Arg,
     CallFunction,
@@ -24,13 +26,13 @@ from torch._inductor.pattern_matcher import (
     register_graph_pattern,
 )
 from .logging_utils import get_inductor_logger
-from .propagate_hints import get_op_hints
+from .propagate_hints import get_op_hints, DimHint
 from .propagate_named_dims import named_dims_for_sym
 
 aten = torch.ops.aten
 
 logger = get_inductor_logger("work_division")
-hints_logger = get_inductor_logger("process_hints")
+hints_logger = get_inductor_logger("resolve_hints")
 
 _RESHAPE_OPS = (
     aten.view.default,
@@ -255,82 +257,164 @@ def _unflatten_bmm_batch_dims(
                 graph.erase_node(expand_node)
 
 
-def _hint_split_counts(op) -> dict[str, int]:
-    """Return {dim_name: split_count} from all hints on op (keys 'tiles' or 'slices')."""
-    result: dict[str, int] = {}
-    for hint_dict in get_op_hints(op).values():
+def _hint_levels(op) -> list[dict[str, int]]:
+    """Return per-level split counts, outermost first (sorted by hint ID).
+
+    Each entry is {dim_name: split_count} for one hint scope. Outer hint IDs
+    are smaller than inner hint IDs (guaranteed by spyre_hint counter order).
+    """
+    levels = []
+    for _, hint_dict in sorted(get_op_hints(op).items()):
+        level: dict[str, int] = {}
         for key in ("tiles", "slices"):
             if isinstance(hint_dict.get(key), dict):
-                result.update(hint_dict[key])
-    return result
+                level.update(hint_dict[key])
+        if level:
+            levels.append(level)
+    return levels
 
 
-def _dim_sizes(op) -> dict[str, int]:
-    """Return {dim_name: declared_size} for all named dims on op."""
-    return {
-        name: size
-        for sym in op.loop_var_dims
-        for name, size in named_dims_for_sym(op, sym)
-    }
+def resolve_hints(operations: list[Operation]) -> None:
+    """Resolve spyre_hint annotations into DimHint and stamp onto each op.
 
-
-def process_hints(operations: list) -> None:
+    For each op, reads the hint scopes attached to its FX origins, matches the
+    hinted dimension names against the op's named loop variables, and builds
+    op.spyre_hints: a flat list of DimHint, one per hinted dimension, ordered
+    outermost hint scope first.
     """
-    Process and log spyre hints, and their impact on each op and output buffer
-    """
+    for op in operations:
+        if not isinstance(op, ComputedBuffer) or not getattr(op, "loop_var_dims", None):
+            continue
+        levels = _hint_levels(op)
+        if not levels:
+            op.spyre_hints = []
+            continue
 
-    if not any(_hint_split_counts(op) for op in operations):
-        return
-
-    ops = [
-        op
-        for op in operations
-        if isinstance(op, ComputedBuffer) and getattr(op, "loop_var_dims", None)
-    ]
-
-    hints_logger.info("=== process_hints ===")
-
-    for op in ops:
-        splits = _hint_split_counts(op)
-        dim_sizes = _dim_sizes(op)
+        # Build a flat lookup from dimension name to (split_count, level_idx)
+        # so we can quickly resolve each loop variable below.
+        dim_to_level: dict[str, tuple[int, int]] = {}
+        for level_idx, level_splits in enumerate(levels):
+            for name, count in level_splits.items():
+                dim_to_level[name] = (count, level_idx)
 
         rw = op.get_read_writes()
+        # Collect the full iteration range for each loop symbol from the
+        # read/write index expressions.
         all_ranges = {
             s: int(v) for dep in [*rw.reads, *rw.writes] for s, v in dep.ranges.items()
         }
         reduction_dims = set(op.reduction_named_dims or [])
 
-        hints_logger.info(f"{op.get_operation_name()}:")
-        hints_logger.info("  Loop vars:")
-        for sym in op.loop_var_dims:
-            sym_range = all_ranges.get(sym, "?")
+        # Walk the op's loop variables in order.  For each one, check whether
+        # any of its named dimensions appear in a hint scope.  If so, create a
+        # DimHint.  Collect into a flat list keyed by (level_idx, loop_var_idx)
+        # so we can sort outermost-first after the walk.
+        unsorted: list[tuple[int, int, DimHint]] = []
+        for i, sym in enumerate(op.loop_var_dims):
             nd = named_dims_for_sym(op, sym)
-            nd_str = ", ".join(f"{n}={s}" for n, s in nd) if nd else "(none)"
-
-            tags = []
-            if any(n in reduction_dims for n, _ in nd):
-                tags.append("[reduction]")
-            for n, _ in nd:
-                if n in splits:
-                    k = splits[n]
-                    sliced = sym_range // k if isinstance(sym_range, int) else "?"
-                    tags.append(f"sliced by {k}: {sym_range} -> {sliced}")
-            suffix = ("  " + "  ".join(tags)) if tags else ""
-            hints_logger.info(
-                f"    {sym}  range={sym_range}  Named Dim(s): {nd_str}{suffix}"
+            hinted_names = [name for name, _ in nd if name in dim_to_level]
+            if not hinted_names:
+                continue
+            split_count, level_idx = dim_to_level[hinted_names[0]]
+            unsorted.append(
+                (
+                    level_idx,
+                    i,
+                    DimHint(
+                        dim_names=hinted_names,
+                        range_size=all_ranges.get(sym, 0),
+                        split_count=split_count,
+                        dim_index=i,
+                        is_reduction=any(
+                            name in reduction_dims for name in hinted_names
+                        ),
+                    ),
+                )
             )
+        op.spyre_hints = [h for _, _, h in sorted(unsorted)]
 
-        if op.named_dims:
-            hints_logger.info(f"  Output buffer: {op.get_name()}")
-            for name in op.named_dims:
-                size = dim_sizes.get(name, "?")
-                if name in splits and isinstance(size, int):
-                    k = splits[name]
+    if hints_logger.isEnabledFor(logging.INFO):
+        ops = [
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer) and getattr(op, "spyre_hints", None)
+        ]
+        if ops:
+            hints_logger.info("=== resolve_hints ===")
+            for op in ops:
+                hints_logger.info(f"{op.get_operation_name()}:")
+                for h in op.spyre_hints:
+                    per_tile = h.range_size // h.split_count if h.range_size else "?"
+                    reduction_tag = "  [reduction]" if h.is_reduction else ""
                     hints_logger.info(
-                        f"    {name}  size={size}  sliced by {k}: {size} -> {size // k}"
+                        f"  {h.dim_names}  range={h.range_size}"
+                        f"  split_count={h.split_count}  -> {per_tile} per tile"
+                        f"  dim_index={h.dim_index}{reduction_tag}"
                     )
-                else:
-                    hints_logger.info(f"    {name}  size={size}")
+
+
+def _group_spec(spyre_hints: list[DimHint]) -> list[tuple]:
+    """Build the coarse_tile() spec from op.spyre_hints.
+
+    Returns a list of (K, tiled_dims) tuples, one per hinted dim, outermost
+    first.  Reduction dims are excluded — coarse tiling only tiles compute dims.
+    """
+    return [
+        (sympy.Integer(h.split_count), [h.dim_index])
+        for h in spyre_hints
+        if not h.is_reduction
+    ]
+
+
+def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
+    """Build coarse_tile() groups from op.spyre_hints (set by resolve_hints).
+
+    coarse_tile() requires ops to be grouped: all ops in a group share the same
+    tiling spec and are tiled together inside the same loop nest.  We walk
+    operations in topological order and collect consecutive ops that carry
+    identical hints into one group, breaking whenever the hint changes or an
+    op has no hint at all.
+    """
+
+    def _key(op):
+        # Summarise an op's tiling intent as a hashable tuple so we can detect
+        # when consecutive ops share the same hint and belong in the same group.
+        # Reduction dims are excluded: coarse tiling only tiles compute dims.
+        resolved = getattr(op, "spyre_hints", [])
+        if not resolved:
+            return None
+        return (
+            tuple((h.split_count, h.dim_index) for h in resolved if not h.is_reduction)
+            or None
+        )  # all-reduction hint → treat as un-hinted
+
+    groups = []
+    current_ops: list[Operation] = []
+    current_key = None
+
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        key = _key(op)
+
+        if key is not None and key == current_key:
+            # Same hint as the previous op: extend the current group.
+            current_ops.append(op)
+        else:
+            # Hint changed (or this op has no hint): flush the current group,
+            # then start a new one if this op is hinted.
+            if current_ops and current_key is not None:
+                spec = _group_spec(current_ops[0].spyre_hints)
+                groups.append((current_ops, spec))
+            current_ops = [op] if key is not None else []
+            current_key = key
+
+    # Flush the final group.
+    if current_ops and current_key is not None:
+        spec = _group_spec(current_ops[0].spyre_hints)
+        groups.append((current_ops, spec))
+
+    return groups
 
 
 def convert_constant_with_graph_node(graph: torch.fx.Graph) -> None:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR brings together PR #2309 and PR #2250.  It connects the user annotated spyre-hints of 2309 with the coarse tiling transformation of 2250.   

The connection is made in 2 steps
1. **Packaging of hints**: There is a pass `resolve_hints` added in `temp_passes` that combines both the spyre-hints and named dimensions, making them conveniently available to any downstream pass.  It produces a field on each node called `nested_hints` that contains lists of `DimHints`  
2.  **Group construction**:  Coarse tiling is driven by its own input data structure that has groups and split_count.   Function `hints_to_coarse_tile_groups` converts the `nested_hints` from 1 into the coarse tile groups to drive coarse tiling

The existing 5 e2e coarse tiling tests from 2250 have been cloned and modified to be driven by spyre-hints instead of a manual config.

#### Which issue(s) this PR is related to:
#2150

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
