### PR TITLE
feat(test framework): add force_xfail behaviour for global.supported_dtypes

### DIFF
--- a/tests/configs/example_test_config.yaml
+++ b/tests/configs/example_test_config.yaml
@@ -1,161 +1,22 @@
+### This is just an example config ###
 test_suite_config:
   files:
-    - path: ${TORCH_ROOT}/test/test_modules.py
-      unlisted_test_mode: skip
-      tests:
-        - names:
-            - TestModule::test_forward
-          mode: mandatory_success
-          edits:
-            modules:
-              include:
-                - name: torch.nn.BatchNorm2d
-                  description: add batchnorm even though not in global.supported_modules
-              exclude:
-                - name: torch.nn.Linear
-                  description: Linear causes OOM on this test
-
     - path: ${TORCH_ROOT}/test/test_binary_ufuncs.py
       unlisted_test_mode: skip
       tests:
         - names:
             - TestBinaryUfuncs::test_scalar_support
             - TestBinaryUfuncs::test_contig_vs_transposed
-          mode: xfail
+          mode: mandatory_success
           tags:
             - model_1
             - model_2
-          edits:
-            ops:
-              include:
-                - name: add
-                  description: inject add — binary_ufuncs_with_references excludes it if ref is None
-              exclude:
-                - name: gcd
-                  description: gcd causes buffer alignment errors for this test
-            dtypes:
-              include:
-                - name: float32
-              exclude:
-                - name: bfloat16
-                  description: bfloat16 unsupported on Spyre for this test
-
-        # Single test — name as a list with one entry (or plain string, both accepted)
-        - names:
-            - TestBinaryUfuncs::test_add
-          mode: mandatory_success
-          tags:
-            - tag_for_add
-
-    - path: ${TORCH_DEVICE_ROOT}/tests/test_regex.py
-      unlisted_test_mode: skip
-      tests: []
-
-    - path: ${TORCH_ROOT}/test/test_view_ops.py
-      unlisted_test_mode: mandatory_success
-      tests:
-        - names: # Tests that pass with no special config needed
-            - TestViewOps::test_as_strided_gradients
-            - TestViewOps::test_contiguous_self
-            - TestViewOps::test_unbind
-            - TestOldViewOps::test_atleast_gradient
-            - TestOldViewOps::test_contiguous
-            - TestOldViewOps::test_resize_as_preserves_strides
-          mode: mandatory_success
-        - names: # Tests that pass with extra dtypes allowed
-            - TestViewOps::test_conj_self
-          mode: mandatory_success
-          edits:
-            dtypes:
-              include:
-                - name: bfloat16
-                - name: int16
-                - name: int32
-                - name: float32
-                - name: float64
-                - name: int8
-                - name: uint8
-        - names: # Tests that pass for float16 but fail for int64
-            - TestViewOps::test_view_dtype_upsize_errors # NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 
-            - TestViewOps::test_view_tensor_split   # NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 
-            - TestOldViewOps::test_transposes_errors   # NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 
-          mode: mandatory_success
-          edits:
-            dtypes:
-              exclude:
-                - name: int64
-        - names: # Tests that fail 
-            - TestViewOps::test_advanced_indexing_nonview   # NotImplementedError: Could not run 'aten::index.Tensor_out' https://github.com/torch-spyre/torch-spyre/issues/1219
-            - TestViewOps::test_advanced_indexing_assignment   # NotImplementedError aten::_index_put_impl_ https://github.com/torch-spyre/torch-spyre/issues/692
-            - TestViewOps::test_conj_view_with_shared_memory   # RuntimeError: Spyre backend does not support dtype ComplexFloat https://github.com/torch-spyre/torch-spyre/issues/678
-            - TestViewOps::test_flatten_view   # torch._inductor.exc.InductorError: CalledProcessError 'dxp_standalone' (not implemented yet) https://github.com/torch-spyre/torch-spyre/issues/903
-            - TestViewOps::test_unfold_view   # NotImplementedError aten::unfold https://github.com/torch-spyre/torch-spyre/issues/688
-            - TestViewOps::test_T_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_as_strided_inplace_view  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_as_strided_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_basic_indexing_ellipses_view  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_basic_indexing_newaxis_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_basic_indexing_slice_view  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_contiguous_nonview   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_diagonal_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_expand_as_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_expand_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_flatten_nonview   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_movedim_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_narrow_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_permute_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_reshape_as_view  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_reshape_nonview   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_reshape_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 
-            - TestViewOps::test_select_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_squeeze_inplace_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_squeeze_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_t_inplace_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_t_view    # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_transpose_inplace_view  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_transpose_view  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_unbind_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_unsqueeze_inplace_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_unsqueeze_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_view_as_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_view_copy_out  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_view_copy_output_contiguous  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_view_copy   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestViewOps::test_view_tensor_dsplit  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 (float16), NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
-            - TestViewOps::test_view_tensor_hsplit   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 (float16), NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
-            - TestViewOps::test_view_tensor_vsplit  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 (float16), NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
-            - TestViewOps::test_view_view   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestOldViewOps::test_T  # RuntimeError: Comparing, Error in codegen for ComputedBuffer https://github.com/torch-spyre/torch-spyre/issues/1226
-            - TestOldViewOps::test_big_transpose  # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestOldViewOps::test_broadcast_to  # AssertionError: Tensor-likes are not close https://github.com/torch-spyre/torch-spyre/issues/1227 (float16),  NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
-            - TestOldViewOps::test_expand  # NotImplementedError aten::unfold https://github.com/torch-spyre/torch-spyre/issues/688
-            - TestOldViewOps::test_flatten   # AssertionError: The length of the sequences mismatch: 1 != 0 https://github.com/torch-spyre/torch-spyre/issues/729
-            - TestOldViewOps::test_memory_format_resize_   # NotImplementedError aten::resize_ https://github.com/torch-spyre/torch-spyre/issues/730 
-            - TestOldViewOps::test_memory_format_resize_as   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestOldViewOps::test_python_types   # RuntimeError: Spyre backend does not support dtype Double https://github.com/torch-spyre/torch-spyre/issues/1228
-            - TestOldViewOps::test_ravel   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80
-            - TestOldViewOps::test_reshape_view_semantics   # RuntimeError: Error: In-device copy not implemented https://github.com/torch-spyre/torch-spyre/issues/80 (float16), NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
-            - TestOldViewOps::test_resize_all_dtypes_and_devices   # NotImplementedError aten::resize_ https://github.com/torch-spyre/torch-spyre/issues/730
-            - TestOldViewOps::test_resize_as_all_dtypes_and_devices   # NotImplementedError aten::resize_ https://github.com/torch-spyre/torch-spyre/issues/730 
-            - TestOldViewOps::test_transposes   # RuntimeError: Comparing, Error in codegen for ComputedBuffer https://github.com/torch-spyre/torch-spyre/issues/1226 (float16),  NotImplementedError aten::random_.from https://github.com/torch-spyre/torch-spyre/issues/549 (int64)
-            - TestOldViewOps::test_view_all_dtypes_and_devices   # RuntimeError: Spyre backend does not support dtype Double https://github.com/torch-spyre/torch-spyre/issues/1228
-          mode: xfail
-        - names: # Tests that are not supported OR crash pytest with seg faults
-            - TestViewOps::test_conj_imag_view  # Complex not supported https://github.com/torch-spyre/torch-spyre/issues/697
-            - TestViewOps::test_real_imag_view  # Complex not supported https://github.com/torch-spyre/torch-spyre/issues/694 
-            - TestViewOps::test_set_real_imag  # Complex not supported https://github.com/torch-spyre/torch-spyre/issues/700
-            - TestViewOps::test_view_as_real  # Complex not supported https://github.com/torch-spyre/torch-spyre/issues/652
-            - TestOldViewOps::test_atleast   # Signal Received: 11 (Segmentation fault) https://github.com/torch-spyre/torch-spyre/issues/728
-            - TestOldViewOps::test_empty_reshape   # Segmentation fault https://github.com/torch-spyre/torch-spyre/issues/1229
-            - TestOldViewOps::test_transpose_vs_numpy   # Signal Received: 11 (Segmentation fault) https://github.com/torch-spyre/torch-spyre/issues/727
-            - TestOldViewOps::test_view_empty   # Segmentation fault https://github.com/torch-spyre/torch-spyre/issues/1229
-            - TestOldViewOps::test_view    # Segmentation fault https://github.com/torch-spyre/torch-spyre/issues/1231
-          mode: skip
-
   global:
     supported_dtypes:
       - name: float16
       - name: int64
