### PR TITLE
fix(unroll): correct per-tile HBM byte stride for tiled dimensions

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1334,6 +1334,42 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
+    @config.patch({"coarse_tiling": True})
+    def test_hint_h_tiling_elementwise(self):
+        """spyre_hint(slices={"H": 2}) tiles elementwise multiply over the H dimension.
+
+        Regression test for a bug in _byte_stride_for_arg (unroll.py) where
+        align_tensors rewrites device_coordinates but leaves stride_map stale,
+        causing per-tile HBM base addresses to advance by the wrong amount when
+        the tiled dimension is not the outermost host dimension (e.g. H in BHLD).
+        """
+        from torch_spyre._inductor import spyre_hint
+
+        torch.manual_seed(42)
+        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
+
+        Q = torch.randn(B, H, Lq, D, dtype=torch.float16)
+        V = torch.randn(B, H, Lk, D, dtype=torch.float16)
+
+        def fn(q, v):
+            with spyre_hint(slices={"H": 2}):
+                return q * v
+
+        ref = fn(Q, V)
+
+        Q_dev = Q.to("spyre")
+        V_dev = V.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("H", H)
+        _declare_tensor_dim("Lq", Lq)
+        _declare_tensor_dim("Lk", Lk)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(Q_dev, ["B", "H", "Lq", "D"])
+        _name_tensor_dims(V_dev, ["B", "H", "Lk", "D"])
+
+        result = torch.compile(fn)(Q_dev, V_dev).cpu()
+        torch.testing.assert_close(result, ref, atol=0.02, rtol=0.1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1346,7 +1346,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
         from torch_spyre._inductor import spyre_hint
 
         torch.manual_seed(42)
-        B, H, Lq, Lk, D = 1, 8, 256, 256, 64
+        B, H, Lq, Lk, D = 1, 8, 256, 256, 64  # Lk == Lq intentionally; same seq-len
 
         Q = torch.randn(B, H, Lq, D, dtype=torch.float16)
         V = torch.randn(B, H, Lk, D, dtype=torch.float16)

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -19,8 +19,9 @@ Covers six areas, each in its own class group:
      TestIterOpSpecs, TestCodegenOpSpecListRoundtrip)
   2. coarse_tile IR pass: range rewriting, attribute stamping, nested groups
      (TestDivideRanges, TestCoarseTile, TestCoarseTileNested)
-  3. CountedLoopSchedulerNode and build_loop_scheduler_nodes
-     (TestHelpers, TestBuildLoopSchedulerNodes)
+  3. CountedLoopSchedulerNode, build_loop_scheduler_nodes, and
+     _tiled_syms_for_sched_node_at_depth
+     (TestHelpers, TestBuildLoopSchedulerNodes, TestTiledSymsForSchedNode)
   4. generate_sdsc and compile_op_spec symbol/affine-stride paths
      (TestTiledByteStride, TestGenerateSdscTiledSymbols,
       TestCompileOpSpecTwoTiledSymbols, TestCompileOpSpecSymbolMapping)
@@ -1819,6 +1820,44 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
         )
         # Should not raise
         _check_reduction_tiling_safety(op)
+
+
+class TestTiledSymsForSchedNode(unittest.TestCase):
+    """Regression test for _tiled_syms_for_sched_node_at_depth.
+
+    loop_tiled_dims stores host-range indices (e.g. 1 for H in [B=1,H,Lq,D])
+    but the iteration space skips unit-size dims (B=1 dropped), so H is at
+    iteration-space index 0.  The function must map between the two.
+    """
+
+    def test_unit_batch_dim_skipped(self):
+        """[B=1,H=8,Lq=256,D=64] with loop_tiled_dims=[[1]] must return H (c0).
+
+        Without the fix, index 1 is used directly and returns c1 (Lq) instead.
+        """
+        from torch_spyre._inductor.scheduler import _tiled_syms_for_sched_node_at_depth
+        from torch._inductor.scheduler import SchedulerNode
+
+        host_ranges = [1, 8, 256, 64]
+        non_unit = [r for r in host_ranges if r != 1]
+        it_syms = [Symbol(f"c{i}") for i in range(len(non_unit))]
+        it_space = {s: Integer(r) for s, r in zip(it_syms, non_unit)}
+
+        ir_op = MagicMock()
+        ir_op.data.ranges = [Integer(r) for r in host_ranges]
+        ir_op.loop_tiled_dims = [[1]]
+
+        snode = MagicMock(spec=SchedulerNode)
+        snode.node = ir_op
+
+        with patch(
+            "torch_spyre._inductor.scheduler.iteration_space",
+            return_value=it_space,
+        ):
+            result = _tiled_syms_for_sched_node_at_depth(snode, 0)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0]), "c0")  # H, not c1 (Lq)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/codegen/unroll.py
+++ b/torch_spyre/_inductor/codegen/unroll.py
@@ -52,45 +52,30 @@ logger = get_inductor_logger("codegen.unroll")
 def _byte_stride_for_arg(arg: TensorArg, tiled_sym: Symbol, tile_range: int) -> int:
     """Byte advance per loop iteration for a single TensorArg.
 
-    For each device dimension d where the tiled symbol drives a non-zero delta,
-    the device stride (in elements) is the product of all device sizes below
-    dimension d: math.prod(device_size[d+1:]).  The total byte advance is:
+    Computes the byte advance using:
+        delta[d] = coord_d(sym=tile_range, others=0) - coord_d(sym=0, others=0)
+        byte_stride = dot(delta, stride_map) * bytes_per_elem
 
-        sum over d where delta_d != 0:
-            delta_d * math.prod(device_size[d+1:]) * bytes_per_elem
-
-    Using device_size rather than stride_map is correct because the
-    device dimensions are row-major (device_size drives the strides), while
-    stride_map encodes host-memory layout information that is invalidated by
-    align_tensors reordering the device coordinates.
+    This correctly handles non-linear device coordinates such as the stick
+    layout's ``floor(c/64)`` and ``Mod(c, 64)`` expressions.
     """
