### PR TITLE
Enable coarse tiling of matmul input 1

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -955,6 +955,33 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.1, rtol=0.1)
 
+    # ------------------------------------------------------------------
+    # Matmul with row-tiling: tile the M dimension of x @ y
+    # ------------------------------------------------------------------
+
+    @config.patch({"coarse_tiling": True})
+    def test_hint_matmul_row_tiling(self):
+        """spyre_hint(slices={"M": 4}) tiles matmul over the row (M) dimension."""
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 256, 128, 64
+        x = torch.randn(M, K, dtype=torch.float16) * 0.01
+        y = torch.randn(K, N, dtype=torch.float16) * 0.01
+
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+
+        def fn(x, y):
+            _name_tensor_dims(x, ["M", "K"])
+            _name_tensor_dims(y, ["K", "N"])
+            with spyre_hint(slices={"M": 4}):
+                return x @ y
+
+        compare_with_cpu(
+            fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1788,22 +1788,6 @@ def _make_tiled_reduction_op(
 class TestCoarseTileReductionPropagation(unittest.TestCase):
     """Tests for insert_tiling_propagation Reduction support."""
 
-    def test_matmul_in_loop_raises(self):
-        from torch_spyre._inductor.coarse_tile import _check_reduction_tiling_safety
-        from torch_spyre._inductor.constants import BATCH_MATMUL_OP
-
-        op = _make_tiled_reduction_op(
-            "matmul0",
-            ranges=[Integer(4), Integer(4), Integer(4)],
-            reduction_ranges=[Integer(64)],
-            reduction_type=BATCH_MATMUL_OP,
-            loop_group_id=(0,),
-            loop_count=[Integer(4)],
-            loop_tiled_dims=[[0]],
-        )
-        with self.assertRaises(RuntimeError, msg="matmul inside loop should raise"):
-            _check_reduction_tiling_safety(op)
-
     def test_reduction_tiled_reduction_dim_raises(self):
         from torch_spyre._inductor.coarse_tile import _check_reduction_tiling_safety
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -79,7 +79,6 @@ from torch._inductor.ir import (
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
-from .constants import BATCH_MATMUL_OP
 from .logging_utils import get_inductor_logger
 
 logger = get_inductor_logger("coarse_tile")
@@ -151,8 +150,8 @@ def insert_tiling_propagation(
 ) -> None:
     """Insert full-sized buffers and copy/mutation ops for tiled ops.
 
-    Handles Pointwise and Reduction ComputedBuffers.  For Reductions, matrix
-    multiply (batchmatmul) and tiled reduction dims raise RuntimeError.
+    Handles Pointwise and Reduction ComputedBuffers.  For Reductions, tiled
+    dims that fall in the reduction_ranges index range raise RuntimeError.
 
     For each eligible ComputedBuffer in a tiling group, if its result is
     consumed by any operation outside the loop (different loop_group_id or
@@ -185,20 +184,11 @@ def insert_tiling_propagation(
 def _check_reduction_tiling_safety(op: ComputedBuffer) -> None:
     """Raise RuntimeError for unsupported Reduction-in-loop configurations.
 
-    Two cases are rejected:
-    1. Matrix multiply (batchmatmul) inside a tiling loop — not supported.
-    2. Any tiled dim that falls in the reduction_ranges index range — the
-       accumulation-buffer logic for a tiled reduction dim is not yet
-       implemented.
+    Rejects any tiled dim that falls in the reduction_ranges index range — the
+    accumulation-buffer logic for a tiled reduction dim is not yet implemented.
     """
     data = op.data
     assert isinstance(data, Reduction)
-
-    if data.reduction_type == BATCH_MATMUL_OP:
-        raise RuntimeError(
-            f"coarse_tile: matrix multiply op {op.get_name()!r} inside a "
-            "tiling loop is not supported."
-        )
 
     n_output_dims = len(data.ranges)
     loop_tiled_dims: list[list[int]] = getattr(op, "loop_tiled_dims", [])

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -689,6 +689,15 @@ def propagate_mutation_layouts(
                 output = n.node.get_layout()
                 layouts = list(compute_layouts(n.node, output, output_dep, args))
                 n.node.layout = layouts[0]
+        elif isinstance(n.node.data, Reduction):
+            real = n.node.layout.real_layout()
+            if isinstance(real, FixedTiledLayout):
+                n.node.layout = real
+            else:
+                logger.warning(
+                    "propagate_mutation_layouts: unhandled mutation Reduction"
+                    f" op {n.node.get_name()}: real_layout is {type(real)}"
+                )
         else:
             logger.warning(
                 f"propagate_mutation_layouts: unhandled mutation op {type(n.node.data)}"


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR relaxes the matmul check in coarse tiling was too strict,  It works fine as long as you are not tiling a reduction dimension, nor a stick dimension.

Added a matmul test with coarse tiling of the first input along the non-reduction dimension.


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2150

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
