### PR TITLE
feat(coarse_tile): pool-allocate tiled intermediate buffers

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1265,7 +1265,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
         )
 
-    @unittest.skip("TODO: coarse tiling correctness not yet resolved")
     @config.patch({"coarse_tiling": True})
     def test_hint_flash_attention(self):
         """Flash attention tiled over H (4 slices) and Lk (2 slices) via nested spyre_hints."""
@@ -1329,7 +1328,7 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             result,
             ref,
             equal_nan=True,
-            atol=1.0,
+            atol=0.01,
             rtol=0.1,
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -254,13 +254,6 @@ def _propagate_tiled_op(
     )
     full_buf = _allocate_full_buffer(op, full_ranges, operations, group_start_idx)
 
-    if not is_graph_output:
-        # Mark as pool-eligible: this buffer is an intermediate (written inside
-        # the tiled loop, read outside it).  memory_planning will assign it a
-        # pool address, allowing it to share memory with other non-overlapping
-        # intermediates.
-        full_buf.layout.allocation["pool_pending"] = True
-
     has_inside = _has_inside_consumers(buf_name, loop_group_id, operations)
 
     if has_inside:

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -254,6 +254,13 @@ def _propagate_tiled_op(
     )
     full_buf = _allocate_full_buffer(op, full_ranges, operations, group_start_idx)
 
+    if not is_graph_output:
+        # Mark as pool-eligible: this buffer is an intermediate (written inside
+        # the tiled loop, read outside it).  memory_planning will assign it a
+        # pool address, allowing it to share memory with other non-overlapping
+        # intermediates.
+        full_buf.layout.allocation["pool_pending"] = True
+
     has_inside = _has_inside_consumers(buf_name, loop_group_id, operations)
 
     if has_inside:

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -156,6 +156,9 @@ class SpyreEmptyFallback(ir.ExternKernel):
         pass
 
     def should_allocate(self) -> bool:
+        layout = self.get_layout()
+        if isinstance(layout, FixedTiledLayout) and "pool" in layout.allocation:
+            return False
         return True
 
     def get_mutation_names(self) -> Sequence[str]:

--- a/torch_spyre/_inductor/memory_planning.py
+++ b/torch_spyre/_inductor/memory_planning.py
@@ -22,7 +22,7 @@ from torch._inductor.scheduler import (
 from torch._inductor.ir import FallbackKernel
 from torch._inductor.virtualized import V
 from .constants import SEGMENT_SIZE, INTERMEDIATES_SEGMENT
-from .ir import FixedTiledLayout
+from .ir import FixedTiledLayout, SpyreEmptyFallback
 from .scheduler import CountedLoopSchedulerNode
 from .logging_utils import get_inductor_logger, _get_env_bool
 
@@ -141,7 +141,7 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     Collects pool candidates from two sources:
     - Kernel intermediates: buffers both written and read within the graph,
       detected via written & read sets on ComputedBuffer nodes.
-    - Buffers tagged by coarse_tile.py with allocation["pool_pending"] = True.
+    - SpyreEmptyFallback full buffers created by coarse_tile.py (non-outputs).
       These are ExternKernel nodes invisible to the written & read path above.
 
     For each candidate, assigns layout.allocation["pool"] = INTERMEDIATES_SEGMENT + offset.
@@ -217,17 +217,21 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
         name for name in (written & read) - io_names if _is_kernel_intermediate(name)
     }
 
-    # Source 2: buffers tagged by coarse_tile.py with allocation["pool_pending"].
-    # These are ExternKernel nodes excluded from non_kernel_nodes above.
+    # Source 2: SpyreEmptyFallback full buffers created by coarse_tile.py.
+    # These are ExternKernel nodes excluded from non_kernel_nodes above, so they
+    # never appear in written & read.  Any non-output, non-LX SpyreEmptyFallback
+    # with a FixedTiledLayout is a coarse-tile intermediate to pool-allocate.
+    # "lx" not in allocation guards against buffers already claimed by LX scratchpad
+    # planning, which runs in CustomPreSchedulingPasses before memory_planning.
     for n in flat_nodes:
         if n.read_writes.writes:
             name = next(iter(n.read_writes.writes)).name
             buf = V.graph.get_buffer(name)
