### PR TITLE
Add persistent caching for Spyre kernel compilation

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_hash_coverage_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_hash_coverage_config.yaml
@@ -1,0 +1,6 @@
+test_suite_config:
+  labels: [unit, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_hash_coverage.py
+      unlisted_test_mode: mandatory_success
+

--- a/tests/configs/torch_spyre_tests/test_kernel_caching_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_kernel_caching_config.yaml
@@ -1,0 +1,6 @@
+test_suite_config:
+  labels: [unit, regression, integration, trunk]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/test_kernel_caching.py
+      unlisted_test_mode: mandatory_success
+

--- a/tests/inductor/test_hash_coverage.py
+++ b/tests/inductor/test_hash_coverage.py
@@ -1,0 +1,450 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for compute_specs_hash — verifying hash coverage.
+
+Each test class covers one category from the Hash Coverage Table:
+
+  TestLoopSpecTripCount        — LoopSpec.count changes the hash
+  TestSymbolKindTagging        — pool / kernel_slice / kernel_derived offsets change hash
+  TestAffineStridesHashed      — affine_strides (tile byte strides) change hash
+  TestIterationSpaceHashed     — different iter-space sizes → different hash
+  TestOpFuncHashed             — different op names → different hash
+  TestDebugHandleStripped      — debug_handle_ is stripped before hashing
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sympy import Symbol, Integer
+
+
+def _make_tensor_arg(
+    is_input: bool,
+    arg_index: int,
+    size: int = 64,
+    hbm_addr: int | None = None,
+):
+    """Return a minimal TensorArg-like namespace."""
+    from torch_spyre._C import DataFormats, ElementArrangement
+
+    if hbm_addr is None:
+        hbm_addr = arg_index
+
+    ta = MagicMock()
+    ta.is_input = is_input
+    ta.arg_index = arg_index
+    ta.device_dtype = DataFormats.IEEE_FP16
+    ta.device_size = [1, size, 1]  # [outer, stick_dim, stick]
+    ta.device_coordinates = [Integer(0), Symbol("c0") % size, Integer(0)]
+    ta.allocation = {"hbm": hbm_addr}
+    ta.device_tile_advance_expr = None
+    ta.element_arrangement = ElementArrangement.STANDARD
+    ta.work_division = None
+    return ta
+
+
+def _make_op_spec(
+    op: str = "add",
+    size: int = 64,
+    hbm_addr_in: int = 0,
+    hbm_addr_out: int = 128,
+    is_reduction: bool = False,
+    tiled_symbols=None,
+    tiled_symbol_trip_counts=None,
+):
+    """Return a minimal OpSpec for a single-input elementwise op."""
+    from torch_spyre._inductor.op_spec import OpSpec, TensorArg
+    from torch_spyre._inductor.core_mapping import derive_operation_mapping
+    from torch_spyre._C import DataFormats
+
+    c0 = Symbol("c0")
+
+    in_arg = TensorArg(
+        is_input=True,
+        arg_index=0,
+        device_dtype=DataFormats.IEEE_FP16,
+        device_size=[1, size, 1],
+        device_coordinates=[Integer(0), c0 % size, Integer(0)],
+        allocation={"hbm": hbm_addr_in},
+    )
+    out_arg = TensorArg(
+        is_input=False,
+        arg_index=1,
+        device_dtype=DataFormats.IEEE_FP16,
+        device_size=[1, size, 1],
+        device_coordinates=[Integer(0), c0 % size, Integer(0)],
+        allocation={"hbm": hbm_addr_out},
+    )
+
+    iteration_space = {c0: (Integer(size), 1)}
+
+    spec = OpSpec(
+        op=op,
+        is_reduction=is_reduction,
+        iteration_space=iteration_space,
+        args=[in_arg, out_arg],
+        op_info={},
+        tiled_symbols=tiled_symbols or [],
+        tiled_symbol_trip_counts=tiled_symbol_trip_counts or {},
+    )
+    # Populate the finalized core mapping — required by compile_op_spec
+    # (upstream added a guard: ValueError if core_id_to_work_slice is None).
+    spec.core_id_to_work_slice = derive_operation_mapping(iteration_space)
+    return spec
+
+
+def _make_loop_spec(count: int, body_op: str = "add", size: int = 64):
+    """Return a minimal LoopSpec wrapping one OpSpec."""
+    from torch_spyre._inductor.op_spec import LoopSpec
+
+    op = _make_op_spec(op=body_op, size=size)
+    return LoopSpec(count=count, body=[op])
+
+
+def _hash(specs, use_symbols: bool = False):
+    """Call compute_specs_hash with the given specs.  Patches version helpers
+    to stable strings so tests are environment-independent.
+    """
+    from torch_spyre.execution.kernel_cache import compute_specs_hash
+
+    with (
+        patch(
+            "torch_spyre.execution.kernel_cache._get_dxp_version",
+            return_value="test-dxp-1.0",
+        ),
+        patch(
+            "torch_spyre.execution.kernel_cache._get_torch_spyre_version",
+            return_value="test-spyre-0.0",
+        ),
+        patch(
+            "torch_spyre._inductor.config.bundle_symbolic_args",
+            use_symbols,
+        ),
+    ):
+        return compute_specs_hash(specs, kernel_name="test_kernel")
+
+
+class TestLoopSpecTripCount(unittest.TestCase):
+    """LoopSpec.count must be part of the hash.  Two loop-wrapped ops that are
+    structurally identical but differ in trip count must produce different keys."""
+
+    def test_different_loop_counts_produce_different_hashes(self):
+        loop_4 = _make_loop_spec(count=4)
+        loop_8 = _make_loop_spec(count=8)
+
+        h4 = _hash([loop_4])
+        h8 = _hash([loop_8])
+
+        self.assertNotEqual(
+            h4,
+            h8,
+            "LoopSpec with count=4 and count=8 must produce different hashes — "
+            "trip count must be included in the hash.",
+        )
+
+    def test_same_loop_count_produces_same_hash(self):
+        loop_a = _make_loop_spec(count=4)
+        loop_b = _make_loop_spec(count=4)
+
+        self.assertEqual(
+            _hash([loop_a]),
+            _hash([loop_b]),
+            "Identical LoopSpec (same count, same body) must produce the same hash.",
+        )
+
+    def test_nested_loop_count_is_hashed(self):
+        """Hash must differ if inner loop count changes even when outer matches."""
+        from torch_spyre._inductor.op_spec import LoopSpec
+
+        op = _make_op_spec()
+        inner_2 = LoopSpec(count=2, body=[op])
+        inner_4 = LoopSpec(count=4, body=[op])
+        outer_a = LoopSpec(count=10, body=[inner_2])
+        outer_b = LoopSpec(count=10, body=[inner_4])
+
+        self.assertNotEqual(
+            _hash([outer_a]),
+            _hash([outer_b]),
+            "Changing inner loop count must change the hash.",
+        )
+
+
+class TestSymbolKindTagging(unittest.TestCase):
+    """When use_symbols=True, pool / kernel_slice / kernel_derived offsets
+    must be included in the hash so that two graphs with identical SDSC JSON
+    but different baked HBM addresses produce different keys."""
+
+    def test_pool_offset_changes_hash_when_use_symbols_true(self):
+        """Two pool tensors at different offsets must hash differently."""
+        op_offset_0 = _make_op_spec(hbm_addr_in=0)
+        op_offset_0.args[0].allocation.pop("hbm", None)
+        op_offset_0.args[0].allocation["hbm_pool"] = 0
+
+        op_offset_512 = _make_op_spec(hbm_addr_in=512)
+        op_offset_512.args[0].allocation.pop("hbm", None)
+        op_offset_512.args[0].allocation["hbm_pool"] = 512
+
+        h0 = _hash([op_offset_0], use_symbols=True)
+        h512 = _hash([op_offset_512], use_symbols=True)
+
+        self.assertNotEqual(
+            h0,
+            h512,
+            "Pool offset 0 and 512 must produce different hashes when use_symbols=True.",
+        )
+
+    def test_pool_offset_ignored_when_use_symbols_false(self):
+        """With use_symbols=False, the explicit pool-offset tags are NOT appended
+        to content_parts.  However, pool addresses are baked into the SDSC JSON
+        as negative sentinel symbol IDs by compile_op_spec, so two tensors at
+        different pool offsets will still produce different hashes via the JSON.
+        This test documents that behaviour."""
+        op_offset_0 = _make_op_spec(hbm_addr_in=0)
+        op_offset_0.args[0].allocation.pop("hbm", None)
+        op_offset_0.args[0].allocation["hbm_pool"] = 0
+
+        op_offset_512 = _make_op_spec(hbm_addr_in=512)
+        op_offset_512.args[0].allocation.pop("hbm", None)
+        op_offset_512.args[0].allocation["hbm_pool"] = 512
+
+        h0 = _hash([op_offset_0], use_symbols=False)
+        h512 = _hash([op_offset_512], use_symbols=False)
+
+        # Pool addresses appear as negative sentinel IDs in the SDSC JSON, so
+        # different offsets produce different JSON and therefore different hashes
+        # even when use_symbols=False (no explicit pool: tags are added).
+        self.assertNotEqual(
+            h0,
+            h512,
+            "Pool addresses are baked as negative sentinel IDs in the SDSC JSON — "
+            "different offsets produce different hashes even with use_symbols=False.",
+        )
+
+
+class TestAffineStridesHashed(unittest.TestCase):
+    """affine_strides (per-level tile byte strides) must be included in
+    compute_specs_hash.  Two ops that differ only in tile stride must produce
+    different cache keys so they do not share a cache entry.
+    """
+
+    def _make_tiled_op_spec(self, tile_stride_bytes: int, size: int = 256):
+        """Return an OpSpec that has a non-empty device_tile_advance_expr.
+
+        tile_stride_bytes simulates the per-element advance for a coarse-tiled
+        tensor.  In practice this would be set by coarse_tile.py; here we
+        inject it directly onto the TensorArg to produce a non-zero affine
+        stride via generate_sdsc's per-level stride logic.
+        """
+        from torch_spyre._inductor.op_spec import TensorArg
+        from torch_spyre._C import DataFormats
+
+        c0 = Symbol("c0")
+        # Minted level symbol — the kind used by spyre_kernel._get_or_mint_level_symbol
+        lvl_sym = Symbol("_tile_adv_add_lvl0")
+
+        in_arg = TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=DataFormats.IEEE_FP16,
+            device_size=[1, size, 1],
+            device_coordinates=[Integer(0), c0 % size, Integer(0)],
+            allocation={"hbm": 0},
+            # tile_stride_bytes / 2 because num_bytes(FP16) == 2
+            device_tile_advance_expr=lvl_sym * (tile_stride_bytes // 2),
+        )
+        out_arg = TensorArg(
+            is_input=False,
+            arg_index=1,
+            device_dtype=DataFormats.IEEE_FP16,
+            device_size=[1, size, 1],
+            device_coordinates=[Integer(0), c0 % size, Integer(0)],
+            allocation={"hbm": size * 2},
+            device_tile_advance_expr=lvl_sym * (tile_stride_bytes // 2),
+        )
+
+        from torch_spyre._inductor.op_spec import OpSpec
+        from torch_spyre._inductor.core_mapping import derive_operation_mapping
+
+        iteration_space = {c0: (Integer(size), 1)}
+        spec = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space=iteration_space,
+            args=[in_arg, out_arg],
+            op_info={},
+            tiled_symbols=[[lvl_sym]],  # one nesting level
+            tiled_symbol_trip_counts={lvl_sym: size // (tile_stride_bytes // 2)},
+        )
+        spec.core_id_to_work_slice = derive_operation_mapping(iteration_space)
+        return spec
+
+    def test_different_tile_strides_produce_different_hashes(self):
+        """Ops that differ only in tile stride must produce different hashes."""
+        op_stride_128 = self._make_tiled_op_spec(tile_stride_bytes=128)
+        op_stride_256 = self._make_tiled_op_spec(tile_stride_bytes=256)
+
+        try:
+            h128 = _hash([op_stride_128])
+            h256 = _hash([op_stride_256])
+        except Exception as e:
+            self.skipTest(f"Skipping affine_strides test — compile_op_spec raised: {e}")
+
+        self.assertNotEqual(
+            h128,
+            h256,
+            "Ops with different tile strides must produce different hashes — "
+            "affine_strides must be included in compute_specs_hash.",
+        )
+
+
+# Iteration-space sizes are hashed
+class TestIterationSpaceHashed(unittest.TestCase):
+    """Different iteration-space sizes must produce different hashes."""
+
+    def test_different_sizes_produce_different_hashes(self):
+        op_64 = _make_op_spec(size=64)
+        op_128 = _make_op_spec(size=128)
+
+        self.assertNotEqual(
+            _hash([op_64]),
+            _hash([op_128]),
+            "Ops with different iteration-space sizes must hash differently.",
+        )
+
+    def test_same_sizes_produce_same_hash(self):
+        op_a = _make_op_spec(size=64)
+        op_b = _make_op_spec(size=64)
+
+        self.assertEqual(
+            _hash([op_a]),
+            _hash([op_b]),
+            "Identical ops must produce the same hash.",
+        )
+
+
+# Op name (opfunc) is hashed
+class TestOpFuncHashed(unittest.TestCase):
+    """Different op names must produce different hashes."""
+
+    def test_different_ops_produce_different_hashes(self):
+        op_add = _make_op_spec(op="add")
+        op_mul = _make_op_spec(op="mul")
+
+        h_add = _hash([op_add])
+        h_mul = _hash([op_mul])
+
+        self.assertNotEqual(
+            h_add,
+            h_mul,
+            "add and mul ops must produce different hashes.",
+        )
+
+    def test_same_op_produces_same_hash(self):
+        op_a = _make_op_spec(op="exp")
+        op_b = _make_op_spec(op="exp")
+
+        self.assertEqual(
+            _hash([op_a]),
+            _hash([op_b]),
+        )
+
+
+# debug_handle_ is stripped before hashing (no false misses)
+class TestDebugHandleStripped(unittest.TestCase):
+    """debug_handle_ must be removed from the SDSC JSON before hashing so that
+    process-specific buffer names do not cause false cache misses."""
+
+    def test_debug_handle_does_not_affect_hash(self):
+        """Two SDSC dicts identical except for debug_handle_ must hash the same."""
+        from torch_spyre.execution.kernel_cache import _strip_debug_handles
+
+        base = {
+            "0_add": {
+                "numCoresUsed_": 4,
+                "dscs_": [{"add": {"numCoresUsed_": 4}}],
+            }
+        }
+        with_handle = {
+            "0_add": {
+                **base["0_add"],
+                "debug_handle_": {"id": "99999", "ir_chain": ["buf123", "buf456"]},
+            }
+        }
+
+        stripped_base = _strip_debug_handles(base)
+        stripped_with = _strip_debug_handles(with_handle)
+
+        self.assertEqual(
+            json.dumps(stripped_base, sort_keys=True),
+            json.dumps(stripped_with, sort_keys=True),
+            "After stripping, dicts that differ only in debug_handle_ must be equal.",
+        )
+
+    def test_debug_handle_stripped_at_all_nesting_levels(self):
+        """debug_handle_ nested inside dscs_ must also be stripped."""
+        from torch_spyre.execution.kernel_cache import _strip_debug_handles
+
+        sdsc = {
+            "0_add": {
+                "debug_handle_": {"id": "1"},
+                "dscs_": [{"add": {"debug_handle_": {"id": "2"}, "numCoresUsed_": 2}}],
+            }
+        }
+        result = _strip_debug_handles(sdsc)
+        self.assertNotIn("debug_handle_", result["0_add"])
+        self.assertNotIn("debug_handle_", result["0_add"]["dscs_"][0]["add"])
+
+
+# Version strings affect hash (environment independence guard)
+class TestVersionStringsHashed(unittest.TestCase):
+    """Changing any version string (torch, torch_spyre, dxp) must change the hash."""
+
+    def _hash_with_versions(self, dxp_ver: str, spyre_ver: str):
+        from torch_spyre.execution.kernel_cache import compute_specs_hash
+        from unittest.mock import patch
+
+        op = _make_op_spec()
+        with (
+            patch(
+                "torch_spyre.execution.kernel_cache._get_dxp_version",
+                return_value=dxp_ver,
+            ),
+            patch(
+                "torch_spyre.execution.kernel_cache._get_torch_spyre_version",
+                return_value=spyre_ver,
+            ),
+            patch("torch_spyre._inductor.config.bundle_symbolic_args", False),
+        ):
+            return compute_specs_hash([op], kernel_name="ver_test")
+
+    def test_dxp_version_change_changes_hash(self):
+        h1 = self._hash_with_versions("1.0.0", "0.0.1")
+        h2 = self._hash_with_versions("2.0.0", "0.0.1")
+        self.assertNotEqual(h1, h2, "dxp version change must change the hash.")
+
+    def test_torch_spyre_version_change_changes_hash(self):
+        h1 = self._hash_with_versions("1.0.0", "0.0.1")
+        h2 = self._hash_with_versions("1.0.0", "0.0.2")
+        self.assertNotEqual(h1, h2, "torch_spyre version change must change the hash.")
+
+    def test_same_versions_same_hash(self):
+        h1 = self._hash_with_versions("1.0.0", "0.0.1")
+        h2 = self._hash_with_versions("1.0.0", "0.0.1")
+        self.assertEqual(h1, h2, "Same versions must produce the same hash.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/inductor/test_kernel_provenance.py
+++ b/tests/inductor/test_kernel_provenance.py
@@ -670,13 +670,14 @@ class TestKernelProvenancePropagation:
                 "torch_spyre.execution.kernel_runner.prepare_kernel",
                 return_value="jobplan",
             ) as prepare_kernel,
+            patch("torch_spyre.execution.kernel_runner.torch.spyre._impl._lazy_init"),
         ):
             runner = SpyreSDSCKernelRunner(
                 "sdsc_fused_mm_0",
                 "/tmp/kernel",
                 kernel_provenance=descriptor,
             )
-
+            assert runner.jobplan == "jobplan"
         assert runner.kernel_provenance is descriptor
         assert runner.profiler_event_name == _event_name(descriptor)
         assert runner.jobplan == "jobplan"
@@ -697,9 +698,10 @@ class TestKernelProvenancePropagation:
                 "torch_spyre.execution.kernel_runner.prepare_kernel",
                 return_value="jobplan",
             ) as prepare_kernel,
