### PR TITLE
feat(test framwork): patch @onlyNativeDeviceTypes at runtime from framework to collet tests OOT

### DIFF
--- a/tests/configs/upstream_tests/test_view_ops_config.yaml
+++ b/tests/configs/upstream_tests/test_view_ops_config.yaml
@@ -11,6 +11,42 @@ test_suite_config:
             - TestOldViewOps::test_contiguous
             - TestOldViewOps::test_resize_as_preserves_strides
           mode: mandatory_success
+
+        ############################################################
+        ## Tests that fail on spyre with @onlyNativeDeviceTypes ###
+        ## Previously skipped since our framework did not support 
+        ## this decorator patch at runtime. It now supports it
+        ############################################################
+        - names:
+            - TestViewOps::test_chunk_view
+            - TestViewOps::test_conj_view_with_shared_memory
+            - TestViewOps::test_flatten_nonview
+            - TestViewOps::test_split_view
+            - TestViewOps::test_view_tensor_dsplit
+            - TestViewOps::test_view_tensor_hsplit
+            - TestViewOps::test_view_tensor_vsplit
+            - TestViewOps::test_reshape
+            - TestOldViewOps::test_transpose_invalid
+            - TestViewOps::test_view_dtype_upsize_errors
+            - TestViewOps::test_view_tensor_split
+            - TestOldViewOps::test_broadcast_to
+            - TestOldViewOps::test_tensor_split_indices
+            - TestOldViewOps::test_tensor_split_sections
+          mode: xfail
+          # segmentation faults with @onlyNativeDeviceTypes
+        - names:
+            - TestViewOps::test_view_as_complex
+            - TestViewOps::test_view_dtype_new
+          mode: skip
+          # tests that pass with @onlyNativeDeviceTypes which was SKIPPED previously
+        - names:
+            - TestViewOps::test_imag_noncomplex
+            - TestViewOps::test_as_strided_overflow_storage_offset
+            - TestOldViewOps::test_resize_overflow
+            - TestOldViewOps::test_tensor_split_errors
+          mode: mandatory_success
+
+
         #######################################################################
         #### New test added in pytorch 2.11 which is failing - hence xfail ####
         #######################################################################
@@ -82,7 +118,7 @@ test_suite_config:
             # - TestViewOps::test_view_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
             - TestOldViewOps::test_T  # RuntimeError: Comparing, Error in codegen for ComputedBuffer https://github.com/torch-spyre/torch-spyre/issues/1226
             - TestOldViewOps::test_big_transpose  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestOldViewOps::test_broadcast_to  # AssertionError: Tensor-likes are not close https://github.com/torch-spyre/torch-spyre/issues/1227 (float16),  NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
+            # - TestOldViewOps::test_broadcast_to  # AssertionError: Tensor-likes are not close https://github.com/torch-spyre/torch-spyre/issues/1227 (float16),  NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
             - TestOldViewOps::test_expand  # NotImplementedError aten::unfold https://github.com/torch-spyre/torch-spyre/issues/688
             - TestOldViewOps::test_flatten   # AssertionError: The length of the sequences mismatch: 1 != 0 https://github.com/torch-spyre/torch-spyre/issues/729
             - TestOldViewOps::test_memory_format_resize_   # NotImplementedError aten::resize_ https://github.com/torch-spyre/torch-spyre/issues/730 

--- a/tests/oot_test_base_common.py
+++ b/tests/oot_test_base_common.py
@@ -43,6 +43,7 @@ from oot_upstream_patcher import (
     _OOTModuleDtypePatcher,
     _OOTOpMarkerPatcher,
     _OOTPrecisionOverridePatcher,
+    _OOTNativeDeviceTypesPatcher,
 )
 from oot_test_config_models import (
     OOTTestConfig,
@@ -623,6 +624,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
     @classmethod
     def instantiate_test(cls, name, test, *, generic_cls=None):
         _OOTOnlyOnPatcher(test, _OOT_DEVICE_TYPE).patch()
+        _OOTNativeDeviceTypesPatcher.patch()
         cls._load_test_suite_config()
 
         # ------------------------------------------------------------------

--- a/tests/oot_upstream_patcher.py
+++ b/tests/oot_upstream_patcher.py
@@ -62,6 +62,45 @@ def _extract_base_module_name(name: str) -> str:
     return name
 
 
+class _OOTNativeDeviceTypesPatcher:
+    """Patches NATIVE_DEVICES in common_device_type to include 'privateuse1'.
+
+    @onlyNativeDeviceTypes and @onlyNativeDeviceTypesAnd both check
+    self.device_type against the module-level NATIVE_DEVICES tuple at call
+    time:
+
+        if self.device_type not in NATIVE_DEVICES: raise SkipTest
+
+    Unlike @onlyOn, there is no decorator instance to mutate -- the check is
+    a plain name lookup against a module global. So we patch the module
+    global directly.
+
+    NATIVE_DEVICES already includes torch._C._get_privateuse1_backend_name()
+    but TorchTestBase.device_type is reset to the literal string "privateuse1"
+    in setUpClass when PYTORCH_TESTING_DEVICE_ONLY_FOR=privateuse1 is set.
+    That means the runtime check sees "privateuse1" and misses the registered
+     name entry.
+
+    Injecting "privateuse1" into NATIVE_DEVICES (once, at module level) fixes
+    both decorators simultaneously for the lifetime of the process.
+
+    This patcher is intentionally stateless after patch() runs calling it
+    multiple times is safe because we check membership before appending.
+    """
+
+    @staticmethod
+    def patch() -> None:
+        """Append 'privateuse1' to NATIVE_DEVICES if not already present.
+
+        NATIVE_DEVICES is a tuple, so we reassign the module attribute with a
+        new tuple rather than mutating in-place.
+        """
+        import torch.testing._internal.common_device_type as _cdt
+
+        if "privateuse1" not in _cdt.NATIVE_DEVICES:
+            _cdt.NATIVE_DEVICES = _cdt.NATIVE_DEVICES + ("privateuse1",)
+
+
 class _OOTOnlyOnPatcher:
     """Patches @onlyOn decorated test methods to also allow privateuse1.
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds a new upstream patcher for `@onlyNativeDeviceTypes` to collect tests that define to run on spyre and hence update the `test_view_ops.yaml` to cover more tests which were earlier getting skipped for not having spyre in onlyNativeDeviceTypes.


Previously 
```bash
============ 25 passed, 28 skipped, 29 xfailed, 1 xpassed in 12.23s ============
```

Now (no tests skipped uneccesarily)
```bash
============ 30 passed, 45 xfailed, 5 xpassed in 11.73s  ============
```