-    import math as _math
+    assert arg.stride_map is not None, (
+        "_byte_stride_for_arg: TensorArg has no stride_map — "
+        "all TensorArgs reaching the unroller must be constructed with stride_map"
+    )
     all_syms: set = set()
     for expr in arg.device_coordinates:
         all_syms |= expr.free_symbols
     sub_zero = {s: 0 for s in all_syms}
     sub_range = {**sub_zero, tiled_sym: tile_range}
-    # stride_map has one extra entry when the device layout was produced by
-    # align_tensors (5 entries for 4 device coordinates).  In that case
-    # stride_map[d] no longer encodes the correct host-element stride after the
-    # coordinate reshuffle, so we fall back to the device row-major stride
-    # (product of inner device_sizes).  When len(stride_map)==len(coords) the
-    # layout was not reshuffled and stride_map[d] is the element stride directly.
-    use_device_size = len(arg.stride_map) == len(arg.device_coordinates) + 1
-
     total_elem_stride = 0
-    n = len(arg.device_coordinates)
     for d, coord_expr in enumerate(arg.device_coordinates):
         at_range = int(coord_expr.subs(sub_range))
         at_zero = int(coord_expr.subs(sub_zero))
         delta = at_range - at_zero
         if delta == 0:
             continue
-        if use_device_size:
-            device_stride = _math.prod(arg.device_size[d + 1 :]) if d + 1 < n else 1
-        else:
-            device_stride = arg.stride_map[d]
-        total_elem_stride += delta * device_stride
+        total_elem_stride += delta * arg.stride_map[d]
     return total_elem_stride * num_bytes(arg.device_dtype)
 
 

--- a/torch_spyre/_inductor/codegen/unroll.py
+++ b/torch_spyre/_inductor/codegen/unroll.py
@@ -52,30 +52,45 @@ logger = get_inductor_logger("codegen.unroll")
 def _byte_stride_for_arg(arg: TensorArg, tiled_sym: Symbol, tile_range: int) -> int:
     """Byte advance per loop iteration for a single TensorArg.
 
-    Computes the byte advance using:
-        delta[d] = coord_d(sym=tile_range, others=0) - coord_d(sym=0, others=0)
-        byte_stride = dot(delta, stride_map) * bytes_per_elem
+    For each device dimension d where the tiled symbol drives a non-zero delta,
+    the device stride (in elements) is the product of all device sizes below
+    dimension d: math.prod(device_size[d+1:]).  The total byte advance is:
 
-    This correctly handles non-linear device coordinates such as the stick
-    layout's ``floor(c/64)`` and ``Mod(c, 64)`` expressions.
+        sum over d where delta_d != 0:
+            delta_d * math.prod(device_size[d+1:]) * bytes_per_elem
+
+    Using device_size rather than stride_map is correct because the
+    device dimensions are row-major (device_size drives the strides), while
+    stride_map encodes host-memory layout information that is invalidated by
+    align_tensors reordering the device coordinates.
     """
-    assert arg.stride_map is not None, (
-        "_byte_stride_for_arg: TensorArg has no stride_map — "
-        "all TensorArgs reaching the unroller must be constructed with stride_map"
-    )
+    import math as _math
     all_syms: set = set()
     for expr in arg.device_coordinates:
         all_syms |= expr.free_symbols
     sub_zero = {s: 0 for s in all_syms}
     sub_range = {**sub_zero, tiled_sym: tile_range}
