### PR TITLE
refactor: move build_loop_scheduler_nodes to CustomPreFusionPasses

### DIFF
--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -210,9 +210,9 @@ class CustomPreFusionPasses(CustomNodePassBase):
     def get_passes(self):
         # build_loop_scheduler_nodes runs unconditionally: it is a no-op when
         # coarse_tiling=False because no nodes carry loop_group_id attributes.
-        # Running here (before any fusion) ensures CountedLoopSchedulerNode.can_fuse
-        # returning False protects loop groups from both Inductor's own fusion pass
-        # and spyre_fuse_nodes.
+        # Running here (before Inductor's fusion pass) ensures CountedLoopSchedulerNodes
+        # are visible to SuperDSCScheduling.can_fuse_vertical/horizontal (which return
+        # False), so loop groups survive Inductor fusion intact.
         return [propagate_mutation_layouts, build_loop_scheduler_nodes]
 
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -208,7 +208,12 @@ class CustomPreFusionPasses(CustomNodePassBase):
     """
 
     def get_passes(self):
-        return [propagate_mutation_layouts]
+        # build_loop_scheduler_nodes runs unconditionally: it is a no-op when
+        # coarse_tiling=False because no nodes carry loop_group_id attributes.
+        # Running here (before any fusion) ensures CountedLoopSchedulerNode.can_fuse
+        # returning False protects loop groups from both Inductor's own fusion pass
+        # and spyre_fuse_nodes.
+        return [propagate_mutation_layouts, build_loop_scheduler_nodes]
 
 
 class CustomPostFusionPasses(CustomNodePassBase):
@@ -221,9 +226,7 @@ class CustomPostFusionPasses(CustomNodePassBase):
     """
 
     def get_passes(self):
-        # build_loop_scheduler_nodes runs unconditionally: it is a no-op when
-        # coarse_tiling=False because no nodes carry loop_group_id attributes.
-        return [memory_planning, build_loop_scheduler_nodes, spyre_fuse_nodes]
+        return [memory_planning, spyre_fuse_nodes]
 
 
 class CustomPreSchedulingPasses(CustomGraphPass):

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -218,9 +218,11 @@ def build_loop_scheduler_nodes(
     a data-flow dependency crossing the group boundary, which is a bug in
     the tiling pass.
 
-    Running before any fusion ensures CountedLoopSchedulerNode.can_fuse returning
-    False protects loop groups from both Inductor's own fusion pass and
-    spyre_fuse_nodes.
+    Running before Inductor's fusion pass ensures CountedLoopSchedulerNodes are
+    visible to SuperDSCScheduling.can_fuse_vertical/horizontal (which return False),
+    so loop groups survive Inductor fusion intact.  spyre_fuse_nodes is separately
+    protected because it only fuses plain SchedulerNodes (isinstance check), causing
+    CountedLoopSchedulerNodes to force a bundle boundary.
     """
     result = _build_loop_group(nodes, depth=0)
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -206,7 +206,7 @@ def _build_loop_group(
 def build_loop_scheduler_nodes(
     nodes: list[BaseSchedulerNode],
 ) -> list[BaseSchedulerNode]:
-    """Post-fusion pass: wrap loop-group SchedulerNodes into CountedLoopSchedulerNodes.
+    """Pre-fusion pass: wrap loop-group SchedulerNodes into CountedLoopSchedulerNodes.
 
     Reads loop_group_id and loop_count attributes stamped on ir.Operation
     objects by the coarse-tiling IR pass.  Nodes without these attributes
@@ -218,9 +218,9 @@ def build_loop_scheduler_nodes(
     a data-flow dependency crossing the group boundary, which is a bug in
     the tiling pass.
 
-    This pass runs before spyre_fuse_nodes so that CountedLoopSchedulerNodes
-    are already formed before fusion; CountedLoopSchedulerNode.can_fuse returns
-    False, which prevents the loop groups from being merged by the fusion pass.
+    Running before any fusion ensures CountedLoopSchedulerNode.can_fuse returning
+    False protects loop groups from both Inductor's own fusion pass and
+    spyre_fuse_nodes.
     """
     result = _build_loop_group(nodes, depth=0)
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Moves build_loop_scheduler_nodes to CustomPreFusionPasses. 
Running before any fusion is more robust: CountedLoopSchedulerNode.can_fuse returning False now protects loop groups from both Inductor's own fusion pass and spyre_fuse_nodes, rather than only the latter.

#### Which issue(s) this PR is related to:

Part of #1358 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
