### PR TITLE
Decompose comparison Scalar ops to avoid Constant kernel reject (#2222)

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -1201,6 +1201,34 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 ),
             },
         },
+        ("test_cmp_scalar", "test_cmp_scalar_cpu"): {
+            "ops_dict": {
+                "eq": torch.eq,
+                "ne": torch.ne,
+                "ge": torch.ge,
+                "le": torch.le,
+                "gt": torch.gt,
+                "lt": torch.lt,
+            },
+            "param_sets": {
+                "1d_fp16_zero": (
+                    cached_randn((256,), dtype=torch.float16),
+                    0,
+                ),
+                "1d_fp16_float": (
+                    cached_randn((256,), dtype=torch.float16),
+                    0.5,
+                ),
+                "2d_fp16_zero": (
+                    cached_randn((64, 128), dtype=torch.float16),
+                    0,
+                ),
+                "3d_fp16_zero": (
+                    cached_randn((2, 32, 128), dtype=torch.float16),
+                    0,
+                ),
+            },
+        },
         (
             "test_where",
             "test_where_cpu",
@@ -3704,6 +3732,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
     def test_cmp_scalar_int64_cpu(self, op, x, scalar):
         # Test comparison ops with int64 tensors and scalar values.
         self.compare_with_cpu(op, x, scalar, run_eager=True, run_compile=False)
+
+    def test_cmp_scalar_cpu(self, op, x, scalar):
+        # Compiled-path comparison of a tensor against a Python scalar.
+        # Without the aten.{op}.Scalar decompositions in decompositions.py the
+        # kernel rejects the scalar Constant operand. See #2222.
+        self.compare_with_cpu(op, x, scalar, run_eager=False)
 
     def test_linear_fn(self, x, weight, bias):
         # NOTE: relaxing atol from 2e-1 to 3e-1 for multi-dim work division, single element fails without

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -692,6 +692,33 @@ def sub_with_alpha(
         return torch.sub(self, scaled_other)
 
 
+# The Spyre kernel rejects scalar Constant operands to comparison ops in
+# spyre_kernel.py store(). Materialize the scalar as a broadcast tensor via
+# full_like so the comparison sees two TensorAccess arguments. See #2222.
+#
+# Registered only in the inductor decomp table (not via PrivateUse1) because
+# the Constant rejection is a compile-time bug; the eager path is unaffected
+# and rewriting it would change behavior of existing eager fallbacks.
+def _make_cmp_scalar_decomp(tensor_op):
+    def decomp(self: torch.Tensor, other) -> torch.Tensor:
+        return tensor_op(self, torch.ops.aten.full_like(self, other))
+
+    return decomp
+
+
+for _scalar_op, _tensor_op in (
+    (torch.ops.aten.gt.Scalar, torch.ops.aten.gt.Tensor),
+    (torch.ops.aten.lt.Scalar, torch.ops.aten.lt.Tensor),
+    (torch.ops.aten.ge.Scalar, torch.ops.aten.ge.Tensor),
+    (torch.ops.aten.le.Scalar, torch.ops.aten.le.Tensor),
+    (torch.ops.aten.eq.Scalar, torch.ops.aten.eq.Tensor),
+    (torch.ops.aten.ne.Scalar, torch.ops.aten.ne.Tensor),
+):
+    decomp.register_decomposition([_scalar_op], spyre_decompositions)(
+        _make_cmp_scalar_decomp(_tensor_op)
+    )
+
+
 ###############################################################################################
 ##                           Register custom kernels for Spyre.                              ##
 ###############################################################################################


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The Spyre kernel's store() in spyre_kernel.py rejects any PointwiseOp argument that is not a TensorAccess, but Inductor lowers aten.{gt,lt,ge,le,eq,ne}.Scalar to a Pointwise containing ops.constant(scalar) — failing with:

    Unsupported: unexpected argument Constant(value=0.0, ...)
    to greaterthan

Add decompositions that rewrite op(tensor, scalar) into op(tensor, full_like(tensor, scalar)) for all six comparison overloads, so the comparison sees two TensorAccess operands. The full_like flows through the identity-broadcast path introduced in #2232.

The decomps are registered only in the inductor decomp table (not via PrivateUse1) because the Constant rejection is compile-time; touching the eager path would change behavior of existing eager fallbacks (test_cmp_scalar_int64).

Adds test_cmp_scalar covering all six ops across 1d/2d/3d fp16 inputs.

#### Which issue(s) this PR is related to:

Fixes #2222

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