-            layout = buf.layout if isinstance(buf.layout, FixedTiledLayout) else None
             if (
-                layout is not None
-                and "pool_pending" in layout.allocation
-                and "lx" not in layout.allocation
+                isinstance(buf, SpyreEmptyFallback)
+                and isinstance(buf.layout, FixedTiledLayout)
+                and "lx" not in buf.layout.allocation
+                and name not in io_names
             ):
                 pool_candidates.add(name)
                 logger.debug(
@@ -248,9 +252,11 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
 
     # Track (end_step, offset, size) so we can free blocks promptly.
     pending_frees: list[tuple[int, int, int]] = []
-    # In coarse_tile case 2 (mutation), the tiled op's layout and full_buf's
-    # layout share the same allocation dict object, so both names appear in
-    # intermediates but must only be allocated once.  Track by dict id.
+    # In coarse_tile case 2 (mutation), the tiled op's layout is
+    # MutationLayoutSHOULDREMOVE whose real_layout() returns full_buf's
+    # FixedTiledLayout — the same object and allocation dict.  The tiled op's
+    # name enters pool_candidates via written & read (source 1); full_buf's name
+    # via source 2.  Only allocate the shared dict once.
     assigned_alloc_ids: set[int] = set()
 
     for name, (start, end) in sorted_bufs:
@@ -278,7 +284,6 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
         size = _compute_size_bytes(name)
         offset = allocator.allocate(size)
 
-        layout.allocation.pop("pool_pending", None)
         layout.allocation["pool"] = INTERMEDIATES_SEGMENT + offset
         assigned_alloc_ids.add(id(layout.allocation))
 

--- a/torch_spyre/_inductor/memory_planning.py
+++ b/torch_spyre/_inductor/memory_planning.py
@@ -23,6 +23,7 @@ from torch._inductor.ir import FallbackKernel
 from torch._inductor.virtualized import V
 from .constants import SEGMENT_SIZE, INTERMEDIATES_SEGMENT
 from .ir import FixedTiledLayout
+from .scheduler import CountedLoopSchedulerNode
 from .logging_utils import get_inductor_logger, _get_env_bool
 
 logger = get_inductor_logger("MEMORY_PLANNING")
@@ -108,9 +109,9 @@ def _compute_size_bytes(name: str) -> int:
 
 def _compute_live_ranges(
     nodes: list[BaseSchedulerNode],
-    intermediates: set[str],
+    pool_candidates: set[str],
 ) -> dict[str, tuple[int, int]]:
-    """Return {buf_name: (start_step, end_step)} for each intermediate.
+    """Return {buf_name: (start_step, end_step)} for each pool candidate.
 
     start_step: timestep of the node that writes the buffer.
     end_step: last timestep at which any node reads the buffer.
@@ -121,24 +122,30 @@ def _compute_live_ranges(
     for idx, node in enumerate(nodes):
         rw = node.read_writes
         for dep in rw.writes:
-            if dep.name in intermediates:
+            if dep.name in pool_candidates:
                 start[dep.name] = idx
         for dep in rw.reads:
-            if dep.name in intermediates:
+            if dep.name in pool_candidates:
                 end[dep.name] = idx
 
     live_ranges: dict[str, tuple[int, int]] = {}
-    for name in intermediates:
+    for name in pool_candidates:
         if name in start:
             live_ranges[name] = (start[name], end.get(name, len(nodes) + 1))
     return live_ranges
 
 
 def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
-    """Assign intermediate tensors addresses in the same segment.
-    Identifies intermediate buffers (not graph inputs/outputs, not already LX-allocated), performs
-    live range analysis, and assigns layout.allocation["pool"] = address so
-    that non-overlapping intermediates share a hbm segment.
+    """Pool-allocate buffers so non-overlapping tensors share the HBM intermediates segment.
+
+    Collects pool candidates from two sources:
+    - Kernel intermediates: buffers both written and read within the graph,
+      detected via written & read sets on ComputedBuffer nodes.
+    - Buffers tagged by coarse_tile.py with allocation["pool_pending"] = True.
+      These are ExternKernel nodes invisible to the written & read path above.
+
+    For each candidate, assigns layout.allocation["pool"] = INTERMEDIATES_SEGMENT + offset.
+    Graph inputs/outputs and LX-allocated buffers are excluded.
     """
 
     if not _MEMORY_PLAN_ENABLED:
@@ -154,7 +161,22 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
         ExternKernelSchedulerNode,
         NopKernelSchedulerNode,
     )
-    non_kernel_nodes = [n for n in nodes if not isinstance(n, _kernel_arg_types)]
+
+    # build_loop_scheduler_nodes may have already run in pre-fusion, wrapping
+    # tiled ops into CountedLoopSchedulerNodes.  Flatten them so individual ops
+    # are visible at distinct timesteps for written/read detection and live-range
+    # analysis.
+    def _iter_all_nodes(
+        node_list: list[BaseSchedulerNode],
+    ):
+        for n in node_list:
+            if isinstance(n, CountedLoopSchedulerNode):
+                yield from _iter_all_nodes(n.get_nodes())
+            else:
+                yield n
+
+    flat_nodes: list[BaseSchedulerNode] = list(_iter_all_nodes(nodes))
+    non_kernel_nodes = [n for n in flat_nodes if not isinstance(n, _kernel_arg_types)]
 
     written = {
         dep.name
@@ -179,7 +201,7 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
         and isinstance(layout := io_buf.get_layout(), FixedTiledLayout)
     }
 
-    def _is_intermediate(name: str) -> bool:
+    def _is_kernel_intermediate(name: str) -> bool:
         buf = V.graph.get_buffer(name)
         if buf is None:
             return False
@@ -190,14 +212,34 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
             and id(layout.allocation) not in io_alloc_ids
         )
 
-    intermediates = {
-        name for name in (written & read) - io_names if _is_intermediate(name)
+    # Source 1: buffers written and read within the graph (kernel intermediates).
+    pool_candidates: set[str] = {
+        name for name in (written & read) - io_names if _is_kernel_intermediate(name)
     }
-    if not intermediates:
+
+    # Source 2: buffers tagged by coarse_tile.py with allocation["pool_pending"].
+    # These are ExternKernel nodes excluded from non_kernel_nodes above.
+    for n in flat_nodes:
+        if n.read_writes.writes:
+            name = next(iter(n.read_writes.writes)).name
+            buf = V.graph.get_buffer(name)
+            layout = buf.layout if isinstance(buf.layout, FixedTiledLayout) else None
+            if (
+                layout is not None
+                and "pool_pending" in layout.allocation
+                and "lx" not in layout.allocation
+            ):
+                pool_candidates.add(name)
+                logger.debug(
+                    "memory_planning: adding coarse-tile full buffer %s to pool candidates",
+                    name,
+                )
+
+    if not pool_candidates:
         V.graph.pool_size = 0
         return nodes
 
-    live_ranges = _compute_live_ranges(nodes, intermediates)
+    live_ranges = _compute_live_ranges(flat_nodes, pool_candidates)
 
     # Sort by start step so the allocator processes tensors in execution order.
     sorted_bufs = sorted(live_ranges.items(), key=lambda kv: kv[1][0])
@@ -206,6 +248,10 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
 
     # Track (end_step, offset, size) so we can free blocks promptly.
     pending_frees: list[tuple[int, int, int]] = []
+    # In coarse_tile case 2 (mutation), the tiled op's layout and full_buf's
+    # layout share the same allocation dict object, so both names appear in
+    # intermediates but must only be allocated once.  Track by dict id.
+    assigned_alloc_ids: set[int] = set()
 
     for name, (start, end) in sorted_bufs:
         # Free any blocks whose live range ended before this start step.
@@ -218,14 +264,23 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
                 still_live.append(entry)
         pending_frees = still_live
 
-        size = _compute_size_bytes(name)
-        offset = allocator.allocate(size)
-
-        # Assign HBM address directly to layout.allocation.
         buf = V.graph.get_buffer(name)
         layout = buf.get_layout()
         assert isinstance(layout, FixedTiledLayout)
+
+        if id(layout.allocation) in assigned_alloc_ids:
+            logger.debug(
+                "memory_planning: %s shares alloc dict with already-assigned buffer, skipping",
+                name,
+            )
+            continue
+
+        size = _compute_size_bytes(name)
+        offset = allocator.allocate(size)
+
+        layout.allocation.pop("pool_pending", None)
         layout.allocation["pool"] = INTERMEDIATES_SEGMENT + offset
+        assigned_alloc_ids.add(id(layout.allocation))
 
         pending_frees.append((end, offset, size))
 
@@ -242,7 +297,7 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     pool_extent = allocator.get_pool_end()
     logger.info(
         "memory_planning: assigned %d intermediates, peak concurrent usage %.2f GB, pool extent %.2f GB / %.2f GB",
-        len(sorted_bufs),
+        len(live_ranges),
         peak / (1024**3),
         pool_extent / (1024**3),
         SEGMENT_SIZE / (1024**3),

--- a/torch_spyre/_inductor/memory_planning.py
+++ b/torch_spyre/_inductor/memory_planning.py
@@ -184,6 +184,17 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
         for dep in node.read_writes.writes
         if dep.name not in graph_outputs
     }
+
+    # SpyreEmptyFallback nodes allocate a buffer but emit no dep-tracked write
+    # so they never appear in `written` via the dep walk above.  Collect them here explicitly
+    written |= {
+        node.get_name()
+        for node in flat_nodes
+        if isinstance(node, ExternKernelSchedulerNode)
+        and isinstance(node.node, SpyreEmptyFallback)
+        and node.get_name() not in graph_outputs
+    }
+
     read = {
         dep.name
         for node in non_kernel_nodes
@@ -201,7 +212,7 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
         and isinstance(layout := io_buf.get_layout(), FixedTiledLayout)
     }
 
-    def _is_kernel_intermediate(name: str) -> bool:
+    def _is_intermediate(name: str) -> bool:
         buf = V.graph.get_buffer(name)
         if buf is None:
             return False
@@ -212,38 +223,14 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
             and id(layout.allocation) not in io_alloc_ids
         )
 
-    # Source 1: buffers written and read within the graph (kernel intermediates).
-    pool_candidates: set[str] = {
-        name for name in (written & read) - io_names if _is_kernel_intermediate(name)
+    intermediates = {
+        name for name in (written & read) - io_names if _is_intermediate(name)
     }
-
-    # Source 2: SpyreEmptyFallback full buffers created by coarse_tile.py.
-    # These are ExternKernel nodes excluded from non_kernel_nodes above, so they
-    # never appear in written & read.  Any non-output, non-LX SpyreEmptyFallback
-    # with a FixedTiledLayout is a coarse-tile intermediate to pool-allocate.
-    # "lx" not in allocation guards against buffers already claimed by LX scratchpad
-    # planning, which runs in CustomPreSchedulingPasses before memory_planning.
-    for n in flat_nodes:
-        if n.read_writes.writes:
-            name = next(iter(n.read_writes.writes)).name
-            buf = V.graph.get_buffer(name)
-            if (
-                isinstance(buf, SpyreEmptyFallback)
-                and isinstance(buf.layout, FixedTiledLayout)
-                and "lx" not in buf.layout.allocation
-                and name not in io_names
-            ):
-                pool_candidates.add(name)
-                logger.debug(
-                    "memory_planning: adding coarse-tile full buffer %s to pool candidates",
-                    name,
-                )
-
-    if not pool_candidates:
+    if not intermediates:
         V.graph.pool_size = 0
         return nodes
 
-    live_ranges = _compute_live_ranges(flat_nodes, pool_candidates)
+    live_ranges = _compute_live_ranges(nodes, intermediates)
 
     # Sort by start step so the allocator processes tensors in execution order.
     sorted_bufs = sorted(live_ranges.items(), key=lambda kv: kv[1][0])
@@ -252,12 +239,6 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
 
     # Track (end_step, offset, size) so we can free blocks promptly.
     pending_frees: list[tuple[int, int, int]] = []
-    # In coarse_tile case 2 (mutation), the tiled op's layout is
-    # MutationLayoutSHOULDREMOVE whose real_layout() returns full_buf's
-    # FixedTiledLayout — the same object and allocation dict.  The tiled op's
-    # name enters pool_candidates via written & read (source 1); full_buf's name
-    # via source 2.  Only allocate the shared dict once.
-    assigned_alloc_ids: set[int] = set()
 
     for name, (start, end) in sorted_bufs:
         # Free any blocks whose live range ended before this start step.
@@ -270,22 +251,14 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
                 still_live.append(entry)
         pending_frees = still_live
 
-        buf = V.graph.get_buffer(name)
-        layout = buf.get_layout()
-        assert isinstance(layout, FixedTiledLayout)
-
-        if id(layout.allocation) in assigned_alloc_ids:
-            logger.debug(
-                "memory_planning: %s shares alloc dict with already-assigned buffer, skipping",
-                name,
-            )
-            continue
-
         size = _compute_size_bytes(name)
         offset = allocator.allocate(size)
 
+        # Assign HBM address directly to layout.allocation.
+        buf = V.graph.get_buffer(name)
+        layout = buf.get_layout()
+        assert isinstance(layout, FixedTiledLayout)
         layout.allocation["pool"] = INTERMEDIATES_SEGMENT + offset
-        assigned_alloc_ids.add(id(layout.allocation))
 
         pending_frees.append((end, offset, size))
 
@@ -302,7 +275,7 @@ def memory_planning(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     pool_extent = allocator.get_pool_end()
     logger.info(
         "memory_planning: assigned %d intermediates, peak concurrent usage %.2f GB, pool extent %.2f GB / %.2f GB",
-        len(live_ranges),
+        len(sorted_bufs),
         peak / (1024**3),
         pool_extent / (1024**3),
         SEGMENT_SIZE / (1024**3),

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -514,7 +514,11 @@ class SpyreKernel(Kernel[CSEVariable]):
         layout = buf.get_layout()
         if not isinstance(layout, FixedTiledLayout):
             raise Unsupported(f"{name} does not have FixedTiledLayout")
-        _ = self.args.output(name)
+        # Pool buffers are intermediates whose address is baked into the TensorArg
+        # allocation dict; registering them as outputs would overflow SEGMENT_OFFSETS.
+        # (lx buffers are already excluded from spyre_kernel_args in _tensor_arg.)
+        if "pool" not in layout.allocation:
+            _ = self.args.output(name)
         index = sympy_subs(index, V.graph.sizevars.precomputed_replacements)
         dst = TensorAccess(name, index, layout)
         real_dst_name = V.graph.scheduler.mutation_real_name.get(name, name)
@@ -570,7 +574,11 @@ class SpyreKernel(Kernel[CSEVariable]):
         layout = buf.get_layout()
         if not isinstance(layout, FixedTiledLayout):
             raise Unsupported(f"{name} does not have FixedTiledLayout")
-        _ = self.args.output(name)
+        # Pool buffers are intermediates whose address is baked into the TensorArg
+        # allocation dict; registering them as outputs would overflow SEGMENT_OFFSETS.
+        # (lx buffers are already excluded from spyre_kernel_args in _tensor_arg.)
+        if "pool" not in layout.allocation:
+            _ = self.args.output(name)
         index = sympy_subs(index, V.graph.sizevars.precomputed_replacements)
         dst = TensorAccess(name, index, layout)
         real_dst_name = V.graph.scheduler.mutation_real_name.get(name, name)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Flash attention with coarse tiling was failing with "too many input/output tensors" because SpyreEmptyFallback full buffers created by _propagate_tiled_op were  being registered as dedicated output tensors instead of pool-allocated intermediates.

- memory_planning.py: Add a second pool-candidate source: non-output SpyreEmptyFallback buffers with a FixedTiledLayout and no LX allocation. These are  ExternKernel nodes invisible to the existing written-and-read path. Also flatten CountedLoopSchedulerNodes before live-range analysis (required because build_loop_scheduler_nodes now runs pre-fusion), and track assigned_alloc_ids to avoid double-allocating the shared FixedTiledLayout dict on the mutation path.

- spyre_kernel.py: Skip args.output() in store() and store_reduction() for pool-allocated buffers — their HBM address is already baked into the TensorArg allocation dict, so registering them as outputs wastes SEGMENT_OFFSETS slots.

- test_coarse_tile_e2e.py: Enable test_hint_flash_attention and tighten tolerance to atol=0.01 (observed max diff ~0.004).


#### Which issue(s) this PR is related to:
https://github.com/torch-spyre/torch-spyre/issues/2150
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:



**Standalone Driver version of Flash Attention WSR Test**
```

import math

import torch
from torch_spyre._inductor import config, spyre_hint
import torch_spyre._inductor.propagate_named_dims as pnd

declare_tensor_dim = pnd.declare_tensor_dim
name_tensor_dims = pnd.name_tensor_dims

torch.manual_seed(0xAFFE)
torch.manual_seed(3)

B, H, Lq, Lk, D = 1, 8, 256, 256, 64
block_size = 128

queries_t = torch.randn(B, H, Lq, D, dtype=torch.float16)
keys_t = torch.randn(B, H, Lk, D, dtype=torch.float16)
values_t = torch.randn(B, H, Lk, D, dtype=torch.float16)


def flash(queries, keys, values):
    scale = 1.0 / math.sqrt(math.sqrt(D))

    output = torch.zeros_like(queries)
    M = torch.full(
        (B, H, Lq), float("-inf"), device=queries.device, dtype=torch.float16
    )
    with spyre_hint(slices={"B": 1}):
        with spyre_hint(slices={"H": 2}):
            with spyre_hint(slices={"Lk": 2}):
                keys_T = keys.transpose(-1, -2).contiguous()

                denominator = torch.zeros((B, H, Lq), device=queries.device, dtype=torch.float16)
                scores = torch.matmul(queries * scale, keys_T * scale)  # B, H, Lq, Lk
                scores = scores.transpose(-1, -2).contiguous()  # avoid stick reduction: B, H, Lk, Lq
                block_max = torch.amax(scores, dim=-2)  # B, H, Lq
                max_running = torch.maximum(M, block_max)  # B, H, Lq

                exp_scores = torch.exp(
                    scores - max_running.unsqueeze(-2)
                )  # B, H, Lk, Lq
                correction = torch.exp(M - max_running)  # B, H, Lq

                denominator = denominator * correction + exp_scores.sum(dim=-2)  # B, H, Lq
                output = (
                    output * correction.unsqueeze(-1)
                    + torch.matmul(exp_scores.transpose(-1, -2), values)  # B, H, Lq, D
                )
                M = max_running
    return output / denominator.unsqueeze(-1)


# CPU reference
ref = flash(queries_t, keys_t, values_t)

# Device run
queries_dev = queries_t.to("spyre")
keys_dev = keys_t.to("spyre")
values_dev = values_t.to("spyre")

declare_tensor_dim("B", B)
declare_tensor_dim("H", H)
declare_tensor_dim("Lq", Lq)
declare_tensor_dim("Lk", Lk)
declare_tensor_dim("D", D)

name_tensor_dims(queries_dev, ["B", "H", "Lq", "D"])
name_tensor_dims(keys_dev, ["B", "H", "Lk", "D"])
name_tensor_dims(values_dev, ["B", "H", "Lk", "D"])  

config.coarse_tiling = True

try:
    result = torch.compile(flash)(queries_dev, keys_dev, values_dev).cpu()
except Exception as e:
    import traceback
    print(f"compile/run failed (expected during group analysis):")
    traceback.print_exc()
    raise SystemExit(0)

print("ref:   ", ref.flatten()[:8])
print("result:", result.flatten()[:8])
print("max abs diff:", torch.abs(ref - result).amax().item())

torch.testing.assert_close(
    result,
    ref,
    equal_nan=True,
    atol=0.01,
    rtol=0.1,
    msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
)
print("PASSED")
```