+      - name: float32
+        force_xfail: true
     supported_ops:
       - name: add
         dtypes:
@@ -165,11 +26,7 @@ test_suite_config:
               rtol: 1e-3
           - name: int64
       - name: mul
+        # force_xfail: true
       - name: sub
       - name: gcd
-        force_xfail: true
-    supported_modules:
-      - name: torch.nn.Linear
-      - name: torch.nn.Conv2d
-      - name: torch.nn.ReLU
-        force_xfail: true
+        # force_xfail: true

--- a/tests/oot_test_base_common.py
+++ b/tests/oot_test_base_common.py
@@ -333,6 +333,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
     ] = {}  # {module_name -> config}
     GLOBAL_SUPPORTED_DTYPES: Optional[Set[torch.dtype]] = None  # None = no filtering
     GLOBAL_DTYPE_PRECISION: Dict[torch.dtype, "Precision"] = {}
+    GLOBAL_DTYPE_FORCE_XFAIL: Set[torch.dtype] = set()
 
     # File-level module filtering (populated during config load)
     # Use None as sentinel to indicate not yet initialized, avoiding shared mutable default
@@ -383,6 +384,9 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         cls.GLOBAL_SUPPORTED_DTYPES = config.global_config.resolved_supported_dtypes()
         cls.GLOBAL_DTYPE_PRECISION = (
             config.global_config.resolved_supported_dtypes_precision()
+        )
+        cls.GLOBAL_DTYPE_FORCE_XFAIL = (
+            config.global_config.resolved_supported_dtypes_force_xfail()
         )
 
         file_entry: FileEntry = resolve_current_file(config, path)
