### PR TITLE
prototype of work_distr + LX cooptimization

### DIFF
--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -245,9 +245,11 @@ class TestMeasureHBMUsageCoOptimizing(TestMeasureHBMUsageScratchPad):
         self,
         model: Callable[[Unpack[Ts]], torch.Tensor],
         args: tuple[Unpack[Ts]],
+        strict: bool = False,
         **kwargs,
     ):
-        """Compare HBM transfers with cooptimization off vs on."""
+        """Compare HBM transfers with cooptimization off vs on. If
+        `strict`, asserts coopt < default; otherwise coopt ≤ default."""
         with ts_inductor_config.patch(lx_planning=True):
             with ts_inductor_config.patch(co_optimizing_lx_planning=False):
                 result_default, hbm_default = self.measure_hbm_transfers(model, args)
@@ -255,10 +257,12 @@ class TestMeasureHBMUsageCoOptimizing(TestMeasureHBMUsageScratchPad):
             with ts_inductor_config.patch(co_optimizing_lx_planning=True):
                 result_coopt, hbm_coopt = self.measure_hbm_transfers(model, args)
 
-        self.assertLessEqual(
+        cmp = self.assertLess if strict else self.assertLessEqual
+        rel = "<" if strict else "≤"
+        cmp(
             hbm_coopt,
             hbm_default,
-            f"Expected cooptimization to be ≤ default HBM, got "
+            f"Expected cooptimization to be {rel} default HBM, got "
             f"coopt={hbm_coopt} default={hbm_default}",
         )
         self.assertTrue(
@@ -273,20 +277,7 @@ class TestMeasureHBMUsageCoOptimizing(TestMeasureHBMUsageScratchPad):
         flip the pointwise ops to cols and pin all 4 → strictly lower HBM."""
         f = functools.partial(torch.softmax, dim=0)
         x = self.rand_device((512, 1024))
-
-        with ts_inductor_config.patch(lx_planning=True):
-            with ts_inductor_config.patch(co_optimizing_lx_planning=False):
-                _, hbm_default = self.measure_hbm_transfers(f, (x,))
-            torch.compiler.reset()
-            with ts_inductor_config.patch(co_optimizing_lx_planning=True):
-                _, hbm_coopt = self.measure_hbm_transfers(f, (x,))
-
-        self.assertLess(
-            hbm_coopt,
-            hbm_default,
-            f"Expected cooptimization to strictly reduce HBM for softmax(dim=0), "
-            f"got coopt={hbm_coopt} default={hbm_default}",
-        )
+        self.common(f, (x,), strict=True)
 
     def test_softmax_dim_neg1_no_regression(self):
         """softmax(dim=-1) is the well-behaved baseline where DefaultAllocator

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -216,5 +216,85 @@ class TestMeasureHBMUsageScratchPad(TestScratchpadUsage):
     # TODO: Add additional ops
 
 
+@unittest.skipUnless(
+    ts_inductor_config.co_optimizing_lx_planning,
+    "CO_OPTIMIZING_LX_PLANNING is off; skipping cooptimization tests",
+)
+class TestMeasureHBMUsageCoOptimizing(TestMeasureHBMUsageScratchPad):
+    """Compares HBM transfers between DefaultAllocator and
+    StrategyBCoOptimizingAllocator. The cooptimizing allocator should be ≤ default on every shape,
+    and should strictly improve on cases where adjacent ops disagree on which
+    iteration-space dim to split — the canonical example is softmax(dim=0)
+    where work_distribution picks rows for the pointwise ops and cols for the
+    reduction ops, forcing 3 of 4 shared buffers to HBM under DefaultAllocator.
+
+    Skipped unless `CO_OPTIMIZING_LX_PLANNING=1` is set in the environment;
+    otherwise the cooptimization code path doesn't activate and there's
+    nothing to compare.
+    """
+
+    @override
+    def setUp(self):
+        super().setUp()
+        # Cooptimization needs > 1 core to have anything to optimize.
+        self.patchers.append(ts_inductor_config.patch("sencores", 4))
+        self.patchers[-1].__enter__()
+
+    @override
+    def run_test(
+        self,
+        model: Callable[[Unpack[Ts]], torch.Tensor],
+        args: tuple[Unpack[Ts]],
+        **kwargs,
+    ):
+        """Compare HBM transfers with cooptimization off vs on."""
+        with ts_inductor_config.patch(lx_planning=True):
+            with ts_inductor_config.patch(co_optimizing_lx_planning=False):
+                result_default, hbm_default = self.measure_hbm_transfers(model, args)
+            torch.compiler.reset()
+            with ts_inductor_config.patch(co_optimizing_lx_planning=True):
+                result_coopt, hbm_coopt = self.measure_hbm_transfers(model, args)
+
+        self.assertLessEqual(
+            hbm_coopt,
+            hbm_default,
+            f"Expected cooptimization to be ≤ default HBM, got "
+            f"coopt={hbm_coopt} default={hbm_default}",
+        )
+        self.assertTrue(
+            torch.allclose(result_default, result_coopt, atol=1e-4),
+            "Results do not match between cooptimization on and off",
+        )
+
+    def test_softmax_dim0_strictly_lower_hbm(self):
+        """The canonical motivating case from the design doc. softmax(dim=0)
+        has every adjacent op pair disagreeing on which dim to split, so
+        DefaultAllocator only pins 1 of 4 shared buffers; Strategy B should
+        flip the pointwise ops to cols and pin all 4 → strictly lower HBM."""
+        f = functools.partial(torch.softmax, dim=0)
+        x = self.rand_device((512, 1024))
+
+        with ts_inductor_config.patch(lx_planning=True):
+            with ts_inductor_config.patch(co_optimizing_lx_planning=False):
+                _, hbm_default = self.measure_hbm_transfers(f, (x,))
+            torch.compiler.reset()
+            with ts_inductor_config.patch(co_optimizing_lx_planning=True):
+                _, hbm_coopt = self.measure_hbm_transfers(f, (x,))
+
+        self.assertLess(
+            hbm_coopt,
+            hbm_default,
+            f"Expected cooptimization to strictly reduce HBM for softmax(dim=0), "
+            f"got coopt={hbm_coopt} default={hbm_default}",
+        )
+
+    def test_softmax_dim_neg1_no_regression(self):
+        """softmax(dim=-1) is the well-behaved baseline where DefaultAllocator
+        already pins everything pinnable. Strategy B must match (no regression)."""
+        f = functools.partial(torch.softmax, dim=-1)
+        x = self.rand_device((512, 1024))
+        self.common(f, (x,))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -19,6 +19,9 @@ from typing import Callable, Optional
 from torch.utils._config_module import install_config_module
 
 lx_planning: bool = os.environ.get("LX_PLANNING", "0") == "1"
+co_optimizing_lx_planning: bool = (
+    os.environ.get("CO_OPTIMIZING_LX_PLANNING", "0") == "1"
+)
 chunk_large_tensors: bool = os.environ.get("CHUNK_LARGE_TENSORS", "0") == "1"
 
 global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == "1"

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -14,7 +14,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Callable, NamedTuple, TypeVar, Union
+from typing import Callable, NamedTuple, Optional, TypeVar, Union
 
 import torch
 import sympy
@@ -712,7 +712,10 @@ def _is_matmul_op(op: Operation) -> bool:
 # TODO: refactor core assignment so the LX planner consumes determined
 # assignments instead of re-deriving them here.
 def _per_core_view_on_buf(
-    op: Operation, dep: MemoryDep, buf_name: str
+    op: Operation,
+    dep: MemoryDep,
+    buf_name: str,
+    cache: Optional[dict] = None,
 ) -> tuple[PerCoreView, bool]:
     """Build a PerCoreView describing how `op` slices `buf_name` via `dep`.
 
@@ -730,15 +733,30 @@ def _per_core_view_on_buf(
          producing work_slice_dims keyed by device-dim index.
       4. Build the core-to-slot mapping (k_fast-aware) and re-key it
          by device-dim so it's independent of op-local symbol names.
+
+    Pass an optional `cache` dict to memoize results across calls,
+    keyed by (op.op_it_space_splits, dep, buf_name).
     """
+    coeff_splits: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
+    if cache is not None:
+        # dicts aren't hashable; freeze each into a frozenset of items so
+        # the key is hashable and order-independent.
+        out, red = coeff_splits
+        key = (frozenset(out.items()), frozenset(red.items()), dep, buf_name)
+        hit = cache.get(key)
+        if hit is not None:
+            return hit
+
     # Step 1: recover {iter-symbol: split} from op.op_it_space_splits.
     # The op-level write_index / read_index (for *any* buffer the op
     # writes / reads, not necessarily buf_name) bridge stride-keyed
     # coeff_splits back to scheduler symbols.
     rw = op.get_read_writes()
-    coeff_splits: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
     if not any(n > 1 for d in coeff_splits for n in d.values()):
-        return PerCoreView(work_slice_dims=(), core_to_slot=()), False
+        result = (PerCoreView(work_slice_dims=(), core_to_slot=()), False)
+        if cache is not None:
+            cache[key] = result
+        return result
     write_index = next(iter(rw.writes)).index
     read_index = next((d.index for d in rw.reads), write_index)
     iter_space = iteration_space_from_op(op)
@@ -826,4 +844,7 @@ def _per_core_view_on_buf(
         work_slice_dims=tuple(sorted(work_slice_dims.items())),
         core_to_slot=tuple(pruned_core_to_slot),
     )
-    return view, has_partial_reduction
+    result = (view, has_partial_reduction)
+    if cache is not None:
+        cache[key] = result
+    return result

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -52,7 +52,10 @@ from .insert_restickify import insert_restickify, finalize_layouts
 from .memory_planning import memory_planning
 from .work_division import span_reduction, work_distribution, k_fast_division
 from .pass_utils import apply_splits_from_index_coeff, iteration_space_from_op
-from .scratchpad.allocator import scratchpad_planning
+from .scratchpad.allocator import (
+    StrategyBCoOptimizingAllocator,
+    scratchpad_planning,
+)
 from .fusion import spyre_fuse_nodes
 from .scheduler import build_loop_scheduler_nodes
 from .constants import DEVICE_NAME
@@ -267,7 +270,12 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         )
         work_distribution(operations, k_fast_ops)
         if config.lx_planning:
-            scratchpad_planning(graph)
+            allocator = (
+                StrategyBCoOptimizingAllocator()
+                if config.co_optimizing_lx_planning
+                else None
+            )
+            scratchpad_planning(graph, allocator=allocator)
 
         if logger.isEnabledFor(logging.INFO):
             logger.info("AFTER PRE-SCHEDULING\n%s", _format_operations(operations))

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -298,10 +298,6 @@ class StrategyBCoOptimizingAllocator(DefaultAllocator):
     space, the worst case matches DefaultAllocator.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.lx_limit = int((2 << 20) * (1.0 - config.dxp_lx_frac_avail))
-
     def plan_allocation(self, graph: GraphLowering):
         for p in self.pre_optimization_passes:
             p.apply_pass(graph)

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -332,9 +332,11 @@ class StrategyBCoOptimizingAllocator(DefaultAllocator):
     ) -> list[int]:
         """DFS over the option cross-product, scoring each leaf via
         _score_layout. Returns the option index per op for the leaf
-        with minimum HBM bytes. No early-stop pruning — the search is
-        bounded by option count (≤ K^N leaves with K=6, small N) so
-        full enumeration is cheap and stays solver-agnostic.
+        with minimum HBM bytes. No early-stop pruning — bounded by
+        ≤ K^N leaves where N counts ops with >1 option (most return
+        [seed]). Per-leaf cost is one full _generate_buffers +
+        plan_layout pass; the `cache` param on _per_core_view_on_buf
+        amortizes sympy work if it ever becomes hot.
         """
         chosen: list[int] = [0] * len(ops)
         best_total: float = math.inf
