### PR TITLE
Ensure constant tensors do not get restickified

### DIFF
--- a/tests/inductor/test_restickify.py
+++ b/tests/inductor/test_restickify.py
@@ -763,6 +763,71 @@ def test_wrong_optimal_cost_fails():
         _compare(func, a, b, c, d, e, optimal_cost=0)
 
 
+# ------- Constant tensor STL tests ---------
+
+
+def test_constant_plus_xt():
+    """ones_like(x) + x.t() — constant tensor should adopt x.t()'s stick, cost 0."""
+    x = torch.randn((S, S), dtype=torch.float16)
+    _compare(lambda x: torch.ones_like(x) + x.t(), x, optimal_cost=0)
+
+
+def test_constant_in_conflict_chain():
+    """ones_like(x) + x.t() + y — constant adopts winning STL, doesn't add to conflict cost."""
+    x, y = _make_tensors(2, S, S)
+    _compare(lambda x, y: torch.ones_like(x) + x.t() + y, x, y, optimal_cost=S * S)
+
+
+def test_constant_matmul_x():
+    """ones_like(y) @ y — constant should get col-major STL that matmul x needs, cost 0."""
+    y = _make_tensors(1, S, S)[0]
+    _compare(lambda y: torch.ones_like(y) @ y, y, optimal_cost=0)
+
+
+def test_two_constants_plus_xt():
+    """ones_like(x) + zeros_like(x) + x.t() — two flexible constants, cost still 0."""
+    x = torch.randn((S, S), dtype=torch.float16)
+    _compare(
+        lambda x: torch.ones_like(x) + torch.zeros_like(x) + x.t(), x, optimal_cost=0
+    )
+
+
+def test_full_plus_xt():
+    """torch.full + x.t() — full tensor constant should adopt x.t()'s stick, cost 0."""
+    x = torch.randn((S, S), dtype=torch.float16)
+    _compare(
+        lambda x: torch.full((S, S), 0.5, dtype=torch.float16, device=x.device) + x.t(),
+        x,
+        optimal_cost=0,
+    )
+
+
+def test_fill_plus_xt():
+    """empty_like + fill_ + x.t() — mutation-based constant should adopt x.t()'s stick, cost 0."""
+    x = torch.randn((S, S), dtype=torch.float16)
+
+    def fn(x):
+        e = torch.empty_like(x)
+        e.fill_(1.0)
+        return e + x.t()
+
+    _compare(fn, x, optimal_cost=0)
+
+
+def test_arange_plus_xt():
+    """arange.view + x.t() — correctness check only.
+
+    arange lowers to FallbackKernel which gets a fixed generic layout, so the
+    downstream add may still need a restickify.  No optimal_cost asserted.
+    """
+    x = torch.randn((S, S), dtype=torch.float16)
+    _compare(
+        lambda x: torch.arange(S * S, dtype=torch.float16, device=x.device).view(S, S)
+        + x.t(),
+        x,
+    )
+
+
 # ------- Unsupported stick configurations ---------
 
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -673,18 +673,17 @@ def propagate_spyre_tensor_layouts(
             args = _get_prop_args(rw.reads)
             output = op.get_layout()
             if not args:
-                is_constant_fill = all(
+                mem_reads = [r for r in rw.reads if isinstance(r, MemoryDep)]
+                is_constant_fill = bool(mem_reads) and all(
                     isinstance(V.graph.get_buffer(r.name), SpyreConstantFallback)
-                    for r in rw.reads
-                    if isinstance(r, MemoryDep)
+                    for r in mem_reads
                 )
                 if is_constant_fill:
                     op.layouts = _all_constant_layouts(op)
                 else:
                     logger.warning(
                         f"{op.get_name()} has no propagatable args but reads non-constant "
-                        f"buffers {[r.name for r in rw.reads if isinstance(r, MemoryDep)]}; "
-                        f"falling back to generic layout"
+                        f"buffers {[r.name for r in mem_reads]}; falling back to generic layout"
                     )
                     op.layouts = [generic_layout(op)]
                 op.restick_cost_fn = AnyInNode.from_args()

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -588,6 +588,39 @@ def compute_layouts(
     return layouts
 
 
+def _all_constant_layouts(op: Operation) -> list[SpyreTensorLayout]:
+    """Return one STL per valid stick dimension for a constant-valued buffer.
+
+    A constant tensor (ones_like, full, zeros_like, ...) has no real memory
+    access pattern — every element is the same scalar broadcast from a
+    SpyreConstantFallback.  Because the content is uniform, any stick layout
+    is correct.  Offering all valid choices lets the optimizer pick whichever
+    is compatible with the rest of the graph at zero cost, avoiding a needless
+    restickify.
+
+    Only dimensions with at least elems_per_stick elements are valid stick
+    candidates — smaller dims produce sentinel -1 entries in stride_map that
+    insert_restickify cannot handle.
+    """
+    output: FixedLayout = op.get_layout()
+    c_size = [concretize_expr(s) for s in output.size]
+    c_stride = [concretize_expr(s) for s in output.stride]
+    elems_per_stick = get_elem_in_stick(output.dtype)
+    layouts = [
+        SpyreTensorLayout(
+            c_size,
+            c_stride,
+            output.dtype,
+            [d for d in range(len(c_size)) if d != stick_dim] + [stick_dim],
+        )
+        for stick_dim in range(len(c_size))
+        if c_size[stick_dim] >= elems_per_stick
+    ]
+    if not layouts:
+        layouts = [generic_layout(op)]
+    return layouts
+
+
 def generic_layout(op: Operation) -> SpyreTensorLayout:
     output: FixedLayout = op.get_layout()
     # Concretize for C++ SpyreTensorLayout constructor.
@@ -640,7 +673,20 @@ def propagate_spyre_tensor_layouts(
             args = _get_prop_args(rw.reads)
             output = op.get_layout()
             if not args:
-                op.layouts = [generic_layout(op)]
+                is_constant_fill = all(
+                    isinstance(V.graph.get_buffer(r.name), SpyreConstantFallback)
+                    for r in rw.reads
+                    if isinstance(r, MemoryDep)
+                )
+                if is_constant_fill:
+                    op.layouts = _all_constant_layouts(op)
+                else:
+                    logger.warning(
+                        f"{op.get_name()} has no propagatable args but reads non-constant "
+                        f"buffers {[r.name for r in rw.reads if isinstance(r, MemoryDep)]}; "
+                        f"falling back to generic layout"
+                    )
+                    op.layouts = [generic_layout(op)]
                 op.restick_cost_fn = AnyInNode.from_args()
             elif isinstance(op.data, (Pointwise, Reduction)):
                 op.layouts = compute_layouts(op, output, output_dep, args)


### PR DESCRIPTION

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Analyzing our flash attention WSR example we noticed that the constant buffers were being restickified, which is unnecessary.  This PR modifies propagate_layouts to give constant tensors the option to be any layout (produces a layout with each host dim as the stick) rather than just one default layout.  This allows the global optimizer to always have a compatible layout available to choose from when paired with other ops.

Several restickify tests added all confirming zero cost (no restickifies) with these changes.


#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/2150

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