+            patch("torch_spyre.execution.kernel_runner.torch.spyre._impl._lazy_init"),
         ):
             runner = SpyreSDSCKernelRunner("sdsc_fused_mm_0", "/tmp/kernel")
-
+            assert runner.jobplan == "jobplan"
         assert runner.kernel_provenance is None
         assert runner.profiler_event_name is None
         prepare_kernel.assert_called_once_with("/tmp/kernel/spyreCodeDir")

--- a/tests/test_kernel_caching.py
+++ b/tests/test_kernel_caching.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for SpyreAsyncCompile persistent kernel caching.
+
+Each test runs inside ``torch._inductor.utils.fresh_cache()``, which redirects
+all Inductor / Spyre cache I/O to a fresh temporary directory.  The developer's
+real cache is never read or modified by these tests.
+
+Run with:
+    python -m pytest tests/test_kernel_caching.py -v
+    python -m pytest tests/test_kernel_caching.py -v -k test_cache_hit
+"""
+
+import os
+import unittest
+import torch
+import torch_spyre  # noqa: F401 — side-effects: registers Spyre backend
+
+import torch_spyre._inductor.config as spyre_config
+from torch._inductor.utils import fresh_cache
+
+from torch_spyre.execution.kernel_cache import (
+    allocate_compile_dir,
+    commit_compile_dir,
+    get_cache_root_dir,
+    get_cache_stats,
+    get_cached_kernel_dir,
+)
+
+DEVICE = torch.device("spyre")
+
+
+def _simple_fn(x: torch.Tensor) -> torch.Tensor:
+    return torch.softmax(x, dim=-1)
+
+
+def _make_input(shape=(64, 512), dtype=torch.float16):
+    return torch.rand(*shape, dtype=dtype).to(DEVICE)
+
+
+class TestCacheMissOnColdStart(unittest.TestCase):
+    def test_cache_is_empty_before_first_compile(self):
+        """Cache must be empty before any torch.compile() is called."""
+        with fresh_cache():
+            torch._dynamo.reset()
+            stats = get_cache_stats()
+            self.assertEqual(stats["total_cached_kernels"], 0)
+
+    def test_first_compile_populates_cache(self):
+        """After one torch.compile() run, at least one kernel should be cached."""
+        with fresh_cache(), spyre_config.patch({"spyre_kernel_cache": True}):
+            torch._dynamo.reset()
+            compiled = torch.compile(_simple_fn)
+            compiled(_make_input())
+
+            stats = get_cache_stats()
+            self.assertGreater(
+                stats["total_cached_kernels"],
+                0,
+                "Expected at least one kernel in cache after first compile",
+            )
+
+
+class TestCacheArtifactCompleteness(unittest.TestCase):
+    REQUIRED = [
+        "bundle.mlir",
+        os.path.join("spyreCodeDir", "init_binary.bin"),
+        os.path.join("spyreCodeDir", "spyrecode.json"),
+    ]
+
+    def test_all_required_artifacts_present(self):
+        """Every cached kernel directory must contain all required artifacts."""
+        with fresh_cache(), spyre_config.patch({"spyre_kernel_cache": True}):
+            torch._dynamo.reset()
+            torch.compile(_simple_fn)(_make_input())
+
+            cache_root = get_cache_root_dir()
+            cached_entries = [
+                d
+                for d in os.listdir(cache_root)
+                if os.path.isdir(os.path.join(cache_root, d))
+            ]
+            self.assertGreater(len(cached_entries), 0, "No cached entries found")
+
+            for entry in cached_entries:
+                entry_dir = os.path.join(cache_root, entry)
+                for artifact in self.REQUIRED:
+                    self.assertTrue(
+                        os.path.isfile(os.path.join(entry_dir, artifact)),
+                        f"Missing artifact '{artifact}' in cache entry '{entry}'",
+                    )
+
+                has_sdsc = any(
+                    f.startswith("sdsc_") and f.endswith(".json")
+                    for f in os.listdir(entry_dir)
+                )
+                self.assertTrue(
+                    has_sdsc,
+                    f"No sdsc_N.json files found in cache entry '{entry}'",
+                )
+
+
+class TestPartialCacheEntryTreatedAsMiss(unittest.TestCase):
+    def test_partial_write_does_not_produce_cache_hit(self):
+        """A directory missing spyreCodeDir/init_binary.bin must be a cache miss."""
+        with fresh_cache():
+            cache_root = get_cache_root_dir()
+            fake_key = "c" + "a" * 63
+            fake_dir = os.path.join(cache_root, fake_key)
+            os.makedirs(os.path.join(fake_dir, "spyreCodeDir"), exist_ok=True)
+
+            with open(os.path.join(fake_dir, "bundle.mlir"), "w") as f:
+                f.write("fake bundle")
+            with open(os.path.join(fake_dir, "sdsc_0.json"), "w") as f:
+                f.write("{}")
+            with open(
+                os.path.join(fake_dir, "spyreCodeDir", "spyrecode.json"), "w"
+            ) as f:
+                f.write("{}")
+            # init_binary.bin intentionally missing
+
+            result = get_cached_kernel_dir(fake_key)
+            self.assertIsNone(
+                result,
+                "Expected cache miss for partial entry missing init_binary.bin",
+            )
+
+
+class TestCacheDisabledViaConfig(unittest.TestCase):
+    def test_cache_disabled_leaves_cache_empty(self):
+        """With spyre_kernel_cache=False, the kernel cache must remain empty."""
+        import torch_spyre._inductor.config as spyre_config
+
+        with fresh_cache():
+            torch._dynamo.reset()
+            original = spyre_config.spyre_kernel_cache
+            spyre_config.spyre_kernel_cache = False
+            try:
+                torch.compile(_simple_fn)(_make_input())
+                self.assertEqual(
+                    get_cache_stats()["total_cached_kernels"],
+                    0,
+                    "Expected empty cache when spyre_kernel_cache=False",
+                )
+            finally:
+                spyre_config.spyre_kernel_cache = original
+
+
+class TestForceDisableCaches(unittest.TestCase):
+    def test_force_disable_caches_leaves_cache_empty(self):
+        """torch._inductor.config.force_disable_caches must bypass the Spyre cache."""
+        with fresh_cache():
+            torch._dynamo.reset()
+            with torch._inductor.config.patch({"force_disable_caches": True}):
+                torch.compile(_simple_fn)(_make_input())
+
+            self.assertEqual(
+                get_cache_stats()["total_cached_kernels"],
+                0,
+                "Expected empty cache when force_disable_caches=True",
+            )
+
+
+class TestDifferentOpsProduceDifferentKeys(unittest.TestCase):
+    def test_softmax_and_relu_have_different_cache_entries(self):
+        """Two different ops must not share a cache entry."""
+        with fresh_cache(), spyre_config.patch({"spyre_kernel_cache": True}):
+            torch._dynamo.reset()
+            x = _make_input()
+
+            torch.compile(lambda a: torch.softmax(a, dim=-1))(x)
+            count_after_softmax = get_cache_stats()["total_cached_kernels"]
+
+            torch._dynamo.reset()
+            torch.compile(lambda a: torch.relu(a))(x)
+            count_after_relu = get_cache_stats()["total_cached_kernels"]
+
+            self.assertGreater(
+                count_after_relu,
+                count_after_softmax,
+                "Expected a new cache entry for relu vs softmax",
+            )
+
+
+class TestSameOpReusesCacheEntry(unittest.TestCase):
+    def test_same_op_compiled_twice_uses_same_cache_entry(self):
+        """Compiling the same op twice must not create duplicate cache entries."""
+        with fresh_cache():
+            torch._dynamo.reset()
+            x = _make_input()
+
+            torch.compile(lambda a: torch.softmax(a, dim=-1))(x)
+            count_first = get_cache_stats()["total_cached_kernels"]
+
+            torch._dynamo.reset()
+            torch.compile(lambda a: torch.softmax(a, dim=-1))(x)
+            count_second = get_cache_stats()["total_cached_kernels"]
+
+            self.assertEqual(
+                count_first,
+                count_second,
+                "Expected no new cache entries when compiling the same op twice",
+            )
+
+
+class TestClearCache(unittest.TestCase):
+    def test_clear_cache_removes_all_entries(self):
+        """clear_cache() must leave total_cached_kernels == 0."""
+        from torch_spyre.execution.kernel_cache import clear_cache
+
+        with fresh_cache(), spyre_config.patch({"spyre_kernel_cache": True}):
+            torch._dynamo.reset()
+            torch.compile(_simple_fn)(_make_input())
+
+            self.assertGreater(get_cache_stats()["total_cached_kernels"], 0)
+
+            clear_cache()
+            stats = get_cache_stats()
+            self.assertEqual(stats["total_cached_kernels"], 0)
+            self.assertAlmostEqual(stats["cache_size_mb"], 0.0, places=1)
+
+
+class TestAtomicCommit(unittest.TestCase):
+    def test_concurrent_commit_same_key_does_not_corrupt(self):
+        """Four threads compiling the same key concurrently must leave exactly one valid entry."""
+        import threading
+
+        fake_key = "c" + "b" * 63
+
+        with fresh_cache():
+            errors = []
+
+            def do_compile():
+                try:
+                    # Each thread gets its own allocated tmp dir with the same key.
+                    tmp_dir = allocate_compile_dir(fake_key)
+                    # Populate it with the minimal required artifacts.
+                    os.makedirs(os.path.join(tmp_dir, "spyreCodeDir"), exist_ok=True)
+                    for name in ["bundle.mlir", "sdsc_0.json"]:
+                        with open(os.path.join(tmp_dir, name), "w") as f:
+                            f.write("content")
+                    for name in ["init_binary.bin", "spyrecode.json"]:
+                        with open(
+                            os.path.join(tmp_dir, "spyreCodeDir", name), "wb"
+                        ) as f:
+                            f.write(b"content")
+                    commit_compile_dir(tmp_dir, fake_key)
+                except Exception as e:
+                    errors.append(e)
+
+            threads = [threading.Thread(target=do_compile) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            self.assertEqual(errors, [], f"Concurrent commit raised errors: {errors}")
+
+            result = get_cached_kernel_dir(fake_key)
+            self.assertIsNotNone(
+                result, "Expected a valid cache entry after concurrent commit"
+            )
+
+
+class TestNoDiskIOOnCacheHit(unittest.TestCase):
+    def test_generate_bundle_skipped_on_cache_hit(self):
+        """On a kernel cache hit generate_bundle must not be called."""
+        from unittest.mock import patch
+
+        with fresh_cache(), spyre_config.patch({"spyre_kernel_cache": True}):
+            torch._dynamo.reset()
+            # Populate the cache on first run.
+            torch.compile(_simple_fn)(_make_input())
+
+            # Second compile (after dynamo reset) must hit the cache.
+            torch._dynamo.reset()
+            with patch(
+                "torch_spyre.execution.async_compile.generate_bundle"
+            ) as mock_gen:
+                torch.compile(_simple_fn)(_make_input())
+
+            mock_gen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -154,6 +154,7 @@ def enable_spyre_compile_fx_wrapper():
             try:
                 if uses_spyre:
                     torch.spyre._impl._lazy_init()
+
                     # AOTAutograd uses the dict passed via ``decompositions=``
                     # to decompose the joint graph; Spyre-specific
                     # decompositions must be applied at this stage so ops like

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -196,5 +196,12 @@ native_layout_packer: bool = _get_env_bool("TORCH_SPYRE_NATIVE_PACKER", True)
 
 # When symbolic cost_expr fails, use the fallback cost instead of erroring out
 _cpsat_warn_on_cost_expr: bool = True
+# Enable persistent on-disk caching of compiled Spyre kernels across
+# invocations.
+# Set SPYRE_KERNEL_CACHE=0 to disable.
+# To force recompilation (bypass lookup but still save), use the standard
+# PyTorch flag: TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 / set
+# torch._inductor.config.force_disable_caches = True.
+spyre_kernel_cache: bool = os.environ.get("SPYRE_KERNEL_CACHE", "0") == "1"
 
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/execution/__init__.py
+++ b/torch_spyre/execution/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .kernel_cache import get_kernel_registry  # noqa: F401

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tempfile
-from typing import Any, cast
-from collections.abc import Sequence
 import os
 import shutil
 import subprocess
-import torch
+import tempfile
 import uuid
+from typing import Any, cast
+from collections.abc import Sequence
 
+import torch
 from torch._inductor.async_compile import AsyncCompile
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch_spyre._inductor import config as _spyre_config
@@ -37,6 +37,14 @@ from torch_spyre._inductor.kernel_provenance import (
 from torch_spyre._inductor.codegen.bundle import generate_bundle
 from torch_spyre.profiler._ffdc import CATEGORY_COMPILE_BACKEND, try_collect
 from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
+from .kernel_cache import (
+    allocate_compile_dir,
+    commit_compile_dir,
+    compute_specs_hash,
+    get_cached_kernel_dir,
+    get_kernel_registry,
+    _move_to_failed_dir,
+)
 
 logger = get_inductor_logger("sdsc_compile")
 
@@ -78,6 +86,36 @@ def get_output_dir(kernel_name: str):
     return kernel_output_dir
 
 
+def _compile_to_dir(
+    kernel_name: str,
+    compile_dir: str,
+    specs,
+    pool_size: int,
+) -> None:
+    """Run generate_bundle then dxp_standalone for ``specs`` into ``compile_dir``.
+
+    Shared by the cache-miss path and the no-cache path so that any change to
+    the compilation sequence is applied in both places automatically.
+    """
+    generate_bundle(kernel_name, compile_dir, specs, pool_size=pool_size)
+
+    with torch.profiler.record_function(f"dxp_standalone:{kernel_name}"):
+        try:
+            subprocess.run(
+                ["dxp_standalone", "-d", compile_dir],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            try_collect(
+                exc,
+                logger=logger,
+                failure_category=CATEGORY_COMPILE_BACKEND,
+                kernel_name=kernel_name,
+                code_dir=compile_dir,
+            )
+            raise
+
+
 class SpyreAsyncCompile(AsyncCompile):
     """Spyre kernel compilation (`sdsc`), plus the upstream AsyncCompile.
 
