### PR TITLE
Generate SuperDSCs with with symbolic addresses 

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2068,21 +2068,47 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
         mlir = self._bundle([op0] + ops_rest, symbolic_args=True, fake_compile=fake)
 
-        # All 12 HBM symbols become input_arg parameters (kernel args)
+        # Symbols with the same address are deduped: 12 symbols → 6 unique params
+        # (sym_values has many repeats: 0x400000000, 0x800000000, 0x0, 0xC00000000,
+        #  0x1000000000, 0x1400000000 are the 6 distinct values)
         self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
-        self.assertIn("%sym_0_2: !sdscbundle.input_arg<index>", mlir)
-        self.assertIn("%sym_0_12: !sdscbundle.input_arg<index>", mlir)
-        # Extract ops for all params
-        self.assertIn("%sym_0_1_extracted = sdscbundle.input_arg_extract", mlir)
-        self.assertIn("%sym_0_2_extracted = sdscbundle.input_arg_extract", mlir)
+        self.assertIn("%sym_0_6: !sdscbundle.input_arg<index>", mlir)
+        self.assertNotIn("%sym_0_7:", mlir)
         # First sdsc_execute uses first two extracted names
         self.assertIn(
             "sdscbundle.sdsc_execute (%sym_0_1_extracted, %sym_0_2_extracted)", mlir
         )
-        # No arith.constant for any symbol (all are input_arg params)
+        # Duplicate addresses reuse existing extracted SSA names
         self.assertNotIn("arith.constant", mlir)
-        # No pool parameter
         self.assertNotIn("%pool:", mlir)