+    # stride_map has one extra entry when the device layout was produced by
+    # align_tensors (5 entries for 4 device coordinates).  In that case
+    # stride_map[d] no longer encodes the correct host-element stride after the
+    # coordinate reshuffle, so we fall back to the device row-major stride
+    # (product of inner device_sizes).  When len(stride_map)==len(coords) the
+    # layout was not reshuffled and stride_map[d] is the element stride directly.
+    use_device_size = len(arg.stride_map) == len(arg.device_coordinates) + 1
+
     total_elem_stride = 0
+    n = len(arg.device_coordinates)
     for d, coord_expr in enumerate(arg.device_coordinates):
         at_range = int(coord_expr.subs(sub_range))
         at_zero = int(coord_expr.subs(sub_zero))
         delta = at_range - at_zero
         if delta == 0:
             continue
-        total_elem_stride += delta * arg.stride_map[d]
+        if use_device_size:
+            device_stride = _math.prod(arg.device_size[d + 1 :]) if d + 1 < n else 1
+        else:
+            device_stride = arg.stride_map[d]
+        total_elem_stride += delta * device_stride
     return total_elem_stride * num_bytes(arg.device_dtype)
 
 

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -57,6 +57,12 @@ def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -
     Uses ``loop_tiled_dims[depth]`` from the IR node and the SchedulerNode's
     ``iteration_space`` (which produces the same symbols as ``create_op_spec``
     uses to build ``OpSpec.tiled_symbols``).