@@ -114,13 +152,9 @@ class SpyreAsyncCompile(AsyncCompile):
         unimp = find_unimplemented(list(specs))
         if unimp is not None:
             logger.warning(
-                f"WARNING: Compiling unimplemented {unimp.op} to runtime exception"
+                "WARNING: Compiling unimplemented %s to runtime exception", unimp.op
             )
             return SpyreUnimplementedRunner(kernel_name, unimp.op)
-
-        # Generate SDSC Bundle from OpSpecs
-        output_dir = get_output_dir(kernel_name)
-        generate_bundle(kernel_name, output_dir, specs, pool_size=pool_size)
 
         self._provenance_attempt_count += 1
         try:
@@ -145,23 +179,59 @@ class SpyreAsyncCompile(AsyncCompile):
                 )
             kernel_provenance = None
 
-        # Invoke backend compiler of SDSC Bundle
-        with torch.profiler.record_function(f"dxp_standalone:{kernel_name}"):
-            try:
-                subprocess.run(
-                    ["dxp_standalone", "-d", output_dir],
-                    check=True,
-                )
-            except Exception as exc:
-                try_collect(
-                    exc,
-                    logger=logger,
-                    failure_category=CATEGORY_COMPILE_BACKEND,
-                    kernel_name=kernel_name,
-                    code_dir=output_dir,
-                )
-                raise
+        use_cache = (
+            _spyre_config.spyre_kernel_cache
+            and not torch._inductor.config.force_disable_caches
+        )
 
