### PR TITLE
test(ppc64): add options to skip prohibitively slow tests on PowerPC 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ module = ["torch_spyre._inductor.*"]
 disable_error_code = ["attr-defined"]
 
 [tool.pytest.ini_options]
+markers = [
+    "spyre_slow_on_ppc64: tests that are prohibitively slow on PowerPC",
+]
 filterwarnings = [
     # PyTorch 2.10.0+: Suppress torch.jit.script_method DeprecationWarning triggered by
     # importing torch._inductor.compile_fx (which transitively imports torch.utils.mkldnn).
@@ -95,6 +98,9 @@ filterwarnings = [
     "ignore::DeprecationWarning:torch.jit._script",
 ]
 norecursedirs = ['tests/models']
+addopts = [
+    "-m", "not spyre_slow_on_ppc64",
+]
 
 [tool.uv]
 required-version = ">=0.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ disable_error_code = ["attr-defined"]
 
 [tool.pytest.ini_options]
 markers = [
-    "spyre_slow_on_ppc64: tests that are prohibitively slow on PowerPC",
+    "longrunning_on_ppc64: tests that are prohibitively slow on PowerPC",
 ]
 filterwarnings = [
     # PyTorch 2.10.0+: Suppress torch.jit.script_method DeprecationWarning triggered by
@@ -99,7 +99,7 @@ filterwarnings = [
 ]
 norecursedirs = ['tests/models']
 addopts = [
-    "-m", "not spyre_slow_on_ppc64",
+    "-m", "not longrunning_on_ppc64",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ filterwarnings = [
     # importing torch._inductor.compile_fx (which transitively imports torch.utils.mkldnn).
     # https://github.com/pytorch/pytorch/blob/v2.11.0/torch/jit/_script.py#L366
     "ignore::DeprecationWarning:torch.jit._script",
+    # pytest 9: upstream PyTorch conftest.py still uses the deprecated py.path.local
+    # signature for hooks Suppress until PyTorch updates.
+    # we have pinned to pytest~=9.0.0, the warning may have become a hard error in pytest 9.
+    "ignore::pytest.PytestRemovedIn9Warning",
 ]
 norecursedirs = ['tests/models']
 addopts = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -400,7 +400,7 @@ def pytest_collection_modifyitems(config, items):
     # ── Mark slow tests on PowerPC ──
     # Large matmul tests are prohibitively slow on PowerPC (hardware
     # completion latency + large tensor sizes). Skip them via the
-    # spyre_slow_on_ppc64 marker so they still run on x86.
+    # longrunning_on_ppc64 marker so they still run on x86.
     if platform.machine().startswith("ppc64"):
         slow_on_ppc64_patterns = [
             "test_large_matmul",
@@ -409,7 +409,7 @@ def pytest_collection_modifyitems(config, items):
             for pattern in slow_on_ppc64_patterns:
                 if pattern in item.nodeid:
                     item.add_marker(
-                        pytest.mark.spyre_slow_on_ppc64(
+                        pytest.mark.longrunning_on_ppc64(
                             reason=f"slow on {platform.machine()}"
                         )
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 
 import os
 from pathlib import Path
+import platform
 import yaml
 import pytest
 
@@ -396,6 +397,23 @@ def pytest_collection_modifyitems(config, items):
         ignored_files = {
             "tests/test_modules_custom.py",
         }
+    # ── Mark slow tests on PowerPC ──
+    # Large matmul tests are prohibitively slow on PowerPC (hardware
+    # completion latency + large tensor sizes). Skip them via the
+    # spyre_slow_on_ppc64 marker so they still run on x86.
+    if platform.machine().startswith("ppc64"):
+        slow_on_ppc64_patterns = [
+            "test_large_matmul",
+        ]
+        for item in items:
+            for pattern in slow_on_ppc64_patterns:
+                if pattern in item.nodeid:
+                    item.add_marker(
+                        pytest.mark.spyre_slow_on_ppc64(
+                            reason=f"slow on {platform.machine()}"
+                        )
+                    )
+                    break
 
     selected_models = config.getoption("--model") or []
     if not selected_models:

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -525,7 +525,7 @@ def analyze(path):
         tree = ast.parse(source, filename=path)
     except SyntaxError as e:
         print(json.dumps({"error": f"SyntaxError: {e}"})); return
-    
+
     # Pre-scan for names assigned from parametrize(...) calls (e.g. parametrize_unary_ufuncs).
     # These are used as decorators and must be recognised as equivalent to @parametrize.
     parametrize_names = _get_parametrize_names(tree)
@@ -888,7 +888,7 @@ if '${cls}' in globals():
 #     privateuse1/spyre. Re-injected here WITHOUT only_for so TorchTestBase
 #     can generate the spyre variant and control it via the YAML config.
 # Classes with no 'device' arg are safe when YAML mode is 'skip'.
- 
+
 import sys as _sys, os as _os
 _sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
 
@@ -937,7 +937,7 @@ _restricted_names = set([${quoted_restricted_list}])
 def _do_pre_import():
     """Capture original class objects before the star-import deletes them."""
     import torch.testing._internal.common_device_type as _cdtype
-    
+
     real_fn = _cdtype.instantiate_device_type_tests
 
     def _capturing_instantiate(cls, *args, **kwargs):
@@ -1360,8 +1360,11 @@ _run_pytest_isolated() {
             rm -rf "${_LOGDIR}"
         else
             echo "[torch_oot_device_tests_run] Running serial test"
-            # Regular pytest for non-distributed tests
-            python3 -m pytest "$_base" "${_args[@]}"
+            # Regular pytest for non-distributed tests.
+            # Pass -c explicitly so pytest picks up torch-spyre's
+            # pyproject.toml (markers, addopts, filterwarnings, etc.)
+            # even though we cd'd into the test file's directory.
+            python3 -m pytest -c "${TORCH_DEVICE_ROOT}/pyproject.toml" "$_base" "${_args[@]}"
             echo $? > "$_exit_tmp"
         fi
     ) || true
@@ -1483,7 +1486,7 @@ for i in "${!RUN_FILES[@]}"; do
     # so conftest.py files are discovered correctly.
     #
     # If the probe finds 0 matching tests (exit code 5) the -m flag is stripped
-    # from _FILE_PYTEST_ARGS so the file's tests all run normally. 
+    # from _FILE_PYTEST_ARGS so the file's tests all run normally.
     # the marker filter applies to files that USE that marker
     # family; files that don't use it are unaffected.
     #


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Current `make tests` and `pytests tests` don't work properly on PowerPC. 

Large matmul tests are prohibitively slow on PowerPC hardware. Add a pytest marker `spyre_slow_on_ppc64` that auto-applies on ppc64 platforms, and configure pytest to skip marked tests by default. 

The config in tests/conftest.py is not picked up by current `make tests` - make tests run each tests in a sub-folder. This is fixed so the marker config is always picked up.

Minor trailing whitespace cleanup in run_test.sh.


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:

An issue is created for tracking this: https://github.com/torch-spyre/torch-spyre/issues/2392