### PR TITLE
 add `make clean` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,13 @@ TEST_CONFIGS ?= tests/configs/torch_spyre_tests
 .PHONY: tests
 tests: ## Run all torch spyre tests by default (except distributed). Override with: make tests TEST_CONFIGS="tests/configs/..."
 	@bash tests/run_test.sh $(TEST_CONFIGS) $(PYTEST_ARGS)
+
+.PHONY: clean
+clean: ## Remove auto-generated OOT wrappers, conftest files, merged configs, and __pycache__ under tests/
+	@find tests/ -name '*__oot_wrapper.py' -delete
+	@find tests/ -name '__oot_conftest_*.py' -delete
+	@find tests/ -name '_oot_merged_config_*.yaml' -delete
+	@find tests/ -name '_spyre_merged_config_*.yaml' -delete
+	@find tests/ -name '*.markers.json' -delete
+	@find tests/ -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
+	@echo "Cleaned auto-generated files under tests/"


### PR DESCRIPTION
The clean target removes these auto-generated files under tests/:

  | Pattern | Source |
|---|---|
| `*__oot_wrapper.py` | Generated by `run_test.sh` for uncontrolled/restricted test classes |
| `__oot_conftest_*.py` | Generated conftest patches for device list inclusion |
| `_oot_merged_config_*.yaml` | Merged YAML configs from multi-config runs |
| `_spyre_merged_config_*.yaml` | Merged configs from module test runs |
| `*.markers.json` | Sidecar marker files from `TorchTestBase` |
| `__pycache__/` | Python bytecode caches |

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
