### PR TITLE
fix(coarse_tile): clear stale Inductor IR caches after _divide_range mutations

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -67,7 +67,12 @@ from torch_spyre._inductor.constants import (
     SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
 from torch_spyre._inductor.loop_info import CoarseTileInfo
-from torch_spyre._inductor.coarse_tile import coarse_tile, _divide_ranges
+from torch_spyre._inductor.coarse_tile import (
+    _LOOPS_FREE_SYMS_KEY,
+    _REDUCTION_FREE_SYMS_KEY,
+    _divide_ranges,
+    coarse_tile,
+)
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
 from torch_spyre._inductor.scheduler import (
     CountedLoopSchedulerNode,
@@ -631,6 +636,57 @@ class TestDivideRanges(unittest.TestCase):
 
         op = _make_op(MagicMock(spec=Operation))
         _divide_ranges(op, Integer(4), tiled_dims=[0])
+
+    def test_cache_invalidated_after_divide_pointwise(self):
+        from torch._inductor.ir import ComputedBuffer, FixedLayout, Pointwise
+
+        N = sympy.Symbol("N", positive=True)
+        pw = Pointwise(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda index: sympy.Integer(1),
+            ranges=[N, Integer(32)],
+        )
+        layout = FixedLayout(torch.device("cpu"), torch.float16, [N, Integer(32)])
+        op = ComputedBuffer(name="buf0", layout=layout, data=pw)
+
+        pw.get_free_symbol_uses()  # prime the cache
+        self.assertTrue(hasattr(pw, _LOOPS_FREE_SYMS_KEY))
+
+        _divide_ranges(op, Integer(4), tiled_dims=[0])
+
+        self.assertFalse(hasattr(pw, _LOOPS_FREE_SYMS_KEY))
+
+    def test_cache_invalidated_after_divide_reduction(self):
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,
+            Reduction,
+            ReductionHint,
+        )
+
+        N = sympy.Symbol("N", positive=True)
+        red = Reduction(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda index, rindex: sympy.Integer(1),
+            ranges=[N],
+            reduction_ranges=[Integer(128)],
+            reduction_type="sum",
+            src_dtype=torch.float16,
+            reduction_hint=ReductionHint.DEFAULT,
+        )
+        layout = FixedLayout(torch.device("cpu"), torch.float16, [N])
+        op = ComputedBuffer(name="buf0", layout=layout, data=red)
+
+        red.get_free_symbol_uses()  # prime both Loops and Reduction cache entries
+        self.assertTrue(hasattr(red, _LOOPS_FREE_SYMS_KEY))
+        self.assertTrue(hasattr(red, _REDUCTION_FREE_SYMS_KEY))
+
+        _divide_ranges(op, Integer(4), tiled_dims=[0])
+
+        self.assertFalse(hasattr(red, _LOOPS_FREE_SYMS_KEY))
+        self.assertFalse(hasattr(red, _REDUCTION_FREE_SYMS_KEY))
 
 
 def _mock_op_out_coords(op):

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -55,6 +55,8 @@ import torch
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     ComputedBuffer,
+    Layout,
+    Loops,
     MutationLayoutSHOULDREMOVE,
     Operation,
     Pointwise,
@@ -219,6 +221,42 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
         hints_logger.info("%s", "\n".join(summary_lines))
 
     return groups
+
+
+def _cache_key(cached_method: object) -> str:
+    """Return the cache attribute name used by a cache_on_self / cache_on_self_and_args method.
+
+    cache_on_self uses key ``f"__{fn.__name__}_cache"``; cache_on_self_and_args uses
+    ``f"__{class_name}_{fn.__name__}_cache"``.  Both patterns are captured as the
+    ``key`` free variable in the method's ``.clear_cache`` closure — extract it once
+    at module load so misspellings or upstream renames fail loudly on import.
+    """
+    clear_fn = getattr(cached_method, "clear_cache")  # AttributeError if absent
+    for i, name in enumerate(clear_fn.__code__.co_freevars):
+        if name == "key":
+            return clear_fn.__closure__[i].cell_contents
+    raise AttributeError(
+        f"Cannot find 'key' in clear_cache closure of {cached_method!r}"
+    )
+
+
+# Resolve cache keys once at import time — any rename in upstream IR will raise
+# AttributeError here rather than silently no-oping at runtime.
+_LOOPS_FREE_SYMS_KEY = _cache_key(Loops.get_free_symbol_uses)
+_LOOPS_INNER_FN_STR_KEY = _cache_key(Loops.inner_fn_str)
+_LOOPS_INNER_FN_OPCOUNT_KEY = _cache_key(Loops.inner_fn_opcount)
+_REDUCTION_FREE_SYMS_KEY = _cache_key(Reduction.get_free_symbol_uses)
+_LAYOUT_FREE_SYMS_KEY = _cache_key(Layout.get_free_symbol_uses)
+_COMPUTED_BUF_FREE_SYMS_KEY = _cache_key(ComputedBuffer.get_free_symbol_uses)
+_COMPUTED_BUF_SIZES_KEY = _cache_key(ComputedBuffer.get_default_sizes_body)
+
+
+def _clear_cache(obj: object, key: str) -> None:
+    # cache_on_self/cache_on_self_and_args store results via object.__setattr__ to
+    # bypass frozen-dataclass guards (Loops, Reduction, Layout); clearing must also
+    # use object.__delattr__ — plain delattr() raises FrozenInstanceError.
+    if hasattr(obj, key):
+        object.__delattr__(obj, key)
 
 
 # ---------------------------------------------------------------------------
@@ -1229,6 +1267,17 @@ def _divide_ranges(
     # Loops is a frozen dataclass; use object.__setattr__ to mutate it.
     object.__setattr__(data, "ranges", ranges)
 
+    # Invalidate Loops-level caches that read ranges.
+    _clear_cache(data, _LOOPS_FREE_SYMS_KEY)
+    _clear_cache(data, _LOOPS_INNER_FN_STR_KEY)
+    _clear_cache(data, _LOOPS_INNER_FN_OPCOUNT_KEY)
+    if isinstance(data, Reduction):
+        _clear_cache(data, _REDUCTION_FREE_SYMS_KEY)
+
+    # Invalidate ComputedBuffer-level caches derived from data.ranges.
+    _clear_cache(op, _COMPUTED_BUF_SIZES_KEY)
+    _clear_cache(op, _COMPUTED_BUF_FREE_SYMS_KEY)
+
     # Sync layout.size, layout.stride, and layout.device_layout with the new ranges.
     from torch._inductor.ir import FixedLayout, FlexibleLayout
 
@@ -1245,6 +1294,10 @@ def _divide_ranges(
 
     # Recompute contiguous strides for the smaller buffer.
     layout.stride = list(FlexibleLayout.contiguous_strides(new_size))
+
+    # Invalidate Layout- and ComputedBuffer-level caches that read size/stride.
+    _clear_cache(layout, _LAYOUT_FREE_SYMS_KEY)
+    _clear_cache(op, _COMPUTED_BUF_FREE_SYMS_KEY)
 
     # Rebuild SpyreTensorLayout for the new host size, preserving the
     # within-stick dimension.  stride_map[-1] is the element stride of the


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md
).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`_divide_ranges` mutates the `ranges` field on a frozen `Loops`/`Reduction`
dataclass and updates `size`/`stride` on the associated `Layout`, but several
`cache_on_self` / `cache_on_self_and_args` caches on those objects memoize
values derived from those fields.  Without invalidation the downstream
scheduler reads stale sizes and produces incorrect work-division plans.

The fix adds explicit invalidation after each mutation:

| Object | Caches cleared |
|---|---|
| `Loops` | `get_free_symbol_uses`, `inner_fn_str`, `inner_fn_opcount` |
| `Reduction` | `get_free_symbol_uses` (separate key from `Loops`) |
| `Layout` | `get_free_symbol_uses` |
| `ComputedBuffer` | `get_free_symbol_uses`, `get_default_sizes_body` |

Because `Loops`, `Reduction`, and `Layout` are frozen dataclasses,
`cache_on_self` stores results via `object.__setattr__` to bypass the freeze
guard.  Clearing must correspondingly use `object.__delattr__` — plain
`delattr()` raises `FrozenInstanceError`.

To avoid hardcoding private cache-key strings that would silently no-op if
upstream ever renames a method, the keys are derived at module load time by
inspecting the `key` free variable in each cached method's `.clear_cache()`
closure.  This turns any upstream rename into a loud `AttributeError` on
import rather than a silent correctness regression.

#### Which issue(s) this PR is related to:

Part of #1358 
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

`cache_on_self` / `cache_on_self_and_args` both expose a `.clear_cache(instance)`
helper, but it uses plain `delattr()` internally and therefore cannot be called
directly on frozen-dataclass instances.  The `_cache_key()` helper introduced
here extracts the key string from that closure so we can use `object.__delattr__`
ourselves, while still binding to the method name symbolically rather than
copy-pasting a string literal.

#### Does this PR introduce a user-facing change?

No. This is an internal IR-pass correctness fix; there is no change to the
public API or operator support.

#### Additional note:

`Layout` was refactored upstream (custom `__init__` + property setters replacing
declared dataclass fields) between the original branch base and the rebase onto
current `main`.  The frozen-dataclass invariant still holds for `Layout` — its
`__delattr__` is the dataclass-generated one — but it happens to allow
`object.__delattr__` on dynamically-added cache attributes because it has zero
declared `__dataclass_fields__` to protect.  The `_clear_cache` helper is
correct in either case.