@@ -380,10 +382,9 @@ class StrategyBCoOptimizingAllocator(DefaultAllocator):
         graph: GraphLowering,
         buf_total_bytes: dict[str, int],
     ) -> int:
-        """HBM bytes under the current split assignment. Charges any
-        buffer that _generate_buffers excluded (filtered out as HBM) or
-        that the solver couldn't place in LX. Solver-agnostic — swap
-        layout_planning for any MemoryPlanSolver.
+        """HBM bytes under the current split assignment: total device
+        bytes of every buffer the solver couldn't pin. Non-committing
+        (addresses land on throwaway buffers) and solver-agnostic.
         """
         buffers = self._generate_buffers(graph)
         allocation = self.layout_planning.plan_layout(buffers)

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import math
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
 from torch._inductor.ir import ComputedBuffer, Operation, MutationLayoutSHOULDREMOVE
 from torch._inductor.graph import GraphLowering
 
+from torch_spyre._inductor.pass_utils import (
+    apply_splits_from_index_coeff,
+    concretize_expr,
+    iteration_space_from_op,
+    splits_by_index_coeff,
+)
 from torch_spyre._inductor.scratchpad.plan_solver import (
     GreedyLayoutSolver,
     LifetimeBoundBuffer,
@@ -37,6 +45,8 @@ from torch_spyre._inductor.scratchpad.utils import (
 )
 
 from torch_spyre._inductor import config
+
+logger = logging.getLogger(__name__)
 
 
 class ScratchpadAllocator(ABC):
@@ -213,6 +223,179 @@ class DefaultAllocator(ScratchpadAllocator):
         self._push_allocation(graph, allocation)
         for p in self.post_optimization_passes:
             p.apply_pass(graph)
+
+
+DEFAULT_VARIANT_CAP = 6
+
+
+def _enum_split_options(op: Operation) -> list[tuple[dict, dict]]:
+    """Generate split options based on the seed (current committed
+    split) by flipping the split factor onto a different output dim.
+    Returns ≤ DEFAULT_VARIANT_CAP options with the seed at index 0. If
+    the seed is unsplit or reduction-axis-only, returns the seed alone.
+    """
+    seed: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
+    output_splits, reduction_splits = seed
+    if not output_splits or not isinstance(op, ComputedBuffer):
+        return [seed]
+
+    # Recover seed's per-symbol form to mutate the slicing.
+    rw = op.get_read_writes()
+    write_index = next(iter(rw.writes)).index
+    first_read = next(iter(rw.reads), None)
+    read_index = first_read.index if first_read is not None else write_index
+    iter_space = iteration_space_from_op(op)
+    seed_per_sym = apply_splits_from_index_coeff(
+        seed, write_index, read_index, iter_space
+    )
+
+    # v1: only single output-dim splits are flipped. Reduction-axis
+    # splits are skipped (flipping would change has_partial_reduction);
+    # multi-dim splits (e.g. k_fast (1, n, k)) aren't yet handled.
+    sliced_output_syms = [
+        s for s in seed_per_sym if seed_per_sym[s] > 1 and write_index.coeff(s) != 0
+    ]
+    if len(sliced_output_syms) != 1:
+        return [seed]
+    seed_sym = sliced_output_syms[0]
+    seed_factor = int(seed_per_sym[seed_sym])
+
+    options: list[tuple[dict, dict]] = [seed]
+    seen: set[tuple] = {_canonical_key(seed)}
+    for sym, extent in iter_space.items():
+        extent_int = concretize_expr(extent)
+        if (
+            sym is seed_sym
+            or write_index.coeff(sym) == 0
+            or extent_int <= 1
+            or extent_int % seed_factor != 0
+        ):
+            continue
+        variant_per_sym = dict(seed_per_sym)
+        variant_per_sym[seed_sym] = 1
+        variant_per_sym[sym] = seed_factor
+        variant = splits_by_index_coeff(variant_per_sym, write_index, read_index)
+        key = _canonical_key(variant)
+        if key in seen:
+            continue
+        options.append(variant)
+        seen.add(key)
+        if len(options) >= DEFAULT_VARIANT_CAP:
+            break
+    return options
+
+
+def _canonical_key(splits: tuple[dict, dict]) -> tuple:
+    """Hashable key for a (output_splits, reduction_splits) pair."""
+    out, red = splits
+    return (tuple(sorted(out.items())), tuple(sorted(red.items())))
+
+
+class StrategyBCoOptimizingAllocator(DefaultAllocator):
+    """`Strategy B` assumes work_distribution committed one best option (seed). Here we
+    first add a few variants based on the seed, pick the combination that minimizes HBM
+    bytes among all, then defer to DefaultAllocator's flow. As seed is in the search
+    space, the worst case matches DefaultAllocator.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lx_limit = int((2 << 20) * (1.0 - config.dxp_lx_frac_avail))
+
+    def plan_allocation(self, graph: GraphLowering):
+        for p in self.pre_optimization_passes:
+            p.apply_pass(graph)
+
+        # Enumerate options, run search, commit winners back to op_it_space_splits.
+        ops = graph.operations
+        options_per_op = [_enum_split_options(op) for op in ops]
+        best_chosen = self._search(graph, ops, options_per_op)
+
+        for op, opt_idx, options in zip(ops, best_chosen, options_per_op):
+            chosen = options[opt_idx]
+            if chosen != getattr(op, "op_it_space_splits", ({}, {})):
+                op.op_it_space_splits = chosen
+
+        # Standard downstream flow on the now-fixed winning splits. Mirrors
+        # DefaultAllocator.plan_allocation past the pre-passes.
+        buffers = self._generate_buffers(graph)
+        allocation = self.layout_planning.plan_layout(buffers)
+        self._push_allocation(graph, allocation)
+        for p in self.post_optimization_passes:
+            p.apply_pass(graph)
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def _search(
+        self,
+        graph: GraphLowering,
+        ops: list[Operation],
+        options_per_op: list[list[tuple[dict, dict]]],
+    ) -> list[int]:
+        """DFS over the option cross-product, scoring each leaf via
+        _score_layout. Returns the option index per op for the leaf
+        with minimum HBM bytes. No early-stop pruning — the search is
+        bounded by option count (≤ K^N leaves with K=6, small N) so
+        full enumeration is cheap and stays solver-agnostic.
+        """
+        chosen: list[int] = [0] * len(ops)
+        best_total: float = math.inf
+        best_chosen: list[int] = list(chosen)
+
+        buf_total_bytes: dict[str, int] = {
+            name: math.prod(buf.layout.device_layout.device_size[:-1]) * 128
+            for name, buf in graph.name_to_buffer.items()
+        }
+
+        def recurse(op_idx: int) -> None:
+            nonlocal best_total, best_chosen
+            if op_idx == len(ops):
+                hbm = self._score_layout(graph, buf_total_bytes)
+                if hbm < best_total:
+                    best_total = hbm
+                    best_chosen = list(chosen)  # list() makes a copy
+                return
+
+            op = ops[op_idx]
+            options = options_per_op[op_idx]
+
+            # Mutate-and-undo: stash and restore op.op_it_space_splits.
+            # If the op originally lacked the attribute, restore it as
+            # ({}, {}) — equivalent to "unset" for all readers (which use
+            # getattr(..., ({}, {})) or hasattr+empty-dict default).
+            prev_split: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
+            for opt_idx, option in enumerate(options):
+                op.op_it_space_splits = option
+                chosen[op_idx] = opt_idx
+                recurse(op_idx + 1)
+            op.op_it_space_splits = prev_split
+
+        recurse(0)
+        return best_chosen
+
+    # ------------------------------------------------------------------
+    # Leaf scoring
+    # ------------------------------------------------------------------
+
+    def _score_layout(
+        self,
+        graph: GraphLowering,
+        buf_total_bytes: dict[str, int],
+    ) -> int:
+        """HBM bytes under the current split assignment. Charges any
+        buffer that _generate_buffers excluded (filtered out as HBM) or
+        that the solver couldn't place in LX. Solver-agnostic — swap
+        layout_planning for any MemoryPlanSolver.
+        """
+        buffers = self._generate_buffers(graph)
+        allocation = self.layout_planning.plan_layout(buffers)
+        pinned_names = {b.name for b in allocation if b.address is not None}
+
+        return sum(
+            total for name, total in buf_total_bytes.items() if name not in pinned_names
+        )
 
 
 def scratchpad_planning(

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -22,6 +22,7 @@ from torch_spyre._inductor.pass_utils import _per_core_view_on_buf
 
 OP_OUTPUT_GOOD_FOR_LX_REUSE = [
     "max",
+    "amax",
     "sum",
     # "clone",
     "exp",

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -20,6 +20,8 @@ from torch._inductor.ir import Operation
 from torch_spyre._inductor import config
 from torch_spyre._inductor.pass_utils import _per_core_view_on_buf
 
+# Op outputs eligible for LX-pinning. `amax` is the lowered form of
+# `max`; both names are listed to match whichever the IR shows.
 OP_OUTPUT_GOOD_FOR_LX_REUSE = [
     "max",
     "amax",


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

First version of **work distribution + LX co-optimization**. Based on given split conditions, in LX pass we `add variants -> evaluate -> commit the best`. This version simply uses "dim flipping" to create new split options, evaluates based on total HBM access, and updates the split plan with the "best choice". 

The motivating example is `softmax(dim=0)` with multicore, where the default split conditions are not the optimal for LX pinning.



#### Which issue(s) this PR is related to:

#234 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
