### PR TITLE
Updates to group formation and coarse tiling to support flash attention example

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1197,19 +1197,10 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
         values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
 
-        _declare_tensor_dim("B", B)
-        _declare_tensor_dim("H", H)
-        _declare_tensor_dim("Lq", Lq)
-        _declare_tensor_dim("Lk", Lk)
-        _declare_tensor_dim("D", D)
-
         scale = 1.0 / math.sqrt(math.sqrt(D))
         lk_slices = Lk // block_size
 
         def flash(queries, keys, values):
-            _name_tensor_dims(queries, ["B", "H", "Lq", "D"])
-            _name_tensor_dims(keys, ["B", "H", "Lk", "D"])
-            _name_tensor_dims(values, ["B", "H", "Lk", "D"])
             output = torch.zeros_like(queries)
             M = torch.full(
                 (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
@@ -1234,18 +1225,31 @@ class TestCoarseTileSpyreHints(InductorTestCase):
                             exp_scores.transpose(-1, -2), values
                         )
                         M = max_running
-                        out = output / denominator.unsqueeze(-1)
-            return out
+            return output / denominator.unsqueeze(-1)
 
-        compare_with_cpu(
-            flash,
-            queries_t,
-            keys_t,
-            values_t,
-            run_compile=True,
-            run_eager=False,
-            atol=5.0,  # TODO: tighten once coarse tiling correctness is fixed
+        # CPU reference first, then device setup — matching the driver pattern exactly
+        ref = flash(queries_t, keys_t, values_t)
+
+        queries_dev = queries_t.to("spyre")
+        keys_dev = keys_t.to("spyre")
+        values_dev = values_t.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("Lk", Lk)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
+        _name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
+        _name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])
+
+        result = torch.compile(flash)(queries_dev, keys_dev, values_dev).cpu()
+        torch.testing.assert_close(
+            result,
+            ref,
+            equal_nan=True,
+            atol=1.0,
             rtol=0.1,
+            msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -83,7 +83,7 @@ def _groups_nested_k2_m4(operations: list[Operation]):
     ops = [op for op in operations if isinstance(op, ComputedBuffer)]
     if not ops:
         return []
-    return [(ops, [(sympy.Integer(2), [0]), (sympy.Integer(4), [1])])]
+    return [(ops, [(0, sympy.Integer(2), [0]), (0, sympy.Integer(4), [1])])]
 
 
 def _groups_nested_k2_m2(operations: list[Operation]):
@@ -91,7 +91,7 @@ def _groups_nested_k2_m2(operations: list[Operation]):
     ops = [op for op in operations if isinstance(op, ComputedBuffer)]
     if not ops:
         return []
-    return [(ops, [(sympy.Integer(2), [0]), (sympy.Integer(2), [1])])]
+    return [(ops, [(0, sympy.Integer(2), [0]), (0, sympy.Integer(2), [1])])]
 
 
 def _groups_per_op_tiled_dim(operations: list[Operation]):
@@ -1181,6 +1181,71 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         compare_with_cpu(
             fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
+        )
+
+    @unittest.skip("TODO: coarse tiling correctness not yet resolved")
+    @config.patch({"coarse_tiling": True})
+    def test_hint_flash_attention(self):
+        """Flash attention tiled over H (4 slices) and Lk (2 slices) via nested spyre_hints."""
+        import math
+        from torch_spyre._inductor import spyre_hint
+
+        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
+        block_size = 128
+
+        queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
+        keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+        values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
+
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("Lk", Lk)
+        _declare_tensor_dim("D", D)
+
+        scale = 1.0 / math.sqrt(math.sqrt(D))
+        lk_slices = Lk // block_size
+
+        def flash(queries, keys, values):
+            _name_tensor_dims(queries, ["B", "H", "Lq", "D"])
+            _name_tensor_dims(keys, ["B", "H", "Lk", "D"])
+            _name_tensor_dims(values, ["B", "H", "Lk", "D"])
+            output = torch.zeros_like(queries)
+            M = torch.full(
+                (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
+            )
+            with spyre_hint(
+                slices={"B": 1}
+            ):  # 3 nested scopes exercises multi-hint logic
+                with spyre_hint(slices={"H": 4}):
+                    with spyre_hint(slices={"Lk": lk_slices}):
+                        keys_T = keys.transpose(-1, -2).contiguous()
+                        denominator = torch.zeros(
+                            (B, H, Lq), device=queries.device, dtype=torch.float16
+                        )
+                        scores = torch.matmul(queries * scale, keys_T * scale)
+                        scores = scores.transpose(-1, -2).contiguous()
+                        block_max = torch.amax(scores, dim=-2)
+                        max_running = torch.maximum(M, block_max)
+                        exp_scores = torch.exp(scores - max_running.unsqueeze(-2))
+                        correction = torch.exp(M - max_running)
+                        denominator = denominator * correction + exp_scores.sum(dim=-2)
+                        output = output * correction.unsqueeze(-1) + torch.matmul(
+                            exp_scores.transpose(-1, -2), values
+                        )
+                        M = max_running
+                        out = output / denominator.unsqueeze(-1)
+            return out
+
+        compare_with_cpu(
+            flash,
+            queries_t,
+            keys_t,
+            values_t,
+            run_compile=True,
+            run_eager=False,
+            atol=5.0,  # TODO: tighten once coarse tiling correctness is fixed
+            rtol=0.1,
         )
 
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -657,12 +657,12 @@ class TestCoarseTile(unittest.TestCase):
 
 
 class TestCoarseTileNested(unittest.TestCase):
-    """Verify that the nested group format [(K1, dims1), (K2, dims2)] works."""
+    """Verify that the nested group format [(hint_id, K1, dims1), ...] works."""
 
     def test_nested_spec_stamps_list_attributes(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(Integer(4), [0]), (Integer(2), [1])])])