+
+    def test_same_kernel_arg_across_sdsc_deduped(self):
+        """The same kernel arg address appearing in two SDSCs maps to one input_arg param."""
+        # Simulates softmax: arg_index=0 appears in both op0 and op1.
+        a = _make_minimal_op_spec("a")
+        b = _make_minimal_op_spec("b")
+        base = 0x400000000  # SEGMENT_OFFSETS[1], arg_index=0
+        call_count = [0]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            call_count[0] += 1
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(base)
+            return _make_tiled_json(idx, sym_id), [base], [{}], [SymbolKind.kernel()]
+
+        mlir = self._bundle([a, b], symbolic_args=True, fake_compile=fake)
+
+        # Only one input_arg param (deduped cross-SDSC)
+        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
+        self.assertNotIn("%sym_0_2:", mlir)
+        # Both sdsc_execute ops reference the same extracted name
+        execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
+        self.assertEqual(
+            execute_lines[0].split("(")[1].split(")")[0], "%sym_0_1_extracted"
+        )
+        self.assertEqual(
+            execute_lines[1].split("(")[1].split(")")[0], "%sym_0_1_extracted"
+        )
 
     def test_pool_offset_constants_deduped(self):
         """Pool symbols with the same offset share one arith.addi SSA variable."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -341,8 +341,8 @@ def _fake_compile_op_spec(
     symbol_id_offset: int = 0,
     use_symbols: bool = True,
 ):
-    """Stub that returns (json, [], []) — no real SDSC compilation."""
-    return {f"{idx}_{op_spec.op}": {"op": op_spec.op}}, [], []
+    """Stub that returns (json, [], [], []) — no real SDSC compilation."""
+    return {f"{idx}_{op_spec.op}": {"op": op_spec.op}}, [], [], []
 
 
 def _read_mlir(output_dir: str) -> str:
@@ -873,7 +873,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
         s = Symbol("s")
         sdsc_spec = _make_sdsc_spec(s, iter_range=64, device_stride=128)
         symbols: list[int] = []
-        _, _, affine_strides = generate_sdsc(
+        _, _, affine_strides, _ = generate_sdsc(
             0,
             sdsc_spec,
             symbols,
@@ -905,7 +905,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
         s = Symbol("s")
         sdsc_spec = _make_sdsc_spec(s)
         symbols: list[int] = []
-        sdsc_json, _, _ = generate_sdsc(
+        sdsc_json, _, _, _ = generate_sdsc(
             0,
             sdsc_spec,
             symbols,
@@ -923,7 +923,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
         s = Symbol("s")
         sdsc_spec = _make_sdsc_spec(s)
         symbols: list[int] = []
-        _, _, affine_strides = generate_sdsc(
+        _, _, affine_strides, _ = generate_sdsc(
             0,
             sdsc_spec,
             symbols,
@@ -940,7 +940,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             s, start_address=lx_addr, allocation={"lx": lx_addr}
         )
         symbols: list[int] = []
-        _, local_sym_values, affine_strides = generate_sdsc(
+        _, local_sym_values, affine_strides, _ = generate_sdsc(
             0,
             sdsc_spec,
             symbols,
@@ -956,7 +956,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
         s = Symbol("s")
         sdsc_spec = _make_sdsc_spec(s)
         symbols: list[int] = []
-        sdsc_json, local_sym_values, _ = generate_sdsc(
+        sdsc_json, local_sym_values, _, _ = generate_sdsc(
             0,
             sdsc_spec,
             symbols,
@@ -1001,7 +1001,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             coordinate_masking={},
         )
         symbols: list[int] = []
-        _, local_sym_values, affine_strides = generate_sdsc(
+        _, local_sym_values, affine_strides, _ = generate_sdsc(
             0,
             sdsc_spec,
             symbols,
@@ -1053,7 +1053,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_produce_two_stride_entries(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
         hbm_strides = [d for d in affine_strides if len(d) > 0]
         self.assertGreater(len(hbm_strides), 0)
         for tensor_strides in hbm_strides:
@@ -1062,7 +1062,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_strides_are_positive(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
         for tensor_strides in affine_strides:
             for sym, stride in tensor_strides.items():
                 self.assertGreater(stride, 0)
@@ -1072,7 +1072,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
     def test_affine_strides_non_empty_for_tiled_op(self):
         op_spec = _make_tiled_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
         has_strides = any(len(d) > 0 for d in affine_strides)
         self.assertTrue(
             has_strides,
@@ -1308,7 +1308,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
-            return _make_tiled_json(idx, sym_id), [0x1000], [{s: stride}]
+            return _make_tiled_json(idx, sym_id), [0x1000], [{s: stride}], []
 
         op = _make_minimal_op_spec("a")
         op.tiled_symbols = [s]
@@ -1328,7 +1328,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x2000)
-            return _make_tiled_json(idx, sym_id), [0x2000], [{}]
+            return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
 
         op = _make_minimal_op_spec("b")
         loop = LoopSpec(count=Integer(2), body=[op])
@@ -1346,7 +1346,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x3000)
-            return _make_tiled_json(idx, sym_id), [0x3000], [{s: stride}]
+            return _make_tiled_json(idx, sym_id), [0x3000], [{s: stride}], []
 
         op = _make_minimal_op_spec("c")
         op.tiled_symbols = [s]
@@ -1363,7 +1363,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x4000)
-            return _make_tiled_json(idx, sym_id), [0x4000], [{s: 512}]
+            return _make_tiled_json(idx, sym_id), [0x4000], [{s: 512}], []
 
         op = _make_minimal_op_spec("d")
         op.tiled_symbols = [s]
@@ -1382,7 +1382,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
-            return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}]
+            return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
 
         op = _make_minimal_op_spec("a")
         op.tiled_symbols = [s]
@@ -1435,6 +1435,7 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [0x1000],
                 [{s0: outer_stride, s1: inner_stride}],
+                ["kernel"],
             )
 
         return fake_compile
@@ -1901,6 +1902,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 json_out,
                 [arg.allocation["hbm"] for arg in op_spec.args],
                 [{} for _ in op_spec.args],
+                ["kernel" for _ in op_spec.args],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
@@ -1934,6 +1936,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
+                ["kernel"],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
@@ -1945,7 +1948,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def test_non_tensor_arg_symbols_remain_as_constants(self):
         c0 = Symbol("c0")
         op_a = self._make_op_spec_with_hbm_args("a", [0])
-        # op_b: arg_index=-1, not a kernel arg (intermediate buffer)
+        # op_b: arg_index=-1, pool-allocated (fake returns "pool" kind)
         op_b = OpSpec(
             op="b",
             is_reduction=False,
@@ -1970,15 +1973,17 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(values[i])
-            return _make_tiled_json(idx, sym_id), [values[i]], [{}]
+            kind = "kernel" if i == 0 else "pool"  # op_b has pool allocation
+            return _make_tiled_json(idx, sym_id), [values[i]], [{}], [kind]
 
         mlir = self._bundle([op_a, op_b], symbolic_args=True, fake_compile=fake)
 
-        # First sym → parameter (tensor arg at arg_index=0)
+        # First sym → parameter (kernel tensor arg)
         self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
         self.assertNotIn("arith.constant 17179869184", mlir)
-        # Second sym → constant (intermediate, arg_index=-1)
-        self.assertIn("arith.constant 0 : index", mlir)
+        # Second sym → pool: arith.addi %pool_extracted, <offset>
+        self.assertIn("%pool: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%sym_2 = arith.addi %pool_extracted", mlir)
 
     def test_symbolic_args_false_no_params(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
@@ -1990,6 +1995,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
+                ["kernel"],
             )
 
         mlir = self._bundle([a], symbolic_args=False, fake_compile=fake)
@@ -2048,25 +2054,32 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                     ],
                 }
             }
-            return json_out, sym_values[start : start + n], [{} for _ in range(n)]
+            # All symbols in this test are kernel args — all become input_arg params.
+            symbol_kind_flags = ["kernel"] * n
+            return (
+                json_out,
+                sym_values[start : start + n],
+                [{} for _ in range(n)],
+                symbol_kind_flags,
+            )
 
         mlir = self._bundle([op0] + ops_rest, symbolic_args=True, fake_compile=fake)
 
-        # Func signature has 2 params (arg_index 0 and 1)
-        self.assertIn(
-            "func.func @sdsc_bundle("
-            "%sym_0_1: !sdscbundle.input_arg<index>,"
-            " %sym_0_2: !sdscbundle.input_arg<index>)",
-            mlir,
-        )
+        # All 12 HBM symbols become input_arg parameters (kernel args)
+        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%sym_0_2: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%sym_0_12: !sdscbundle.input_arg<index>", mlir)
+        # Extract ops for all params
         self.assertIn("%sym_0_1_extracted = sdscbundle.input_arg_extract", mlir)
         self.assertIn("%sym_0_2_extracted = sdscbundle.input_arg_extract", mlir)
-        # First sdsc_execute uses extracted names
+        # First sdsc_execute uses first two extracted names
         self.assertIn(
             "sdscbundle.sdsc_execute (%sym_0_1_extracted, %sym_0_2_extracted)", mlir
         )
-        # No %sym_0_3 — only two tensor args
-        self.assertNotIn("%sym_0_3", mlir)
+        # No arith.constant for any symbol (all are input_arg params)
+        self.assertNotIn("arith.constant", mlir)
+        # No pool parameter
+        self.assertNotIn("%pool:", mlir)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1817,5 +1817,257 @@ class TestTiledSymsForSchedNode(unittest.TestCase):
         self.assertEqual(str(result[0]), "c0")  # H, not c1 (Lq)
 
 
+class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _bundle(self, specs, symbolic_args=False, fake_compile=None):
+        if fake_compile is None:
+            fake_compile = _fake_compile_op_spec
+        with patch(
+            "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+            side_effect=fake_compile,
+        ):
+            generate_bundle(
+                "test_kernel",
+                self.tmpdir,
+                specs,
+                use_symbols=True,
+                unroll_loops=False,
+                symbolic_args=symbolic_args,
+            )
+        return _read_mlir(self.tmpdir)
+
+    def _make_op_spec_with_hbm_args(self, name: str, arg_indices: list) -> OpSpec:
+        """Minimal OpSpec whose TensorArgs have the given arg_indices and hbm allocation."""
+        c0 = Symbol("c0")
+        args = [
+            TensorArg(
+                is_input=(i == 0),
+                arg_index=idx,
+                device_dtype=_FP16,
+                device_size=[2, 64],
+                device_coordinates=[Integer(0), c0],
+                allocation={"hbm": 0x400000000 * (idx + 1)},
+            )
+            for i, idx in enumerate(arg_indices)
+        ]
+        return OpSpec(
+            op=name,
+            is_reduction=False,
+            iteration_space={c0: (Integer(128), 1)},
+            args=args,
+            op_info={},
+        )
+
+    def test_signature_accepts_symbolic_args_param(self):
+        a = _make_minimal_op_spec("a")
+        mlir = self._bundle([a], symbolic_args=False)
+        self.assertIn("sdsc_execute", mlir)
+
+    def test_func_signature_has_params_for_tensor_args(self):
+        a = self._make_op_spec_with_hbm_args("a", [0, 1])
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            for i, arg in enumerate(op_spec.args):
+                symbols.append(arg.allocation["hbm"])
+            ids = [-(symbol_id_offset + i + 1) for i in range(len(op_spec.args))]
+            json_out = {
+                f"{idx}_{op_spec.op}": {
+                    "numCoresUsed_": 1,
+                    "dscs_": [
+                        {
+                            "op": {
+                                "scheduleTree_": [
+                                    {
+                                        "component_": "hbm",
+                                        "startAddressCoreCorelet_": {
+                                            "data_": {"[0, 0, 0]": str(ids[j])}
+                                        },
+                                    }
+                                    for j in range(len(op_spec.args))
+                                ]
+                            }
+                        }
+                    ],
+                }
+            }
+            return (
+                json_out,
+                [arg.allocation["hbm"] for arg in op_spec.args],
+                [{} for _ in op_spec.args],
+            )
+
+        mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
+
+        self.assertIn(
+            "func.func @sdsc_bundle("
+            "%sym_0_1: !sdscbundle.input_arg<index>,"
+            " %sym_0_2: !sdscbundle.input_arg<index>)",
+            mlir,
+        )
+        self.assertIn(
+            "%sym_0_1_extracted = sdscbundle.input_arg_extract value from"
+            " %sym_0_1 : !sdscbundle.input_arg<index> -> index",
+            mlir,
+        )
+        self.assertIn(
+            "%sym_0_2_extracted = sdscbundle.input_arg_extract value from"
+            " %sym_0_2 : !sdscbundle.input_arg<index> -> index",
+            mlir,
+        )
+        self.assertNotIn("arith.constant 17179869184", mlir)
+        self.assertNotIn("arith.constant 34359738368", mlir)
+
+    def test_sdsc_execute_uses_extracted_names(self):
+        a = self._make_op_spec_with_hbm_args("a", [0])
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(op_spec.args[0].allocation["hbm"])
+            return (
+                _make_tiled_json(idx, sym_id),
+                [op_spec.args[0].allocation["hbm"]],
+                [{}],
+            )
+
+        mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
+
+        self.assertIn("sdscbundle.sdsc_execute (%sym_0_1_extracted)", mlir)
+        self.assertNotIn("sdsc_execute (%sym_0_1)", mlir)
+        self.assertNotIn("sdsc_execute (%sym_1)", mlir)
+
+    def test_non_tensor_arg_symbols_remain_as_constants(self):
+        c0 = Symbol("c0")
+        op_a = self._make_op_spec_with_hbm_args("a", [0])
+        # op_b: arg_index=-1, not a kernel arg (intermediate buffer)
+        op_b = OpSpec(
+            op="b",
+            is_reduction=False,
+            iteration_space={c0: (Integer(128), 1)},
+            args=[
+                TensorArg(
+                    is_input=True,
+                    arg_index=-1,
+                    device_dtype=_FP16,
+                    device_size=[2, 64],
+                    device_coordinates=[Integer(0), c0],
+                    allocation={"hbm": 0x0},
+                )
+            ],
+            op_info={},
+        )
+        call_count = [0]
+        values = [0x400000000, 0x0]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            i = call_count[0]
+            call_count[0] += 1
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(values[i])
+            return _make_tiled_json(idx, sym_id), [values[i]], [{}]
+
+        mlir = self._bundle([op_a, op_b], symbolic_args=True, fake_compile=fake)
+
+        # First sym → parameter (tensor arg at arg_index=0)
+        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
+        self.assertNotIn("arith.constant 17179869184", mlir)
+        # Second sym → constant (intermediate, arg_index=-1)
+        self.assertIn("arith.constant 0 : index", mlir)
+
+    def test_symbolic_args_false_no_params(self):
+        a = self._make_op_spec_with_hbm_args("a", [0])
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(op_spec.args[0].allocation["hbm"])
+            return (
+                _make_tiled_json(idx, sym_id),
+                [op_spec.args[0].allocation["hbm"]],
+                [{}],
+            )
+
+        mlir = self._bundle([a], symbolic_args=False, fake_compile=fake)
+
+        self.assertIn("func.func @sdsc_bundle()", mlir)
+        self.assertNotIn("input_arg", mlir)
+        self.assertIn("arith.constant 17179869184", mlir)
+
+    def test_multi_sdsc_two_tensor_args_snapshot(self):
+        """Two tensor args on first op; remaining ops use arith.constant symbols."""
+        op0 = self._make_op_spec_with_hbm_args("op0", [0, 1])
+        ops_rest = [_make_minimal_op_spec(f"op{i}") for i in range(1, 5)]
+        call_count = [0]
+        # sym values: first two are tensor args, rest are intermediates
+        sym_values = [
+            0x400000000,
+            0x800000000,  # op0: tensor args
+            0x0,
+            0x400000000,
+            0x800000000,  # op1
+            0x800000000,
+            0xC00000000,  # op2
+            0xC00000000,
+            0x1000000000,  # op3
+            0xC00000000,
+            0x1000000000,
+            0x1400000000,  # op4
+        ]
+        sym_counts = [2, 3, 2, 2, 3]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            i = call_count[0]
+            call_count[0] += 1
+            n = sym_counts[i]
+            start = sum(sym_counts[:i])
+            local_ids = [-(symbol_id_offset + j + 1) for j in range(n)]
+            for v in sym_values[start : start + n]:
+                symbols.append(v)
+            json_out = {
+                f"{idx}_{op_spec.op}": {
+                    "numCoresUsed_": 1,
+                    "dscs_": [
+                        {
+                            "op": {
+                                "scheduleTree_": [
+                                    {
+                                        "component_": "hbm",
+                                        "startAddressCoreCorelet_": {
+                                            "data_": {"[0, 0, 0]": str(local_ids[j])}
+                                        },
+                                    }
+                                    for j in range(n)
+                                ]
+                            }
+                        }
+                    ],
+                }
+            }
+            return json_out, sym_values[start : start + n], [{} for _ in range(n)]
+
+        mlir = self._bundle([op0] + ops_rest, symbolic_args=True, fake_compile=fake)
+
+        # Func signature has 2 params (arg_index 0 and 1)
+        self.assertIn(
+            "func.func @sdsc_bundle("
+            "%sym_0_1: !sdscbundle.input_arg<index>,"
+            " %sym_0_2: !sdscbundle.input_arg<index>)",
+            mlir,
+        )
+        self.assertIn("%sym_0_1_extracted = sdscbundle.input_arg_extract", mlir)
+        self.assertIn("%sym_0_2_extracted = sdscbundle.input_arg_extract", mlir)
+        # First sdsc_execute uses extracted names
+        self.assertIn(
+            "sdscbundle.sdsc_execute (%sym_0_1_extracted, %sym_0_2_extracted)", mlir
+        )
+        # No %sym_0_3 — only two tensor args
+        self.assertNotIn("%sym_0_3", mlir)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -47,6 +47,7 @@ from torch.utils._ordered_set import OrderedSet
 
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.codegen.bundle import generate_bundle
+from torch_spyre._inductor.codegen.compute_ops import SymbolKind
 from torch_spyre._inductor.codegen.compute_ops import (
     _tiled_byte_stride,
     generate_sdsc,
@@ -1435,7 +1436,7 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [0x1000],
                 [{s0: outer_stride, s1: inner_stride}],
-                [("kernel", 0)],
+                [SymbolKind.kernel()],
             )
 
         return fake_compile
@@ -1902,7 +1903,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 json_out,
                 [arg.allocation["hbm"] for arg in op_spec.args],
                 [{} for _ in op_spec.args],
-                [("kernel", 0) for _ in op_spec.args],
+                [SymbolKind.kernel() for _ in op_spec.args],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
@@ -1936,7 +1937,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
-                [("kernel", 0)],
+                [SymbolKind.kernel()],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
@@ -1973,7 +1974,9 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(values[i])
-            kind = ("kernel", 0) if i == 0 else ("pool", 0)  # op_b has pool allocation
+            kind = (
+                SymbolKind.kernel() if i == 0 else SymbolKind.pool()
+            )  # op_b has pool allocation
             return _make_tiled_json(idx, sym_id), [values[i]], [{}], [kind]
 
         mlir = self._bundle([op_a, op_b], symbolic_args=True, fake_compile=fake)
@@ -1995,7 +1998,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
-                [("kernel", 0)],
+                [SymbolKind.kernel()],
             )
 
         mlir = self._bundle([a], symbolic_args=False, fake_compile=fake)
@@ -2055,7 +2058,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 }
             }
             # All symbols in this test are kernel args — all become input_arg params.
-            symbol_kind_flags = [("kernel", 0)] * n
+            symbol_kind_flags = [SymbolKind.kernel()] * n
             return (
                 json_out,
                 sym_values[start : start + n],
@@ -2096,7 +2099,12 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(pool_values[i])
-            return _make_tiled_json(idx, sym_id), [pool_values[i]], [{}], [("pool", 0)]
+            return (
+                _make_tiled_json(idx, sym_id),
+                [pool_values[i]],
+                [{}],
+                [SymbolKind.pool()],
+            )
 
         mlir = self._bundle([a, b, c], symbolic_args=True, fake_compile=fake)
 
@@ -2111,6 +2119,152 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         self.assertEqual(execute_lines[0].split("(")[1].split(")")[0], "%sym_1")
         self.assertEqual(execute_lines[1].split("(")[1].split(")")[0], "%sym_2")
         self.assertEqual(execute_lines[2].split("(")[1].split(")")[0], "%sym_1")
+
+
+class TestSymbolKind(unittest.TestCase):
+    """Unit tests for the SymbolKind dataclass."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_import(self):
+        _ = SymbolKind  # importable as a top-level name
+
+    def test_kernel_base_kind(self):
+        sk = SymbolKind.kernel()
+        self.assertEqual(sk.kind, "kernel")
+        self.assertFalse(sk.is_derived)
+        self.assertFalse(sk.is_pool)
+
+    def test_kernel_derived_kind_carries_base_index_and_offset(self):
+        sk = SymbolKind.kernel_derived(base_sym_idx=3, offset=512)
+        self.assertEqual(sk.kind, "kernel_derived")
+        self.assertEqual(sk.base_sym_idx, 3)
+        self.assertEqual(sk.offset, 512)
+        self.assertTrue(sk.is_derived)
+        self.assertFalse(sk.is_pool)
+
+    def test_pool_kind(self):
+        sk = SymbolKind.pool()
+        self.assertEqual(sk.kind, "pool")
+        self.assertFalse(sk.is_derived)
+        self.assertTrue(sk.is_pool)
+
+    def test_generate_sdsc_two_cores_emits_kernel_derived_with_base_idx(self):
+        """With num_cores=2, the second per-core tiled symbol should be kernel_derived
+        and carry the index of the first (kernel base) symbol."""
+
+        s = Symbol("s")
+        core_id = Symbol("core_id")
+        from sympy import Mod
+
+        # Mirror the existing TestGenerateSdscTiledSymbols multi-core test but
+        # with arg_index=0 to exercise the kernel/kernel_derived kind path.
+        tensor = SDSCArgs(
+            layout="A",
+            dim_order=[s],
+            data_format=_FP16,
+            scales={s: 1},
+            strides={s: 128},
+            offsets={s: 0},
+            max_dim_sizes={s: -1},
+            allocation={"hbm": 0x1000},
+            start_address=0x1000,
+            backGap={},
+            arg_index=0,  # kernel arg → kinds should be kernel + kernel_derived
+        )
+        sdsc_spec = SDSCSpec(
+            opfunc="add",
+            execution_unit="sfp",
+            data_format=_FP16,
+            num_inputs=1,
+            iteration_space={s: 32},
+            num_cores=2,
+            work_slices={s: 2},
+            core_id_to_work_slice={s: Mod(core_id, 2)},
+            padding={},
+            layouts={"A": {"dim_order": [s], "stick_dim_order": s, "stick_size": 64}},
+            args=[tensor],
+            constants={},
+            coordinate_masking={},
+        )
+        symbols: list[int] = []
+        _, _, _, kinds = generate_sdsc(
+            0,
+            sdsc_spec,
+            symbols,
+            symbol_id_offset=0,
+            tiled_symbols=[s],
+            use_symbols=True,
+        )
+        self.assertEqual(len(kinds), 2)
+        self.assertIsInstance(kinds[0], SymbolKind)
+        self.assertEqual(kinds[0].kind, "kernel")
+        self.assertIsInstance(kinds[1], SymbolKind)
+        self.assertEqual(kinds[1].kind, "kernel_derived")
+        self.assertEqual(kinds[1].base_sym_idx, 0)  # base is symbols[0]
+        self.assertEqual(kinds[1].offset, symbols[1] - symbols[0])
+
+    def test_bundle_kernel_derived_no_backward_scan(self):
+        """bundle.py uses SymbolKind.base_sym_idx directly — no backward scan needed.
+        Two ops, same kernel arg but different per-core offsets share one param."""
+        a = _make_minimal_op_spec("a")
+        b = _make_minimal_op_spec("b")
+
+        call_count = [0]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            i = call_count[0]
+            call_count[0] += 1
+            base = 0x400000000
+            off = 1024
+            if i == 0:
+                # op0: sym 0 = kernel base, sym 1 = kernel_derived +1024
+                symbols.append(base)
+                symbols.append(base + off)
+                kinds = [SymbolKind.kernel(), SymbolKind.kernel_derived(0, off)]
+                json0 = _make_tiled_json(idx, -(symbol_id_offset + 1))
+                return json0, [base, base + off], [{}, {}], kinds
+            else:
+                # op1: reuses same derived offset — sym 2
+                symbols.append(base + off)
+                kinds = [SymbolKind.kernel_derived(0, off)]
+                json1 = _make_tiled_json(idx, -(symbol_id_offset + 1))
+                return json1, [base + off], [{}], kinds
+
+        with patch(
+            "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+            side_effect=fake,
+        ):
+            generate_bundle(
+                "test_kernel",
+                self.tmpdir,
+                [a, b],
+                use_symbols=True,
+                unroll_loops=False,
+                symbolic_args=True,
+            )
+        mlir = _read_mlir(self.tmpdir)
+
+        # Only one input_arg param (the kernel base)
+        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
+        self.assertNotIn("%sym_0_2:", mlir)
+        # Derived address emitted once as arith.addi (deduped across both ops)
+        self.assertEqual(mlir.count("arith.constant 1024"), 1)
+        self.assertEqual(mlir.count("arith.addi %sym_0_1_extracted"), 1)
+        # op0's execute has the kernel base; op1's execute has the derived %sym_N
+        # Both refer to the same canonical derived SSA — no second arith.addi for op1
+        self.assertIn("sdscbundle.sdsc_execute (%sym_0_1_extracted)", mlir)
+        # op1 operand is the canonical derived var (%sym_2), not a new addi
+        execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
+        op1_operand = execute_lines[1].split("(")[1].split(")")[0].strip()
+        self.assertTrue(op1_operand.startswith("%sym_"), op1_operand)
+        self.assertNotIn("input_arg_extract", op1_operand)
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1436,7 +1436,7 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [0x1000],
                 [{s0: outer_stride, s1: inner_stride}],
-                [SymbolKind.kernel()],
+                [SymbolKind.kernel(0)],
             )
 
         return fake_compile
@@ -1903,25 +1903,25 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 json_out,
                 [arg.allocation["hbm"] for arg in op_spec.args],
                 [{} for _ in op_spec.args],
-                [SymbolKind.kernel() for _ in op_spec.args],
+                [SymbolKind.kernel(arg.arg_index) for arg in op_spec.args],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
 
         self.assertIn(
             "func.func @sdsc_bundle("
-            "%sym_0_1: !sdscbundle.input_arg<index>,"
-            " %sym_0_2: !sdscbundle.input_arg<index>)",
+            "%arg_0_base_addr: !sdscbundle.input_arg<index>,"
+            " %arg_1_base_addr: !sdscbundle.input_arg<index>)",
             mlir,
         )
         self.assertIn(
-            "%sym_0_1_extracted = sdscbundle.input_arg_extract value from"
-            " %sym_0_1 : !sdscbundle.input_arg<index> -> index",
+            "%arg_0 = sdscbundle.input_arg_extract value from"
+            " %arg_0_base_addr : !sdscbundle.input_arg<index> -> index",
             mlir,
         )
         self.assertIn(
-            "%sym_0_2_extracted = sdscbundle.input_arg_extract value from"
-            " %sym_0_2 : !sdscbundle.input_arg<index> -> index",
+            "%arg_1 = sdscbundle.input_arg_extract value from"
+            " %arg_1_base_addr : !sdscbundle.input_arg<index> -> index",
             mlir,
         )
         self.assertNotIn("arith.constant 17179869184", mlir)
