### PR TITLE
Support multi-stick padding

### DIFF
--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -517,6 +517,19 @@ class TestSpyreTensorLayout(TestCase):
         compiled_result = compiled(x_dev, y_dev).cpu()
         torch.testing.assert_close(cpu_result, compiled_result, rtol=1e-3, atol=1e-3)
 
+    def test_add_with_beyond_stick_padding_1d(self):
+        x = torch.rand(80, dtype=torch.float16)
+        y = torch.rand(80, dtype=torch.float16)
+        cpu_result = x + y
+        fp16 = get_device_dtype(torch.float16)
+        stl = SpyreTensorLayout([3, 64], [64, 1], fp16)
+        _ = x.to("spyre")  # required for lazy device initialization
+        x_dev = x.to(device_layout=stl)
+        y_dev = y.to(device_layout=stl)
+        compiled = torch.compile(torch.add)
+        compiled_result = compiled(x_dev, y_dev).cpu()
+        torch.testing.assert_close(cpu_result, compiled_result, rtol=1e-3, atol=1e-3)
+
     def test_add_with_mixed_layout_dim_orders(self):
         """Compiled add where x and y have different device layouts."""
         x = torch.rand(3, 2, 2048, dtype=torch.float16)

--- a/tests/tensor/test_tensor_layout.py
+++ b/tests/tensor/test_tensor_layout.py
@@ -478,6 +478,45 @@ class TestSpyreTensorLayout(TestCase):
         self.assertEqual(x_stl.device_size, [256, 1, 512, 64])
         self.assertEqual(x_stl.stride_map, [1, -1, 256, -1])
 
