### PR TITLE
Add alternative hint name: num_tiles_per_dim

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -837,7 +837,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         x = torch.randn(B, D, dtype=torch.float16)
 
         def softmax_fn(x):
-            with spyre_hint(slices={"B": 4}):
+            with spyre_hint(tiles={"B": 4}):
                 max_val = x.amax(dim=-1, keepdim=True)
                 x_shifted = x - max_val
                 exp_x = x_shifted.exp()
@@ -895,7 +895,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
         def fn(a, b, c):
             with spyre_hint(slices={"A": 2}):
-                with spyre_hint(slices={"B": 4}):
+                with spyre_hint(num_tiles_per_dim={"B": 4}):
                     y = a + b
                     z = y * c
                     return z

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -389,7 +389,7 @@ def _get_hint_scopes(op) -> list[dict[str, int]]:
     scopes = []
     for _, hint_dict in sorted(get_op_hints(op).items()):
         scope: dict[str, int] = {}
-        for key in ("tiles", "slices"):
+        for key in ("tiles", "slices", "num_tiles_per_dim"):
             if isinstance(hint_dict.get(key), dict):
                 scope.update(hint_dict[key])
         if scope:
@@ -435,7 +435,7 @@ def assign_dim_hints(operations: list[Operation]) -> None:
         }
         dim_to_level: dict[str, tuple[int, int, int]] = {}
         for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
-            for key in ("tiles", "slices"):
+            for key in ("tiles", "slices", "num_tiles_per_dim"):
                 for name, count in (hint_dict.get(key) or {}).items():
                     dim_to_level[name] = (count, level_idx, hint_id)
 
@@ -477,7 +477,7 @@ def assign_dim_hints(operations: list[Operation]) -> None:
         for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
             if hint_id in matched_hint_ids:
                 continue
-            for key in ("tiles", "slices"):
+            for key in ("tiles", "slices", "num_tiles_per_dim"):
                 dims = hint_dict.get(key) or {}
                 if dims:
                     name, count = next(iter(dims.items()))


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] feature

#### What this PR does:

This PR adds support for `num_tiles_per_dim ` in for example `spyre_hint(num_tiles_per_dim={"D": 4})` for better readability.

#### Which issue(s) this PR is related to:

Epic #206.

#### Does this PR introduce a user-facing change?

A new hint keyword `num_tiles_per_hint` that less ambiguous than the existing `slices` and `tiles` keywords.