@@ -1937,12 +1937,12 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
-                [SymbolKind.kernel()],
+                [SymbolKind.kernel(0)],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
 
-        self.assertIn("sdscbundle.sdsc_execute (%sym_0_1_extracted)", mlir)
+        self.assertIn("sdscbundle.sdsc_execute (%arg_0)", mlir)
         self.assertNotIn("sdsc_execute (%sym_0_1)", mlir)
         self.assertNotIn("sdsc_execute (%sym_1)", mlir)
 
@@ -1975,18 +1975,18 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(values[i])
             kind = (
-                SymbolKind.kernel() if i == 0 else SymbolKind.pool()
+                SymbolKind.kernel(0) if i == 0 else SymbolKind.pool()
             )  # op_b has pool allocation
             return _make_tiled_json(idx, sym_id), [values[i]], [{}], [kind]
 
         mlir = self._bundle([op_a, op_b], symbolic_args=True, fake_compile=fake)
 
         # First sym → parameter (kernel tensor arg)
-        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
         self.assertNotIn("arith.constant 17179869184", mlir)
-        # Second sym → pool: arith.addi %pool_extracted, <offset>
-        self.assertIn("%pool: !sdscbundle.input_arg<index>", mlir)
-        self.assertIn("%sym_2 = arith.addi %pool_extracted", mlir)
+        # Second sym → pool: arith.addi %pool, <offset>
+        self.assertIn("%pool_base_addr: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%pool_addr_0 = arith.addi %pool", mlir)
 
     def test_symbolic_args_false_no_params(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
@@ -1998,7 +1998,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
-                [SymbolKind.kernel()],
+                [SymbolKind.kernel(0)],
             )
 
         mlir = self._bundle([a], symbolic_args=False, fake_compile=fake)
@@ -2057,8 +2057,10 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                     ],
                 }
             }
-            # All symbols in this test are kernel args — all become input_arg params.
-            symbol_kind_flags = [SymbolKind.kernel()] * n
+            # All symbols are kernel args; use the running symbol index as arg_index
+            # so each unique value produces a distinct input_arg param.
+            sym_start = sum(sym_counts[:i])
+            symbol_kind_flags = [SymbolKind.kernel(sym_start + j) for j in range(n)]
             return (
                 json_out,
                 sym_values[start : start + n],
@@ -2068,16 +2070,14 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
         mlir = self._bundle([op0] + ops_rest, symbolic_args=True, fake_compile=fake)
 
-        # Symbols with the same address are deduped: 12 symbols → 6 unique params
-        # (sym_values has many repeats: 0x400000000, 0x800000000, 0x0, 0xC00000000,
-        #  0x1000000000, 0x1400000000 are the 6 distinct values)
-        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
-        self.assertIn("%sym_0_6: !sdscbundle.input_arg<index>", mlir)
-        self.assertNotIn("%sym_0_7:", mlir)
+        # 12 symbols with 6 unique values → 6 unique params
+        # Param names derive from arg_index (= symbol position in sym_values list)
+        self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%arg_1_base_addr: !sdscbundle.input_arg<index>", mlir)
+        # There are exactly 6 input_arg params (each appears twice: param + extract)
+        self.assertEqual(mlir.count("!sdscbundle.input_arg<index>"), 6 * 2)
         # First sdsc_execute uses first two extracted names
-        self.assertIn(
-            "sdscbundle.sdsc_execute (%sym_0_1_extracted, %sym_0_2_extracted)", mlir
-        )
+        self.assertIn("sdscbundle.sdsc_execute (%arg_0, %arg_1)", mlir)
         # Duplicate addresses reuse existing extracted SSA names
         self.assertNotIn("arith.constant", mlir)
         self.assertNotIn("%pool:", mlir)
@@ -2094,21 +2094,17 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(base)
-            return _make_tiled_json(idx, sym_id), [base], [{}], [SymbolKind.kernel()]
+            return _make_tiled_json(idx, sym_id), [base], [{}], [SymbolKind.kernel(0)]
 
         mlir = self._bundle([a, b], symbolic_args=True, fake_compile=fake)
 
         # Only one input_arg param (deduped cross-SDSC)
-        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
         self.assertNotIn("%sym_0_2:", mlir)
         # Both sdsc_execute ops reference the same extracted name
         execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
-        self.assertEqual(
-            execute_lines[0].split("(")[1].split(")")[0], "%sym_0_1_extracted"
-        )
-        self.assertEqual(
-            execute_lines[1].split("(")[1].split(")")[0], "%sym_0_1_extracted"
-        )
+        self.assertEqual(execute_lines[0].split("(")[1].split(")")[0], "%arg_0")
+        self.assertEqual(execute_lines[1].split("(")[1].split(")")[0], "%arg_0")
 
     def test_pool_offset_constants_deduped(self):
         """Pool symbols with the same offset share one arith.addi SSA variable."""
@@ -2137,14 +2133,16 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         # Exactly two arith.constant / arith.addi pairs (offsets 0 and 2048)
         self.assertEqual(mlir.count("arith.constant 0 : index"), 1)
         self.assertEqual(mlir.count("arith.constant 2048 : index"), 1)
-        self.assertEqual(mlir.count("arith.addi %pool_extracted"), 2)
-        # op[0] and op[2] both use %sym_1 (offset 0); op[1] uses %sym_2 (offset 2048)
-        self.assertIn("sdscbundle.sdsc_execute (%sym_1)", mlir)
-        self.assertIn("sdscbundle.sdsc_execute (%sym_2)", mlir)
+        self.assertEqual(mlir.count("arith.addi %pool"), 2)
+        # op[0] and op[2] both use %pool_addr_0; op[1] uses %pool_addr_2048
+        self.assertIn("sdscbundle.sdsc_execute (%pool_addr_0)", mlir)
+        self.assertIn("sdscbundle.sdsc_execute (%pool_addr_2048)", mlir)
         execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
-        self.assertEqual(execute_lines[0].split("(")[1].split(")")[0], "%sym_1")
-        self.assertEqual(execute_lines[1].split("(")[1].split(")")[0], "%sym_2")
-        self.assertEqual(execute_lines[2].split("(")[1].split(")")[0], "%sym_1")
+        self.assertEqual(execute_lines[0].split("(")[1].split(")")[0], "%pool_addr_0")
+        self.assertEqual(
+            execute_lines[1].split("(")[1].split(")")[0], "%pool_addr_2048"
+        )
+        self.assertEqual(execute_lines[2].split("(")[1].split(")")[0], "%pool_addr_0")
 
 
 class TestSymbolKind(unittest.TestCase):
@@ -2162,13 +2160,13 @@ class TestSymbolKind(unittest.TestCase):
         _ = SymbolKind  # importable as a top-level name
 
     def test_kernel_base_kind(self):
-        sk = SymbolKind.kernel()
+        sk = SymbolKind.kernel(0)
         self.assertEqual(sk.kind, "kernel")
         self.assertFalse(sk.is_derived)
         self.assertFalse(sk.is_pool)
 
     def test_kernel_derived_kind_carries_base_index_and_offset(self):
-        sk = SymbolKind.kernel_derived(base_sym_idx=3, offset=512)
+        sk = SymbolKind.kernel_derived(base_sym_idx=3, offset=512, arg_index=0)
         self.assertEqual(sk.kind, "kernel_derived")
         self.assertEqual(sk.base_sym_idx, 3)
         self.assertEqual(sk.offset, 512)
@@ -2253,13 +2251,13 @@ class TestSymbolKind(unittest.TestCase):
                 # op0: sym 0 = kernel base, sym 1 = kernel_derived +1024
                 symbols.append(base)
                 symbols.append(base + off)
-                kinds = [SymbolKind.kernel(), SymbolKind.kernel_derived(0, off)]
+                kinds = [SymbolKind.kernel(0), SymbolKind.kernel_derived(0, off, 0)]
                 json0 = _make_tiled_json(idx, -(symbol_id_offset + 1))
                 return json0, [base, base + off], [{}, {}], kinds
             else:
                 # op1: reuses same derived offset — sym 2
                 symbols.append(base + off)
-                kinds = [SymbolKind.kernel_derived(0, off)]
+                kinds = [SymbolKind.kernel_derived(0, off, 0)]
                 json1 = _make_tiled_json(idx, -(symbol_id_offset + 1))
                 return json1, [base + off], [{}], kinds
 
@@ -2278,18 +2276,18 @@ class TestSymbolKind(unittest.TestCase):
         mlir = _read_mlir(self.tmpdir)
 
         # Only one input_arg param (the kernel base)
-        self.assertIn("%sym_0_1: !sdscbundle.input_arg<index>", mlir)
+        self.assertIn("%arg_0_base_addr: !sdscbundle.input_arg<index>", mlir)
         self.assertNotIn("%sym_0_2:", mlir)
         # Derived address emitted once as arith.addi (deduped across both ops)
         self.assertEqual(mlir.count("arith.constant 1024"), 1)
-        self.assertEqual(mlir.count("arith.addi %sym_0_1_extracted"), 1)
+        self.assertEqual(mlir.count("arith.addi %arg_0"), 1)
         # op0's execute has the kernel base; op1's execute has the derived %sym_N
         # Both refer to the same canonical derived SSA — no second arith.addi for op1
-        self.assertIn("sdscbundle.sdsc_execute (%sym_0_1_extracted)", mlir)
-        # op1 operand is the canonical derived var (%sym_2), not a new addi
+        self.assertIn("sdscbundle.sdsc_execute (%arg_0)", mlir)
+        # op1 operand is the canonical derived var (%arg_0_core_1024), not a new addi
         execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
         op1_operand = execute_lines[1].split("(")[1].split(")")[0].strip()
-        self.assertTrue(op1_operand.startswith("%sym_"), op1_operand)
+        self.assertIn("arg_0_core", op1_operand)  # derived from arg_0 with offset
         self.assertNotIn("input_arg_extract", op1_operand)
 
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1435,7 +1435,7 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [0x1000],
                 [{s0: outer_stride, s1: inner_stride}],
-                ["kernel"],
+                [("kernel", 0)],
             )
 
         return fake_compile
@@ -1902,7 +1902,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 json_out,
                 [arg.allocation["hbm"] for arg in op_spec.args],
                 [{} for _ in op_spec.args],
-                ["kernel" for _ in op_spec.args],
+                [("kernel", 0) for _ in op_spec.args],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
@@ -1936,7 +1936,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
-                ["kernel"],
+                [("kernel", 0)],
             )
 
         mlir = self._bundle([a], symbolic_args=True, fake_compile=fake)
@@ -1973,7 +1973,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(values[i])
-            kind = "kernel" if i == 0 else "pool"  # op_b has pool allocation
+            kind = ("kernel", 0) if i == 0 else ("pool", 0)  # op_b has pool allocation
             return _make_tiled_json(idx, sym_id), [values[i]], [{}], [kind]
 
         mlir = self._bundle([op_a, op_b], symbolic_args=True, fake_compile=fake)
@@ -1995,7 +1995,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 _make_tiled_json(idx, sym_id),
                 [op_spec.args[0].allocation["hbm"]],
                 [{}],
-                ["kernel"],
+                [("kernel", 0)],
             )
 
         mlir = self._bundle([a], symbolic_args=False, fake_compile=fake)
@@ -2055,7 +2055,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 }
             }
             # All symbols in this test are kernel args — all become input_arg params.