+    def test_add_with_beyond_stick_padding_2d(self):
+        x = torch.rand(4, 80, dtype=torch.float16)
+        y = torch.rand(4, 80, dtype=torch.float16)
+        cpu_result = x + y
+        fp16 = get_device_dtype(torch.float16)
+        stl = SpyreTensorLayout([3, 4, 64], [64, 80, 1], fp16)
+        _ = x.to("spyre")  # required for lazy device initialization
+        x_dev = x.to(device_layout=stl)
+        y_dev = y.to(device_layout=stl)
+        compiled = torch.compile(torch.add)
+        compiled_result = compiled(x_dev, y_dev).cpu()
+        torch.testing.assert_close(cpu_result, compiled_result, rtol=1e-3, atol=1e-3)
+
+    def test_add_with_beyond_stick_padding_3d(self):
+        x = torch.rand(3, 4, 80, dtype=torch.float16)
+        y = torch.rand(3, 4, 80, dtype=torch.float16)
+        cpu_result = x + y
+        fp16 = get_device_dtype(torch.float16)
+        stl = SpyreTensorLayout([4, 3, 3, 64], [80, 64, 320, 1], fp16)
+        _ = x.to("spyre")  # required for lazy device initialization
+        x_dev = x.to(device_layout=stl)
+        y_dev = y.to(device_layout=stl)
+        compiled = torch.compile(torch.add)
+        compiled_result = compiled(x_dev, y_dev).cpu()
+        torch.testing.assert_close(cpu_result, compiled_result, rtol=1e-3, atol=1e-3)
+
+    def test_add_with_beyond_stick_padding_4d(self):
+        x = torch.rand(2, 3, 4, 80, dtype=torch.float16)
+        y = torch.rand(2, 3, 4, 80, dtype=torch.float16)
+        cpu_result = x + y
+        fp16 = get_device_dtype(torch.float16)
+        stl = SpyreTensorLayout([3, 4, 3, 2, 64], [320, 80, 64, 960, 1], fp16)
+        _ = x.to("spyre")  # required for lazy device initialization
+        x_dev = x.to(device_layout=stl)
+        y_dev = y.to(device_layout=stl)
+        compiled = torch.compile(torch.add)
+        compiled_result = compiled(x_dev, y_dev).cpu()
+        torch.testing.assert_close(cpu_result, compiled_result, rtol=1e-3, atol=1e-3)
+
     def test_add_with_mixed_layout_dim_orders(self):
         """Compiled add where x and y have different device layouts."""
         x = torch.rand(3, 2, 2048, dtype=torch.float16)

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -281,12 +281,14 @@ def _get_padded_iteration_space(
         if stick_sym not in max_stick_size or stick_size > max_stick_size[stick_sym]:
             max_stick_size[stick_sym] = stick_size
         stick_dims[stick_sym] = stick_dim
+        sm = op_spec_arg.stride_map
         for i, coord in enumerate(op_spec_arg.device_coordinates[:-1]):
             if stick_sym in coord.free_symbols:
-                # Only count zero-offset stick-count dims. A non-zero offset
-                # means this tensor is a view into a parent buffer; its
-                # device_size reflects the parent, not this op's allocation.
-                if coord.subs(stick_sym, 0) == 0 and not op_spec_arg.is_input:
+                # stride_map[i+1] != 1 means a row dim exists between the
+                # stick-count and within-stick dims: a genuine beyond-nearest-
+                # stick allocation. stride_map[i+1] == 1 means this dim spans
+                # the flat host index (possibly a parent-buffer view).
+                if sm is not None and i + 1 < len(sm) and sm[i + 1] != 1:
                     allocated_sticks.setdefault(stick_sym, []).append(
                         (op_spec_arg.device_size[i], stick_size)
                     )
@@ -297,15 +299,10 @@ def _get_padded_iteration_space(
         stick_dim = stick_dims[stick_sym]
         it_elems = sdsc_iteration_space[stick_dim]
         min_sticks = (it_elems + stick_size - 1) // stick_size
-        # The maximum valid allocated stick count is min_sticks scaled by the
-        # largest dtype ratio (max_stick_size / stick_size). This bounds genuine
-        # beyond-nearest-stick allocations and filters parent buffer views whose
-        # device_size can be arbitrarily larger.
-        max_valid = min_sticks * max_stick_size[stick_sym] // stick_size
         candidates = [
             (n * eps + stick_size - 1) // stick_size
             for n, eps in allocated_sticks.get(stick_sym, [])
-            if min_sticks <= (n * eps + stick_size - 1) // stick_size <= max_valid
+            if (n * eps + stick_size - 1) // stick_size >= min_sticks
         ]
         target = (min(candidates) if candidates else min_sticks) * stick_size
         if target > it_elems:

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -284,19 +284,19 @@ def _get_padded_iteration_space(
         sm = op_spec_arg.stride_map
         for i, coord in enumerate(op_spec_arg.device_coordinates[:-1]):
             if stick_sym in coord.free_symbols:
-                # device_size[i] * stride_map[i] != stride_map[i+1] means the
-                # allocated sticks exceed what the row stride implies — a genuine
-                # beyond-nearest-stick allocation. When they are equal the sticks
-                # exactly tile the row (normal allocation or parent-buffer view).
-                if (
-                    sm is not None
-                    and i + 1 < len(sm)
-                    and sm[i + 1] not in (-1, 1)
-                    and op_spec_arg.device_size[i] * sm[i] != sm[i + 1]
-                ):
-                    allocated_sticks.setdefault(stick_sym, []).append(
-                        (op_spec_arg.device_size[i], stick_size)
-                    )
+                # A genuine beyond-nearest-stick allocation has
+                # device_size[i] * stride_map[i] != the nearest non-(-1) row
+                # stride. Check stride_map[i-1] first, then stride_map[i+1].
+                adj = None
+                if sm is not None:
+                    for j in [i - 1, i + 1]:
+                        if 0 <= j < len(sm) and sm[j] not in (-1, 1):
+                            adj = sm[j]
+                            break
+                    if adj is not None and op_spec_arg.device_size[i] * sm[i] != adj:
+                        allocated_sticks.setdefault(stick_sym, []).append(
+                            (op_spec_arg.device_size[i], stick_size)
+                        )
                 break
 
     padding: dict = {}

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -32,7 +32,7 @@ from torch_spyre._inductor.constants import (
 from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre._inductor.op_spec import OpSpec, TensorArg
-from torch_spyre._inductor.pass_utils import padded_stick_count
+from torch_spyre._inductor.views import padded_stick_count
 
 from .compute_ops import SymbolKind, generate_sdsc
 

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -33,7 +33,6 @@ from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre._inductor.op_spec import OpSpec
 from torch_spyre._inductor.op_spec import TensorArg
-from torch_spyre._inductor.dtype_ops import DtypeOpTable
 
 from .compute_ops import SymbolKind, generate_sdsc
 
@@ -258,29 +257,57 @@ def _get_layout_label(
 
 def _get_padded_iteration_space(
     op_spec_args: list[TensorArg],
-    sdsc_args: list[SDSCArgs],
     sdsc_iteration_space: dict,
-    layouts: dict,
-    dim_order,
+    symbol_mapping: dict,
 ) -> dict:
-    """
-    Compute padding per dim when device size exceeds iteration space.
+    """Extend/align sdsc_iteration_space for each arg's stick dim.
 
-    Update sdsc_iteration_space when padding is needed.
-    Returns a mapping of dim -> padding amount
+    Must run before _create_sdsc_tensors so backGap is computed against the
+    final iteration space.  Returns a mapping of dim -> padding added.
     """
+    # Collect candidate (stick_count, elems_per_stick) pairs per stick symbol,
+    # and the maximum elems_per_stick per symbol for unit conversion.
+    allocated_sticks: dict = {}
+    max_stick_size: dict = {}
+    stick_dims: dict = {}
+    for op_spec_arg in op_spec_args:
+        stick_size = op_spec_arg.device_dtype.elems_per_stick()
+        orig_syms = op_spec_arg.device_coordinates[-1].free_symbols
+        if len(orig_syms) != 1:
+            continue
+        stick_sym = next(iter(orig_syms))
+        stick_dim = symbol_mapping.get(stick_sym)
+        if stick_dim is None or stick_dim not in sdsc_iteration_space:
+            continue
+        if stick_sym not in max_stick_size or stick_size > max_stick_size[stick_sym]:
+            max_stick_size[stick_sym] = stick_size
+        stick_dims[stick_sym] = stick_dim
+        for i, coord in enumerate(op_spec_arg.device_coordinates[:-1]):
+            if stick_sym in coord.free_symbols:
+                # Only count zero-offset stick-count dims. A non-zero offset
+                # means this tensor is a view into a parent buffer; its
+                # device_size reflects the parent, not this op's allocation.
+                if coord.subs(stick_sym, 0) == 0 and not op_spec_arg.is_input:
+                    allocated_sticks.setdefault(stick_sym, []).append(
+                        (op_spec_arg.device_size[i], stick_size)
+                    )
+                break
+
     padding: dict = {}
-    for sdsc_arg, op_spec_arg, dim_order in zip(sdsc_args, op_spec_args, dim_order):
-        layout = layouts[sdsc_arg.layout]
-        stick_dim = layout["stick_dim_order"]
-        dev_size = op_spec_arg.device_size[-2::-1]
-        for idx, dim in enumerate(dim_order):
-            if idx >= len(dev_size) or dim != stick_dim:
-                continue
-            unaligned = sdsc_iteration_space[dim] % layout["stick_size"]
-            if unaligned > 0:
-                padding[dim] = layout["stick_size"] - unaligned
-                sdsc_iteration_space[dim] += padding[dim]
+    for stick_sym, stick_size in max_stick_size.items():
+        stick_dim = stick_dims[stick_sym]
+        it_elems = sdsc_iteration_space[stick_dim]
+        min_sticks = (it_elems + stick_size - 1) // stick_size
+        # Convert each candidate to max stick_size units before comparing.
+        candidates = [
+            (n * eps + stick_size - 1) // stick_size
+            for n, eps in allocated_sticks.get(stick_sym, [])
+            if (n * eps + stick_size - 1) // stick_size >= min_sticks
+        ]
+        target = (min(candidates) if candidates else min_sticks) * stick_size
+        if target > it_elems:
+            padding[stick_dim] = target - it_elems
+            sdsc_iteration_space[stick_dim] = target
     return padding
 
 
@@ -509,14 +536,27 @@ def _extend_matmul_k_to_padded(
         )
         return
 
-    # Compute K_padded by rounding K up to the next stick boundary.
-    # Reading K_padded from y_arg.device_size would be wrong when y is a view
-    # (e.g. a slice) of a larger buffer: device_size reflects the underlying
-    # allocation's K extent, not the slice's logical K, so it can be larger
-    # than the matmul's actual K and would over-extend the iteration space.
     stick_size = y_arg.device_dtype.elems_per_stick()
     k_current = sdsc_iteration_space[k_sym]
     k_padded = ((k_current + stick_size - 1) // stick_size) * stick_size
+
+    # Also extend K if y was allocated with more sticks than the minimum (beyond-
+    # nearest-stick padding). Locate the device dim whose coordinate is
+    # floor(k_sym/stick_size) to find the allocated K stick count.
+    k_outer_coord = floor(k_sym / stick_size)
+    k_stick_count_dim = next(
+        (
+            i
+            for i, coord in enumerate(y_arg.device_coordinates[:-1])
+            if coord.subs(symbol_mapping) == k_outer_coord
+        ),
+        None,
+    )
+    if k_stick_count_dim is not None:
+        k_min_sticks = (k_current + stick_size - 1) // stick_size
+        k_device_sticks = y_arg.device_size[k_stick_count_dim]
+        if k_device_sticks > k_min_sticks:
+            k_padded = max(k_padded, k_device_sticks * stick_size)
 
     if k_padded > k_current:
         logger.debug(
@@ -568,6 +608,11 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     if is_matmul:
         _extend_matmul_k_to_padded(op_spec, sdsc_iteration_space, symbol_mapping)
 
+    # Must run before _create_sdsc_tensors so backGap sees the final space.
+    padding = _get_padded_iteration_space(
+        list(op_spec.args), sdsc_iteration_space, symbol_mapping
+    )
+
     args, layouts, missing_dim = _create_sdsc_tensors(
         op_spec,
         symbol_mapping,
@@ -579,31 +624,6 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
         # A dimension was added to the iteration space, update splits and work slices
         dim_splits[missing_dim] = 1
         work_slices[missing_dim] = 1
-
-    # In case of same type conversion (identity op) user gets compile time error & avoid
-    # changing the padding logic here to fix errors with torch.split() for 3d shapes.
-    is_dtype_op = DtypeOpTable.is_dtype_op(op_spec.op) and op_spec.op != IDENTITY_OP
-    if is_matmul or is_dtype_op:
-        pad_args, pad_sdsc_args, dim_order = (
-            list(op_spec.args),
-            args,
-            [arg.dim_order for arg in args],
-        )
-    elif op_spec.is_reduction:
-        pad_args, pad_sdsc_args, dim_order = (
-            [op_spec.args[0]],
-            [args[0]],
-            [args[0].dim_order],
-        )
-    else:
-        pad_args, pad_sdsc_args, dim_order = (
-            [op_spec.args[-1]],
-            [args[-1]],
-            [args[-1].dim_order],
-        )
-    padding = _get_padded_iteration_space(
-        pad_args, pad_sdsc_args, sdsc_iteration_space, layouts, dim_order
-    )
     constants = dict(op_spec.op_info.get("constants", {})) if op_spec.op_info else {}
     coordinate_masking = _get_coordinate_mask(sdsc_iteration_space, args[-1], padding)
     if coordinate_masking:

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -21,6 +21,7 @@ from sympy import Integer, Symbol, Expr, Mod, floor
 from torch._inductor.virtualized import V
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.constants import (
+    IDENTITY_OP,
     INPUT_DIM_LABELS,
     OUTPUT_DIM_LABELS,
     LAYOUT_LABELS,

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -31,8 +31,8 @@ from torch_spyre._inductor.constants import (
 )
 from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.logging_utils import get_inductor_logger
-from torch_spyre._inductor.op_spec import OpSpec
-from torch_spyre._inductor.op_spec import TensorArg
+from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+from torch_spyre._inductor.pass_utils import padded_stick_count
 
 from .compute_ops import SymbolKind, generate_sdsc
 
@@ -260,13 +260,11 @@ def _get_padded_iteration_space(
     sdsc_iteration_space: dict,
     symbol_mapping: dict,
 ) -> dict:
-    """Extend/align sdsc_iteration_space for each arg's stick dim.
-
-    Must run before _create_sdsc_tensors so backGap is computed against the
-    final iteration space.  Returns a mapping of dim -> padding added.
     """
-    # Collect candidate (stick_count, elems_per_stick) pairs per stick symbol,
-    # and the maximum elems_per_stick per symbol for unit conversion.
+    Compute padding per dim when device size exceeds iteration space.
+
+    Returns a mapping of dim -> padding amount
+    """
     allocated_sticks: dict = {}
     max_stick_size: dict = {}
     stick_dims: dict = {}
@@ -282,23 +280,15 @@ def _get_padded_iteration_space(
         if stick_sym not in max_stick_size or stick_size > max_stick_size[stick_sym]:
             max_stick_size[stick_sym] = stick_size
         stick_dims[stick_sym] = stick_dim
-        sm = op_spec_arg.stride_map
-        for i, coord in enumerate(op_spec_arg.device_coordinates[:-1]):
-            if stick_sym in coord.free_symbols:
-                # A genuine beyond-nearest-stick allocation has
-                # device_size[i] * stride_map[i] != the nearest non-(-1) row
-                # stride. Check stride_map[i-1] first, then stride_map[i+1].
-                adj = None
-                if sm is not None:
-                    for j in [i - 1, i + 1]:
-                        if 0 <= j < len(sm) and sm[j] not in (-1, 1):
-                            adj = sm[j]
-                            break
-                    if adj is not None and op_spec_arg.device_size[i] * sm[i] != adj:
-                        allocated_sticks.setdefault(stick_sym, []).append(
-                            (op_spec_arg.device_size[i], stick_size)
-                        )
-                break
+        if op_spec_arg.stride_map is not None:
+            n = padded_stick_count(
+                op_spec_arg.device_coordinates,
+                op_spec_arg.device_size,
+                op_spec_arg.stride_map,
+                stick_sym,
+            )
+            if n is not None:
+                allocated_sticks.setdefault(stick_sym, []).append((n, stick_size))
 
     padding: dict = {}
     for stick_sym, stick_size in max_stick_size.items():
@@ -546,9 +536,7 @@ def _extend_matmul_k_to_padded(
     k_current = sdsc_iteration_space[k_sym]
     k_padded = ((k_current + stick_size - 1) // stick_size) * stick_size
 
-    # Also extend K if y was allocated with more sticks than the minimum (beyond-
-    # nearest-stick padding). Locate the device dim whose coordinate is
-    # floor(k_sym/stick_size) to find the allocated K stick count.
+    # Also extend K if y was allocated with more sticks than the minimum.
     k_outer_coord = floor(k_sym / stick_size)
     k_stick_count_dim = next(
         (
@@ -614,7 +602,6 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     if is_matmul:
         _extend_matmul_k_to_padded(op_spec, sdsc_iteration_space, symbol_mapping)
 
-    # Must run before _create_sdsc_tensors so backGap sees the final space.
     padding = _get_padded_iteration_space(
         list(op_spec.args), sdsc_iteration_space, symbol_mapping
     )

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -284,11 +284,16 @@ def _get_padded_iteration_space(
         sm = op_spec_arg.stride_map
         for i, coord in enumerate(op_spec_arg.device_coordinates[:-1]):
             if stick_sym in coord.free_symbols:
-                # stride_map[i+1] != 1 means a row dim exists between the
-                # stick-count and within-stick dims: a genuine beyond-nearest-
-                # stick allocation. stride_map[i+1] == 1 means this dim spans
-                # the flat host index (possibly a parent-buffer view).
-                if sm is not None and i + 1 < len(sm) and sm[i + 1] != 1:
+                # device_size[i] * stride_map[i] != stride_map[i+1] means the
+                # allocated sticks exceed what the row stride implies — a genuine
+                # beyond-nearest-stick allocation. When they are equal the sticks
+                # exactly tile the row (normal allocation or parent-buffer view).
+                if (
+                    sm is not None
+                    and i + 1 < len(sm)
+                    and sm[i + 1] not in (-1, 1)
+                    and op_spec_arg.device_size[i] * sm[i] != sm[i + 1]
+                ):
                     allocated_sticks.setdefault(stick_sym, []).append(
                         (op_spec_arg.device_size[i], stick_size)
                     )

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -21,7 +21,6 @@ from sympy import Integer, Symbol, Expr, Mod, floor
 from torch._inductor.virtualized import V
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.constants import (
-    IDENTITY_OP,
     INPUT_DIM_LABELS,
     OUTPUT_DIM_LABELS,
     LAYOUT_LABELS,
@@ -298,11 +297,15 @@ def _get_padded_iteration_space(
         stick_dim = stick_dims[stick_sym]
         it_elems = sdsc_iteration_space[stick_dim]
         min_sticks = (it_elems + stick_size - 1) // stick_size
-        # Convert each candidate to max stick_size units before comparing.
+        # The maximum valid allocated stick count is min_sticks scaled by the
+        # largest dtype ratio (max_stick_size / stick_size). This bounds genuine
+        # beyond-nearest-stick allocations and filters parent buffer views whose
+        # device_size can be arbitrarily larger.
+        max_valid = min_sticks * max_stick_size[stick_sym] // stick_size
         candidates = [
             (n * eps + stick_size - 1) // stick_size
             for n, eps in allocated_sticks.get(stick_sym, [])
-            if (n * eps + stick_size - 1) // stick_size >= min_sticks
+            if min_sticks <= (n * eps + stick_size - 1) // stick_size <= max_valid
         ]
         target = (min(candidates) if candidates else min_sticks) * stick_size
         if target > it_elems:

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -260,16 +260,17 @@ def _get_padded_iteration_space(
     sdsc_iteration_space: dict,
     symbol_mapping: dict,
 ) -> dict:
-    """
-    Compute padding per dim when device size exceeds iteration space.
+    """Extend sdsc_iteration_space to match each arg's device allocation.
 
-    Returns a mapping of dim -> padding amount
+    Must run before _create_sdsc_tensors so backGap is computed against the
+    final iteration space.  Returns a mapping of dim -> padding added.
     """
-    allocated_sticks: dict = {}
-    max_stick_size: dict = {}
+    max_elems_per_stick: dict = {}
     stick_dims: dict = {}
+    # (device_stick_count, elems_per_stick) keyed by stick symbol.
+    device_stick_counts: dict = {}
     for op_spec_arg in op_spec_args:
-        stick_size = op_spec_arg.device_dtype.elems_per_stick()
+        elems_per_stick = op_spec_arg.device_dtype.elems_per_stick()
         orig_syms = op_spec_arg.device_coordinates[-1].free_symbols
         if len(orig_syms) != 1:
             continue
@@ -277,30 +278,39 @@ def _get_padded_iteration_space(
         stick_dim = symbol_mapping.get(stick_sym)
         if stick_dim is None or stick_dim not in sdsc_iteration_space:
             continue
-        if stick_sym not in max_stick_size or stick_size > max_stick_size[stick_sym]:
-            max_stick_size[stick_sym] = stick_size
+        if (
+            stick_sym not in max_elems_per_stick
+            or elems_per_stick > max_elems_per_stick[stick_sym]
+        ):
+            max_elems_per_stick[stick_sym] = elems_per_stick
         stick_dims[stick_sym] = stick_dim
         if op_spec_arg.stride_map is not None:
-            n = padded_stick_count(
+            device_stick_count = padded_stick_count(
                 op_spec_arg.device_coordinates,
                 op_spec_arg.device_size,
                 op_spec_arg.stride_map,
                 stick_sym,
             )
-            if n is not None:
-                allocated_sticks.setdefault(stick_sym, []).append((n, stick_size))
+            if device_stick_count is not None:
+                device_stick_counts.setdefault(stick_sym, []).append(
+                    (device_stick_count, elems_per_stick)
+                )
 
     padding: dict = {}
-    for stick_sym, stick_size in max_stick_size.items():
+    for stick_sym, elems_per_stick in max_elems_per_stick.items():
         stick_dim = stick_dims[stick_sym]
         it_elems = sdsc_iteration_space[stick_dim]
-        min_sticks = (it_elems + stick_size - 1) // stick_size
-        candidates = [
-            (n * eps + stick_size - 1) // stick_size
-            for n, eps in allocated_sticks.get(stick_sym, [])
-            if (n * eps + stick_size - 1) // stick_size >= min_sticks
-        ]
-        target = (min(candidates) if candidates else min_sticks) * stick_size
+        min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
+        # Use the smallest device stick count that covers min_sticks, converting
+        # to max_elems units to handle dtype mismatches (e.g. fp32 vs fp16).
+        result = min_sticks
+        for dev_sticks, dev_elems_per_stick in device_stick_counts.get(stick_sym, []):
+            in_max_units = (
+                dev_sticks * dev_elems_per_stick + elems_per_stick - 1
+            ) // elems_per_stick
+            if min_sticks <= in_max_units < result:
+                result = in_max_units
+        target = result * elems_per_stick
         if target > it_elems:
             padding[stick_dim] = target - it_elems
             sdsc_iteration_space[stick_dim] = target

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -290,6 +290,7 @@ def _get_padded_iteration_space(
                 op_spec_arg.device_size,
                 op_spec_arg.stride_map,
                 stick_sym,
+                it_elems=sdsc_iteration_space[stick_dim],
             )
             if device_stick_count is not None:
                 device_stick_counts.setdefault(stick_sym, []).append(

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -303,14 +303,15 @@ def _get_padded_iteration_space(
         min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
         # Use the smallest device stick count that covers min_sticks, converting
         # to max_elems units to handle dtype mismatches (e.g. fp32 vs fp16).
-        result = min_sticks
+        result = None
         for dev_sticks, dev_elems_per_stick in device_stick_counts.get(stick_sym, []):
             in_max_units = (
                 dev_sticks * dev_elems_per_stick + elems_per_stick - 1
             ) // elems_per_stick
-            if min_sticks <= in_max_units < result:
-                result = in_max_units
-        target = result * elems_per_stick
+            if in_max_units >= min_sticks:
+                if result is None or in_max_units < result:
+                    result = in_max_units
+        target = (result if result is not None else min_sticks) * elems_per_stick
         if target > it_elems:
             padding[stick_dim] = target - it_elems
             sdsc_iteration_space[stick_dim] = target
@@ -556,10 +557,20 @@ def _extend_matmul_k_to_padded(
         ),
         None,
     )
-    if k_stick_count_dim is not None:
+    if k_stick_count_dim is not None and y_arg.stride_map is not None:
         k_min_sticks = (k_current + stick_size - 1) // stick_size
-        k_device_sticks = y_arg.device_size[k_stick_count_dim]
-        if k_device_sticks > k_min_sticks:
+        k_sym_var = next(iter(y_arg.device_coordinates[-1].free_symbols), None)
+        k_device_sticks = (
+            padded_stick_count(
+                y_arg.device_coordinates,
+                y_arg.device_size,
+                y_arg.stride_map,
+                k_sym_var,
+            )
+            if k_sym_var is not None
+            else None
+        )
+        if k_device_sticks is not None and k_device_sticks > k_min_sticks:
             k_padded = max(k_padded, k_device_sticks * stick_size)
 
     if k_padded > k_current:

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -285,12 +285,17 @@ def _get_padded_iteration_space(
             max_elems_per_stick[stick_sym] = elems_per_stick
         stick_dims[stick_sym] = stick_dim
         if op_spec_arg.stride_map is not None:
+            # Input slices of larger parents are indistinguishable from
+            # beyond-nearest-stick in the 1D path; pass it_elems for outputs only.
+            it_elems_arg = (
+                sdsc_iteration_space[stick_dim] if not op_spec_arg.is_input else None
+            )
             device_stick_count = padded_stick_count(
                 op_spec_arg.device_coordinates,
                 op_spec_arg.device_size,
                 op_spec_arg.stride_map,
                 stick_sym,
-                it_elems=sdsc_iteration_space[stick_dim],
+                it_elems=it_elems_arg,
             )
             if device_stick_count is not None:
                 device_stick_counts.setdefault(stick_sym, []).append(
@@ -304,15 +309,14 @@ def _get_padded_iteration_space(
         min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
         # Use the smallest device stick count that covers min_sticks, converting
         # to max_elems units to handle dtype mismatches (e.g. fp32 vs fp16).
-        result = None
-        for dev_sticks, dev_elems_per_stick in device_stick_counts.get(stick_sym, []):
-            in_max_units = (
-                dev_sticks * dev_elems_per_stick + elems_per_stick - 1
-            ) // elems_per_stick
-            if in_max_units >= min_sticks:
-                if result is None or in_max_units < result:
-                    result = in_max_units
-        target = (result if result is not None else min_sticks) * elems_per_stick
+        alloc_sticks = [
+            (dev_sticks * dev_elems_per_stick + elems_per_stick - 1) // elems_per_stick
+            for dev_sticks, dev_elems_per_stick in device_stick_counts.get(
+                stick_sym, []
+            )
+        ]
+        result = min((s for s in alloc_sticks if s >= min_sticks), default=min_sticks)
+        target = result * elems_per_stick
         if target > it_elems:
             padding[stick_dim] = target - it_elems
             sdsc_iteration_space[stick_dim] = target
@@ -560,7 +564,9 @@ def _extend_matmul_k_to_padded(
     )
     if k_stick_count_dim is not None and y_arg.stride_map is not None:
         k_min_sticks = (k_current + stick_size - 1) // stick_size
-        k_sym_var = next(iter(y_arg.device_coordinates[-1].free_symbols), None)
+        # Use the variable from the K outer coord, not the within-stick variable.
+        k_outer_syms = y_arg.device_coordinates[k_stick_count_dim].free_symbols
+        k_sym_var = next(iter(k_outer_syms), None)
         k_device_sticks = (
             padded_stick_count(
                 y_arg.device_coordinates,

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -181,27 +181,6 @@ def device_coordinates(stl: SpyreTensorLayout, dep: MemoryDep) -> list[sympy.Exp
     return coords
 
 
-def padded_stick_count(
-    device_coords: list,
-    device_size: list[int],
-    stride_map: list[int],
-    stick_sym,
-) -> int | None:
-    """Return number of stick if dimension is padded beyond nearest
-    multiple of the stick size.
-    """
-    for i, coord in enumerate(device_coords[:-1]):
-        if stick_sym not in coord.free_symbols:
-            continue
-        for j in [i - 1, i + 1]:
-            if 0 <= j < len(stride_map) and stride_map[j] not in (-1, 1):
-                if device_size[i] * stride_map[i] != stride_map[j]:
-                    return device_size[i]
-                break
-        break
-    return None
-
-
 def iter_var_id(stick_expr) -> int:
     """Iteration variable index from a stick expr: Mod(d2,64) -> 2, d2 -> 2.
     Returns -1 for constant-zero (scalar/broadcast, no real stick).

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -181,6 +181,27 @@ def device_coordinates(stl: SpyreTensorLayout, dep: MemoryDep) -> list[sympy.Exp
     return coords
 
 
+def padded_stick_count(
+    device_coords: list,
+    device_size: list[int],
+    stride_map: list[int],
+    stick_sym,
+) -> int | None:
+    """Return number of stick if dimension is padded beyond nearest
+    multiple of the stick size.
+    """
+    for i, coord in enumerate(device_coords[:-1]):
+        if stick_sym not in coord.free_symbols:
+            continue
+        for j in [i - 1, i + 1]:
+            if 0 <= j < len(stride_map) and stride_map[j] not in (-1, 1):
+                if device_size[i] * stride_map[i] != stride_map[j]:
+                    return device_size[i]
+                break
+        break
+    return None
+
+
 def iter_var_id(stick_expr) -> int:
     """Iteration variable index from a stick expr: Mod(d2,64) -> 2, d2 -> 2.
     Returns -1 for constant-zero (scalar/broadcast, no real stick).

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -806,14 +806,17 @@ def simplify_op_spec(op_spec):
                 0, len(arg.device_coordinates) - len(old_stride_map)
             )
             old_sym_to_idx = {}
-            for j, coord in enumerate(old_coords):
+            for j, coord in enumerate(old_coords[:-1]):
                 for sym in coord.free_symbols:
                     old_sym_to_idx.setdefault(sym, j)
-            for d, coord in enumerate(arg.device_coordinates):
+            last = len(old_stride_map) - 1
+            for d, coord in enumerate(arg.device_coordinates[:-1]):
                 syms = coord.free_symbols
                 if not syms:
                     continue
                 j = old_sym_to_idx.get(next(iter(syms)))
-                if j is not None and j < len(old_stride_map):
+                if j is not None and j < last:
                     new_stride_map[d] = old_stride_map[j]
+            # Always preserve the within-stick stride from the original last entry.
+            new_stride_map[len(arg.device_coordinates) - 1] = old_stride_map[last]
             arg.stride_map = new_stride_map

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -649,10 +649,10 @@ def align_tensors(
 
 
 def padded_stick_count(
-    device_coords: list,
+    device_coords: list[sympy.Expr],
     device_size: list[int],
     stride_map: list[int],
-    stick_sym,
+    stick_sym: sympy.Symbol,
 ) -> int | None:
     """Return padded stick count if stick dim padding is beyond the
     nearest multiple of the stick size.

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -181,6 +181,8 @@ def compute_coordinates(
         # find primary dim with largest stride less than or equal to step
         primary_stride = 0
         primary_dim = -1
+        outer_stride = 0
+        outer_dim = -1
         for dim in range(n):
             if size[dim] == 1:
                 continue  # ignore dim with size 1
@@ -196,6 +198,15 @@ def compute_coordinates(
                     coordinates[dim] += var * step % next_stride[dim] // st
                 else:
                     coordinates[dim] += var * step // st
+            elif st > concrete_step and st > concrete_limit and st > outer_stride:
+                outer_stride = st
+                outer_dim = dim
+        # Emit the (always-zero) outer-stick coord so normalize_coordinates builds
+        # the correct Term for multi-stick padded layouts.  Guard: outermost above-
+        # range dim must be the stick-count dim (stride == stick size) with no
+        # broadcast dims (all strides positive).
+        if outer_dim >= 0 and outer_stride == size[-1] and all(s != 0 for s in stride):
+            coordinates[outer_dim] += var * step // outer_stride
         # add term for primary dim
         if primary_stride > 0:
             if next_stride[primary_dim] < concrete_limit:

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -672,10 +672,17 @@ def padded_stick_count(
                 ):
                     return device_size[i] - offset
                 break
-        if not found_adj and it_elems is not None and stride_map[last] == 1:
+        if (
+            not found_adj
+            and it_elems is not None
+            and stride_map[last] == 1
+            and coord.free_symbols == {stick_sym}
+            and offset == 0
+        ):
+            # 1D beyond-nearest-stick: contiguous (stride[-1]==1), outer coord
+            # has only stick_sym, no offset into a larger buffer.
             nearest = (it_elems + stride_map[i] - 1) // stride_map[i]
-            remaining = device_size[i] - offset
-            if remaining > nearest:
-                return remaining
+            if device_size[i] > nearest:
+                return device_size[i]
         break
     return None

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -657,12 +657,13 @@ def padded_stick_count(
     """Return padded stick count if stick dim padding is beyond the
     nearest multiple of the stick size.
     """
+    last = len(stride_map) - 1
     for i, coord in enumerate(device_coords[:-1]):
         if stick_sym not in coord.free_symbols:
             continue
         offset = int(coord.as_coeff_Add()[0])
         for j in [i - 1, i + 1]:
-            if 0 <= j < len(stride_map) and stride_map[j] not in (-1, 1):
+            if 0 <= j < last and stride_map[j] not in (-1, 1):
                 if device_size[i] * stride_map[i] != stride_map[j]:
                     return device_size[i] - offset
                 break

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -654,19 +654,17 @@ def padded_stick_count(
     stride_map: list[int],
     stick_sym,
 ) -> int | None:
-    """Return the allocated stick count if the tensor has a beyond-nearest-stick
-    outer dim for stick_sym, otherwise None.
-
-    A beyond-nearest-stick dim has device_size[i] * stride_map[i] != the
-    nearest non-(-1) adjacent stride in stride_map.
+    """Return padded stick count if stick dim padding is beyond the
+    nearest multiple of the stick size.
     """
     for i, coord in enumerate(device_coords[:-1]):
         if stick_sym not in coord.free_symbols:
             continue
+        offset = int(coord.as_coeff_Add()[0])
         for j in [i - 1, i + 1]:
             if 0 <= j < len(stride_map) and stride_map[j] not in (-1, 1):
                 if device_size[i] * stride_map[i] != stride_map[j]:
-                    return device_size[i]
+                    return device_size[i] - offset
                 break
         break
     return None

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -646,3 +646,27 @@ def align_tensors(
     }
 
     return new_iteration_space, new_tensors
+
+
+def padded_stick_count(
+    device_coords: list,
+    device_size: list[int],
+    stride_map: list[int],
+    stick_sym,
+) -> int | None:
+    """Return the allocated stick count if the tensor has a beyond-nearest-stick
+    outer dim for stick_sym, otherwise None.
+
+    A beyond-nearest-stick dim has device_size[i] * stride_map[i] != the
+    nearest non-(-1) adjacent stride in stride_map.
+    """
+    for i, coord in enumerate(device_coords[:-1]):
+        if stick_sym not in coord.free_symbols:
+            continue
+        for j in [i - 1, i + 1]:
+            if 0 <= j < len(stride_map) and stride_map[j] not in (-1, 1):
+                if device_size[i] * stride_map[i] != stride_map[j]:
+                    return device_size[i]
+                break
+        break
+    return None

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -653,6 +653,7 @@ def padded_stick_count(
     device_size: list[int],
     stride_map: list[int],
     stick_sym: sympy.Symbol,
+    it_elems: int | None = None,
 ) -> int | None:
     """Return padded stick count if stick dim padding is beyond the
     nearest multiple of the stick size.
@@ -662,10 +663,19 @@ def padded_stick_count(
         if stick_sym not in coord.free_symbols:
             continue
         offset = int(coord.as_coeff_Add()[0])
+        found_adj = False
         for j in [i - 1, i + 1]:
             if 0 <= j < last and stride_map[j] not in (-1, 1):
-                if device_size[i] * stride_map[i] != stride_map[j]:
+                found_adj = True
+                if stride_map[j] > stride_map[i] and (
+                    device_size[i] * stride_map[i] != stride_map[j]
+                ):
                     return device_size[i] - offset
                 break
+        if not found_adj and it_elems is not None and stride_map[last] == 1:
+            nearest = (it_elems + stride_map[i] - 1) // stride_map[i]
+            remaining = device_size[i] - offset
+            if remaining > nearest:
+                return remaining
         break
     return None

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -42,10 +42,10 @@ from .pass_utils import (
     get_mem_deps_from_rw,
     device_coordinates,
     iteration_space_from_op,
-    padded_stick_count,
     splits_by_index_coeff,
     apply_splits_from_index_coeff,
 )
+from .views import padded_stick_count
 from typing import Callable
 
 from .logging_utils import get_inductor_logger

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -192,7 +192,8 @@ def adjust_it_space_for_sticks(
     """
     adjusted_space = dict(it_space)
     max_elems: dict[Symbol, int] = {}
-    allocated_sticks: dict[Symbol, list[tuple[int, int]]] = {}
+    # (device_stick_count, elems_per_stick) keyed by stick variable.
+    device_stick_counts: dict[Symbol, list[tuple[int, int]]] = {}
     for td in tensor_deps:
         stick_expr = td.device_coords[-1]
         if len(stick_expr.free_symbols) != 1:
@@ -203,25 +204,30 @@ def adjust_it_space_for_sticks(
         elems_per_stick = td.layout.device_layout.elems_per_stick()
         if stick_var not in max_elems or elems_per_stick > max_elems[stick_var]:
             max_elems[stick_var] = elems_per_stick
-        n = padded_stick_count(
+        device_stick_count = padded_stick_count(
             td.device_coords,
             td.layout.device_layout.device_size,
             td.layout.device_layout.stride_map,
             stick_var,
         )
-        if n is not None:
-            allocated_sticks.setdefault(stick_var, []).append((n, elems_per_stick))
+        if device_stick_count is not None:
+            device_stick_counts.setdefault(stick_var, []).append(
+                (device_stick_count, elems_per_stick)
+            )
 
     for stick_var, elems_per_stick in max_elems.items():
         it_elems = concretize_expr(adjusted_space[stick_var])
         min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
-        # Convert candidates to max_elems units to handle dtype mismatches.
-        candidates = [
-            (n * eps + elems_per_stick - 1) // elems_per_stick
-            for n, eps in allocated_sticks.get(stick_var, [])
-            if (n * eps + elems_per_stick - 1) // elems_per_stick >= min_sticks
-        ]
-        adjusted_space[stick_var] = min(candidates) if candidates else min_sticks
+        # Use the smallest device stick count that covers min_sticks, converting
+        # to max_elems units to handle dtype mismatches (e.g. fp32 vs fp16).
+        result = min_sticks
+        for dev_sticks, dev_elems_per_stick in device_stick_counts.get(stick_var, []):
+            in_max_units = (
+                dev_sticks * dev_elems_per_stick + elems_per_stick - 1
+            ) // elems_per_stick
+            if min_sticks <= in_max_units < result:
+                result = in_max_units
+        adjusted_space[stick_var] = result
 
     return adjusted_space, max_elems
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -191,8 +191,10 @@ def adjust_it_space_for_sticks(
     """
     adjusted_space = dict(it_space)
     max_elems: dict[Symbol, int] = {}
-    # allocated_sticks[var] collects (stick_count, elems_per_stick) pairs from
-    # tensors that have a zero-offset stick-count dim (i.e. not a parent view).
+    # (stick_count, elems_per_stick) pairs keyed by stick variable, collected
+    # from tensors with a beyond-nearest-stick outer dim. The stride_map check
+    # (stride_map[i+1] != 1) distinguishes genuine beyond-nearest-stick
+    # allocations from flat parent buffer views.
     allocated_sticks: dict[Symbol, list[tuple[int, int]]] = {}
     for td in tensor_deps:
         stick_expr = td.device_coords[-1]
@@ -204,13 +206,11 @@ def adjust_it_space_for_sticks(
         elems_per_stick = td.layout.device_layout.elems_per_stick()
         if stick_var not in max_elems or elems_per_stick > max_elems[stick_var]:
             max_elems[stick_var] = elems_per_stick
+        sm = td.layout.device_layout.stride_map
         device_size = td.layout.device_layout.device_size
         for dim_idx, coord in enumerate(td.device_coords[:-1]):
             if stick_var in coord.free_symbols:
-                # Only count zero-offset stick-count dims. A non-zero offset
-                # means this tensor is a view into a parent buffer; its
-                # device_size reflects the parent, not this op's allocation.
-                if coord.subs(stick_var, 0) == 0:
+                if dim_idx + 1 < len(sm) and sm[dim_idx + 1] != 1:
                     allocated_sticks.setdefault(stick_var, []).append(
                         (device_size[dim_idx], elems_per_stick)
                     )
@@ -219,15 +219,11 @@ def adjust_it_space_for_sticks(
     for stick_var, elems_per_stick in max_elems.items():
         it_elems = concretize_expr(adjusted_space[stick_var])
         min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
-        # Cap at min_sticks * dtype_ratio to filter parent buffer views whose
-        # device_size can be arbitrarily larger than the op's working extent.
-        max_valid = min_sticks * max_elems[stick_var] // elems_per_stick
+        # Convert candidates to max_elems units to handle dtype mismatches.
         candidates = [
             (n * eps + elems_per_stick - 1) // elems_per_stick
             for n, eps in allocated_sticks.get(stick_var, [])
-            if min_sticks
-            <= (n * eps + elems_per_stick - 1) // elems_per_stick
-            <= max_valid
+            if (n * eps + elems_per_stick - 1) // elems_per_stick >= min_sticks
         ]
         adjusted_space[stick_var] = min(candidates) if candidates else min_sticks
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -173,6 +173,7 @@ def multi_dim_iteration_space_split(
 def adjust_it_space_for_sticks(
     it_space: dict[Symbol, Expr],
     tensor_deps: list[TensorDep],
+    output_td: TensorDep | None = None,
 ) -> tuple[dict[Symbol, Expr], dict[Symbol, int]]:
     """
     Return a copy of it_space with stick variables converted from elements to
@@ -187,6 +188,10 @@ def adjust_it_space_for_sticks(
     input and an int64 argmax output), the largest elems_per_stick is used
     so the adjustment is conservative (fewer sticks → smaller adjusted size →
     fewer cores assigned to the stick dimension).
+
+    output_td identifies the output tensor; it_elems is passed to
+    padded_stick_count only for outputs (input slices of larger parents are
+    indistinguishable from beyond-nearest-stick in the 1D path).
 
     The original it_space is not mutated.
     """
@@ -204,11 +209,15 @@ def adjust_it_space_for_sticks(
         elems_per_stick = td.layout.device_layout.elems_per_stick()
         if stick_var not in max_elems or elems_per_stick > max_elems[stick_var]:
             max_elems[stick_var] = elems_per_stick
+        it_elems_arg = (
+            concretize_expr(adjusted_space[stick_var]) if td is output_td else None
+        )
         device_stick_count = padded_stick_count(
             td.device_coords,
             td.layout.device_layout.device_size,
             td.layout.device_layout.stride_map,
             stick_var,
+            it_elems=it_elems_arg,
         )
         if device_stick_count is not None:
             device_stick_counts.setdefault(stick_var, []).append(
@@ -218,17 +227,15 @@ def adjust_it_space_for_sticks(
     for stick_var, elems_per_stick in max_elems.items():
         it_elems = concretize_expr(adjusted_space[stick_var])
         min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
-        # Use the smallest device stick count that covers min_sticks, converting
-        # to max_elems units to handle dtype mismatches (e.g. fp32 vs fp16).
-        result = None
-        for dev_sticks, dev_elems_per_stick in device_stick_counts.get(stick_var, []):
-            in_max_units = (
-                dev_sticks * dev_elems_per_stick + elems_per_stick - 1
-            ) // elems_per_stick
-            if in_max_units >= min_sticks:
-                if result is None or in_max_units < result:
-                    result = in_max_units
-        adjusted_space[stick_var] = result if result is not None else min_sticks
+        # Pick the smallest allocation (in max_elems units) that covers min_sticks.
+        alloc_sticks = [
+            (dev_sticks * dev_elems_per_stick + elems_per_stick - 1) // elems_per_stick
+            for dev_sticks, dev_elems_per_stick in device_stick_counts.get(
+                stick_var, []
+            )
+        ]
+        result = min((s for s in alloc_sticks if s >= min_sticks), default=min_sticks)
+        adjusted_space[stick_var] = result
 
     return adjusted_space, max_elems
 
@@ -534,7 +541,9 @@ def span_reduction_pass(
     input_tds, output_td = collect_tensor_deps(op, args)
     all_tds = input_tds + [output_td]
 
-    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(it_space, all_tds)
+    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(
+        it_space, all_tds, output_td
+    )
     min_splits = must_split_vars(
         all_tds, it_space, it_space_adjusted, stick_vars, max_cores
     )
@@ -618,7 +627,7 @@ def work_distribution_pass(
     input_tds, output_td = collect_tensor_deps(op, args)
     all_tds = input_tds + [output_td]
 
-    it_space_adjusted, _ = adjust_it_space_for_sticks(it_space, all_tds)
+    it_space_adjusted, _ = adjust_it_space_for_sticks(it_space, all_tds, output_td)
 
     # Recover splits committed by span_reduction_pass using the same
     # coeff-keyed encoding that codegen uses — stable across passes.
@@ -947,7 +956,9 @@ def _cost_model_divide_op(op: ComputedBuffer, max_cores: int) -> bool:
     all_tds = input_tds + [output_td]
 
     it_space = iteration_space_from_op(op)
-    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(it_space, all_tds)
+    it_space_adjusted, stick_vars = adjust_it_space_for_sticks(
+        it_space, all_tds, output_td
+    )
 
     # op.op_it_space_splits holds span_reduction's commits here: span_reduction
     # runs before this pass, and work_distribution — which would overwrite it —

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -189,9 +189,11 @@ def adjust_it_space_for_sticks(
 
     The original it_space is not mutated.
     """
-    # Pass 1: find the largest elems_per_stick per stick variable.
     adjusted_space = dict(it_space)
     max_elems: dict[Symbol, int] = {}
+    # allocated_sticks[var] collects (stick_count, elems_per_stick) pairs from
+    # tensors that have a zero-offset stick-count dim (i.e. not a parent view).
+    allocated_sticks: dict[Symbol, list[tuple[int, int]]] = {}
     for td in tensor_deps:
         stick_expr = td.device_coords[-1]
         if len(stick_expr.free_symbols) != 1:
@@ -202,15 +204,30 @@ def adjust_it_space_for_sticks(
         elems_per_stick = td.layout.device_layout.elems_per_stick()
         if stick_var not in max_elems or elems_per_stick > max_elems[stick_var]:
             max_elems[stick_var] = elems_per_stick
+        device_size = td.layout.device_layout.device_size
+        for dim_idx, coord in enumerate(td.device_coords[:-1]):
+            if stick_var in coord.free_symbols:
+                # Only count zero-offset stick-count dims. A non-zero offset
+                # means this tensor is a view into a parent buffer; its
+                # device_size reflects the parent, not this op's allocation.
+                if coord.subs(stick_var, 0) == 0:
+                    allocated_sticks.setdefault(stick_var, []).append(
+                        (device_size[dim_idx], elems_per_stick)
+                    )
+                break
 
-    # Pass 2: adjust each variable once using the maximum.
     for stick_var, elems_per_stick in max_elems.items():
-        # FIXME: here we assume padding to a full stick. It may not always be
-        #        the case and we should use a more robust way of computing the
-        #        number of sticks
-        adjusted_space[stick_var] = (
-            adjusted_space[stick_var] + elems_per_stick - 1
-        ) // elems_per_stick
+        it_elems = concretize_expr(adjusted_space[stick_var])
+        min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
+        # Convert each candidate's stick count to max_elems units, then take the
+        # smallest that is >= min_sticks. Converting units handles dtype mismatches
+        # (e.g. fp32 output sticks must be expressed as fp16 stick equivalents).
+        candidates = [
+            (n * eps + elems_per_stick - 1) // elems_per_stick
+            for n, eps in allocated_sticks.get(stick_var, [])
+            if (n * eps + elems_per_stick - 1) // elems_per_stick >= min_sticks
+        ]
+        adjusted_space[stick_var] = min(candidates) if candidates else min_sticks
 
     return adjusted_space, max_elems
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -210,7 +210,11 @@ def adjust_it_space_for_sticks(
         device_size = td.layout.device_layout.device_size
         for dim_idx, coord in enumerate(td.device_coords[:-1]):
             if stick_var in coord.free_symbols:
-                if dim_idx + 1 < len(sm) and sm[dim_idx + 1] != 1:
+                if (
+                    dim_idx + 1 < len(sm)
+                    and sm[dim_idx + 1] not in (-1, 1)
+                    and device_size[dim_idx] * sm[dim_idx] != sm[dim_idx + 1]
+                ):
                     allocated_sticks.setdefault(stick_var, []).append(
                         (device_size[dim_idx], elems_per_stick)
                     )

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -219,13 +219,15 @@ def adjust_it_space_for_sticks(
     for stick_var, elems_per_stick in max_elems.items():
         it_elems = concretize_expr(adjusted_space[stick_var])
         min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
-        # Convert each candidate's stick count to max_elems units, then take the
-        # smallest that is >= min_sticks. Converting units handles dtype mismatches
-        # (e.g. fp32 output sticks must be expressed as fp16 stick equivalents).
+        # Cap at min_sticks * dtype_ratio to filter parent buffer views whose
+        # device_size can be arbitrarily larger than the op's working extent.
+        max_valid = min_sticks * max_elems[stick_var] // elems_per_stick
         candidates = [
             (n * eps + elems_per_stick - 1) // elems_per_stick
             for n, eps in allocated_sticks.get(stick_var, [])
-            if (n * eps + elems_per_stick - 1) // elems_per_stick >= min_sticks
+            if min_sticks
+            <= (n * eps + elems_per_stick - 1) // elems_per_stick
+            <= max_valid
         ]
         adjusted_space[stick_var] = min(candidates) if candidates else min_sticks
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -210,11 +210,12 @@ def adjust_it_space_for_sticks(
         device_size = td.layout.device_layout.device_size
         for dim_idx, coord in enumerate(td.device_coords[:-1]):
             if stick_var in coord.free_symbols:
-                if (
-                    dim_idx + 1 < len(sm)
-                    and sm[dim_idx + 1] not in (-1, 1)
-                    and device_size[dim_idx] * sm[dim_idx] != sm[dim_idx + 1]
-                ):
+                adj = None
+                for j in [dim_idx - 1, dim_idx + 1]:
+                    if 0 <= j < len(sm) and sm[j] not in (-1, 1):
+                        adj = sm[j]
+                        break
+                if adj is not None and device_size[dim_idx] * sm[dim_idx] != adj:
                     allocated_sticks.setdefault(stick_var, []).append(
                         (device_size[dim_idx], elems_per_stick)
                     )

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -42,6 +42,7 @@ from .pass_utils import (
     get_mem_deps_from_rw,
     device_coordinates,
     iteration_space_from_op,
+    padded_stick_count,
     splits_by_index_coeff,
     apply_splits_from_index_coeff,
 )
@@ -191,10 +192,6 @@ def adjust_it_space_for_sticks(
     """
     adjusted_space = dict(it_space)
     max_elems: dict[Symbol, int] = {}
-    # (stick_count, elems_per_stick) pairs keyed by stick variable, collected
-    # from tensors with a beyond-nearest-stick outer dim. The stride_map check
-    # (stride_map[i+1] != 1) distinguishes genuine beyond-nearest-stick
-    # allocations from flat parent buffer views.
     allocated_sticks: dict[Symbol, list[tuple[int, int]]] = {}
     for td in tensor_deps:
         stick_expr = td.device_coords[-1]
@@ -206,20 +203,14 @@ def adjust_it_space_for_sticks(
         elems_per_stick = td.layout.device_layout.elems_per_stick()
         if stick_var not in max_elems or elems_per_stick > max_elems[stick_var]:
             max_elems[stick_var] = elems_per_stick
-        sm = td.layout.device_layout.stride_map
-        device_size = td.layout.device_layout.device_size
-        for dim_idx, coord in enumerate(td.device_coords[:-1]):
-            if stick_var in coord.free_symbols:
-                adj = None
-                for j in [dim_idx - 1, dim_idx + 1]:
-                    if 0 <= j < len(sm) and sm[j] not in (-1, 1):
-                        adj = sm[j]
-                        break
-                if adj is not None and device_size[dim_idx] * sm[dim_idx] != adj:
-                    allocated_sticks.setdefault(stick_var, []).append(
-                        (device_size[dim_idx], elems_per_stick)
-                    )
-                break
+        n = padded_stick_count(
+            td.device_coords,
+            td.layout.device_layout.device_size,
+            td.layout.device_layout.stride_map,
+            stick_var,
+        )
+        if n is not None:
+            allocated_sticks.setdefault(stick_var, []).append((n, elems_per_stick))
 
     for stick_var, elems_per_stick in max_elems.items():
         it_elems = concretize_expr(adjusted_space[stick_var])

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -220,14 +220,15 @@ def adjust_it_space_for_sticks(
         min_sticks = (it_elems + elems_per_stick - 1) // elems_per_stick
         # Use the smallest device stick count that covers min_sticks, converting
         # to max_elems units to handle dtype mismatches (e.g. fp32 vs fp16).
-        result = min_sticks
+        result = None
         for dev_sticks, dev_elems_per_stick in device_stick_counts.get(stick_var, []):
             in_max_units = (
                 dev_sticks * dev_elems_per_stick + elems_per_stick - 1
             ) // elems_per_stick
-            if min_sticks <= in_max_units < result:
-                result = in_max_units
-        adjusted_space[stick_var] = result
+            if in_max_units >= min_sticks:
+                if result is None or in_max_units < result:
+                    result = in_max_units
+        adjusted_space[stick_var] = result if result is not None else min_sticks
 
     return adjusted_space, max_elems
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
Previously, we had an assumption that when the stick dimension is padded then it is padded up to the nearest multiple of the stick size. This PR removes this assumptions and adds test cases that previously failed. This enabled padding scenarios where dimensions are padded beyond the nearest stick boundary (e.g., padding for work division to get dimensions to divide nicely across cores). 

#### Which issue(s) this PR is related to:
Fixes #2214 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