+        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(2), [1])])])
         self.assertEqual(op.loop_group_id, (0, 0))
         self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_tiled_dims, [[0], [1]])
@@ -670,14 +670,14 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(Integer(4), [0]), (Integer(2), [1])])])
+        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(2), [1])])])
         self.assertEqual(data.ranges[0], Integer(64))
         self.assertEqual(data.ranges[1], Integer(64))
 
     def test_nested_spec_outer_only_divides_outer_dim(self):
         data = _make_pointwise([Integer(32), Integer(64), Integer(16)])
         op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(Integer(4), [0]), (Integer(8), [1])])])
+        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(8), [1])])])
         self.assertEqual(data.ranges[0], Integer(8))
         self.assertEqual(data.ranges[1], Integer(8))
         self.assertEqual(data.ranges[2], Integer(16))
@@ -691,7 +691,7 @@ class TestCoarseTileNested(unittest.TestCase):
             [op0, op1],
             [
                 ([op0], Integer(4)),
-                ([op1], [(Integer(4), [0]), (Integer(2), [1])]),
+                ([op1], [(0, Integer(4), [0]), (0, Integer(2), [1])]),
             ],
         )
         self.assertEqual(op0.loop_group_id, (0,))
@@ -708,7 +708,7 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_same_dim_different_counts(self):
         data = _make_pointwise([Integer(256)])
         op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(Integer(4), [0]), (Integer(2), [0])])])
