### PR TITLE
Disable backgap / offsets for lx tensors

### DIFF
--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -397,7 +397,9 @@ def _create_sdsc_tensors(
                 data_format=arg_data_format,
                 scales=scales,
                 strides=strides,
-                offsets=offsets,
+                offsets=offsets
+                if "lx" not in arg.allocation
+                else {},  # TODO: handle lx offsets
                 max_dim_sizes=max_dim_sizes,
                 allocation=arg.allocation,
                 start_address=arg.allocation.get("pool")
@@ -405,7 +407,9 @@ def _create_sdsc_tensors(
                 else arg.allocation.get("lx")
                 if "lx" in arg.allocation
                 else arg.allocation.get("hbm"),
-                backGap=backGap,
+                backGap=backGap
+                if "lx" not in arg.allocation
+                else {},  # TODO: handle lx backgaps
             )
         )
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR disables the backGaps / offsets lx tensors. Due to backend bugs and differences in handling from hbm, this currently breaks.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