+        if use_cache:
+            # Hash the specs in-memory BEFORE any disk I/O.  On a cache hit
+            # neither generate_bundle nor dxp_standalone runs at all.
+            try:
+                cache_key = compute_specs_hash(
+                    specs, kernel_name=kernel_name, pool_size=pool_size
+                )
+            except RuntimeError as e:
+                logger.warning(
+                    "Kernel cache disabled for %s: could not compute cache key: %s. "
+                    "Set SPYRE_KERNEL_CACHE=0 to suppress this warning.",
+                    kernel_name,
+                    e,
+                )
+            else:
+                logger.debug("Bundle cache key: %s", cache_key)
+
+                cached_dir = get_cached_kernel_dir(cache_key)
+                if cached_dir is not None:
+                    logger.debug("Cache HIT: Using cached kernel from: %s", cached_dir)
+                    get_kernel_registry().record_hit(cache_key)
+                    return SpyreSDSCKernelRunner(
+                        kernel_name, cached_dir, kernel_provenance=kernel_provenance
+                    )
+
+                logger.debug("Cache MISS: Compiling kernel")
+                get_kernel_registry().record_miss(cache_key)
+
+                # Allocate a temp dir INSIDE the cache root (same filesystem)
+                # so the rename in commit_compile_dir is atomic on POSIX.
+                compile_dir: str = allocate_compile_dir(cache_key)
+                try:
+                    _compile_to_dir(kernel_name, compile_dir, specs, pool_size)
+                    cached_dir = commit_compile_dir(compile_dir, cache_key)
+                    logger.debug("Kernel compiled and cached at: %s", cached_dir)
+                    return SpyreSDSCKernelRunner(
+                        kernel_name, cached_dir, kernel_provenance=kernel_provenance
+                    )
+                except Exception:  # subprocess.CalledProcessError:
+                    # Move the failed dir to failed/ for manual debugging
+                    # rather than leaving .tmp. dirs accumulating in the root.
+                    _move_to_failed_dir(compile_dir)
+                    raise
+
+        # Caching disabled (SPYRE_KERNEL_CACHE=0 or force_disable_caches).
+        # Compile into a throw-away temp dir that lives for this process only.
+        output_dir = get_output_dir(kernel_name)
+        _compile_to_dir(kernel_name, output_dir, specs, pool_size)
         return SpyreSDSCKernelRunner(
             kernel_name,
             output_dir,
@@ -186,7 +256,7 @@ class SpyreAsyncCompile(AsyncCompile):
         unimp = find_unimplemented(list(specs))
         if unimp is not None:
             logger.warning(
-                f"WARNING: Compiling unimplemented {unimp.op} to runtime exception"
+                "WARNING: Compiling unimplemented %s to runtime exception", unimp.op
             )
             return SpyreUnimplementedRunner(kernel_name, unimp.op)
 

--- a/torch_spyre/execution/kernel_cache.py
+++ b/torch_spyre/execution/kernel_cache.py
@@ -1,0 +1,549 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import shutil
+import uuid
+from collections.abc import Sequence
+from functools import lru_cache
+from typing import Optional
+
+import torch
+from torch._inductor.codecache import code_hash
+from torch._inductor.runtime.runtime_utils import cache_dir
+
+from torch_spyre._inductor.logging_utils import get_inductor_logger
+
+
+logger = get_inductor_logger("kernel_cache")
+
+# All artifacts that dxp_standalone must produce for a valid compiled kernel.
+# A cache entry is only considered a hit if every one of these is present.
+_REQUIRED_ARTIFACTS = [
+    "bundle.mlir",
+    os.path.join("spyreCodeDir", "init_binary.bin"),
+    os.path.join("spyreCodeDir", "spyrecode.json"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Per-process kernel hash registry — maps cache_key to debug metadata.
+# Populated by compute_specs_hash(). Hit/miss wiring (record_hit/record_miss)
+# is deferred to a follow-up PR; saving the registry summary to disk will land
+# alongside that wiring. Access via get_kernel_registry() for read, or
+# directly for tests.
+# ---------------------------------------------------------------------------
+
+
+class _KernelHashRegistry:
+    """Process-lifetime registry mapping cache_key to kernel debug metadata.
+
+    Thread-safe for read-heavy workloads (GIL protects the dict). Each entry
+    is a plain dict with keys:
+        kernel_name  str        kernel name from async_compile.sdsc()
+        ops          list[str]  op names of every OpSpec in the tree, depth-first
+        loop_counts  list[str]  str(count) for every LoopSpec, depth-first
+        pool_offsets list[str]  "arg{idx}:{offset}" for every hbm_pool arg
+        hit_count    int        number of cache HITs for this key
+        miss_count   int        number of cache MISSes (compiled fresh) for this key
+    """
+
+    def __init__(self):
+        self._registry: dict[str, dict] = {}
+
+    def register(
+        self,
+        cache_key: str,
+        kernel_name: str,
+        ops: list[str],
+        loop_counts: list[str],
+        pool_offsets: list[str],
+    ) -> None:
+        """Record the hash ingredients for cache_key.
+
+        Called once per compute_specs_hash invocation. If the same key is seen
+        again (e.g. after dynamo reset), metadata is updated and counters preserved.
+        """
+        if cache_key not in self._registry:
+            self._registry[cache_key] = {
+                "kernel_name": kernel_name,
+                "kernel_names": [kernel_name] if kernel_name else [],
+                "ops": ops,
+                "loop_counts": loop_counts,
+                "pool_offsets": pool_offsets,
+                "hit_count": 0,
+                "miss_count": 0,
+            }
+        else:
+            # Same key, potentially a new kernel_name (e.g. after dynamo reset).
+            # Update metadata but keep counters.
+            entry = self._registry[cache_key]
+            entry["kernel_name"] = kernel_name
+            entry["ops"] = ops
+            entry["loop_counts"] = loop_counts
+            entry["pool_offsets"] = pool_offsets
+            if kernel_name and kernel_name not in entry["kernel_names"]:
+                entry["kernel_names"].append(kernel_name)
+
+    def record_hit(self, cache_key: str) -> None:
+        if cache_key in self._registry:
+            self._registry[cache_key]["hit_count"] += 1
+
+    def record_miss(self, cache_key: str) -> None:
+        if cache_key in self._registry:
+            self._registry[cache_key]["miss_count"] += 1
+
+    def get(self, cache_key: str) -> Optional[dict]:
+        return self._registry.get(cache_key)
+
+    def all_entries(self) -> dict[str, dict]:
+        return dict(self._registry)
+
+    def summary(self) -> str:
+        """Return a human-readable summary table of all registered kernels."""
+        if not self._registry:
+            return "KernelHashRegistry: empty"
+        lines = [
+            "KernelHashRegistry:",
+            f"  {'HASH':>16}  {'KERNEL':40}  {'OPS':30}  LOOPS  POOL_OFFSETS  HIT  MISS  NAMES",
+            f"  {'-' * 16}  {'-' * 40}  {'-' * 30}  {'-' * 5}  {'-' * 12}  {'-' * 3}  {'-' * 4}  {'-' * 20}",
+        ]
+        for key, meta in self._registry.items():
+            ops_str = ",".join(meta["ops"])[:30]
+            loops_str = ",".join(meta["loop_counts"]) or "-"
+            pool_str = ",".join(meta["pool_offsets"]) or "-"
+            names_str = ",".join(meta.get("kernel_names", []))[:20] or "-"
+            lines.append(
+                f"  {key[:16]:>16}  {meta['kernel_name']:40}  {ops_str:30}"
+                f"  {loops_str:5}  {pool_str:12}"
+                f"  {meta['hit_count']:3}  {meta['miss_count']:4}  {names_str:20}"
+            )
+        return "\n".join(lines)
+
+
+_registry = _KernelHashRegistry()
+
+
+def get_kernel_registry() -> _KernelHashRegistry:
+    """Return the process-global kernel hash registry."""
+    return _registry
+
+
+@lru_cache(maxsize=1)
+def _get_dxp_version() -> str:
+    """Return a combined deeptools+flex version string from the Spyre components file.
+
+    Reads the path given by the ``LIB_VERSION_FILE`` environment variable
+    (set in the container build) and extracts the ``ibm-deeptools`` and
+    ``flex`` entries.  Both components influence compiled output and must
+    therefore both appear in the cache key.
+
+    Raises ``RuntimeError`` if ``LIB_VERSION_FILE`` is unset, the file is
+    missing, or either the ``ibm-deeptools`` or ``flex`` entry cannot be
+    found  callers must disable caching rather than risk stale cache hits
+    with an unknown compiler version.
+    """
+    components_file = os.environ.get("LIB_VERSION_FILE")
+    if not components_file:
+        raise RuntimeError(
+            "LIB_VERSION_FILE is not set; cannot determine compiler version "
+            "for cache key. Set SPYRE_KERNEL_CACHE=0 to run without caching."
+        )
+    versions: dict[str, str] = {}
+    try:
+        with open(components_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    lib_name, lib_ver = line.split(":", 1)
+                except ValueError:
+                    continue
+                name = lib_name.strip()
+                if name in ("ibm-deeptools", "ibm-flex"):
+                    versions[name] = lib_ver.strip()
+    except FileNotFoundError:
+        raise RuntimeError(
+            f"Spyre components file not found at {components_file!r}; "
+            "cannot determine compiler version for cache key. "
+            "Set SPYRE_KERNEL_CACHE=0 to run without caching."
+        )
+    for lib in ("ibm-deeptools", "ibm-flex"):
+        if lib not in versions:
+            raise RuntimeError(
+                f"'{lib}' entry not found in {components_file!r}; "
+                "cannot determine compiler version for cache key. "
+                "Set SPYRE_KERNEL_CACHE=0 to run without caching."
+            )
+    return f"deeptools={versions['ibm-deeptools']};flex={versions['ibm-flex']}"
+
+
+@lru_cache(maxsize=1)
+def _get_torch_spyre_version() -> str:
+    """Return the torch_spyre package version string."""
+    from torch_spyre.version import __version__
+
+    return __version__
+
+
+def get_cache_root_dir() -> str:
+    """Return the root directory for the persistent kernel cache."""
+    cache_root = os.path.join(cache_dir(), "inductor-spyre-cache")
+    os.makedirs(cache_root, exist_ok=True)
+    return cache_root
+
+
+def _strip_debug_handles(obj):
+    """Recursively remove "debug_handle_" keys from a JSON-serialisable object.
+
+    debug_handle_ carries Inductor-assigned buffer names and source file paths
+    that are process/run-specific. Including them in the cache key causes false
+    misses (identical graphs with different buffer names hash differently) and
+    does not affect compilation correctness — dxp_standalone ignores the field.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: _strip_debug_handles(v) for k, v in obj.items() if k != "debug_handle_"
+        }
+    if isinstance(obj, list):
+        return [_strip_debug_handles(item) for item in obj]
+    return obj
+
+
+def compute_specs_hash(
+    specs: Sequence, kernel_name: str = "", pool_size: int = 0
+) -> str:
+    """Compute a cache key from OpSpec objects without any disk I/O.
+
+    The key is a SHA-256 hash covering: the JSON of every sdsc_N.json dict
+    (op structure, iteration space, tiling, shapes, dtypes), the trip count of
+    every LoopSpec, all baked symbol offsets (pool, kernel_slice, derived),
+    the total pool allocation size, and the versions of torch, torch_spyre,
+    dxp_standalone, and the active compile config.
+
+    Args:
+        specs:       The OpSpec/LoopSpec tree to hash.
+        kernel_name: Optional name stored in the registry for debugging.
+        pool_size:   Total HBM pool allocation in bytes, emitted as
+                     ``sdscbundle.device_mem_allocate`` in bundle.mlir.
+                     Must be included so that kernels that differ only in
+                     their pool size get different cache keys.
+    """
+    from torch_spyre._inductor.codegen.superdsc import compile_op_spec
+    from torch_spyre._inductor.op_spec import LoopSpec, OpSpec
+    from torch_spyre._inductor import config as _spyre_config
+
+    use_symbols = _spyre_config.bundle_symbolic_args
+
+    specs_list = list(specs)
+
+    content_parts: list[bytes] = []
+    symbols: list[int] = []
+    symbol_id_offset = 0
+    sdsc_idx = 0
+
+    # Debug metadata collected in parallel with content_parts.
+    _debug_ops: list[str] = []
+    _debug_loop_counts: list[str] = []
+    _debug_pool_offsets: list[str] = []
+
+    def _collect(entries):
+        nonlocal sdsc_idx, symbol_id_offset
+        for entry in entries:
+            if isinstance(entry, LoopSpec):
+                # Include the trip count so loops with different iteration
+                # counts never collide, even when their body OpSpecs produce
+                # identical SDSC JSON.
+                loop_count_str = str(entry.count)
+                content_parts.append(f"loop_count:{loop_count_str}".encode())
+                _debug_loop_counts.append(loop_count_str)
+                logger.debug("  [hash] LoopSpec  count=%s", loop_count_str)
+                _collect(entry.body)
+            elif isinstance(entry, OpSpec):
+                sdsc_json, local_sym_values, affine_strides, local_symbol_kinds = (
+                    compile_op_spec(
+                        sdsc_idx,
+                        entry,
+                        symbols,
+                        symbol_id_offset,
+                    )
+                )
+                symbol_id_offset += len(local_sym_values)
+                sdsc_idx += 1
+                # Strip debug_handle_ before hashing: it contains run-specific
+                # buffer names and source paths that must not affect the key.
+                hashable_json = _strip_debug_handles(sdsc_json)
+                content_parts.append(json.dumps(hashable_json, sort_keys=True).encode())
+                # Include affine_strides in the hash: these are the per-tensor,
+                # per-loop-level byte strides emitted as affine.apply ops in
+                # bundle.mlir.  Two ops with identical SDSC JSON but different
+                # tile strides produce different compiled kernels and must not
+                # share a cache entry.
+                if any(
+                    any(level_strides for level_strides in per_level)
+                    for per_level in affine_strides
+                ):
+                    content_parts.append(
+                        json.dumps(
+                            [
+                                [
+                                    {str(k): v for k, v in level.items()}
+                                    for level in per_level
+                                ]
+                                for per_level in affine_strides
+                            ],
+                            sort_keys=True,
+                        ).encode()
+                    )
+                _debug_ops.append(entry.op)
+                logger.debug(
+                    "  [hash] OpSpec[%d] op=%s  iter_space=%s  n_args=%d",
+                    sdsc_idx - 1,
+                    entry.op,
+                    {str(k): str(v[0]) for k, v in entry.iteration_space.items()},
+                    len(entry.args),
+                )
+
+                # Include baked symbol offsets (pool, kernel_slice, derived)
+                # when use_symbols=True. These are emitted as concrete MLIR
+                # constants in bundle.mlir but appear only as negative sentinel
+                # IDs in sdsc_N.json, so they must be hashed separately to
+                # distinguish graphs that differ only in their offsets.
+                if use_symbols:
+                    for sk in local_symbol_kinds:
+                        if sk.kind == "pool":
+                            tag = f"pool:{sk.offset}"
+                            content_parts.append(tag.encode())
+                            _debug_pool_offsets.append(tag)
+                            logger.debug("  [hash]   pool offset=%d", sk.offset)
+                        elif sk.kind == "kernel_slice":
+                            tag = f"slice:arg{sk.arg_index}:{sk.offset}"
+                            content_parts.append(tag.encode())
+                            _debug_pool_offsets.append(tag)
+                            logger.debug(
+                                "  [hash]   slice arg%d offset=%d",
+                                sk.arg_index,
+                                sk.offset,
+                            )
+                        elif sk.kind == "kernel_derived" and sk.offset != 0:
+                            tag = f"derived:arg{sk.arg_index}:{sk.offset}"
+                            content_parts.append(tag.encode())
+                            _debug_pool_offsets.append(tag)
+                            logger.debug(
+                                "  [hash]   derived arg%d offset=%d",
+                                sk.arg_index,
+                                sk.offset,
+                            )
+                        elif sk.kind == "kernel_derived_symbolic":
+                            tag = f"derived_sym:{sk.pytorch_sym}:{sk.split_count}:{sk.core_idx}"
+                            content_parts.append(tag.encode())
+                            _debug_pool_offsets.append(tag)
+                            logger.debug(
+                                "  [hash]   derived_sym %s split=%d core=%d",
+                                sk.pytorch_sym,
+                                sk.split_count,
+                                sk.core_idx,
+                            )
+
+    _collect(specs_list)
+
+    # Include the total pool allocation: it is emitted as
+    # sdscbundle.device_mem_allocate <pool_size> bytes in bundle.mlir.
+    content_parts.append(f"pool_size:{pool_size}".encode())
+
+    content = b"||".join(content_parts)
+    extra = "||".join(
+        [
+            torch.__version__,
+            _get_torch_spyre_version(),
+            _get_dxp_version(),
+        ]
+    )
+
+    cache_key = code_hash(content, extra=extra)
+    logger.info(
+        "Hash inputs summary  kernel=%s  sdsc_count=%d  content_parts=%d  "
+        "content_bytes=%d  use_symbols=%s",
+        kernel_name or "<unknown>",
+        sdsc_idx,
+        len(content_parts),
+        len(content),
+        use_symbols,
+    )
+
+    # Register ingredients in the process-global registry for hit/miss logging.
+    _registry.register(
+        cache_key,
+        kernel_name,
+        _debug_ops,
+        _debug_loop_counts,
+        _debug_pool_offsets,
+    )
+
+    logger.info(
+        "Computed specs hash  kernel=%s  ops=[%s]  loops=[%s]  pool=[%s]  key=%s",
+        kernel_name or "<unknown>",
+        ",".join(_debug_ops),
+        ",".join(_debug_loop_counts) or "-",
+        ",".join(_debug_pool_offsets) or "-",
+        cache_key,
+    )
+    return cache_key
+
+
+def get_cached_kernel_dir(cache_key: str) -> Optional[str]:
+    """Return the cached kernel directory if all required artifacts are present.
+
+    Checks for every entry in _REQUIRED_ARTIFACTS and at least one sdsc_N.json.
+    A partial write from a killed process will fail this check and trigger
+    recompilation.
+    """
+    cache_root = get_cache_root_dir()
+    cached_dir = os.path.join(cache_root, cache_key)
+
+    if not os.path.isdir(cached_dir):
+        logger.info("Cache MISS: No cached kernel found for key %s", cache_key)
+        return None
+
+    missing = [
+        p
+        for p in _REQUIRED_ARTIFACTS
+        if not os.path.isfile(os.path.join(cached_dir, p))
+    ]
+    if missing:
+        logger.info(
+            "Cache MISS: Cached dir exists but missing artifacts %s for key %s",
+            missing,
+            cache_key,
+        )
+        return None
+
+    has_sdsc = any(
+        f.startswith("sdsc_") and f.endswith(".json")
+        for f in os.listdir(cached_dir)
+        if os.path.isfile(os.path.join(cached_dir, f))
+    )
+    if not has_sdsc:
+        logger.info(
+            "Cache MISS: No sdsc_N.json files found in cached dir for key %s",
+            cache_key,
+        )
+        return None
+
+    logger.info("Cache HIT: Found cached kernel at %s", cached_dir)
+    return cached_dir
+
+
+def allocate_compile_dir(cache_key: str) -> str:
+    """Reserve a unique temp directory inside the cache root for compilation.
+
+    Placing it inside the cache root (not /tmp) ensures the subsequent rename
+    in commit_compile_dir is atomic on POSIX.
+    """
+    cache_root = get_cache_root_dir()
+    tmp_dir = os.path.join(cache_root, f"{cache_key}.tmp.{uuid.uuid4().hex}")
+    os.makedirs(tmp_dir, exist_ok=True)
+    return tmp_dir
+
+
+def commit_compile_dir(tmp_dir: str, cache_key: str) -> str:
+    """Atomically promote tmp_dir to <cache_root>/<cache_key>/.
+
+    If another process already committed the same key, discards the temp dir
+    and reuses the existing entry. Returns the final cache dir.
+    """
+    cache_root = get_cache_root_dir()
+    cached_dir = os.path.join(cache_root, cache_key)
+
+    if os.path.isdir(cached_dir):
+        # Another process/thread won the race — discard our copy.
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        logger.info("Cache race resolved: reusing existing entry at %s", cached_dir)
+        return cached_dir
+
+    try:
+        os.rename(tmp_dir, cached_dir)  # Atomic on POSIX (same filesystem)
+        logger.info("Saved compiled kernel to cache: %s", cached_dir)
+    except OSError:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        logger.info("Cache race resolved: reusing existing entry at %s", cached_dir)
+
+    return cached_dir
+
+
+def _move_to_failed_dir(compile_dir: str) -> None:
+    """Move a failed compile dir into a ``failed/`` subdirectory of the cache root.
+
+    Keeps the cache root clean while still retaining failed artifacts for
+    manual debugging (``dxp_standalone -d <path>``).  If the rename itself
+    fails (e.g. cross-device move), the original path is kept and logged.
+    """
+    cache_root = get_cache_root_dir()
+    failed_root = os.path.join(cache_root, "failed")
+    try:
+        os.makedirs(failed_root, exist_ok=True)
+        dest = os.path.join(failed_root, os.path.basename(compile_dir))
+        os.rename(compile_dir, dest)
+        logger.info("Compilation failed; moved compile dir to: %s", dest)
+    except OSError:
+        logger.info(
+            "Compilation failed; could not move compile dir, keeping at: %s",
+            compile_dir,
+        )
+
+
+def get_cache_stats() -> dict:
+    """Return summary statistics about the persistent kernel cache.
+
+    Only counts and sizes committed kernel directories (not in-progress
+    ``.tmp.`` dirs and not the ``failed/`` directory).
+    """
+    cache_root = get_cache_root_dir()
+
+    if not os.path.exists(cache_root):
+        return {"total_cached_kernels": 0, "cache_size_mb": 0.0}
+
+    cached_dirs = [
+        d
+        for d in os.listdir(cache_root)
+        if os.path.isdir(os.path.join(cache_root, d))
+        and not d.endswith(".tmp")
+        and ".tmp." not in d
+        and d != "failed"
+    ]
+
+    # Walk only the committed kernel dirs so that in-progress .tmp. dirs and
+    # the failed/ directory do not inflate the reported size.
+    total_size = 0
+    for entry_name in cached_dirs:
+        entry_path = os.path.join(cache_root, entry_name)
+        for dirpath, _dirnames, filenames in os.walk(entry_path):
+            for filename in filenames:
+                total_size += os.path.getsize(os.path.join(dirpath, filename))
+
+    return {
+        "total_cached_kernels": len(cached_dirs),
+        "cache_size_mb": total_size / (1024 * 1024),
+    }
+
+
+def clear_cache() -> None:
+    """Remove all entries from the persistent kernel cache."""
+    cache_root = get_cache_root_dir()
+    if os.path.exists(cache_root):
+        shutil.rmtree(cache_root)
+        os.makedirs(cache_root, exist_ok=True)
+        logger.info("Kernel cache cleared")

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -47,6 +47,14 @@ class SpyreUnimplementedRunner:
 
 
 class SpyreSDSCKernelRunner:
+    """Kernel runner for a compiled SDSC bundle.
+
+    The jobplan handle is initialised lazily on first call to :meth:`run`.
+    This avoids calling ``prepare_kernel`` (which requires a live C++
+    RuntimeContext) in the compiling process; the context is only guaranteed
+    to be available on the process that actually launches the kernel.
+    """
+
     def __init__(
         self,
         name: str,
@@ -57,10 +65,10 @@ class SpyreSDSCKernelRunner:
         self.code_dir = code_dir
         self.kernel_provenance = kernel_provenance
         self.profiler_event_name: str | None
-        spyrecode_dir = code_dir + "/spyreCodeDir"
+        self._jobplan = None  # initialised lazily, not pickled
+
         if kernel_provenance is None:
             self.profiler_event_name = None
-            self.jobplan = prepare_kernel(spyrecode_dir)
         else:
             self.profiler_event_name = format_kernel_provenance_event_name(
                 kernel_provenance
@@ -72,11 +80,28 @@ class SpyreSDSCKernelRunner:
                 self.profiler_event_name,
                 list(kernel_provenance.debug_handle_ids),
             )
-            with torch.profiler.record_function(f"prepare_kernel:{self.kernel_name}"):
-                self.jobplan = prepare_kernel(
-                    spyrecode_dir,
-                    profiler_name=self.profiler_event_name,
-                )
+
+    @property
+    def jobplan(self):
+        if self._jobplan is None:
+            logger.debug(
+                "Initialising jobplan for %s from %s", self.kernel_name, self.code_dir
+            )
+            # _lazy_init() ensures the C++ RuntimeContext is initialised before
+            # prepare_kernel(), which calls into JobPlanBuilder/getDefaultStream().
+            torch.spyre._impl._lazy_init()
+            spyrecode_dir = self.code_dir + "/spyreCodeDir"
+            if self.profiler_event_name is None:
+                self._jobplan = prepare_kernel(spyrecode_dir)
+            else:
+                with torch.profiler.record_function(
+                    f"prepare_kernel:{self.kernel_name}"
+                ):
+                    self._jobplan = prepare_kernel(
+                        spyrecode_dir,
+                        profiler_name=self.profiler_event_name,
+                    )
+        return self._jobplan
 
     @with_ffdc(CATEGORY_RUNTIME_LAUNCH, logger)
     def run(self, *args, symbolic_args: list[SymbolicArg] | None = None, **kw_args):


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [ X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:


- Implement content-addressed cache using SHA-256 of OpSpec
- Add SPYRE_KERNEL_CACHE and SPYRE_KERNEL_CACHE_FORCE_RECOMPILE flags
- Achieve 4x speedup on subsequent runs (35.18s to 8.43s for Granite 3.3 8B)
- Cache validates bundle.mlir and init.txt existence
- Atomic promotion handles race conditions


#### Which issue(s) this PR is related to:

https://github.com/torch-spyre/torch-spyre/issues/262


#### Does this PR introduce a user-facing change?
No

### Additional note:

#### Testing:

The benchmark script below demonstrates the caching behavior:

```
import time
import torch
import shutil
import os
from transformers import AutoTokenizer
from hf_adapters import AutoSpyreModelForCausalLM

# Clear cache to ensure cold start
cache_dir = f"/tmp/torchinductor_{os.getuid()}/inductor-spyre/"
if os.path.exists(cache_dir):
    shutil.rmtree(cache_dir)
    print(f"Cleared disk cache at {cache_dir}")

# Load model
model_id = "ibm-granite/granite-3.3-8b-instruct"
model = AutoSpyreModelForCausalLM.from_pretrained(model_id)
tokenizer = AutoTokenizer.from_pretrained(model_id)

prompts = ["What is 2+2?"]

# Run 3 times to observe cache behavior
for i in range(1, 4):
    torch._dynamo.reset()  # Force graph re-evaluation
    
    print(f"\n[Run {i}] Starting generation...")
    start_time = time.perf_counter()
    
    outputs = model.generate(tokenizer, prompts, max_new_tokens=10)
    
    end_time = time.perf_counter()
    duration = end_time - start_time
    
    print(f"[Run {i}] Completed in {duration:.4f} seconds")
    print(f"[Run {i}] Output: {outputs[0]}")
    
 ```
 
### Expected Output:

```
[Run 1] Completed
[Run 1] Output: 2 + 2 equals 4.

[Run 2] Completed
[Run 2] Output: 2 + 2 equals 4.

[Run 3] Completed
[Run 3] Output: 2 + 2 equals 4.
```

Console logs will show:

```
Run 1: SPYRE CACHE MISS: sdsc_fused_* messages
Run 2-3: SPYRE CACHE HIT: sdsc_fused_* messages
```


This PR is still in progress. Needs to add the **recompilation checks**. So i am moving this to the Draft for now.
Once checks are in place i will move it to the open state.