-            symbol_kind_flags = ["kernel"] * n
+            symbol_kind_flags = [("kernel", 0)] * n
             return (
                 json_out,
                 sym_values[start : start + n],
@@ -2080,6 +2080,37 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         self.assertNotIn("arith.constant", mlir)
         # No pool parameter
         self.assertNotIn("%pool:", mlir)
+
+    def test_pool_offset_constants_deduped(self):
+        """Pool symbols with the same offset share one arith.addi SSA variable."""
+        # Three pool symbols: offsets 0, 2048, 0.
+        # Expected: 2 arith.constant + 2 arith.addi; sdsc_execute for op[2] reuses %sym_1.
+        a = _make_minimal_op_spec("a")
+        b = _make_minimal_op_spec("b")
+        c = _make_minimal_op_spec("c")
+        call_count = [0]
+        pool_values = [0, 2048, 0]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+            i = call_count[0]
+            call_count[0] += 1
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(pool_values[i])
+            return _make_tiled_json(idx, sym_id), [pool_values[i]], [{}], [("pool", 0)]
+
+        mlir = self._bundle([a, b, c], symbolic_args=True, fake_compile=fake)
+
+        # Exactly two arith.constant / arith.addi pairs (offsets 0 and 2048)
+        self.assertEqual(mlir.count("arith.constant 0 : index"), 1)
+        self.assertEqual(mlir.count("arith.constant 2048 : index"), 1)
+        self.assertEqual(mlir.count("arith.addi %pool_extracted"), 2)
+        # op[0] and op[2] both use %sym_1 (offset 0); op[1] uses %sym_2 (offset 2048)
+        self.assertIn("sdscbundle.sdsc_execute (%sym_1)", mlir)
+        self.assertIn("sdscbundle.sdsc_execute (%sym_2)", mlir)
+        execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
+        self.assertEqual(execute_lines[0].split("(")[1].split(")")[0], "%sym_1")
+        self.assertEqual(execute_lines[1].split("(")[1].split(")")[0], "%sym_2")
+        self.assertEqual(execute_lines[2].split("(")[1].split(")")[0], "%sym_1")
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -167,25 +167,28 @@ def generate_bundle(
         f.write("module {\n")
 
         # Function signature when symbolic_args is active:
-        #   - optional leading %pool param for pool-allocated tensors
-        #   - one !sdscbundle.input_arg<index> param per kernel tensor arg base symbol
+        #   - optional leading %pool_base_addr param for pool-allocated tensors
+        #   - one !sdscbundle.input_arg<index> param per kernel tensor arg, with a
+        #     descriptive formal name %arg_{arg_index}_base_addr; the short form
+        #     %arg_{arg_index} is used in the body after input_arg_extract
         if symbolic_args and use_symbols and (has_pool or kernel_arg_sym_indices):
             params = []
             if has_pool:
-                params.append("%pool: !sdscbundle.input_arg<index>")
-            for pos, _ in enumerate(kernel_arg_sym_indices):
-                params.append(f"%sym_0_{pos + 1}: !sdscbundle.input_arg<index>")
+                params.append("%pool_base_addr: !sdscbundle.input_arg<index>")
+            for sym_idx in kernel_arg_sym_indices:
+                ai = symbol_kinds[sym_idx].arg_index
+                params.append(f"%arg_{ai}_base_addr: !sdscbundle.input_arg<index>")
             f.write(f"\tfunc.func @sdsc_bundle({', '.join(params)}) {{\n")
             if has_pool:
                 f.write(
-                    "\t\t%pool_extracted = sdscbundle.input_arg_extract value from"
-                    " %pool : !sdscbundle.input_arg<index> -> index\n"
+                    "\t\t%pool = sdscbundle.input_arg_extract value from"
+                    " %pool_base_addr : !sdscbundle.input_arg<index> -> index\n"
                 )
-            for pos, _ in enumerate(kernel_arg_sym_indices):
-                n = pos + 1
+            for sym_idx in kernel_arg_sym_indices:
+                ai = symbol_kinds[sym_idx].arg_index
                 f.write(
-                    f"\t\t%sym_0_{n}_extracted = sdscbundle.input_arg_extract value from"
-                    f" %sym_0_{n} : !sdscbundle.input_arg<index> -> index\n"
+                    f"\t\t%arg_{ai} = sdscbundle.input_arg_extract value from"
+                    f" %arg_{ai}_base_addr : !sdscbundle.input_arg<index> -> index\n"
                 )
         else:
             f.write("\tfunc.func @sdsc_bundle() {\n")
@@ -199,29 +202,30 @@ def generate_bundle(
 
         # Emit one declaration per symbol (symbolic_args path):
         #   - "kernel"          → skipped; already a function param + extract op above
-        #   - "kernel_derived"  → arith.addi %sym_0_N_extracted, <per_core_offset>
-        #                         deduped by (base_param_index, offset) pair
-        #   - "pool"            → arith.addi %pool_extracted, <pool_offset>
+        #   - "kernel_derived"  → arith.addi %arg_{arg_index}, <per_core_offset>
+        #                         deduped by (arg_index, offset) pair
+        #   - "pool"            → arith.addi %pool, <pool_offset>
         #                         deduped by pool offset value
         #   - anything else     → arith.constant (use_symbols=False or non-symbolic path)
         # All kernel sym indices to skip during emission (canonical + duplicates).
         kernel_arg_sym_set = set(kernel_arg_sym_indices) | set(kernel_dup_canonical)
-        # Map kernel base sym_idx → positional parameter index (1-based name suffix).
-        # Duplicate kernel sym indices map to the same pos as their canonical.
-        kernel_base_to_pos: dict[int, int] = {
-            sym_idx: pos + 1 for pos, sym_idx in enumerate(kernel_arg_sym_indices)
+        # Map kernel sym_idx → arg_index for SSA name generation.
+        # Duplicate kernel sym indices inherit the arg_index of their canonical.
+        kernel_sym_to_arg_idx: dict[int, int] = {
+            sym_idx: symbol_kinds[sym_idx].arg_index
+            for sym_idx in kernel_arg_sym_indices
         }
         for dup_idx, canon_idx in kernel_dup_canonical.items():
-            if canon_idx in kernel_base_to_pos:
-                kernel_base_to_pos[dup_idx] = kernel_base_to_pos[canon_idx]
+            if canon_idx in kernel_sym_to_arg_idx:
+                kernel_sym_to_arg_idx[dup_idx] = kernel_sym_to_arg_idx[canon_idx]
         # sym_canonical[sym_idx] → canonical SSA name for derived/pool symbols (deduped).
-        # Also pre-populate with duplicate kernel symbols pointing to their canonical name.
+        # Also pre-populate duplicate kernel sym_idx entries with their canonical extracted name.
         sym_canonical: dict[int, str] = {
-            dup_idx: f"%sym_0_{kernel_base_to_pos[dup_idx]}_extracted"
+            dup_idx: f"%arg_{kernel_sym_to_arg_idx[dup_idx]}"
             for dup_idx in kernel_dup_canonical
-            if dup_idx in kernel_base_to_pos
+            if dup_idx in kernel_sym_to_arg_idx
         }
-        # derived_addi_emitted[(base_param_pos, offset)] → SSA name already emitted
+        # derived_addi_emitted[(arg_index, offset)] → SSA name already emitted
         derived_addi_emitted: dict[tuple[int, int], str] = {}
         # pool_addi_emitted[pool_offset_value] → SSA name already emitted
         pool_addi_emitted: dict[int, str] = {}
@@ -231,18 +235,18 @@ def generate_bundle(
                 continue  # replaced by function parameter + extract op (or duplicate)
             sk: SymbolKind | None = symbol_kinds[sym_idx] if symbol_kinds else None
             if sk is not None and sk.is_derived:
-                base_pos = kernel_base_to_pos.get(sk.base_sym_idx)
-                if base_pos is not None:
-                    key = (base_pos, sk.offset)
+                base_ai = kernel_sym_to_arg_idx.get(sk.base_sym_idx)
+                if base_ai is not None:
+                    key = (base_ai, sk.offset)
                     if key not in derived_addi_emitted:
-                        offset_ssa = f"%core_offset_{sym_idx + 1}"
-                        addi_ssa = f"%sym_{sym_idx + 1}"
+                        offset_ssa = f"%arg_{base_ai}_core_offset_{sk.offset}"
+                        addi_ssa = f"%arg_{base_ai}_core_{sk.offset}"
                         f.write(
                             f"\t\t{offset_ssa} = arith.constant {sk.offset} : index\n"
                         )
                         f.write(
                             f"\t\t{addi_ssa} = arith.addi"
-                            f" %sym_0_{base_pos}_extracted, {offset_ssa} : index\n"
+                            f" %arg_{base_ai}, {offset_ssa} : index\n"
                         )
                         derived_addi_emitted[key] = addi_ssa
                     sym_canonical[sym_idx] = derived_addi_emitted[key]
@@ -252,12 +256,11 @@ def generate_bundle(
                     )
             elif sk is not None and sk.is_pool:
                 if value not in pool_addi_emitted:
-                    offset_ssa = f"%pool_offset_{sym_idx + 1}"
-                    addi_ssa = f"%sym_{sym_idx + 1}"
+                    offset_ssa = f"%pool_offset_{value}"
+                    addi_ssa = f"%pool_addr_{value}"
                     f.write(f"\t\t{offset_ssa} = arith.constant {value} : index\n")
                     f.write(
-                        f"\t\t{addi_ssa} = arith.addi %pool_extracted,"
-                        f" {offset_ssa} : index\n"
+                        f"\t\t{addi_ssa} = arith.addi %pool, {offset_ssa} : index\n"
                     )
                     pool_addi_emitted[value] = addi_ssa
                 sym_canonical[sym_idx] = pool_addi_emitted[value]
@@ -278,7 +281,7 @@ def generate_bundle(
             indent=2,
             use_symbols=use_symbols,
             symbolic_args=symbolic_args,
-            kernel_arg_sym_indices=kernel_arg_sym_indices,
+            kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
             sym_canonical=sym_canonical,
         )
 
@@ -407,20 +410,19 @@ def _emit_specs(
     indent: int,
     use_symbols: bool = False,
     symbolic_args: bool = False,
-    kernel_arg_sym_indices: list | None = None,
+    kernel_sym_to_arg_idx: dict | None = None,
     sym_canonical: dict | None = None,
 ) -> None:
     """Recursively emit MLIR ops for specs into file f."""
-    if kernel_arg_sym_indices is None:
-        kernel_arg_sym_indices = []
+    if kernel_sym_to_arg_idx is None:
+        kernel_sym_to_arg_idx = {}
     if sym_canonical is None:
         sym_canonical = {}
 
-    # Map from 0-based symbol index to the extracted SSA name for kernel-arg symbols.
-    # kernel_arg_sym_indices[pos] = sym_idx  →  %sym_0_{pos+1}_extracted
+    # Map from 0-based symbol index to the short SSA name for kernel-arg symbols.
+    # sym_idx → %arg_{arg_index}  (the result of input_arg_extract in the function body)
     kernel_arg_sym_to_name: dict[int, str] = {
-        sym_idx: f"%sym_0_{pos + 1}_extracted"
-        for pos, sym_idx in enumerate(kernel_arg_sym_indices)
+        sym_idx: f"%arg_{ai}" for sym_idx, ai in kernel_sym_to_arg_idx.items()
     }
 
     def _resolve_sym(sid: int) -> str:
@@ -454,7 +456,7 @@ def _emit_specs(
                 indent + 1,
                 use_symbols=use_symbols,
                 symbolic_args=symbolic_args,
-                kernel_arg_sym_indices=kernel_arg_sym_indices,
+                kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
                 sym_canonical=sym_canonical,
             )
             f.write(f"{tab}}}\n")

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -52,6 +52,7 @@ def generate_bundle(
     specs: Sequence,
     use_symbols: bool | None = None,
     unroll_loops: bool | None = None,
+    symbolic_args: bool | None = None,
 ):
     """Output the SDSC Bundle for the OpSpecs in output_dir.
 
@@ -78,6 +79,8 @@ def generate_bundle(
         use_symbols = _spyre_config.bundle_hbm_symbols
     if unroll_loops is None:
         unroll_loops = _spyre_config.unroll_loops
+    if symbolic_args is None:
+        symbolic_args = _spyre_config.bundle_symbolic_args
 
     specs_list: list = unroll_loop_specs(list(specs)) if unroll_loops else list(specs)
 
@@ -120,6 +123,11 @@ def generate_bundle(
     compiled_iter = iter(compiled)
     addr_counter = [0]
 
+    # Derive how many symbols correspond to kernel tensor args (symbolic_args path).
+    num_tensor_args = (
+        _count_tensor_args(specs_list) if (symbolic_args and use_symbols) else 0
+    )
+
     with open(os.path.join(output_dir, "bundle.mlir"), "w") as f:
         logger.info(f"Generating {f.name}")
 
@@ -133,7 +141,22 @@ def generate_bundle(
             )
 
         f.write("module {\n")
-        f.write("\tfunc.func @sdsc_bundle() {\n")
+
+        # Function signature: emit one !sdscbundle.input_arg<index> param per
+        # tensor arg when symbolic_args is active, otherwise no params.
+        if num_tensor_args > 0:
+            params_str = ", ".join(
+                f"%sym_0_{n}: !sdscbundle.input_arg<index>"
+                for n in range(1, num_tensor_args + 1)
+            )
+            f.write(f"\tfunc.func @sdsc_bundle({params_str}) {{\n")
+            for n in range(1, num_tensor_args + 1):
+                f.write(
+                    f"\t\t%sym_0_{n}_extracted = sdscbundle.input_arg_extract value from"
+                    f" %sym_0_{n} : !sdscbundle.input_arg<index> -> index\n"
+                )
+        else:
+            f.write("\tfunc.func @sdsc_bundle() {\n")
 
         # Standard loop constants (only emitted when there are loops).
         if loop_bounds:
@@ -143,8 +166,12 @@ def generate_bundle(
                 f.write(f"\t\t%loop_bound_{lb_idx} = {_mlir_count_value(lb)}\n")
 
         # One arith.constant per symbol ID (symbols[N] → %sym_{N+1}).
-        # Skipped when use_symbols=False (symbols list is empty in that case).
+        # Tensor-arg symbols (indices 0..num_tensor_args-1) are skipped when
+        # symbolic_args is active — they are replaced by function params above.
+        # Skipped entirely when use_symbols=False (symbols list is empty).
         for sym_idx, value in enumerate(symbols):
+            if sym_idx < num_tensor_args:
+                continue
             f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
 
         # Recursive body emission.
@@ -160,6 +187,8 @@ def generate_bundle(
             f,
             indent=2,
             use_symbols=use_symbols,
+            symbolic_args=symbolic_args,
+            num_tensor_args=num_tensor_args,
         )
 
         f.write("\t\treturn\n")
@@ -282,8 +311,17 @@ def _emit_specs(
     f,
     indent: int,
     use_symbols: bool = False,
+    symbolic_args: bool = False,
+    num_tensor_args: int = 0,
 ) -> None:
     """Recursively emit MLIR ops for specs into file f."""
+
+    def _resolve_sym(sid: int) -> str:
+        n = abs(sid)
+        if symbolic_args and num_tensor_args > 0 and n <= num_tensor_args:
+            return f"%sym_0_{n}_extracted"
+        return f"%sym_{n}"
+
     tab = "\t" * indent
     for entry in specs:
         if isinstance(entry, LoopSpec):
@@ -304,6 +342,8 @@ def _emit_specs(
                 f,
                 indent + 1,
                 use_symbols=use_symbols,
+                symbolic_args=symbolic_args,
+                num_tensor_args=num_tensor_args,
             )
             f.write(f"{tab}}}\n")
 
@@ -333,7 +373,7 @@ def _emit_specs(
                     map_idx = affine_map_index[stride_key]
                     addr_name = f"%addr_{addr_counter[0]}"
                     addr_counter[0] += 1
-                    base_addr_name = _sym_id_to_mlir_name(base_sym_id)
+                    base_addr_name = _resolve_sym(base_sym_id)
                     loop_var_str = ", ".join(loop_vars)
                     f.write(
                         f"{tab}{addr_name} = affine.apply #map_{map_idx}"
@@ -344,8 +384,7 @@ def _emit_specs(
             # Each operand position matches one symbol_id entry.
             # Tiled sym_ids use the %addr_N computed above; others use %sym_N.
             operands = [
-                sym_id_to_operand.get(sid, _sym_id_to_mlir_name(sid))
-                for sid in symbol_ids
+                sym_id_to_operand.get(sid, _resolve_sym(sid)) for sid in symbol_ids
             ]
 
             operand_str = ", ".join(operands)
@@ -418,6 +457,24 @@ def _sym_id_to_mlir_name(sym_id: int) -> str:
 # ---------------------------------------------------------------------------
 # Helpers re-exported for tests
 # ---------------------------------------------------------------------------
+
+
+def _count_tensor_args(specs: list) -> int:
+    """Derive the kernel tensor-arg count from TensorArg.arg_index in the specs.
+
+    Returns max(arg_index) + 1 across all HBM-allocated TensorArgs found
+    depth-first. Returns 0 if no HBM tensor args are present.
+    """
+    max_idx = -1
+    for entry in specs:
+        if isinstance(entry, LoopSpec):
+            sub = _count_tensor_args(entry.body)
+            max_idx = max(max_idx, sub - 1)
+        elif isinstance(entry, OpSpec):
+            for arg in entry.args:
+                if "hbm" in arg.allocation and arg.arg_index >= 0:
+                    max_idx = max(max_idx, arg.arg_index)
+    return max_idx + 1
 
 
 def _collect_op_specs(specs: list, result: list) -> None:

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -38,10 +38,11 @@ logger = get_inductor_logger("sdsc_compile")
 #   affine_strides:     list[dict] parallel to SDSCSpec.args —
 #                       {tiled_sym: stride_bytes} for tiled HBM tensors,
 #                       empty dict for non-tiled / lx tensors
-#   symbol_kinds:       list[str] parallel to base_symbol_values —
-#                       "kernel" for kernel tensor args (become input_arg params),
-#                       "pool" for pool-allocated tensors (emit as arith.addi)
-_CompiledEntry = tuple[Any, list[int], list[dict], list[str]]
+#   symbol_kinds:       list[tuple[str, int]] parallel to base_symbol_values —
+#                       ("kernel", 0)           – base addr of a kernel tensor arg
+#                       ("kernel_derived", off) – per-core addr = base + off
+#                       ("pool", 0)             – pool-allocated tensor addr
+_CompiledEntry = tuple[Any, list[int], list[dict], list[tuple[str, int]]]
 
 
 # ---------------------------------------------------------------------------
@@ -127,18 +128,19 @@ def generate_bundle(
     addr_counter = [0]
 
     # Build a per-symbol kind list from compiled entries (symbolic_args path only).
-    # symbol_kinds[i] is "kernel" if symbols[i] came from a kernel tensor arg,
-    # or "pool" if it came from a pool-allocated tensor.
-    symbol_kinds: list[str] = []
+    # Each entry is a (kind_str, aux_int) tuple from compute_ops.generate_sdsc.
+    symbol_kinds: list[tuple[str, int]] = []
     if symbolic_args and use_symbols:
         for _, _, _, local_kinds in compiled:
             symbol_kinds.extend(local_kinds)
 
     # Determine whether a pool parameter is needed (any pool symbol present).
-    has_pool = symbolic_args and use_symbols and any(k == "pool" for k in symbol_kinds)
-    # Indices of kernel-arg symbols (will become input_arg function parameters).
+    has_pool = (
+        symbolic_args and use_symbols and any(k == "pool" for k, _ in symbol_kinds)
+    )
+    # Indices of kernel-base symbols (one per kernel tensor arg; become input_arg params).
     kernel_arg_sym_indices = (
-        [i for i, k in enumerate(symbol_kinds) if k == "kernel"]
+        [i for i, (k, _) in enumerate(symbol_kinds) if k == "kernel"]
         if symbolic_args and use_symbols
         else []
     )
@@ -159,7 +161,7 @@ def generate_bundle(
 
         # Function signature when symbolic_args is active:
         #   - optional leading %pool param for pool-allocated tensors
-        #   - one !sdscbundle.input_arg<index> param per kernel tensor arg symbol
+        #   - one !sdscbundle.input_arg<index> param per kernel tensor arg base symbol
         if symbolic_args and use_symbols and (has_pool or kernel_arg_sym_indices):
             params = []
             if has_pool:
@@ -188,27 +190,76 @@ def generate_bundle(
             for lb_idx, lb in enumerate(loop_bounds):
                 f.write(f"\t\t%loop_bound_{lb_idx} = {_mlir_count_value(lb)}\n")
 
-        # Emit one declaration per symbol:
-        #   - "kernel" symbols → already handled as function params above (skipped)
-        #   - "pool" symbols   → arith.addi %pool_extracted, <pool_offset>
-        #   - all others       → arith.constant (plain HBM or use_symbols=False)
+        # Emit one declaration per symbol (symbolic_args path):
+        #   - "kernel"          → skipped; already a function param + extract op above
+        #   - "kernel_derived"  → arith.addi %sym_0_N_extracted, <per_core_offset>
+        #                         deduped by (base_param_index, offset) pair
+        #   - "pool"            → arith.addi %pool_extracted, <pool_offset>
+        #                         deduped by pool offset value
+        #   - anything else     → arith.constant (use_symbols=False or non-symbolic path)
         kernel_arg_sym_set = set(kernel_arg_sym_indices)
-        pool_sym_set = (
-            {i for i, k in enumerate(symbol_kinds) if k == "pool"}
-            if symbolic_args and use_symbols
-            else set()
-        )
+        # Map kernel base sym_idx → positional parameter index (1-based name suffix).
+        kernel_base_to_pos: dict[int, int] = {
+            sym_idx: pos + 1 for pos, sym_idx in enumerate(kernel_arg_sym_indices)
+        }
+        # sym_canonical[sym_idx] → canonical SSA name for derived/pool symbols (deduped).
+        sym_canonical: dict[int, str] = {}
+        # derived_addi_emitted[(base_param_pos, offset)] → SSA name already emitted
+        derived_addi_emitted: dict[tuple[int, int], str] = {}
+        # pool_addi_emitted[pool_offset_value] → SSA name already emitted
+        pool_addi_emitted: dict[int, str] = {}
+
         for sym_idx, value in enumerate(symbols):
             if sym_idx in kernel_arg_sym_set:
                 continue  # replaced by function parameter + extract op
-            if sym_idx in pool_sym_set:
-                f.write(
-                    f"\t\t%pool_offset_{sym_idx + 1} = arith.constant {value} : index\n"
+            if not symbol_kinds:
+                # use_symbols=False path — no symbol_kinds populated
+                f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
+                continue
+            kind, aux = symbol_kinds[sym_idx]
+            if kind == "kernel_derived":
+                # Find which kernel base parameter this derives from.
+                # The base symbol has the same arg_index; its value = symbols[base_idx].
+                # We locate it by scanning backwards for the nearest "kernel" entry
+                # with value == (value - aux).
+                base_value = value - aux
+                base_sym_idx = next(
+                    (
+                        j
+                        for j in range(sym_idx - 1, -1, -1)
+                        if symbol_kinds[j][0] == "kernel" and symbols[j] == base_value
+                    ),
+                    None,
                 )
-                f.write(
-                    f"\t\t%sym_{sym_idx + 1} = arith.addi %pool_extracted,"
-                    f" %pool_offset_{sym_idx + 1} : index\n"
-                )
+                if base_sym_idx is not None and base_sym_idx in kernel_base_to_pos:
+                    base_pos = kernel_base_to_pos[base_sym_idx]
+                    key = (base_pos, aux)
+                    if key not in derived_addi_emitted:
+                        offset_ssa = f"%core_offset_{sym_idx + 1}"
+                        addi_ssa = f"%sym_{sym_idx + 1}"
+                        f.write(f"\t\t{offset_ssa} = arith.constant {aux} : index\n")
+                        f.write(
+                            f"\t\t{addi_ssa} = arith.addi"
+                            f" %sym_0_{base_pos}_extracted, {offset_ssa} : index\n"
+                        )
+                        derived_addi_emitted[key] = addi_ssa
+                    sym_canonical[sym_idx] = derived_addi_emitted[key]
+                else:
+                    # Fallback: emit as a plain constant if base not found.
+                    f.write(
+                        f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n"
+                    )
+            elif kind == "pool":
+                if value not in pool_addi_emitted:
+                    offset_ssa = f"%pool_offset_{sym_idx + 1}"
+                    addi_ssa = f"%sym_{sym_idx + 1}"
+                    f.write(f"\t\t{offset_ssa} = arith.constant {value} : index\n")
+                    f.write(
+                        f"\t\t{addi_ssa} = arith.addi %pool_extracted,"
+                        f" {offset_ssa} : index\n"
+                    )
+                    pool_addi_emitted[value] = addi_ssa
+                sym_canonical[sym_idx] = pool_addi_emitted[value]
             else:
                 f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
 
@@ -227,6 +278,7 @@ def generate_bundle(
             use_symbols=use_symbols,
             symbolic_args=symbolic_args,
             kernel_arg_sym_indices=kernel_arg_sym_indices,
+            sym_canonical=sym_canonical,
         )
 
         f.write("\t\treturn\n")
@@ -355,10 +407,13 @@ def _emit_specs(
     use_symbols: bool = False,
     symbolic_args: bool = False,
     kernel_arg_sym_indices: list | None = None,
+    sym_canonical: dict | None = None,
 ) -> None:
     """Recursively emit MLIR ops for specs into file f."""
     if kernel_arg_sym_indices is None:
         kernel_arg_sym_indices = []
+    if sym_canonical is None:
+        sym_canonical = {}
 
     # Map from 0-based symbol index to the extracted SSA name for kernel-arg symbols.
     # kernel_arg_sym_indices[pos] = sym_idx  →  %sym_0_{pos+1}_extracted
@@ -370,8 +425,11 @@ def _emit_specs(
     def _resolve_sym(sid: int) -> str:
         # sid is a negative symbol ID; abs(sid)-1 is the 0-based index into symbols[].
         sym_idx = abs(sid) - 1
-        if symbolic_args and sym_idx in kernel_arg_sym_to_name:
-            return kernel_arg_sym_to_name[sym_idx]
+        if symbolic_args:
+            if sym_idx in kernel_arg_sym_to_name:
+                return kernel_arg_sym_to_name[sym_idx]
+            if sym_idx in sym_canonical:
+                return sym_canonical[sym_idx]
         return f"%sym_{abs(sid)}"
 
     tab = "\t" * indent
@@ -396,6 +454,7 @@ def _emit_specs(
                 use_symbols=use_symbols,
                 symbolic_args=symbolic_args,
                 kernel_arg_sym_indices=kernel_arg_sym_indices,
+                sym_canonical=sym_canonical,
             )
             f.write(f"{tab}}}\n")
 

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -32,13 +32,16 @@ logger = get_inductor_logger("sdsc_compile")
 # Types
 # ---------------------------------------------------------------------------
 
-# Compiled SDSC entry: (json_dict, base_symbol_values, affine_strides)
+# Compiled SDSC entry: (json_dict, base_symbol_values, affine_strides, symbol_kinds)
 #   base_symbol_values: list[int] of base HBM byte offsets for this SDSC,
 #                       one per registered symbol ID
 #   affine_strides:     list[dict] parallel to SDSCSpec.args —
 #                       {tiled_sym: stride_bytes} for tiled HBM tensors,
 #                       empty dict for non-tiled / lx tensors
-_CompiledEntry = tuple[Any, list[int], list[dict]]
+#   symbol_kinds:       list[str] parallel to base_symbol_values —
+#                       "kernel" for kernel tensor args (become input_arg params),
+#                       "pool" for pool-allocated tensors (emit as arith.addi)
+_CompiledEntry = tuple[Any, list[int], list[dict], list[str]]
 
 
 # ---------------------------------------------------------------------------
@@ -123,9 +126,21 @@ def generate_bundle(
     compiled_iter = iter(compiled)
     addr_counter = [0]
 
-    # Derive how many symbols correspond to kernel tensor args (symbolic_args path).
-    num_tensor_args = (
-        _count_tensor_args(specs_list) if (symbolic_args and use_symbols) else 0
+    # Build a per-symbol kind list from compiled entries (symbolic_args path only).
+    # symbol_kinds[i] is "kernel" if symbols[i] came from a kernel tensor arg,
+    # or "pool" if it came from a pool-allocated tensor.
+    symbol_kinds: list[str] = []
+    if symbolic_args and use_symbols:
+        for _, _, _, local_kinds in compiled:
+            symbol_kinds.extend(local_kinds)
+
+    # Determine whether a pool parameter is needed (any pool symbol present).
+    has_pool = symbolic_args and use_symbols and any(k == "pool" for k in symbol_kinds)
+    # Indices of kernel-arg symbols (will become input_arg function parameters).
+    kernel_arg_sym_indices = (
+        [i for i, k in enumerate(symbol_kinds) if k == "kernel"]
+        if symbolic_args and use_symbols
+        else []
     )
 
     with open(os.path.join(output_dir, "bundle.mlir"), "w") as f:
@@ -142,15 +157,23 @@ def generate_bundle(
 
         f.write("module {\n")
 
-        # Function signature: emit one !sdscbundle.input_arg<index> param per
-        # tensor arg when symbolic_args is active, otherwise no params.
-        if num_tensor_args > 0:
-            params_str = ", ".join(
-                f"%sym_0_{n}: !sdscbundle.input_arg<index>"
-                for n in range(1, num_tensor_args + 1)
-            )
-            f.write(f"\tfunc.func @sdsc_bundle({params_str}) {{\n")
-            for n in range(1, num_tensor_args + 1):
+        # Function signature when symbolic_args is active:
+        #   - optional leading %pool param for pool-allocated tensors
+        #   - one !sdscbundle.input_arg<index> param per kernel tensor arg symbol
+        if symbolic_args and use_symbols and (has_pool or kernel_arg_sym_indices):
+            params = []
+            if has_pool:
+                params.append("%pool: !sdscbundle.input_arg<index>")
+            for pos, _ in enumerate(kernel_arg_sym_indices):
+                params.append(f"%sym_0_{pos + 1}: !sdscbundle.input_arg<index>")
+            f.write(f"\tfunc.func @sdsc_bundle({', '.join(params)}) {{\n")
+            if has_pool:
+                f.write(
+                    "\t\t%pool_extracted = sdscbundle.input_arg_extract value from"
+                    " %pool : !sdscbundle.input_arg<index> -> index\n"
+                )
+            for pos, _ in enumerate(kernel_arg_sym_indices):
+                n = pos + 1
                 f.write(
                     f"\t\t%sym_0_{n}_extracted = sdscbundle.input_arg_extract value from"
                     f" %sym_0_{n} : !sdscbundle.input_arg<index> -> index\n"
@@ -165,14 +188,29 @@ def generate_bundle(
             for lb_idx, lb in enumerate(loop_bounds):
                 f.write(f"\t\t%loop_bound_{lb_idx} = {_mlir_count_value(lb)}\n")
 
-        # One arith.constant per symbol ID (symbols[N] → %sym_{N+1}).
-        # Tensor-arg symbols (indices 0..num_tensor_args-1) are skipped when
-        # symbolic_args is active — they are replaced by function params above.
-        # Skipped entirely when use_symbols=False (symbols list is empty).
+        # Emit one declaration per symbol:
+        #   - "kernel" symbols → already handled as function params above (skipped)
+        #   - "pool" symbols   → arith.addi %pool_extracted, <pool_offset>
+        #   - all others       → arith.constant (plain HBM or use_symbols=False)
+        kernel_arg_sym_set = set(kernel_arg_sym_indices)
+        pool_sym_set = (
+            {i for i, k in enumerate(symbol_kinds) if k == "pool"}
+            if symbolic_args and use_symbols
+            else set()
+        )
         for sym_idx, value in enumerate(symbols):
-            if sym_idx < num_tensor_args:
-                continue
-            f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
+            if sym_idx in kernel_arg_sym_set:
+                continue  # replaced by function parameter + extract op
+            if sym_idx in pool_sym_set:
+                f.write(
+                    f"\t\t%pool_offset_{sym_idx + 1} = arith.constant {value} : index\n"
+                )
+                f.write(
+                    f"\t\t%sym_{sym_idx + 1} = arith.addi %pool_extracted,"
+                    f" %pool_offset_{sym_idx + 1} : index\n"
+                )
+            else:
+                f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
 
         # Recursive body emission.
         loop_bound_idx = [0]
@@ -188,7 +226,7 @@ def generate_bundle(
             indent=2,
             use_symbols=use_symbols,
             symbolic_args=symbolic_args,
-            num_tensor_args=num_tensor_args,
+            kernel_arg_sym_indices=kernel_arg_sym_indices,
         )
 
         f.write("\t\treturn\n")
@@ -225,15 +263,19 @@ def _compile_specs(
         elif isinstance(entry, OpSpec):
             idx = sdsc_counter[0]
             sdsc_counter[0] += 1
-            sdsc_json, local_sym_values, affine_strides = compile_op_spec(
-                idx,
-                entry,
-                symbols,
-                symbol_id_offset_counter[0],
-                use_symbols=use_symbols,
+            sdsc_json, local_sym_values, affine_strides, local_symbol_kinds = (
+                compile_op_spec(
+                    idx,
+                    entry,
+                    symbols,
+                    symbol_id_offset_counter[0],
+                    use_symbols=use_symbols,
+                )
             )
             symbol_id_offset_counter[0] += len(local_sym_values)
-            compiled.append((sdsc_json, local_sym_values, affine_strides))
+            compiled.append(
+                (sdsc_json, local_sym_values, affine_strides, local_symbol_kinds)
+            )
             file_name = f"sdsc_{idx}.json"
             with open(os.path.join(output_dir, file_name), "w") as f:
                 logger.info(f"Generating {f.name}")
@@ -275,7 +317,7 @@ def _collect_affine_maps(
                 affine_map_index,
             )
         elif isinstance(entry, OpSpec):
-            _, _, affine_strides = next(compiled_iter)
+            _, _, affine_strides, _ = next(compiled_iter)
             for tensor_strides in affine_strides:
                 if not tensor_strides:
                     continue
@@ -312,15 +354,25 @@ def _emit_specs(
     indent: int,
     use_symbols: bool = False,
     symbolic_args: bool = False,
-    num_tensor_args: int = 0,
+    kernel_arg_sym_indices: list | None = None,
 ) -> None:
     """Recursively emit MLIR ops for specs into file f."""
+    if kernel_arg_sym_indices is None:
+        kernel_arg_sym_indices = []
+
+    # Map from 0-based symbol index to the extracted SSA name for kernel-arg symbols.
+    # kernel_arg_sym_indices[pos] = sym_idx  →  %sym_0_{pos+1}_extracted
+    kernel_arg_sym_to_name: dict[int, str] = {
+        sym_idx: f"%sym_0_{pos + 1}_extracted"
+        for pos, sym_idx in enumerate(kernel_arg_sym_indices)
+    }
 
     def _resolve_sym(sid: int) -> str:
-        n = abs(sid)
-        if symbolic_args and num_tensor_args > 0 and n <= num_tensor_args:
-            return f"%sym_0_{n}_extracted"
-        return f"%sym_{n}"
+        # sid is a negative symbol ID; abs(sid)-1 is the 0-based index into symbols[].
+        sym_idx = abs(sid) - 1
+        if symbolic_args and sym_idx in kernel_arg_sym_to_name:
+            return kernel_arg_sym_to_name[sym_idx]
+        return f"%sym_{abs(sid)}"
 
     tab = "\t" * indent
     for entry in specs:
@@ -343,12 +395,12 @@ def _emit_specs(
                 indent + 1,
                 use_symbols=use_symbols,
                 symbolic_args=symbolic_args,
-                num_tensor_args=num_tensor_args,
+                kernel_arg_sym_indices=kernel_arg_sym_indices,
             )
             f.write(f"{tab}}}\n")
 
         elif isinstance(entry, OpSpec):
-            sdsc_json, local_sym_values, affine_strides = next(compiled_iter)
+            sdsc_json, local_sym_values, affine_strides, _ = next(compiled_iter)
             # Determine the JSON filename from the sdsc_json key.
             sdsc_name = next(iter(sdsc_json))
             sdsc_idx = sdsc_name.split("_")[0]
@@ -457,24 +509,6 @@ def _sym_id_to_mlir_name(sym_id: int) -> str:
 # ---------------------------------------------------------------------------
 # Helpers re-exported for tests
 # ---------------------------------------------------------------------------
-
-
-def _count_tensor_args(specs: list) -> int:
-    """Derive the kernel tensor-arg count from TensorArg.arg_index in the specs.
-
-    Returns max(arg_index) + 1 across all HBM-allocated TensorArgs found
-    depth-first. Returns 0 if no HBM tensor args are present.
-    """
-    max_idx = -1
-    for entry in specs:
-        if isinstance(entry, LoopSpec):
-            sub = _count_tensor_args(entry.body)
-            max_idx = max(max_idx, sub - 1)
-        elif isinstance(entry, OpSpec):
-            for arg in entry.args:
-                if "hbm" in arg.allocation and arg.arg_index >= 0:
-                    max_idx = max(max_idx, arg.arg_index)
-    return max_idx + 1
 
 
 def _collect_op_specs(specs: list, result: list) -> None:

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -133,12 +133,24 @@ def generate_bundle(
 
     # Determine whether a pool parameter is needed (any pool symbol present).
     has_pool = symbolic_args and use_symbols and any(sk.is_pool for sk in symbol_kinds)
-    # Indices of kernel-base symbols (one per kernel tensor arg; become input_arg params).
-    kernel_arg_sym_indices = (
-        [i for i, sk in enumerate(symbol_kinds) if sk.kind == "kernel"]
-        if symbolic_args and use_symbols
-        else []
-    )
+    # Indices of kernel-base symbols that become input_arg parameters.
+    # Deduplicated by address value: multiple SDSCs may register the same kernel arg
+    # address independently (no cross-SDSC dedup in generate_sdsc), so we keep only
+    # the first sym_idx for each unique address and map subsequent duplicates to it.
+    # kernel_arg_sym_indices: list of sym_idx values, one per unique kernel arg address.
+    # kernel_dup_canonical: maps duplicate kernel sym_idx → canonical sym_idx.
+    kernel_arg_sym_indices: list[int] = []
+    kernel_dup_canonical: dict[int, int] = {}  # duplicate sym_idx → canonical sym_idx
+    if symbolic_args and use_symbols:
+        seen_kernel_addr: dict[int, int] = {}  # address → canonical sym_idx
+        for i, kind_i in enumerate(symbol_kinds):
+            if kind_i.kind == "kernel":
+                addr = symbols[i]
+                if addr not in seen_kernel_addr:
+                    seen_kernel_addr[addr] = i
+                    kernel_arg_sym_indices.append(i)
+                else:
+                    kernel_dup_canonical[i] = seen_kernel_addr[addr]
 
     with open(os.path.join(output_dir, "bundle.mlir"), "w") as f:
         logger.info(f"Generating {f.name}")
@@ -192,13 +204,23 @@ def generate_bundle(
         #   - "pool"            → arith.addi %pool_extracted, <pool_offset>
         #                         deduped by pool offset value
         #   - anything else     → arith.constant (use_symbols=False or non-symbolic path)
-        kernel_arg_sym_set = set(kernel_arg_sym_indices)
+        # All kernel sym indices to skip during emission (canonical + duplicates).
+        kernel_arg_sym_set = set(kernel_arg_sym_indices) | set(kernel_dup_canonical)
         # Map kernel base sym_idx → positional parameter index (1-based name suffix).
+        # Duplicate kernel sym indices map to the same pos as their canonical.
         kernel_base_to_pos: dict[int, int] = {
             sym_idx: pos + 1 for pos, sym_idx in enumerate(kernel_arg_sym_indices)
         }
+        for dup_idx, canon_idx in kernel_dup_canonical.items():
+            if canon_idx in kernel_base_to_pos:
+                kernel_base_to_pos[dup_idx] = kernel_base_to_pos[canon_idx]
         # sym_canonical[sym_idx] → canonical SSA name for derived/pool symbols (deduped).
-        sym_canonical: dict[int, str] = {}
+        # Also pre-populate with duplicate kernel symbols pointing to their canonical name.
+        sym_canonical: dict[int, str] = {
+            dup_idx: f"%sym_0_{kernel_base_to_pos[dup_idx]}_extracted"
+            for dup_idx in kernel_dup_canonical
+            if dup_idx in kernel_base_to_pos
+        }
         # derived_addi_emitted[(base_param_pos, offset)] → SSA name already emitted
         derived_addi_emitted: dict[tuple[int, int], str] = {}
         # pool_addi_emitted[pool_offset_value] → SSA name already emitted
@@ -206,8 +228,8 @@ def generate_bundle(
 
         for sym_idx, value in enumerate(symbols):
             if sym_idx in kernel_arg_sym_set:
-                continue  # replaced by function parameter + extract op
-            sk = symbol_kinds[sym_idx] if symbol_kinds else None
+                continue  # replaced by function parameter + extract op (or duplicate)
+            sk: SymbolKind | None = symbol_kinds[sym_idx] if symbol_kinds else None
             if sk is not None and sk.is_derived:
                 base_pos = kernel_base_to_pos.get(sk.base_sym_idx)
                 if base_pos is not None:

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -20,6 +20,7 @@ from typing import Any
 import sympy
 
 from torch_spyre._inductor import config as _spyre_config
+from torch_spyre._inductor.codegen.compute_ops import SymbolKind
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec
 from torch_spyre._inductor.codegen.unroll import unroll_loop_specs
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec
@@ -38,11 +39,8 @@ logger = get_inductor_logger("sdsc_compile")
 #   affine_strides:     list[dict] parallel to SDSCSpec.args —
 #                       {tiled_sym: stride_bytes} for tiled HBM tensors,
 #                       empty dict for non-tiled / lx tensors
-#   symbol_kinds:       list[tuple[str, int]] parallel to base_symbol_values —
-#                       ("kernel", 0)           – base addr of a kernel tensor arg
-#                       ("kernel_derived", off) – per-core addr = base + off
-#                       ("pool", 0)             – pool-allocated tensor addr
-_CompiledEntry = tuple[Any, list[int], list[dict], list[tuple[str, int]]]
+#   symbol_kinds:       list[SymbolKind] parallel to base_symbol_values
+_CompiledEntry = tuple[Any, list[int], list[dict], list[SymbolKind]]
 
 
 # ---------------------------------------------------------------------------
@@ -128,19 +126,16 @@ def generate_bundle(
     addr_counter = [0]
 
     # Build a per-symbol kind list from compiled entries (symbolic_args path only).
-    # Each entry is a (kind_str, aux_int) tuple from compute_ops.generate_sdsc.
-    symbol_kinds: list[tuple[str, int]] = []
+    symbol_kinds: list[SymbolKind] = []
     if symbolic_args and use_symbols:
         for _, _, _, local_kinds in compiled:
             symbol_kinds.extend(local_kinds)
 
     # Determine whether a pool parameter is needed (any pool symbol present).
-    has_pool = (
-        symbolic_args and use_symbols and any(k == "pool" for k, _ in symbol_kinds)
-    )
+    has_pool = symbolic_args and use_symbols and any(sk.is_pool for sk in symbol_kinds)
     # Indices of kernel-base symbols (one per kernel tensor arg; become input_arg params).
     kernel_arg_sym_indices = (
-        [i for i, (k, _) in enumerate(symbol_kinds) if k == "kernel"]
+        [i for i, sk in enumerate(symbol_kinds) if sk.kind == "kernel"]
         if symbolic_args and use_symbols
         else []
     )
@@ -212,32 +207,17 @@ def generate_bundle(
         for sym_idx, value in enumerate(symbols):
             if sym_idx in kernel_arg_sym_set:
                 continue  # replaced by function parameter + extract op
-            if not symbol_kinds:
-                # use_symbols=False path — no symbol_kinds populated
-                f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
-                continue
-            kind, aux = symbol_kinds[sym_idx]
-            if kind == "kernel_derived":
-                # Find which kernel base parameter this derives from.
-                # The base symbol has the same arg_index; its value = symbols[base_idx].
-                # We locate it by scanning backwards for the nearest "kernel" entry
-                # with value == (value - aux).
-                base_value = value - aux
-                base_sym_idx = next(
-                    (
-                        j
-                        for j in range(sym_idx - 1, -1, -1)
-                        if symbol_kinds[j][0] == "kernel" and symbols[j] == base_value
-                    ),
-                    None,
-                )
-                if base_sym_idx is not None and base_sym_idx in kernel_base_to_pos:
-                    base_pos = kernel_base_to_pos[base_sym_idx]
-                    key = (base_pos, aux)
+            sk = symbol_kinds[sym_idx] if symbol_kinds else None
+            if sk is not None and sk.is_derived:
+                base_pos = kernel_base_to_pos.get(sk.base_sym_idx)
+                if base_pos is not None:
+                    key = (base_pos, sk.offset)
                     if key not in derived_addi_emitted:
                         offset_ssa = f"%core_offset_{sym_idx + 1}"
                         addi_ssa = f"%sym_{sym_idx + 1}"
-                        f.write(f"\t\t{offset_ssa} = arith.constant {aux} : index\n")
+                        f.write(
+                            f"\t\t{offset_ssa} = arith.constant {sk.offset} : index\n"
+                        )
                         f.write(
                             f"\t\t{addi_ssa} = arith.addi"
                             f" %sym_0_{base_pos}_extracted, {offset_ssa} : index\n"
@@ -245,11 +225,10 @@ def generate_bundle(
                         derived_addi_emitted[key] = addi_ssa
                     sym_canonical[sym_idx] = derived_addi_emitted[key]
                 else:
-                    # Fallback: emit as a plain constant if base not found.
                     f.write(
                         f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n"
                     )
-            elif kind == "pool":
+            elif sk is not None and sk.is_pool:
                 if value not in pool_addi_emitted:
                     offset_ssa = f"%pool_offset_{sym_idx + 1}"
                     addi_ssa = f"%sym_{sym_idx + 1}"
@@ -553,16 +532,6 @@ def _get_tensor_core_sym_id(sdsc_json: dict, tensor_idx: int, core: int) -> int 
                     if key in data:
                         return int(data[key])
     return None
-
-
-def _sym_id_to_mlir_name(sym_id: int) -> str:
-    """Map a negative symbol ID to a %sym_N MLIR name.
-
-    Symbol IDs are assigned sequentially across the whole bundle starting at
-    -1, and symbols[abs(id)-1] holds the corresponding value.  So %sym_N where
-    N = abs(sym_id) is always correct.
-    """
-    return f"%sym_{abs(sym_id)}"
 
 
 # ---------------------------------------------------------------------------

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -24,27 +24,36 @@ class SymbolKind:
     """Classifies a symbol registered in the bundle symbol table.
 
     Three variants (constructed via class methods):
-      - ``kernel()``:                  base HBM address of a kernel tensor arg;
-                                       emitted as a ``!sdscbundle.input_arg`` param.
-      - ``kernel_derived(idx, off)``:  per-core derived address = base + offset;
-                                       emitted as ``arith.addi %sym_0_N_extracted, off``.
-                                       ``base_sym_idx`` is the 0-based index into the
-                                       global ``symbols`` list of the kernel base symbol.
-      - ``pool()``:                    pool-allocated tensor address;
-                                       emitted as ``arith.addi %pool_extracted, value``.
+      - ``kernel(arg_index)``:               base HBM address of a kernel tensor arg;
+                                             emitted as a ``!sdscbundle.input_arg`` param
+                                             named ``%arg_{arg_index}``.
+      - ``kernel_derived(idx, off, arg_i)``: per-core derived address = base + offset;
+                                             emitted as ``arith.addi %arg_{arg_i}, off``.
+                                             ``base_sym_idx`` is the 0-based index into the
+                                             global ``symbols`` list of the kernel base symbol.
+      - ``pool()``:                          pool-allocated tensor address;
+                                             emitted as ``arith.addi %pool, value``.
     """
 
     kind: str
     base_sym_idx: int = -1
     offset: int = 0
+    arg_index: int = -1
 
     @classmethod
-    def kernel(cls) -> "SymbolKind":
-        return cls(kind="kernel")
+    def kernel(cls, arg_index: int) -> "SymbolKind":
+        return cls(kind="kernel", arg_index=arg_index)
 
     @classmethod
-    def kernel_derived(cls, base_sym_idx: int, offset: int) -> "SymbolKind":
-        return cls(kind="kernel_derived", base_sym_idx=base_sym_idx, offset=offset)
+    def kernel_derived(
+        cls, base_sym_idx: int, offset: int, arg_index: int
+    ) -> "SymbolKind":
+        return cls(
+            kind="kernel_derived",
+            base_sym_idx=base_sym_idx,
+            offset=offset,
+            arg_index=arg_index,
+        )
 
     @classmethod
     def pool(cls) -> "SymbolKind":
@@ -320,22 +329,23 @@ def generate_sdsc(
     local_symbol_kind: list[SymbolKind] = []
 
     def _per_core_kind(
-        c: int, is_kernel: bool, core0_addr: int, addr: int, base_sym_idx: int
+        c: int, arg_index: int, core0_addr: int, addr: int, base_sym_idx: int
     ) -> SymbolKind:
         """Return the SymbolKind for a per-core HBM address.
 
-        Core 0 of a kernel arg is the input_arg base; subsequent cores are
-        derived from it.  ``base_sym_idx`` is the 0-based index into the global
-        ``symbols`` list where the core-0 symbol was (or will be) registered.
-        Pool tensors always use SymbolKind.pool().
+        Core 0 of a kernel arg (arg_index >= 0) is the input_arg base; subsequent
+        cores are derived from it.  ``base_sym_idx`` is the 0-based index into the
+        global ``symbols`` list where the core-0 symbol was (or will be) registered.
+        Pool tensors (arg_index < 0) always use SymbolKind.pool().
         """
-        if not is_kernel:
+        if arg_index < 0:
             return SymbolKind.pool()
         if c == 0:
-            return SymbolKind.kernel()
+            return SymbolKind.kernel(arg_index=arg_index)
         return SymbolKind.kernel_derived(
             base_sym_idx=base_sym_idx,
             offset=addr - core0_addr,
+            arg_index=arg_index,
         )
 
     if use_symbols:
@@ -355,7 +365,6 @@ def generate_sdsc(
             if "lx" in tensor.allocation:
                 affine_strides.append({})
                 continue
-            is_kernel = tensor.arg_index >= 0
             core0_addr = tensor.start_address + core_idx_to_slice_offset(
                 tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
             ) * num_bytes(tensor.data_format)
@@ -371,7 +380,9 @@ def generate_sdsc(
                     ) * num_bytes(tensor.data_format)
                     offset_as_symbol(
                         addr,
-                        _per_core_kind(c, is_kernel, core0_addr, addr, base_sym_idx),
+                        _per_core_kind(
+                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
+                        ),
                     )
                 affine_strides.append({})
             else:
@@ -388,7 +399,9 @@ def generate_sdsc(
                     ) * num_bytes(tensor.data_format)
                     offset_as_symbol(
                         addr,
-                        _per_core_kind(c, is_kernel, core0_addr, addr, base_sym_idx),
+                        _per_core_kind(
+                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
+                        ),
                     )
                 affine_strides.append(strides_for_tensor)
 
@@ -398,7 +411,6 @@ def generate_sdsc(
                     f"[{c}, 0, 0]": str(tensor.start_address)
                     for c in range(sdsc_spec.num_cores)
                 }
-            is_kernel = tensor.arg_index >= 0
             core0_addr = tensor.start_address + core_idx_to_slice_offset(
                 tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
             ) * num_bytes(tensor.data_format)
@@ -411,7 +423,9 @@ def generate_sdsc(
                 result[f"[{c}, 0, 0]"] = str(
                     offset_as_symbol(
                         addr,
-                        _per_core_kind(c, is_kernel, core0_addr, addr, base_sym_idx),
+                        _per_core_kind(
+                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
+                        ),
                     )
                 )
             return result

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -272,13 +272,17 @@ def generate_sdsc(
     #
     # When use_symbols=False this dict stays empty (symbols is not modified).
     local_symbols: dict[int, int] = {}
+    # Parallel to local_symbols (insertion order): "kernel" if the symbol came
+    # from a kernel tensor arg (arg_index >= 0), "pool" if pool-allocated.
+    local_symbol_kind: list[str] = []
 
     if use_symbols:
 
-        def offset_as_symbol(s):
+        def offset_as_symbol(s, kind: str):
             if s not in local_symbols:
                 local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
                 symbols.append(s)
+                local_symbol_kind.append(kind)
             return local_symbols[s]
 
         # Compute per-tensor affine strides and register base addresses in symbols.
@@ -289,6 +293,7 @@ def generate_sdsc(
             if "lx" in tensor.allocation:
                 affine_strides.append({})
                 continue
+            kind = "kernel" if tensor.arg_index >= 0 else "pool"
             tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
             if not tensor_tiled:
                 # Non-tiled HBM: register full per-core addresses.
@@ -296,7 +301,7 @@ def generate_sdsc(
                     full_addr = tensor.start_address + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                     ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(full_addr)
+                    offset_as_symbol(full_addr, kind)
                 affine_strides.append({})
             else:
                 # Tiled HBM: symbol value = per-core iter-0 base address.
@@ -310,7 +315,7 @@ def generate_sdsc(
                     base_addr = tensor.start_address + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                     ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(base_addr)
+                    offset_as_symbol(base_addr, kind)
                 affine_strides.append(strides_for_tensor)
 
         def _start_addr_data(tensor):
@@ -319,12 +324,13 @@ def generate_sdsc(
                     f"[{c}, 0, 0]": str(tensor.start_address)
                     for c in range(sdsc_spec.num_cores)
                 }
+            kind = "kernel" if tensor.arg_index >= 0 else "pool"
             result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                 ) * num_bytes(tensor.data_format)
-                result[f"[{c}, 0, 0]"] = str(offset_as_symbol(addr))
+                result[f"[{c}, 0, 0]"] = str(offset_as_symbol(addr, kind))
             return result
 
     else:
@@ -558,4 +564,5 @@ def generate_sdsc(
         },
         list(local_symbols.keys()),
         affine_strides,
+        local_symbol_kind,
     )

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -272,13 +272,15 @@ def generate_sdsc(
     #
     # When use_symbols=False this dict stays empty (symbols is not modified).
     local_symbols: dict[int, int] = {}
-    # Parallel to local_symbols (insertion order): "kernel" if the symbol came
-    # from a kernel tensor arg (arg_index >= 0), "pool" if pool-allocated.
-    local_symbol_kind: list[str] = []
+    # Parallel to local_symbols (insertion order).  Each entry is a tuple:
+    #   ("kernel", 0)            – base address of a kernel tensor arg (input_arg param)
+    #   ("kernel_derived", off)  – per-core derived address: base_addr + off (arith.addi)
+    #   ("pool", 0)              – pool-allocated tensor address (arith.addi from pool base)
+    local_symbol_kind: list[tuple[str, int]] = []
 
     if use_symbols:
 
-        def offset_as_symbol(s, kind: str):
+        def offset_as_symbol(s, kind: tuple[str, int]):
             if s not in local_symbols:
                 local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
                 symbols.append(s)
@@ -293,15 +295,25 @@ def generate_sdsc(
             if "lx" in tensor.allocation:
                 affine_strides.append({})
                 continue
-            kind = "kernel" if tensor.arg_index >= 0 else "pool"
+            is_kernel = tensor.arg_index >= 0
+            core0_addr = tensor.start_address + core_idx_to_slice_offset(
+                tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+            ) * num_bytes(tensor.data_format)
             tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
             if not tensor_tiled:
-                # Non-tiled HBM: register full per-core addresses.
+                # Non-tiled HBM: register per-core addresses.
                 for c in range(sdsc_spec.num_cores):
-                    full_addr = tensor.start_address + core_idx_to_slice_offset(
+                    addr = tensor.start_address + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                     ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(full_addr, kind)
+                    kind: tuple[str, int] = (
+                        ("kernel", 0)
+                        if (is_kernel and c == 0)
+                        else ("kernel_derived", addr - core0_addr)
+                        if is_kernel
+                        else ("pool", 0)
+                    )
+                    offset_as_symbol(addr, kind)
                 affine_strides.append({})
             else:
                 # Tiled HBM: symbol value = per-core iter-0 base address.
@@ -312,10 +324,17 @@ def generate_sdsc(
                         tensor, s, sdsc_spec.iteration_space
                     )
                 for c in range(sdsc_spec.num_cores):
-                    base_addr = tensor.start_address + core_idx_to_slice_offset(
+                    addr = tensor.start_address + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                     ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(base_addr, kind)
+                    kind = (
+                        ("kernel", 0)
+                        if (is_kernel and c == 0)
+                        else ("kernel_derived", addr - core0_addr)
+                        if is_kernel
+                        else ("pool", 0)
+                    )
+                    offset_as_symbol(addr, kind)
                 affine_strides.append(strides_for_tensor)
 
         def _start_addr_data(tensor):
@@ -324,13 +343,23 @@ def generate_sdsc(
                     f"[{c}, 0, 0]": str(tensor.start_address)
                     for c in range(sdsc_spec.num_cores)
                 }
-            kind = "kernel" if tensor.arg_index >= 0 else "pool"
+            is_kernel = tensor.arg_index >= 0
+            core0_addr = tensor.start_address + core_idx_to_slice_offset(
+                tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+            ) * num_bytes(tensor.data_format)
             result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                 ) * num_bytes(tensor.data_format)
-                result[f"[{c}, 0, 0]"] = str(offset_as_symbol(addr, kind))
+                kind_c: tuple[str, int] = (
+                    ("kernel", 0)
+                    if (is_kernel and c == 0)
+                    else ("kernel_derived", addr - core0_addr)
+                    if is_kernel
+                    else ("pool", 0)
+                )
+                result[f"[{c}, 0, 0]"] = str(offset_as_symbol(addr, kind_c))
             return result
 
     else:

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -406,28 +406,19 @@ def generate_sdsc(
                 affine_strides.append(strides_for_tensor)
 
         def _start_addr_data(tensor):
+            # All per-core addresses were already registered by the per-tensor loop
+            # above. Look them up directly rather than re-computing SymbolKind.
             if "lx" in tensor.allocation:
                 return {
                     f"[{c}, 0, 0]": str(tensor.start_address)
                     for c in range(sdsc_spec.num_cores)
                 }
-            core0_addr = tensor.start_address + core_idx_to_slice_offset(
-                tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-            ) * num_bytes(tensor.data_format)
-            base_sym_idx = symbol_id_offset + len(local_symbols)
             result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                 ) * num_bytes(tensor.data_format)
-                result[f"[{c}, 0, 0]"] = str(
-                    offset_as_symbol(
-                        addr,
-                        _per_core_kind(
-                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
-                        ),
-                    )
-                )
+                result[f"[{c}, 0, 0]"] = str(local_symbols[addr])
             return result
 
     else:

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -13,8 +13,50 @@
 # limitations under the License.
 
 
+import dataclasses
+
 from torch_spyre._C import encode_constant, DataFormats
 from sympy import Symbol
+
+
+@dataclasses.dataclass(frozen=True)
+class SymbolKind:
+    """Classifies a symbol registered in the bundle symbol table.
+
+    Three variants (constructed via class methods):
+      - ``kernel()``:                  base HBM address of a kernel tensor arg;
+                                       emitted as a ``!sdscbundle.input_arg`` param.
+      - ``kernel_derived(idx, off)``:  per-core derived address = base + offset;
+                                       emitted as ``arith.addi %sym_0_N_extracted, off``.
+                                       ``base_sym_idx`` is the 0-based index into the
+                                       global ``symbols`` list of the kernel base symbol.
+      - ``pool()``:                    pool-allocated tensor address;
+                                       emitted as ``arith.addi %pool_extracted, value``.
+    """
+
+    kind: str
+    base_sym_idx: int = -1
+    offset: int = 0
+
+    @classmethod
+    def kernel(cls) -> "SymbolKind":
+        return cls(kind="kernel")
+
+    @classmethod
+    def kernel_derived(cls, base_sym_idx: int, offset: int) -> "SymbolKind":
+        return cls(kind="kernel_derived", base_sym_idx=base_sym_idx, offset=offset)
+
+    @classmethod
+    def pool(cls) -> "SymbolKind":
+        return cls(kind="pool")
+
+    @property
+    def is_derived(self) -> bool:
+        return self.kind == "kernel_derived"
+
+    @property
+    def is_pool(self) -> bool:
+        return self.kind == "pool"
 
 
 def core_idx_to_slice_offset(
@@ -229,19 +271,21 @@ def generate_sdsc(
 ):
     """Generate SDSC JSON for one OpSpec.
 
-    Returns a 3-tuple ``(sdsc_json, base_symbol_values, affine_strides)``:
+    Returns a 4-tuple ``(sdsc_json, base_symbol_values, affine_strides, symbol_kinds)``:
     - ``sdsc_json``: the JSON dict to write to ``sdsc_N.json``
-    - ``base_symbol_values``: list of base HBM byte offsets registered in
-      ``symbols``; empty when ``use_symbols=False``
+    - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``;
+      empty when ``use_symbols=False``
     - ``affine_strides``: list (parallel to ``sdsc_spec.args``) of dicts
       ``{tiled_sym: stride_bytes}`` for tiled HBM tensors; always empty when
       ``use_symbols=False``.  Used by ``bundle.py`` to emit ``affine.apply``
       ops inside ``scf.for`` loops.
+    - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``;
+      empty when ``use_symbols=False``.  Classifies each symbol as a kernel base
+      address, per-core derived address, or pool-allocated address.
 
     When ``use_symbols=False``, HBM tensor addresses are baked directly as
-    concrete integers into the SDSC JSON.  No symbol IDs are registered and ``symbols``
-    is not modified.  This is the default until backend symbol-table support
-    is complete.
+    concrete integers into the SDSC JSON.  No symbol IDs are registered and
+    ``symbols`` is not modified.
 
     When ``use_symbols=True``, HBM addresses are registered as negative symbol
     IDs in the JSON and their values appended to ``symbols``, enabling
@@ -272,15 +316,31 @@ def generate_sdsc(
     #
     # When use_symbols=False this dict stays empty (symbols is not modified).
     local_symbols: dict[int, int] = {}
-    # Parallel to local_symbols (insertion order).  Each entry is a tuple:
-    #   ("kernel", 0)            – base address of a kernel tensor arg (input_arg param)
-    #   ("kernel_derived", off)  – per-core derived address: base_addr + off (arith.addi)
-    #   ("pool", 0)              – pool-allocated tensor address (arith.addi from pool base)
-    local_symbol_kind: list[tuple[str, int]] = []
+    # Parallel to local_symbols (insertion order): one SymbolKind per registered symbol.
+    local_symbol_kind: list[SymbolKind] = []
+
+    def _per_core_kind(
+        c: int, is_kernel: bool, core0_addr: int, addr: int, base_sym_idx: int
+    ) -> SymbolKind:
+        """Return the SymbolKind for a per-core HBM address.
+
+        Core 0 of a kernel arg is the input_arg base; subsequent cores are
+        derived from it.  ``base_sym_idx`` is the 0-based index into the global
+        ``symbols`` list where the core-0 symbol was (or will be) registered.
+        Pool tensors always use SymbolKind.pool().
+        """
+        if not is_kernel:
+            return SymbolKind.pool()
+        if c == 0:
+            return SymbolKind.kernel()
+        return SymbolKind.kernel_derived(
+            base_sym_idx=base_sym_idx,
+            offset=addr - core0_addr,
+        )
 
     if use_symbols:
 
-        def offset_as_symbol(s, kind: tuple[str, int]):
+        def offset_as_symbol(s, kind: SymbolKind):
             if s not in local_symbols:
                 local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
                 symbols.append(s)
@@ -299,6 +359,9 @@ def generate_sdsc(
             core0_addr = tensor.start_address + core_idx_to_slice_offset(
                 tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
             ) * num_bytes(tensor.data_format)
+            # base_sym_idx: index in global symbols[] where core-0 will be registered.
+            # Used by kernel_derived symbols to reference their base without searching.
+            base_sym_idx = symbol_id_offset + len(local_symbols)
             tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
             if not tensor_tiled:
                 # Non-tiled HBM: register per-core addresses.
@@ -306,14 +369,10 @@ def generate_sdsc(
                     addr = tensor.start_address + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                     ) * num_bytes(tensor.data_format)
-                    kind: tuple[str, int] = (
-                        ("kernel", 0)
-                        if (is_kernel and c == 0)
-                        else ("kernel_derived", addr - core0_addr)
-                        if is_kernel
-                        else ("pool", 0)
+                    offset_as_symbol(
+                        addr,
+                        _per_core_kind(c, is_kernel, core0_addr, addr, base_sym_idx),
                     )
-                    offset_as_symbol(addr, kind)
                 affine_strides.append({})
             else:
                 # Tiled HBM: symbol value = per-core iter-0 base address.
@@ -327,14 +386,10 @@ def generate_sdsc(
                     addr = tensor.start_address + core_idx_to_slice_offset(
                         tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                     ) * num_bytes(tensor.data_format)
-                    kind = (
-                        ("kernel", 0)
-                        if (is_kernel and c == 0)
-                        else ("kernel_derived", addr - core0_addr)
-                        if is_kernel
-                        else ("pool", 0)
+                    offset_as_symbol(
+                        addr,
+                        _per_core_kind(c, is_kernel, core0_addr, addr, base_sym_idx),
                     )
-                    offset_as_symbol(addr, kind)
                 affine_strides.append(strides_for_tensor)
 
         def _start_addr_data(tensor):
@@ -347,19 +402,18 @@ def generate_sdsc(
             core0_addr = tensor.start_address + core_idx_to_slice_offset(
                 tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
             ) * num_bytes(tensor.data_format)
+            base_sym_idx = symbol_id_offset + len(local_symbols)
             result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                 ) * num_bytes(tensor.data_format)
-                kind_c: tuple[str, int] = (
-                    ("kernel", 0)
-                    if (is_kernel and c == 0)
-                    else ("kernel_derived", addr - core0_addr)
-                    if is_kernel
-                    else ("pool", 0)
+                result[f"[{c}, 0, 0]"] = str(
+                    offset_as_symbol(
+                        addr,
+                        _per_core_kind(c, is_kernel, core0_addr, addr, base_sym_idx),
+                    )
                 )
-                result[f"[{c}, 0, 0]"] = str(offset_as_symbol(addr, kind_c))
             return result
 
     else:

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -651,7 +651,7 @@ def compile_op_spec(
     symbols: list[int],
     symbol_id_offset: int = 0,
     use_symbols: bool = False,
-) -> tuple[Any, list[int], list[dict], list[str]]:
+) -> tuple[Any, list[int], list[dict], list[tuple[str, int]]]:
     sdsc_spec, symbol_mapping = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
     # Translate tiled_symbols from OpSpec's inductor symbols to the renamed

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -52,6 +52,7 @@ class SDSCArgs:
     allocation: dict[str, Any]
     start_address: int | Symbol
     backGap: dict[Symbol, int]
+    arg_index: int = -1
 
     def __str__(self) -> str:
         scales = ", ".join(f"{k}={v}" for k, v in self.scales.items())
@@ -406,6 +407,7 @@ def _create_sdsc_tensors(
                 if "lx" in arg.allocation
                 else arg.allocation.get("hbm"),
                 backGap=backGap,
+                arg_index=arg.arg_index,
             )
         )
 
@@ -649,7 +651,7 @@ def compile_op_spec(
     symbols: list[int],
     symbol_id_offset: int = 0,
     use_symbols: bool = False,
-) -> tuple[Any, list[int], list[dict]]:
+) -> tuple[Any, list[int], list[dict], list[str]]:
     sdsc_spec, symbol_mapping = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
     # Translate tiled_symbols from OpSpec's inductor symbols to the renamed

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -35,7 +35,7 @@ from torch_spyre._inductor.op_spec import OpSpec
 from torch_spyre._inductor.op_spec import TensorArg
 from torch_spyre._inductor.dtype_ops import DtypeOpTable
 
-from .compute_ops import generate_sdsc
+from .compute_ops import SymbolKind, generate_sdsc
 
 logger = get_inductor_logger("codegen.superdsc")
 
@@ -651,7 +651,7 @@ def compile_op_spec(
     symbols: list[int],
     symbol_id_offset: int = 0,
     use_symbols: bool = False,
-) -> tuple[Any, list[int], list[dict], list[tuple[str, int]]]:
+) -> tuple[Any, list[int], list[dict], list[SymbolKind]]:
     sdsc_spec, symbol_mapping = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
     # Translate tiled_symbols from OpSpec's inductor symbols to the renamed

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -46,6 +46,12 @@ core_id_k_fast_emission: bool = (
 # still under development.
 bundle_hbm_symbols: bool = os.environ.get("BUNDLE_HBM_SYMBOLS", "0") == "1"
 
+# When True, the generated func.func @sdsc_bundle takes one
+# !sdscbundle.input_arg<index> parameter per tensor argument and extracts
+# each to a local SSA value, rather than emitting arith.constant offsets.
+# Requires bundle_hbm_symbols=True to have any effect.
+bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "0") == "1"
+
 # When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs
 # before generate_bundle runs.  Set to False to pass LoopSpecs through intact
 # (used with bundle_hbm_symbols=True for the scf.for / affine.apply path).


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Extends the `bundle.mlir` code generator to support symbolic tensor addresses
when `BUNDLE_SYMBOLIC_ARGS=1` is set (requires `BUNDLE_HBM_SYMBOLS=1`).

Previously, the generated `func.func @sdsc_bundle` took no arguments; all tensor
addresses were baked as `arith.constant` values derived from `SEGMENT_OFFSETS`.
With this feature enabled, the function takes one `!sdscbundle.input_arg<index>`
parameter per kernel tensor argument (named `%arg_{arg_index}_base_addr`) and an
optional leading `%pool_base_addr` parameter when pool-allocated intermediates are
present. Each parameter is immediately extracted to a short SSA name for use in
the function body:

```mlir
module {
    func.func @sdsc_bundle(%pool_base_addr: !sdscbundle.input_arg<index>,
                           %arg_0_base_addr: !sdscbundle.input_arg<index>,
                           %arg_1_base_addr: !sdscbundle.input_arg<index>) {
        %pool    = sdscbundle.input_arg_extract value from %pool_base_addr
                       : !sdscbundle.input_arg<index> -> index
        %arg_0   = sdscbundle.input_arg_extract value from %arg_0_base_addr
                       : !sdscbundle.input_arg<index> -> index
        %arg_1   = sdscbundle.input_arg_extract value from %arg_1_base_addr
                       : !sdscbundle.input_arg<index> -> index
        %pool_offset_0    = arith.constant 0 : index
        %pool_addr_0      = arith.addi %pool, %pool_offset_0 : index
        %pool_offset_2048 = arith.constant 2048 : index
        %pool_addr_2048   = arith.addi %pool, %pool_offset_2048 : index
        sdscbundle.sdsc_execute (%arg_0, %pool_addr_0)
            {sdsc_filename="sdsc_0.json", "symbol_ids"=[-1, -2]}
        sdscbundle.sdsc_execute (%arg_0, %pool_addr_0, %pool_addr_2048)
            {sdsc_filename="sdsc_1.json", "symbol_ids"=[-3, -4, -5]}
        sdscbundle.sdsc_execute (%arg_1, %pool_addr_0)
            {sdsc_filename="sdsc_2.json", "symbol_ids"=[-6, -7]}
        return
    }
}
```

Key properties of the generated MLIR:

- **One parameter per unique kernel arg address.** The same `TensorArg.arg_index`
  appearing in multiple SDSCs maps to a single `input_arg` parameter — cross-SDSC
  duplicates are detected and routed to the same extracted SSA name.
- **Pool offsets deduplicated.** Multiple pool tensors with the same byte offset
  share one `arith.constant` / `arith.addi` pair; multiple SDSCs referencing the
  same pool address share the same `%pool_addr_N` SSA variable.
- **Multi-core derived addresses.** When `SENCORES > 1`, per-core addresses for a
  single kernel tensor arg are emitted as `arith.addi %arg_N, <core_offset>` rather
  than additional `input_arg` parameters, keeping the parameter count equal to the
  number of distinct kernel args regardless of core count.
- **Readable naming.** Formal parameter names use the `_base_addr` suffix; the
  short extracted names (`%arg_0`, `%pool`) are what appears in every body
  instruction.

**Files changed:**

| File | Change |
|---|---|
| `config.py` | New `bundle_symbolic_args` flag (`BUNDLE_SYMBOLIC_ARGS`, default `False`) |
| `superdsc.py` | `SDSCArgs` gains `arg_index: int = -1` (propagated from `TensorArg`); `compile_op_spec` return type extended to 4-tuple adding `list[SymbolKind]` |
| `compute_ops.py` | New `SymbolKind` frozen dataclass (`kernel`, `kernel_derived`, `pool` variants); `generate_sdsc` classifies each registered symbol using `tensor.arg_index` and returns the classification as the 4th return value |
| `bundle.py` | `generate_bundle` collects `SymbolKind` lists, deduplicates kernel arg symbols across SDSCs, emits function signature + extract ops, emits pool `arith.addi` pairs (deduped by value), and threads resolution context into `_emit_specs` |

#### Which issue(s) this PR is related to:

Fixes #2402. 

#### Special notes for your reviewer:

**Feature is fully guarded.** Unless both `BUNDLE_HBM_SYMBOLS=1` and
`BUNDLE_SYMBOLIC_ARGS=1` are set the generated `bundle.mlir` is byte-for-byte
identical to the previous output.

**`SymbolKind` carries `arg_index` and `base_sym_idx`.** The `kernel_derived`
variant stores the 0-based index into the global `symbols` list of its kernel-base
symbol directly, so `bundle.py` can look up the parent parameter name without
scanning backwards through the symbol list.

**`SDSCArgs.arg_index` is the discriminant.** `arg_index >= 0` means kernel tensor
arg; `arg_index < 0` means pool or lx — the same invariant enforced by
`spyre_kernel_args` throughout the rest of the codebase.

#### Does this PR introduce a user-facing change?

No change at default settings (`BUNDLE_SYMBOLIC_ARGS` defaults to `False`). When
the flag is enabled, the generated `bundle.mlir` changes from hard-coded
`arith.constant` addresses to `sdscbundle.input_arg` parameters and requires
backend compiler support for the `sdscbundle` input-arg dialect.

#### Additional note:

Tests are in `tests/inductor/test_coarse_tiling.py` in two new test classes:

- `TestGenerateBundleMlirSymbolicArgs` — covers parameter/extract emission,
  pool `arith.addi` deduplication, the `symbolic_args=False` no-op guard, and
  cross-SDSC kernel-arg deduplication.
- `TestSymbolKind` — unit tests for the `SymbolKind` dataclass and for
  `generate_sdsc`'s per-symbol classification with `num_cores > 1`.

All 111 tests in `test_coarse_tiling.py` pass. No changes to
`torch_spyre/execution/`, `scheduler.py`, or `spyre_kernel.py`.