@@ -597,6 +601,14 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
             op_cfg = cls.SUPPORTED_OPS_CONFIG.get(op_name) if op_name else None
             if op_cfg is not None and op_cfg.force_xfail:
                 effective_mode = MODE_XFAIL
+
+        if effective_mode == MODE_MANDATORY_SUCCESS and dtype_str:
+            try:
+                dtype = parse_dtype(dtype_str)
+                if dtype in cls.GLOBAL_DTYPE_FORCE_XFAIL:
+                    effective_mode = MODE_XFAIL
+            except ValueError:
+                pass
 
         # resolve final decision
         if effective_mode == MODE_SKIP:

--- a/tests/oot_test_config_models.py
+++ b/tests/oot_test_config_models.py
@@ -754,6 +754,7 @@ class DtypeNamedItem(BaseModel):
     name: str
     description: Optional[str] = None
     precision: Optional[Precision] = None
+    force_xfail: bool = False
 
 
 class OpsEdits(BaseModel):
@@ -1077,6 +1078,12 @@ class GlobalConfig(BaseModel):
             parse_dtype(item.name): item.precision
             for item in self.supported_dtypes
             if item.precision is not None
+        }
+
+    def resolved_supported_dtypes_force_xfail(self) -> Set[torch.dtype]:
+        """Return the set of dtypes that have force_xfail: true."""
+        return {
+            parse_dtype(item.name) for item in self.supported_dtypes if item.force_xfail
         }
 
     def resolved_supported_ops(self) -> Optional[Set[str]]:


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

This PR 
- adds `force_xfail` behaviour to `global.supported_dtypes`
- cleans up the example config since it is just an example --- we dont need so many entries.

### Without this: (int64 fails)

<img width="1904" height="70" alt="image" src="https://github.com/user-attachments/assets/4bbc3fd1-eade-4904-94b0-cf87da5a936f" />

### with force_xfail (fail -> xfail)
```yaml
global:
    supported_dtypes:
      - name: float16
      - name: int64
        force_xfail: true
```

<img width="1596" height="88" alt="image" src="https://github.com/user-attachments/assets/641bc9d3-de82-4079-923d-5ddd3b59a952" />