+        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(2), [0])])])
         self.assertEqual(data.ranges[0], Integer(32))
         self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_tiled_dims, [[0], [0]])

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -108,10 +108,10 @@ def coarse_tile(
 
         * A scalar ``loop_count`` (with optional third element ``tiled_dims``)
           for a flat single-level loop — tile all ops in ``ops`` by that count.
-        * A list of ``(loop_count, tiled_dims)`` pairs for nested loops —
-          the outermost pair is first, the innermost last.  The ops end up in
-          the innermost loop body; each level's count and dims are stamped on
-          the op and the corresponding iteration ranges are divided.
+        * A list of ``(hint_id, loop_count, tiled_dims)`` triples for nested
+          loops — outermost first.  The ops end up in the innermost loop body;
+          each level's count and dims are stamped on the op and the
+          corresponding iteration ranges are divided.
     tiled_dims:
         Default ``tiled_dims`` for flat groups that do not supply their own.
         ``None`` means tile only dimension 0.  Ignored for nested-spec groups.
@@ -126,13 +126,13 @@ def coarse_tile(
         group_id: tuple[int, ...] = (group_idx,)
 
         if isinstance(spec, list):
-            # Nested spec: list of (loop_count, tiled_dims) pairs.
-            levels: list[tuple[Expr, list[int]]] = spec
+            # Nested spec: list of (hint_id, loop_count, tiled_dims) triples.
+            levels: list[tuple[int, Expr, list[int]]] = spec
         else:
             # Flat spec: scalar loop_count with optional tiled_dims override.
             flat_tiled = group[2] if len(group) > 2 else tiled_dims
             effective_dims: list[int] = [0] if flat_tiled is None else flat_tiled
-            levels = [(spec, effective_dims)]
+            levels = [(0, spec, effective_dims)]
 
         _stamp_group(group_ops, group_id, levels, op_to_position)
 
@@ -218,6 +218,15 @@ def _propagate_tiled_op(
     outside_consumers, is_graph_output = _find_outside_consumers(
         buf_name, loop_group_id, operations
     )
+
+    # If no dims were tiled (loop_tiled_dims all empty), the op is loop-invariant —
+    # mark per_tile_fixed so the unroller reuses the same address each tile.
+    if all(not dims for dims in getattr(op, "loop_tiled_dims", [[]])):
+        from .ir import FixedTiledLayout
+
+        if isinstance(op.layout, FixedTiledLayout):
+            op.layout.per_tile_fixed = True
+        return
 
     if not outside_consumers and not is_graph_output:
         # Loop-internal: the buffer is a per-tile scratch region reused every
@@ -567,31 +576,23 @@ def _patch_graph_outputs(old_name: str, new_buf: ComputedBuffer) -> None:
 def _stamp_group(
     ops: list[Operation],
     group_id: tuple[int, ...],
-    levels: list[tuple[Expr, list[int]]],
+    levels: list[tuple[int, Expr, list[int]]],
     op_to_position: dict[str, int],
 ) -> None:
     """Stamp loop_group_id / loop_count / loop_tiled_dims and divide ranges.
 
-    ``levels`` is a list of ``(loop_count, tiled_dims)`` pairs, outermost
-    first.  The op receives a ``loop_group_id`` whose length equals
-    ``len(levels)`` (one path element per nesting level).  ``loop_count`` and
-    ``loop_tiled_dims`` are stamped as lists parallel to ``levels``.
-
-    Iteration ranges are divided in outermost-first order: outer count applied
-    to outer dims, then inner count applied to inner dims.
+    ``levels`` is a list of ``(hint_id, loop_count, tiled_dims)`` triples,
+    outermost first.  Each op's ranges are divided using its own dim_hints,
+    matched to the correct level by hint_id so that op-specific dim_index
+    values are used rather than the spec op's indices.
     """
     if not ops:
         return
 
     _validate_contiguous(ops, op_to_position, group_id)
 
-    # Build full nested group_id: (group_idx, 0, 0, ...) with len == len(levels).
-    # The inner path elements are always 0 because each level contains exactly
-    # the ops from this group (no siblings at inner depths).
     nested_group_id: tuple[int, ...] = group_id + (0,) * (len(levels) - 1)
-
-    counts = [lvl[0] for lvl in levels]
-    dims_per_level = [lvl[1] for lvl in levels]
+    counts = [lvl[1] for lvl in levels]
 
     for op in ops:
         if not isinstance(op, ComputedBuffer):
@@ -602,19 +603,41 @@ def _stamp_group(
             )
             continue
 
-        for count, dims in levels:
-            _divide_ranges(op, count, dims)
+        # Two ways to drive coarse tiling: (1) a config-supplied groups function
+        # that assigns the same dims to every op in the group, and (2) spyre_hint
+        # annotations where each op carries its own dim_hints with per-op
+        # dim_index values (ops in the same group can have different iteration
+        # spaces, e.g. a broadcast op may lack the tiled dimension entirely).
+        # Use the op's own dim_index when dim_hints are present; fall back to
+        # spec_dims otherwise, or when the op has no matching dim for a level.
+        op_hints = getattr(op, "dim_hints", [])
+        hint_id_to_dim_index: dict[int, int] = {
+            h.hint_id: h.dim_index
+            for h in op_hints
+            if h.dim_index is not None and not h.is_reduction
+        }
+        op_tiled_dims: list[list[int]] = []
+        for hint_id, count, spec_dims in levels:
+            dim_index = hint_id_to_dim_index.get(hint_id) if op_hints else None
+            if not op_hints:
+                effective = spec_dims  # flat/legacy: no dim_hints, use spec directly
+            elif dim_index is not None:
+                effective = [dim_index]  # use this op's own dim_index
+            else:
+                effective = []  # op has no dim for this level — loop-invariant
+            op_tiled_dims.append(effective)
+            _divide_ranges(op, count, effective)
 
         op.loop_group_id = nested_group_id  # type: ignore[attr-defined]
         op.loop_count = counts  # type: ignore[attr-defined]
-        op.loop_tiled_dims = dims_per_level  # type: ignore[attr-defined]
+        op.loop_tiled_dims = op_tiled_dims  # type: ignore[attr-defined]
 
         logger.debug(
             "coarse_tile: stamped %s loop_group_id=%s loop_count=%s loop_tiled_dims=%s",
             op.get_operation_name(),
             nested_group_id,
             counts,
-            dims_per_level,
+            op_tiled_dims,
         )
 
 
@@ -655,9 +678,9 @@ def _divide_ranges(
         ):
             if int(r) % int(loop_count) != 0:
                 raise RuntimeError(
-                    f"coarse_tile: dimension {i} range {r} is not divisible by "
-                    f"loop_count {loop_count}.  All tiled dimensions must be evenly "
-                    f"divisible by the loop trip count."
+                    f"coarse_tile: op {op.get_name()!r} dimension {i} range {r} "
+                    f"is not divisible by loop_count {loop_count}.  All tiled "
+                    f"dimensions must be evenly divisible by the loop trip count."
                 )
             ranges[i] = sympy.Integer(int(r) // int(loop_count))
         else:

--- a/torch_spyre/_inductor/codegen/unroll.py
+++ b/torch_spyre/_inductor/codegen/unroll.py
@@ -72,7 +72,10 @@ def _byte_stride_for_arg(arg: TensorArg, tiled_sym: Symbol, tile_range: int) -> 
     for d, coord_expr in enumerate(arg.device_coordinates):
         at_range = int(coord_expr.subs(sub_range))
         at_zero = int(coord_expr.subs(sub_zero))
-        total_elem_stride += (at_range - at_zero) * arg.stride_map[d]
+        delta = at_range - at_zero
+        if delta == 0:
+            continue
+        total_elem_stride += delta * arg.stride_map[d]
     return total_elem_stride * num_bytes(arg.device_dtype)
 
 

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -122,7 +122,7 @@ def _create_restickify_node(
             "call_function", torch.ops.spyre.restickify.default, (fx_arg_node,)
         )
     # Propagate hint metadata from the consumer op so assign_dim_hints can assign
-    # spyre_hints to the restickify buffer after insertion.
+    # dim_hints to the restickify buffer after insertion.
     for consumer_fx_node in op.origins:
         if "custom" in consumer_fx_node.meta:
             copy_fx_custom_meta(consumer_fx_node, restick_fx_node)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -450,7 +450,7 @@ def copy_fx_custom_meta(src: "torch.fx.Node", dst: "torch.fx.Node") -> None:
 
 
 _SPYRE_METADATA_ATTRS = (
-    "spyre_hints",
+    "dim_hints",
     "loop_group_id",
     "loop_count",
     "loop_tiled_dims",
@@ -461,7 +461,7 @@ def copy_op_metadata(src: ComputedBuffer, dst: ComputedBuffer) -> None:
     """Copy all Spyre pass metadata from src to dst.
 
     Call this whenever a pass reconstructs a ComputedBuffer to ensure
-    spyre_hints and coarse-tiling attrs are not silently dropped.
+    dim_hints and coarse-tiling attrs are not silently dropped.
     """
     for attr in _SPYRE_METADATA_ATTRS:
         if hasattr(src, attr):

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -35,7 +35,6 @@ from .temp_passes import (
     bmm_unflatten_pass,
     mm_to_bmm_pass,
     convert_constant_with_graph_node,
-    assign_dim_hints,
     hints_to_coarse_tile_groups,
 )
 from . import config
@@ -43,7 +42,7 @@ from .propagate_hints import (
     collect_spyre_hints,
     recover_spyre_hints,
 )
-from .propagate_named_dims import propagate_named_dims
+from .propagate_named_dims import propagate_named_dims, assign_dim_hints
 from .propagate_layouts import (
     propagate_mutation_layouts,
     propagate_spyre_tensor_layouts,

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -30,16 +30,15 @@ logger = get_inductor_logger("propagate_hints")
 @dataclasses.dataclass
 class DimHint:
     dim_names: list[str]  # e.g. ["A"]
-    range_size: (
-        int  # full loop range, e.g. 256; 0 means sentinel (scope marker, no real dim)
-    )
+    range_size: int  # full loop range, e.g. 256; 0 when dim not in iteration space
     split_count: int  # from slices={"A": 4}, e.g. 4
-    dim_index: int  # index into op.loop_var_dims / op.data.ranges
+    dim_index: int | None  # index into op.loop_var_dims / op.data.ranges;
+    # None when op is broadcast w.r.t. this hint scope
     is_reduction: bool
     hint_id: int = 0  # the _hint_N counter value identifying the scope
 
 
-# op.spyre_hints: list[DimHint]
+# op.dim_hints: list[DimHint]
 #
 # One entry per hinted dimension, ordered outermost hint scope first.
 # Outer hint IDs are smaller than inner hint IDs (guaranteed by spyre_hint
@@ -50,7 +49,7 @@ class DimHint:
 #       with spyre_hint(slices={"B": 4}):  # inner scope → larger hint ID
 #           y = a + b
 #
-# spyre_hints = [DimHint(dim_names=["A"], split_count=2, dim_index=0, ...),
+# dim_hints = [DimHint(dim_names=["A"], split_count=2, dim_index=0, ...),
 #                 DimHint(dim_names=["B"], split_count=4, dim_index=1, ...)]
 
 
@@ -61,7 +60,7 @@ _hint_counter = 0
 # by call_function node position. Used by recover_spyre_hints to restore
 # meta on nodes renamed by AOT re-tracing (e.g. mm -> mm_default), which
 # drops node.meta["custom"].
-_spyre_hints: list[dict[str, Any] | None] = []
+_dim_hints: list[dict[str, Any] | None] = []
 
 
 def spyre_hint(**kwargs: Any):
@@ -100,9 +99,9 @@ def collect_spyre_hints(graph: torch.fx.Graph) -> None:
     Snapshot call_function nodes' custom meta by topological position.
     Pairs with recover_spyre_hints to survive AOT re-tracing.
     """
-    global _spyre_hints
+    global _dim_hints
 
-    _spyre_hints = [
+    _dim_hints = [
         node.meta.get("custom") for node in graph.nodes if node.op == "call_function"
     ]
 
@@ -113,10 +112,10 @@ def recover_spyre_hints(graph: torch.fx.Graph) -> None:
     snapshot taken by collect_spyre_hints by topological position.
     """
     nodes = [n for n in graph.nodes if n.op == "call_function"]
-    if len(nodes) != len(_spyre_hints):
+    if len(nodes) != len(_dim_hints):
         logger.warning("Warning: unable to recover spyre hints")
         return
-    for node, custom in zip(nodes, _spyre_hints):
+    for node, custom in zip(nodes, _dim_hints):
         if not custom:
             continue
         if node.meta.get("custom") is None:

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import dataclasses
+import logging
 import sympy
 import torch
 from .logging_utils import get_inductor_logger
@@ -32,10 +34,12 @@ from torch._inductor.virtualized import V
 from .errors import Unsupported
 from .pass_utils import host_coordinates, device_coordinates
 from .views import matching_dim, compute_coordinates
+from .propagate_hints import DimHint, get_op_hints
 from torch_spyre._C import SpyreTensorLayout
 from torch.utils.weak import WeakTensorKeyDictionary
 
 logger = get_inductor_logger("propagate_named_dims")
+hints_logger = get_inductor_logger("assign_dim_hints")
 
 
 # Used for propagation of named dims if this pass runs.
@@ -100,7 +104,9 @@ def _compute_named_layout(named_dims):
 def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
     """Map loop vars to named dim names for a single input dep, using named-space coords."""
     buf = _get_buffer(dep)
-    if not hasattr(buf, "named_dims") or buf.named_dims is None:
+    dp = getattr(buf, "_dim_prop_info", None)
+    buf_named_dims = dp.named_dims if dp is not None else None
+    if not buf_named_dims:
         # Scalar broadcast: constant index, contributes nothing to loop_var_dims
         if not dep.index.free_symbols:
             return {}
@@ -110,13 +116,13 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             sym: [_untracked_name(context, sym, int(size))]
             for sym, size in dep.ranges.items()
         }
-    named_size, named_stride = _compute_named_layout(buf.named_dims)
+    named_size, named_stride = _compute_named_layout(buf_named_dims)
     coords = compute_coordinates(named_size, named_stride, dep.ranges, dep.index)
     result: dict[sympy.Symbol, list[str]] = {}
     for i, coord in enumerate(coords):
         if coord.free_symbols:
             sym = _lone_sym(coord)
-            result.setdefault(sym, []).append(buf.named_dims[i])
+            result.setdefault(sym, []).append(buf_named_dims[i])
     for sym, names in result.items():
         actual_range = int(dep.ranges[sym])
         product = 1
@@ -152,7 +158,8 @@ def coords_to_named_dims(coords: list, loop_var_dims: dict) -> list:
 
 def named_dims_for_sym(op: ComputedBuffer, sym: sympy.Symbol) -> list[tuple[str, int]]:
     """Return [(name, size), ...] for the named dims covered by a loop variable."""
-    names = op.loop_var_dims.get(sym, [])
+    dp = getattr(op, "_dim_prop_info", None)
+    names = dp.loop_var_dims.get(sym, []) if dp is not None else []
     return [(n, _named_dims[n]) for n in names if n in _named_dims]
 
 
@@ -190,10 +197,16 @@ def get_reduction_dim(dep: MemoryDep, out_coords: list) -> sympy.Symbol:
     return _lone_sym(reduction_coord)
 
 
+@dataclasses.dataclass
+class _DimPropInfo:
+    named_dims: list = dataclasses.field(default_factory=list)
+    reduction_named_dims: list | None = None
+    loop_var_dims: dict = dataclasses.field(default_factory=dict)
+    loop_var_to_ranges_idx: dict = dataclasses.field(default_factory=dict)
+
+
 def _set_no_named_dims(op):
-    op.named_dims = []
-    op.reduction_named_dims = None
-    op.loop_var_dims = {}
+    op._dim_prop_info = _DimPropInfo()  # type: ignore[attr-defined]
 
 
 def _compute_named_dims(op, inputs):
@@ -211,20 +224,23 @@ def _compute_named_dims(op, inputs):
                     size = int(output_dep.ranges[sym])
                     loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
     named_dims = coords_to_named_dims(out_coords, loop_var_dims)
-    op.named_dims = named_dims
-    op.loop_var_dims = loop_var_dims
-    if isinstance(op.data, Reduction):
-        op.reduction_named_dims = loop_var_dims[
-            get_reduction_dim(inputs[0], out_coords)
-        ]
-    else:
-        op.reduction_named_dims = None
+    op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
+        named_dims=named_dims,
+        loop_var_dims=loop_var_dims,
+        loop_var_to_ranges_idx={
+            _lone_sym(c): i for i, c in enumerate(out_coords) if c.free_symbols
+        },
+        reduction_named_dims=loop_var_dims[get_reduction_dim(inputs[0], out_coords)]
+        if isinstance(op.data, Reduction)
+        else None,
+    )
 
 
 def _log_dep_debug(label: str, dep: MemoryDep) -> None:
     buf = V.graph.get_buffer(dep.name)
     layout = buf.get_layout() if hasattr(buf, "get_layout") else None
-    named_dims = getattr(buf, "named_dims", "?")
+    dp = getattr(buf, "_dim_prop_info", None)
+    named_dims = dp.named_dims if dp is not None else []
     logger.debug(f"  {label} {dep.name}: named_dims={named_dims}")
     if layout is not None:
         logger.debug(
@@ -255,7 +271,8 @@ def _log_op_inputs(op: ComputedBuffer) -> None:
 def _log_op(op: Operation) -> None:
     origins: set = getattr(getattr(op, "data", op), "origins", set())
     aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
-    if not hasattr(op, "loop_var_dims") or not op.loop_var_dims:
+    dp = getattr(op, "_dim_prop_info", None)
+    if dp is None or not dp.loop_var_dims:
         logger.info(
             f"  {op.get_operation_name()}: skipped"
             f" ({type(op).__name__} / {type(getattr(op, 'data', op)).__name__})"
@@ -264,8 +281,7 @@ def _log_op(op: Operation) -> None:
         if isinstance(op, ComputedBuffer):
             _log_op_inputs(op)
             logger.info(
-                f"    output: ({op.get_name()})"
-                f" named_dims={getattr(op, 'named_dims', '?')}"
+                f"    output: ({op.get_name()}) named_dims={dp.named_dims if dp else []}"
             )
         return
     is_reduction = isinstance(op.data, Reduction)
@@ -282,15 +298,15 @@ def _log_op(op: Operation) -> None:
     for dep in list(rw.reads) + list(rw.writes):
         if isinstance(dep, MemoryDep):
             ranges.update({str(s): int(v) for s, v in dep.ranges.items()})
-    for sym, names in op.loop_var_dims.items():
+    for sym, names in dp.loop_var_dims.items():
         sym_range: int | str = ranges.get(str(sym), "?")
         declared = [f"{n}={_named_dims[n] if n in _named_dims else '?'}" for n in names]
         logger.info(
             f"      {sym}: range={sym_range}  named_dim(s)={names}  declared={declared}"
         )
     if is_reduction:
-        logger.info(f"    reduction over: {op.reduction_named_dims}")
-    logger.info(f"    output: ({op.get_name()}) named_dims={op.named_dims}")
+        logger.info(f"    reduction over: {dp.reduction_named_dims}")
+    logger.info(f"    output: ({op.get_name()}) named_dims={dp.named_dims}")
     logger.info("")
 
 
@@ -315,11 +331,13 @@ def propagate_named_dims(
                 layout = tb.data.data.layout
                 if not isinstance(layout, FixedLayout):
                     raise Unsupported(f"graph input {name} does not have a FixedLayout")
-                tb.named_dims = _named_tensor_dims.get(real_input)
+                tb._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
+                    named_dims=_named_tensor_dims.get(real_input) or []
+                )
 
     for op in operations:
         if op.is_no_op():
-            op.named_dims = []
+            _set_no_named_dims(op)
         elif isinstance(op, ComputedBuffer):
             if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
                 continue
@@ -355,8 +373,144 @@ def propagate_named_dims(
     for name in V.graph.graph_input_names:
         tb = V.graph.graph_inputs[name]
         if isinstance(tb, TensorBox):
-            logger.info(f"  {name}: named_dims={tb.named_dims}")
+            dp = getattr(tb, "_dim_prop_info", None)
+            logger.info(f"  {name}: named_dims={dp.named_dims if dp else []}")
 
     logger.info("OPS")
     for op in operations:
         _log_op(op)
+
+
+def _get_hint_scopes(op) -> list[dict[str, int]]:
+    """Return hint scopes the op is inside, outermost first (sorted by hint ID).
+
+    Each entry is {dim_name: split_count} for one spyre_hint() scope.
+    """
+    scopes = []
+    for _, hint_dict in sorted(get_op_hints(op).items()):
+        scope: dict[str, int] = {}
+        for key in ("tiles", "slices"):
+            if isinstance(hint_dict.get(key), dict):
+                scope.update(hint_dict[key])
+        if scope:
+            scopes.append(scope)
+    return scopes
+
+
+def assign_dim_hints(operations: list[Operation]) -> None:
+    """Combine spyre_hint scope annotations with propagated named dimensions.
+
+    Reads the hint scopes (from spyre_hint() context managers in user code,
+    attached to FX nodes via meta["custom"]) and matches hinted dimension names
+    against the named loop variables on each op.  The named loop variables come
+    from propagate_named_dims(), which propagates name_tensor_dims() annotations
+    through the op graph — that pass must run before this one.
+
+    Produces op.dim_hints: a flat list of DimHint, one per hinted dimension,
+    ordered outermost hint scope first.  Consumed by hints_to_coarse_tile_groups
+    to form coarse tiling groups.
+
+    Deletes op._dim_prop_info when done — those fields are only needed here.
+    """
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        dp = getattr(op, "_dim_prop_info", None)
+        if dp is None:
+            op.dim_hints = []  # type: ignore[attr-defined]
+            continue
+        if not dp.loop_var_dims:
+            op.dim_hints = []  # type: ignore[attr-defined]
+            del op._dim_prop_info  # type: ignore[attr-defined]
+            continue
+        levels = _get_hint_scopes(op)
+        if not levels:
+            op.dim_hints = []  # type: ignore[attr-defined]
+            del op._dim_prop_info  # type: ignore[attr-defined]
+            continue
+
+        hint_id_map = {
+            hint_id: hint_dict
+            for hint_id, hint_dict in sorted(get_op_hints(op).items())
+        }
+        dim_to_level: dict[str, tuple[int, int, int]] = {}
+        for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
+            for key in ("tiles", "slices"):
+                for name, count in (hint_dict.get(key) or {}).items():
+                    dim_to_level[name] = (count, level_idx, hint_id)
+
+        rw = op.get_read_writes()
+        all_ranges = {
+            s: int(v) for dep in [*rw.reads, *rw.writes] for s, v in dep.ranges.items()
+        }
+        reduction_dims = set(dp.reduction_named_dims or [])
+        loop_var_dims = dp.loop_var_dims
+        loop_var_to_ranges_idx = dp.loop_var_to_ranges_idx
+
+        unsorted: list[tuple[int, int, DimHint]] = []
+        for i, sym in enumerate(loop_var_dims):
+            nd = named_dims_for_sym(op, sym)
+            hinted_names = [name for name, _ in nd if name in dim_to_level]
+            if not hinted_names:
+                continue
+            split_count, level_idx, hint_id = dim_to_level[hinted_names[0]]
+            ranges_idx = loop_var_to_ranges_idx.get(sym, i)
+            unsorted.append(
+                (
+                    level_idx,
+                    i,
+                    DimHint(
+                        dim_names=hinted_names,
+                        range_size=all_ranges.get(sym, 0),
+                        split_count=split_count,
+                        dim_index=ranges_idx,
+                        is_reduction=any(
+                            name in reduction_dims for name in hinted_names
+                        ),
+                        hint_id=hint_id,
+                    ),
+                )
+            )
+        op.dim_hints = [h for _, _, h in sorted(unsorted)]  # type: ignore[attr-defined]
+
+        matched_hint_ids = {h.hint_id for h in op.dim_hints}
+        for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
+            if hint_id in matched_hint_ids:
+                continue
+            for key in ("tiles", "slices"):
+                dims = hint_dict.get(key) or {}
+                if dims:
+                    name, count = next(iter(dims.items()))
+                    op.dim_hints.append(
+                        DimHint(
+                            dim_names=[name],
+                            range_size=0,
+                            split_count=count,
+                            dim_index=None,
+                            is_reduction=False,
+                            hint_id=hint_id,
+                        )
+                    )
+                    break
+
+        # Clean up temp intermediates — only dim_hints persists.
+        del op._dim_prop_info  # type: ignore[attr-defined]
+
+    if hints_logger.isEnabledFor(logging.INFO):
+        ops = [
+            op
+            for op in operations
+            if isinstance(op, ComputedBuffer) and getattr(op, "dim_hints", None)
+        ]
+        if ops:
+            hints_logger.info("=== assign_dim_hints ===")
+            for op in ops:
+                hints_logger.info(f"{op.get_operation_name()}:")
+                for h in op.dim_hints:
+                    per_tile = h.range_size // h.split_count if h.range_size else "?"
+                    reduction_tag = "  [reduction]" if h.is_reduction else ""
+                    hints_logger.info(
+                        f"  {h.dim_names}  range={h.range_size}"
+                        f"  split_count={h.split_count}  -> {per_tile} per tile"
+                        f"  dim_index={h.dim_index}{reduction_tag}"
+                    )

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -441,14 +441,16 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
         else:
             if current_ops and current_key is not None:
                 spec = _group_spec(_find_spec_op(current_ops).spyre_hints)
-                groups.append((current_ops, spec))
+                if spec:
+                    groups.append((current_ops, spec))
             current_ops = [op] if key is not None else []
             current_key = key
 
     # Flush the final group.
     if current_ops and current_key is not None:
         spec = _group_spec(_find_spec_op(current_ops).spyre_hints)
-        groups.append((current_ops, spec))
+        if spec:
+            groups.append((current_ops, spec))
 
     if hints_logger.isEnabledFor(logging.INFO):
         # Build an interleaved view: walk operations in order, emit group boundaries

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -28,7 +28,6 @@ from torch._inductor.pattern_matcher import (
 from .logging_utils import get_inductor_logger
 from .propagate_hints import get_op_hints, DimHint
 from .pass_utils import copy_fx_custom_meta
-from .propagate_named_dims import named_dims_for_sym
 
 aten = torch.ops.aten
 
@@ -260,141 +259,16 @@ def _unflatten_bmm_batch_dims(
                 graph.erase_node(expand_node)
 
 
-def _hint_levels(op) -> list[dict[str, int]]:
-    """Return per-level split counts, outermost first (sorted by hint ID).
+def _group_spec(dim_hints: list[DimHint]) -> list[tuple]:
+    """Build the coarse_tile() spec from op.dim_hints.
 
-    Each entry is {dim_name: split_count} for one hint scope. Outer hint IDs
-    are smaller than inner hint IDs (guaranteed by spyre_hint counter order).
-    """
-    levels = []
-    for _, hint_dict in sorted(get_op_hints(op).items()):
-        level: dict[str, int] = {}
-        for key in ("tiles", "slices"):
-            if isinstance(hint_dict.get(key), dict):
-                level.update(hint_dict[key])
-        if level:
-            levels.append(level)
-    return levels
-
-
-def assign_dim_hints(operations: list[Operation]) -> None:
-    """Resolve spyre_hint annotations into DimHint and stamp onto each op.
-
-    For each op, reads the hint scopes attached to its FX origins, matches the
-    hinted dimension names against the op's named loop variables, and builds
-    op.spyre_hints: a flat list of DimHint, one per hinted dimension, ordered
-    outermost hint scope first.
-    """
-    for op in operations:
-        if not isinstance(op, ComputedBuffer) or not getattr(op, "loop_var_dims", None):
-            continue
-        levels = _hint_levels(op)
-        if not levels:
-            op.spyre_hints = []
-            continue
-
-        # Build a flat lookup from dimension name to (split_count, level_idx, hint_id)
-        # so we can quickly resolve each loop variable below.
-        hint_id_map = {
-            hint_id: hint_dict
-            for hint_id, hint_dict in sorted(get_op_hints(op).items())
-        }
-        dim_to_level: dict[str, tuple[int, int, int]] = {}
-        for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
-            for key in ("tiles", "slices"):
-                for name, count in (hint_dict.get(key) or {}).items():
-                    dim_to_level[name] = (count, level_idx, hint_id)
-
-        rw = op.get_read_writes()
-        # Collect the full iteration range for each loop symbol from the
-        # read/write index expressions.
-        all_ranges = {
-            s: int(v) for dep in [*rw.reads, *rw.writes] for s, v in dep.ranges.items()
-        }
-        reduction_dims = set(op.reduction_named_dims or [])
-
-        # Walk the op's loop variables in order.  For each one, check whether
-        # any of its named dimensions appear in a hint scope.  If so, create a
-        # DimHint.  Collect into a flat list keyed by (level_idx, loop_var_idx)
-        # so we can sort outermost-first after the walk.
-        unsorted: list[tuple[int, int, DimHint]] = []
-        for i, sym in enumerate(op.loop_var_dims):
-            nd = named_dims_for_sym(op, sym)
-            hinted_names = [name for name, _ in nd if name in dim_to_level]
-            if not hinted_names:
-                continue
-            split_count, level_idx, hint_id = dim_to_level[hinted_names[0]]
-            unsorted.append(
-                (
-                    level_idx,
-                    i,
-                    DimHint(
-                        dim_names=hinted_names,
-                        range_size=all_ranges.get(sym, 0),
-                        split_count=split_count,
-                        dim_index=i,
-                        is_reduction=any(
-                            name in reduction_dims for name in hinted_names
-                        ),
-                        hint_id=hint_id,
-                    ),
-                )
-            )
-        op.spyre_hints = [h for _, _, h in sorted(unsorted)]
-
-        # For every hint scope the op is inside but has no matching dim,
-        # add a sentinel DimHint so the op's hint_id set is complete and
-        # grouping by hint ID correctly places it with its peers.
-        matched_hint_ids = {h.hint_id for h in op.spyre_hints}
-        for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
-            if hint_id in matched_hint_ids:
-                continue
-            for key in ("tiles", "slices"):
-                dims = hint_dict.get(key) or {}
-                if dims:
-                    name, count = next(iter(dims.items()))
-                    op.spyre_hints.append(
-                        DimHint(
-                            dim_names=[name],
-                            range_size=0,
-                            split_count=count,
-                            dim_index=0,
-                            is_reduction=False,
-                            hint_id=hint_id,
-                        )
-                    )
-                    break
-
-    if hints_logger.isEnabledFor(logging.INFO):
-        ops = [
-            op
-            for op in operations
-            if isinstance(op, ComputedBuffer) and getattr(op, "spyre_hints", None)
-        ]
-        if ops:
-            hints_logger.info("=== assign_dim_hints ===")
-            for op in ops:
-                hints_logger.info(f"{op.get_operation_name()}:")
-                for h in op.spyre_hints:
-                    per_tile = h.range_size // h.split_count if h.range_size else "?"
-                    reduction_tag = "  [reduction]" if h.is_reduction else ""
-                    hints_logger.info(
-                        f"  {h.dim_names}  range={h.range_size}"
-                        f"  split_count={h.split_count}  -> {per_tile} per tile"
-                        f"  dim_index={h.dim_index}{reduction_tag}"
-                    )
-
-
-def _group_spec(spyre_hints: list[DimHint]) -> list[tuple]:
-    """Build the coarse_tile() spec from op.spyre_hints.
-
-    Returns a list of (K, tiled_dims) tuples, one per hinted dim, outermost
-    first.  Reduction dims are excluded — coarse tiling only tiles compute dims.
+    Returns a list of (hint_id, K, tiled_dims) tuples, one per hinted dim,
+    outermost first.  Reduction dims are excluded.
     """
     return [
-        (sympy.Integer(h.split_count), [h.dim_index])
-        for h in spyre_hints
-        if not h.is_reduction and h.range_size != 0
+        (h.hint_id, sympy.Integer(h.split_count), [h.dim_index])
+        for h in dim_hints
+        if not h.is_reduction and h.dim_index is not None
     ]
 
 
@@ -404,14 +278,14 @@ def _find_spec_op(ops: list[Operation]) -> Operation:
         (
             o
             for o in ops
-            if any(h.range_size != 0 for h in getattr(o, "spyre_hints", []))
+            if any(h.dim_index is not None for h in getattr(o, "dim_hints", []))
         ),
         ops[0],
     )
 
 
 def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
-    """Build coarse_tile() groups from op.spyre_hints (set by assign_dim_hints).
+    """Build coarse_tile() groups from op.dim_hints (set by assign_dim_hints).
 
     coarse_tile() requires ops to be grouped: all ops in a group share the same
     tiling spec and are tiled together inside the same loop nest.  We walk
@@ -421,7 +295,7 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
     """
 
     def _key(op):
-        resolved = getattr(op, "spyre_hints", [])
+        resolved = getattr(op, "dim_hints", [])
         if not resolved:
             return None
         # Key on the set of hint IDs — ops inside the same hint scope(s) group together.
@@ -440,7 +314,7 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
             current_ops.append(op)
         else:
             if current_ops and current_key is not None:
-                spec = _group_spec(_find_spec_op(current_ops).spyre_hints)
+                spec = _group_spec(_find_spec_op(current_ops).dim_hints)
                 if spec:
                     groups.append((current_ops, spec))
             current_ops = [op] if key is not None else []
@@ -448,7 +322,7 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
 
     # Flush the final group.
     if current_ops and current_key is not None:
-        spec = _group_spec(_find_spec_op(current_ops).spyre_hints)
+        spec = _group_spec(_find_spec_op(current_ops).dim_hints)
         if spec:
             groups.append((current_ops, spec))
 
@@ -464,7 +338,7 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
                 continue
             g_idx = grouped_to_group_idx.get(id(o))
             if g_idx is None:
-                hints = getattr(o, "spyre_hints", [])
+                hints = getattr(o, "dim_hints", [])
                 if hints:
                     ids = sorted({h.hint_id for h in hints})
                     reason = f"hint_ids={ids}"
@@ -482,7 +356,7 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
                     group_ops = groups[g_idx][0]
                     spec_op = _find_spec_op(group_ops)
                     hint_ids = sorted(
-                        {h.hint_id for h in getattr(spec_op, "spyre_hints", [])}
+                        {h.hint_id for h in getattr(spec_op, "dim_hints", [])}
                     )
                     hint_descs = []
                     for hid in hint_ids:
@@ -496,8 +370,8 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
                 # Per-op tiling info.
                 tiling_dims = [
                     f"{h.dim_names}x{h.split_count}"
-                    for h in getattr(o, "spyre_hints", [])
-                    if h.range_size != 0 and not h.is_reduction
+                    for h in getattr(o, "dim_hints", [])
+                    if h.dim_index is not None and not h.is_reduction
                 ]
                 aten_ops = [
                     str(n.target)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:
This PR fixes limitations in coarse tiling to allow the flash attention example to run with two tiled dimensions:  `{"H": 4, "Lk": 2}.

Changes include
- Corner cases in loop unrolling and tiling to handle ops that don't have all the dimensions that are tiled (broadcast)
- Cleanup: Combine number of temp variables being stored on the op into `_dim_prop_info`
- Move `assign_dim_hints` pass out of temp_passes into propagate_named_dims.py because it is no longer temp
- Flash attention test case added
#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/2150
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

full flash driver that passes, and used to generate pytest case
```
import math

import torch
from torch_spyre._inductor import config, spyre_hint
import torch_spyre._inductor.propagate_named_dims as pnd

declare_tensor_dim = pnd.declare_tensor_dim
name_tensor_dims = pnd.name_tensor_dims

torch.manual_seed(0xAFFE)

B, H, Lq, Lk, D = 1, 8, 256, 256, 64
block_size = 128

queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)


def flash(queries, keys, values):
    scale = 1.0 / math.sqrt(math.sqrt(D))

    output = torch.zeros_like(queries)
    M = torch.full(
        (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
    )

    with spyre_hint(slices={"B": 1}):
        with spyre_hint(slices={"H": 4}):
            with spyre_hint(slices={"Lk": Lk // block_size}):
                keys_T = keys.transpose(-1, -2).contiguous()

                denominator = torch.zeros((B, H, Lq), device=queries.device, dtype=torch.float16)
                scores = torch.matmul(queries * scale, keys_T * scale)  # B, H, Lq, Lk
                scores = scores.transpose(-1, -2).contiguous()  # avoid stick reduction: B, H, Lk, Lq
                block_max = torch.amax(scores, dim=-2)  # B, H, Lq
                max_running = torch.maximum(M, block_max)  # B, H, Lq

                exp_scores = torch.exp(
                    scores - max_running.unsqueeze(-2)
                )  # B, H, Lk, Lq
                correction = torch.exp(M - max_running)  # B, H, Lq

                denominator = denominator * correction + exp_scores.sum(dim=-2)  # B, H, Lq
                output = (
                    output * correction.unsqueeze(-1)
                    + torch.matmul(exp_scores.transpose(-1, -2), values)  # B, H, Lq, D
                )
                M = max_running
    return output / denominator.unsqueeze(-1)


# CPU reference
ref = flash(queries_t, keys_t, values_t)

# Device run
queries_dev = queries_t.to("spyre")
keys_dev = keys_t.to("spyre")
values_dev = values_t.to("spyre")

declare_tensor_dim("B", B)
declare_tensor_dim("H", H)
declare_tensor_dim("Lq", Lq)
declare_tensor_dim("Lk", Lk)
declare_tensor_dim("D", D)

name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])  

config.coarse_tiling = True

try:
    result = torch.compile(flash)(queries_dev, keys_dev, values_dev).cpu()
except Exception as e:
    import traceback
    print(f"compile/run failed (expected during group analysis):")
    traceback.print_exc()
    raise SystemExit(0)

print("ref:   ", ref.flatten()[:8])
print("result:", result.flatten()[:8])
print("max abs diff:", torch.abs(ref - result).amax().item())

torch.testing.assert_close(
    result,
    ref,
    equal_nan=True,
    atol=1.0,
    rtol=0.1,
    msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
)
print("PASSED")

````
