### PR TITLE
docs(claude): document Spyre device exclusivity and add subagent testing skil

### DIFF
--- a/.claude/skills/debug-compilation/SKILL.md
+++ b/.claude/skills/debug-compilation/SKILL.md
@@ -202,6 +202,11 @@ execute the compiled binary.
 
 ## Common Debugging Workflow
 
+> **CRITICAL — never run Spyre tests in parallel.**
+> Loading `torch_spyre` gives the process **exclusive access** to the Spyre
+> device until exit. Never use `-n`, pytest-xdist, or any parallel runner —
+> a second process cannot acquire the device and will fail or hang.
+
 1. **Reproduce** with minimal model and `SENCORES=1`
 2. **Set env vars**: `TORCH_SPYRE_DEBUG=1 TORCH_COMPILE_DEBUG=1
    TORCH_LOGS="+inductor"`

--- a/.claude/skills/project-overview/SKILL.md
+++ b/.claude/skills/project-overview/SKILL.md
@@ -220,6 +220,17 @@ python3 -m pytest tests/inductor/        # Compiled ops
 python3 -m pytest tests/tensor/           # Layout tests
 ```
 
+> **CRITICAL — Spyre device is exclusively owned per process.**
+> Importing `torch_spyre` causes the process to acquire the Spyre hardware
+> device exclusively. No second process can load `torch_spyre` until the
+> first exits. Consequences:
+>
+> - **Never run pytest with `-n`, `-n auto`, xdist, or any parallel runner.**
+> - **Never dispatch two subagents that both run tests concurrently.**
+> - In multi-agent workflows: parallelize investigation/coding; serialize all
+>   test execution through a single process. See the `spyre-subagent-testing`
+>   skill for orchestration patterns.
+
 Key test patterns:
 
 - `compare_with_cpu(fn, *inputs)` — runs fn on CPU vs Spyre via torch.compile,

--- a/.claude/skills/spyre-subagent-testing/SKILL.md
+++ b/.claude/skills/spyre-subagent-testing/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: spyre-subagent-testing
+description: "Rules for orchestrators and subagents coordinating test execution in torch-spyre. Use whenever dispatching or writing subagent prompts that may involve running tests."
+---
+
+# Spyre Subagent Testing Coordination
+
+## The Hard Constraint
+
+**The Spyre device is exclusively owned by the first process that loads
+`torch_spyre`.** No second process can acquire the device until the first
+exits. This is a hardware/driver constraint, not a software choice.
+
+This means:
+
+- **Two pytest processes cannot run Spyre tests at the same time.**
+- **Two subagents cannot run tests concurrently.**
+- Even subagents working on completely unrelated test files will deadlock
+  or fail if their test runs overlap.
+
+This is not negotiable and cannot be worked around in software.
+
+---
+
+## Rules for Orchestrators
+
+When using `dispatching-parallel-agents` or any multi-agent pattern in
+torch-spyre, apply these rules:
+
+### 1. Never dispatch parallel test-running agents
+
+The standard "one agent per independent domain, dispatch in parallel"
+pattern **does not apply to test execution** in this project.
+
+```
+# WRONG for torch-spyre:
+Agent 1 → Fix and test feature A   ← runs pytest
+Agent 2 → Fix and test feature B   ← runs pytest concurrently → DEADLOCK
+```
+
+### 2. Separate investigation from verification
+
+Parallelize the investigation/coding phase; serialize the test phase:
+
+```
+# RIGHT for torch-spyre:
+Phase 1 (parallel):
+  Agent 1 → Investigate and fix feature A (no tests)
+  Agent 2 → Investigate and fix feature B (no tests)
+
+Phase 2 (sequential, one process):
+  Run: python3 -m pytest tests/ -k "feature_a or feature_b"
+```
+
+### 3. Assign test execution to exactly one agent (or the orchestrator)
+
+If subagents must run tests, designate a single agent responsible for all
+test execution. Other agents return code changes only; the designated agent
+(or the orchestrator itself) runs all tests after the others complete.
+
+### 4. Never use parallel pytest options
+
+Even within a single agent, never pass `-n`, `-n auto`, `--dist`, or any
+pytest-xdist option. Always run pytest as a single sequential process.
+
+---
+
+## Rules for Subagents
+
+If you are a subagent in torch-spyre and your prompt involves tests:
+
+1. **Do not run tests unless you are the designated test agent.** If your
+   prompt does not explicitly assign you test-running responsibility, return
+   your code changes and let the orchestrator handle test execution.
+
+2. **If you do run tests**, run a single sequential pytest process. No `-n`,
+   no xdist, no background pytest processes.
+
+3. **If tests fail with device acquisition errors**, another process likely
+   holds the device. Do not retry in parallel — report back to the
+   orchestrator to serialize.
+
+---
+
+## Structuring Subagent Prompts
+
+When writing a subagent prompt that may involve tests, include this block:
+
+```
+IMPORTANT — Spyre device constraint: The Spyre device is exclusively owned
+by the first process that loads torch_spyre. Do NOT run pytest in parallel
+with any other process, and do NOT use pytest -n or xdist. If you need to
+run tests, run a single sequential: python3 -m pytest <path>
+[Only run tests if explicitly instructed to do so in this prompt.]
+```
+
+---
+
+## Template: Multi-Agent Workflow for torch-spyre
+
+```
+Phase 1 — Parallel investigation (no test execution):
+  Agent A: "Investigate and implement fix for X. Return the code changes
+            only. Do NOT run tests."
+  Agent B: "Investigate and implement fix for Y. Return the code changes
+            only. Do NOT run tests."
+
+Phase 2 — Sequential verification (orchestrator or single agent):
+  After all agents complete:
+  python3 -m pytest tests/ -k "relevant_tests"
+```

--- a/.claude/skills/write-spyre-op-test/SKILL.md
+++ b/.claude/skills/write-spyre-op-test/SKILL.md
@@ -198,3 +198,9 @@ python3 -m pytest tests/_inductor/test_inductor_ops.py -k "test_my_op"
 # All tests
 python3 -m pytest tests/
 ```