+
+    ``loop_tiled_dims`` stores *host-range* dimension indices (indices into
+    ``op.data.ranges``), which include unit-size batch dimensions that are
+    skipped in the iteration space.  We must map host-range indices to
+    iteration-space key indices by walking ``op.data.ranges`` and counting
+    only the non-unit entries.
     """
     ir_op = sched_node.node
     if ir_op is None:
@@ -69,7 +75,27 @@ def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -
         return []
     it_space = iteration_space(sched_node)
     keys = list(it_space.keys())
-    return [keys[d] for d in dims_per_level[depth] if d < len(keys)]
+
+    # Build a map from host-range index → iteration-space key index.
+    # The iteration space only contains symbols for non-unit ranges, so we
+    # walk op.data.ranges and assign the next it-space slot to each non-unit dim.
+    host_to_it: dict[int, int] = {}
+    try:
+        ranges = ir_op.data.ranges
+        it_idx = 0
+        for host_idx, r in enumerate(ranges):
+            if int(r) != 1:
+                host_to_it[host_idx] = it_idx
+                it_idx += 1
+    except (AttributeError, TypeError):
+        return [keys[d] for d in dims_per_level[depth] if d < len(keys)]
+
+    result = []
+    for d in dims_per_level[depth]:
+        it_idx = host_to_it.get(d)
+        if it_idx is not None and it_idx < len(keys):
+            result.append(keys[it_idx])
+    return result
 
 
 class CountedLoopSchedulerNode(FusedSchedulerNode):

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -77,24 +77,21 @@ def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -
     keys = list(it_space.keys())
 
     # Build a map from host-range index → iteration-space key index.
-    # The iteration space only contains symbols for non-unit ranges, so we
-    # walk op.data.ranges and assign the next it-space slot to each non-unit dim.
+    # loop_tiled_dims is only stamped on ComputedBuffer ops (Pointwise/Reduction),
+    # so data.ranges is always present here.  The iteration space simply omits
+    # unit-size dims, so we walk ranges and count only non-unit entries.
     host_to_it: dict[int, int] = {}
-    try:
-        ranges = ir_op.data.ranges
-        it_idx = 0
-        for host_idx, r in enumerate(ranges):
-            if int(r) != 1:
-                host_to_it[host_idx] = it_idx
-                it_idx += 1
-    except (AttributeError, TypeError):
-        return [keys[d] for d in dims_per_level[depth] if d < len(keys)]
+    it_idx = 0
+    for host_idx, r in enumerate(ir_op.data.ranges):
+        if int(r) != 1:
+            host_to_it[host_idx] = it_idx
+            it_idx += 1
 
     result = []
     for d in dims_per_level[depth]:
-        it_idx = host_to_it.get(d)
-        if it_idx is not None and it_idx < len(keys):
-            result.append(keys[it_idx])
+        mapped = host_to_it.get(d)
+        if mapped is not None and mapped < len(keys):
+            result.append(keys[mapped])
     return result
 
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -783,5 +783,31 @@ def simplify_op_spec(op_spec):
     )
     op_spec.iteration_space = new_op_space_splits
     for arg, t in zip(op_spec.args, new_tensors):
+        old_coords = arg.device_coordinates
+        old_stride_map = arg.stride_map
         arg.device_size = t["size"]
         arg.device_coordinates = t["coordinates"]
+        # Invariant: stride_map[d] must be the host-element stride for
+        # device dimension d.  align_tensors may reorder device_coordinates
+        # without touching stride_map, breaking this invariant.  Restore it
+        # by remapping each entry: for every new coordinate at position d,
+        # locate the old position that held the same iteration symbol and
+        # carry its stride value forward.
+        if old_stride_map is not None:
+            # Extend if align_tensors added coordinate dimensions, padding
+            # with 0 (those positions will never drive a non-zero delta).
+            new_stride_map = list(old_stride_map) + [0] * max(
+                0, len(arg.device_coordinates) - len(old_stride_map)
+            )
+            old_sym_to_idx = {}
+            for j, coord in enumerate(old_coords):
+                for sym in coord.free_symbols:
+                    old_sym_to_idx.setdefault(sym, j)
+            for d, coord in enumerate(arg.device_coordinates):
+                syms = coord.free_symbols
+                if not syms:
+                    continue
+                j = old_sym_to_idx.get(next(iter(syms)))
+                if j is not None and j < len(old_stride_map):
+                    new_stride_map[d] = old_stride_map[j]
+            arg.stride_map = new_stride_map


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

 Fixes three related bugs that caused wrong HBM base-address advances when coarse-tiling over a non-outermost host dimension (e.g. H in [B,H,Lq,D] with B=1).

**ROOT CAUSE**

Three invariants were broken:

1. scheduler.py (_tiled_syms_for_sched_node_at_depth): loop_tiled_dims stores host-range indices (e.g. 1 for H in [B=1,H,Lq,D]), but was used directly as iteration-space  key indices. Since B=1 is dropped from the iteration space, H is at index 0, not 1 — the wrong symbol (Lq) was selected as the tiled symbol.

2. spyre_kernel.py (simplify_op_spec): align_tensors rewrites device_coordinates to rearrange how iteration variables map to device dimensions, but didn't update stride_map to match. After the rewrite, stride_map[d] no longer corresponded to coordinate d, so the unroller read the wrong host stride.

3. unroll.py (_byte_stride_for_arg): relied on stride_map[d] being correct (which broke due to (2) above).

**FIX**

1. In _tiled_syms_for_sched_node_at_depth: walk data.ranges to build a host-index → iteration-space-index mapping, skipping unit-size dims.

2. In simplify_op_spec: after align_tensors reshuffles device_coordinates, remap stride_map entries to stay consistent — for each new coordinate position, find the old  position with the same symbol and carry its stride forward.

3. _byte_stride_for_arg now works correctly because stride_map is kept consistent.

Reproducer (fails with error ~9 before fix, passes after):
 `q * v with spyre_hint(slices={"H": 2}) on [B=1, H=8, Lq=256, D=64]`


#### Which issue(s) this PR is related to:

Part of #1358 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
Standalone version of pytest  `test_hint_h_tiling_elementwise`
```
import math
import torch
from torch_spyre._inductor import config, spyre_hint
import torch_spyre._inductor.propagate_named_dims as pnd

declare_tensor_dim = pnd.declare_tensor_dim
name_tensor_dims = pnd.name_tensor_dims

torch.manual_seed(42)

# Small enough to inspect
B, H, Lq, Lk, D = 1, 8, 256, 256, 64
# NOTE: H must be divisible by H_TILES

Q = torch.randn(B, H, Lq, D, dtype=torch.float16)
K = torch.randn(B, H, Lk, D, dtype=torch.float16)
V = torch.randn(B, H, Lk, D, dtype=torch.float16)

H_TILES = 2 # change to 1 to compare

def attn(q, v):
    with spyre_hint(slices={"H": H_TILES}):
        # pointwise + single matmul — fewest ops that still compile
        out = q * v
    return out

# CPU reference
ref = attn(Q, V)

# Device
Q_d = Q.to("spyre")
V_d = V.to("spyre")

declare_tensor_dim("B", B)
declare_tensor_dim("H", H)
declare_tensor_dim("Lq", Lq)
declare_tensor_dim("Lk", Lk)
declare_tensor_dim("D", D)
name_tensor_dims(Q_d, ["B", "H", "Lq", "D"])
name_tensor_dims(V_d, ["B", "H", "Lk", "D"])

config.coarse_tiling = True

result = torch.compile(attn)(Q_d, V_d).cpu()

print(f"H_TILES={H_TILES}")
print(f"ref:    {ref.flatten()[:8]}")
print(f"result: {result.flatten()[:8]}")
diff = torch.abs(ref - result)
print(f"max abs diff: {diff.amax().item()}")
print(f"per-head max: {diff.amax(dim=(0,2,3))}")

torch.testing.assert_close(
    result, ref, equal_nan=True, atol=0.02, rtol=0.1,
    msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
)
print("PASSED")
```