### PR TITLE
Fix decomposition race condition for fallback ops in CI

### DIFF
--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -139,7 +139,10 @@ def enable_spyre_compile_fx_wrapper():
 
 def _light_autoload():
     from . import decompositions  # noqa: F401
+    from .patches import _patch_make_fallback_for_spyre
 
+    # Patch Inductor's make_fallback before any compilation occurs.
+    _patch_make_fallback_for_spyre()
     enable_spyre_compile_fx_wrapper()
 
 

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -145,7 +145,8 @@ def enable_spyre_decompositions(
         from torch_spyre.ops.fallbacks import fallback_ops
         from torch._ops import OpOverload, OpOverloadPacket
 
-        # Helper function to remove ops from decompositions
+        # Helper function to remove ops from decompositions.
+        # Object identity may fail across imports; fallback to string comparison.
         def _fetch_and_remove_op(ops):
             _removed = {}
             for op in ops:
@@ -155,10 +156,22 @@ def enable_spyre_decompositions(
                         op_ret = decomps.pop(opo, None)
                         if op_ret is not None:
                             _removed[opo] = op_ret
+                        else:
+                            opo_str = str(opo)
+                            for key in list(decomps.keys()):
+                                if str(key) == opo_str:
+                                    _removed[key] = decomps.pop(key)
+                                    break
                 elif isinstance(op, OpOverload):
                     op_ret = decomps.pop(op, None)
                     if op_ret is not None:
                         _removed[op] = op_ret
+                    else:
+                        op_str = str(op)
+                        for key in list(decomps.keys()):
+                            if str(key) == op_str:
+                                _removed[key] = decomps.pop(key)
+                                break
             return _removed
 
         # 1. Add/override spyre-specific decompositions

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -136,3 +136,30 @@ def enable_spyre_context(
             joint_graph.pass_patterns[:] = origin_pass
             Loops.has_large_inner_fn = old_loop
             GraphLowering._update_scheduler = old_update_scheduler  # type: ignore[method-assign]
+
+
+def _patch_make_fallback_for_spyre():
+    # Inductor raises AssertionError in CI when both a PyTorch decomposition and a Spyre
+    # fallback exist for the same op. Force override_decomp=True to bypass this check and
+    # prefer Spyre fallbacks. This race condition happens on all platforms but surfaces
+    # as an error in CI (env CI=true), particularly on s390x.
+    from torch._inductor import lowering, graph
+    from torch_spyre.ops.fallbacks import fallback_ops
+
+    _orig_make_fallback = lowering.make_fallback
+
+    def _patched_make_fallback(
+        op, layout_constraint=None, warn=True, override_decomp=False
+    ):
+        if op in fallback_ops:
+            override_decomp = True
+        return _orig_make_fallback(
+            op,
+            layout_constraint=layout_constraint,
+            warn=warn,
+            override_decomp=override_decomp,
+        )
+
+    lowering.make_fallback = _patched_make_fallback
+    if hasattr(graph, "make_fallback"):
+        graph.make_fallback = _patched_make_fallback


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

  ### Problem
  Inductor raises `AssertionError` in CI when both a PyTorch decomposition and a Spyre fallback kernel exist for the same operator (e.g., `sin`, `cos`). This error only surfaces in CI (`CI=true`) and is triggered more frequently on s390x, but the race condition itself occurs on all platforms.

  ### Solution
  - Patch `lowering.make_fallback()` to force `override_decomp=True` for all ops in Spyre's fallback list, telling Inductor to use our fallback kernels instead of PyTorch decompositions
  - Improve decomposition removal logic to handle object identity mismatches (e.g., across imports or platforms) by falling back to string comparison
  - Call the patch early during `_light_autoload()` before any compilation occurs

  ### Changes
  - **patches.py**: Add `_patch_make_fallback_for_spyre()` to patch Inductor's `make_fallback()` function
  - **__init__.py**: Call the patch during `_light_autoload()`
  - **decompositions.py**: Improve decomposition removal with string comparison fallback

  ### Testing
  - The 48 tests are now passes in CI on s390x


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/2394

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