+
+> **CRITICAL — never run Spyre tests in parallel.**
+> Loading `torch_spyre` gives the process **exclusive access** to the Spyre
+> device until the process exits. Never use `-n`, `-n auto`, pytest-xdist,
+> or any parallel test runner — a second process cannot acquire the device
+> and will fail or hang. Always run pytest as a single sequential process.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # aten/build/ will stop being cleaned.  So be careful when
 # refactoring this file!
 
+.claude/settings.local.json
+
 ## PyTorch
 
 .coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,18 @@ python3 -m pytest tests/
 pre-commit run --all-files
 ```
 
+> **CRITICAL — Spyre device is exclusively owned per process.**
+> Loading `torch_spyre` gives the process exclusive access to the Spyre
+> device until it exits. A second process that loads `torch_spyre` cannot
+> acquire the device and will fail or hang. This affects both local runs
+> and multi-agent workflows:
+>
+> - **Never** run pytest with `-n`, `-n auto`, xdist, or any parallel runner.
+> - **Never** dispatch two subagents that both run tests concurrently.
+> - In multi-agent workflows: parallelize investigation and code changes;
+>   funnel all test execution through a single sequential process at the end.
+>   See the `spyre-subagent-testing` skill for the full orchestration pattern.
+
 Test sub-suites:
 
 | Suite | Path |
@@ -85,6 +97,7 @@ Task-specific guidance is available in `.claude/skills/`. These cover:
 - **write-spyre-op-test** — compiled-path op test framework and patterns
 - **pr-review** — PR review checklist
 - **debug-compilation** — troubleshooting compilation failures
+- **spyre-subagent-testing** — orchestration rules for multi-agent workflows involving tests
 - **write-rfc** — design proposal workflow (RFCs now at https://github.com/torch-spyre/rfcs)
 
 ### Writing SKILL.md Files


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] documentation
- [ ] feature
- [ ] cleanup

#### What this PR does:

Documents the Spyre device exclusivity constraint in CLAUDE.md and the
Claude Code AI assistant skills, and adds a new skill with explicit
orchestration patterns for multi-agent workflows.

**Background:** The Spyre device is exclusively owned by the first process
that loads `torch_spyre` — no second process can acquire it until the first
exits. This caused recurring test failures when running pytest with `-n` /
xdist, and is a particular risk with AI-assisted multi-agent workflows where
subagents are dispatched to investigate and test independently.

**Changes:**

- **`CLAUDE.md`** — adds a prominent critical warning in the Build and Test
  section covering both local parallel runners and multi-agent subagent
  dispatch; references the new skill for orchestration patterns.

- **`.claude/skills/project-overview/SKILL.md`** — documents the constraint
  architecturally in the Testing section so any agent orienting itself in the
  codebase understands the hardware reason, not just the prohibition.

- **`.claude/skills/write-spyre-op-test/SKILL.md`** — adds warning at the
  Running Tests section where pytest commands appear.

- **`.claude/skills/debug-compilation/SKILL.md`** — adds warning at the top
  of the debugging workflow.

- **`.claude/skills/spyre-subagent-testing/SKILL.md`** *(new)* — dedicated
  skill for orchestrators and subagents coordinating test execution. Covers:
  - The hardware constraint and why it applies to multi-agent workflows
  - Rule: never dispatch parallel test-running agents
  - Pattern: parallelize investigation/coding; serialize test execution
  - Copy-paste constraint block for embedding in subagent prompts
  - Template multi-agent workflow for torch-spyre

- **`.gitignore`** — adds `.claude/settings.local.json` (personal per-user
  Claude Code settings that should not be committed).

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
-->

#### Special notes for your reviewer:

The new `spyre-subagent-testing` skill is project-local (`.claude/skills/`)
so it is automatically available to Claude Code sessions in this repo. The
constraint is also stated directly in `CLAUDE.md` (always loaded into
context) so it is visible without requiring explicit skill invocation —
important for multi-agent scenarios where the orchestrator may not think to
invoke a skill before dispatching.

#### Does this PR introduce a user-facing change?

No. This is documentation and AI assistant configuration only; no
production code or test code is changed.

#### Additional note:

The `.claude/` directory contains Claude Code project configuration
(skills, settings). It is already tracked in this repository. The new
skill file follows the existing conventions documented in `CLAUDE.md`.
