### PR TITLE
Lower c10d collectives to async custom ops for compiler visibility

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -386,6 +386,8 @@ jobs:
             config: distributed_tests/test_gather.yaml
           - name: Test Multi-Spyre Allgather
             config: distributed_tests/test_allgather.yaml
+          - name: Test Multi-Spyre Broadcast Compiled
+            config: distributed_tests/test_broadcast_compiled.yaml
 
     steps:
       # See the `test` job above: prebaked path symlinks the baked .github into

--- a/docs/source/user_guide/examples/broadcast_demo_multirank.py
+++ b/docs/source/user_guide/examples/broadcast_demo_multirank.py
@@ -1,0 +1,85 @@
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+
+
+def run_demo():
+    device = torch.device("spyre")
+
+    dist.init_process_group(backend="gloo")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    root_rank = 0
+
+    print(f"Rank {rank}/{world_size} using device {device}")
+
+    c10d._register_process_group("default", dist.group.WORLD)
+
+    # Create tensor - must be at least 128 bytes for spyre-comms
+    # Using 8x8 float32 = 256 bytes (meets minimum requirement)
+    if rank == root_rank:
+        x = torch.ones(8, 8).to(device) * 42.0
+        print(f"Rank {rank} (ROOT) - Initial tensor: {x[0, :4]}")
+    else:
+        x = torch.zeros(8, 8).to(device)
+        # print(f"Rank {rank} - Initial tensor: {x[0, :4]}")
+
+    independent = torch.ones(8, 8).to(device) * 10.0
+
+    def fn(t, ind):
+        # Pre-broadcast computation
+        y = t + t
+
+        # Broadcast from root rank - lowered to broadcast_async
+        y_bcast = torch.ops._c10d_functional.broadcast(y, root_rank, "default")
+
+        # Independent computation (compiler in future can schedule this to overlap with broadcast)
+        ind_result = ind * ind * ind  # 10^3 = 1000
+
+        # Wait for broadcast to complete
+        y_ready = torch.ops._c10d_functional.wait_tensor(y_bcast)
+
+        # Combine results: (42*2)*2 + 1000 = 168 + 1000 = 1168
+        z = y_ready * 2 + ind_result
+        return z
+
+    print(f"Rank {rank} - Compiling function...")
+    compiled_fn = torch.compile(fn)
+
+    print(f"Rank {rank} - Executing broadcast")
+    out = compiled_fn(x, independent)
+
+    print("\n")
+    print(f"Rank {rank} - After broadcast: {out[0, :4]}")
+    print(f"Rank {rank} - Expected: 1168.0 = (42*2)*2 + 10^3")
+    print(f"\n[Rank {rank}] Output shape: {out.shape}\n")
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_demo()
+
+"""
+Rank 1/2 using device spyre
+Rank 0/2 using device spyre
+Rank 1 - Compiling function...
+Rank 0 (ROOT) - Initial tensor: tensor([42., 42., 42., 42.], device='spyre:0')
+Rank 1 - Executing broadcast
+Rank 0 - Compiling function...
+Rank 0 - Executing broadcast
+
+
+Rank 1 - After broadcast: tensor([1168., 1168., 1168., 1168.], device='spyre:0')
+Rank 1 - Expected: 1168.0 = (42*2)*2 + 10^3
+
+[Rank 1] Output shape: torch.Size([8, 8])
+
+
+
+Rank 0 - After broadcast: tensor([1168., 1168., 1168., 1168.], device='spyre:0')
+Rank 0 - Expected: 1168.0 = (42*2)*2 + 10^3
+
+[Rank 0] Output shape: torch.Size([8, 8])
+"""

--- a/tests/configs/distributed_tests/test_broadcast_compiled.yaml
+++ b/tests/configs/distributed_tests/test_broadcast_compiled.yaml
@@ -1,0 +1,27 @@
+# Configuration file for torch-spyre distributed compiled tests
+# Tests the lowering of c10d collective operations to Spyre comms library
+#
+# Usage:
+#   cd torch-spyre/tests
+#   ./run_test.sh configs/distributed_tests/test_broadcast_compiled.yaml
+#
+# The run_test.sh script automatically detects tests in the distributed/
+# directory and launches them with: torchrun --nproc-per-node $AIU_WORLD_SIZE
+
+test_suite_config:
+  files:
+    # Broadcast Compiled Tests - verify collectives lower correctly
+    - path: ${TORCH_DEVICE_ROOT}/tests/distributed/test_broadcast_compiled.py
+      unlisted_test_mode: mandatory_success
+      tests:
+        - names:
+            - TestBroadcastCompiled::test_broadcast_compiled_fp32
+            - TestBroadcastCompiled::test_broadcast_compiled_fp16
+          mode: mandatory_success
+
+  global:
+    # Global configuration for compiled distributed tests
+    # These tests verify lowering of c10d ops to spyre_comms backend
+    supported_dtypes:
+      - name: float16
+      - name: float32

--- a/tests/distributed/test_broadcast_compiled.py
+++ b/tests/distributed/test_broadcast_compiled.py
@@ -1,0 +1,161 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+import torch_spyre  # noqa: F401
+
+# Skip all tests if RANK is not defined, or WORLD_SIZE is not set or less than 2
+if "RANK" not in os.environ:
+    pytest.skip(
+        "RANK environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+if "WORLD_SIZE" not in os.environ:
+    pytest.skip(
+        "WORLD_SIZE environment variable not defined, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+try:
+    world_size = int(os.environ.get("WORLD_SIZE", "0"))
+    if world_size < 2:
+        pytest.skip(
+            f"WORLD_SIZE is {world_size}, need at least 2 for distributed tests",
+            allow_module_level=True,
+        )
+except ValueError:
+    pytest.skip(
+        "WORLD_SIZE environment variable is not a valid integer, skipping distributed tests",
+        allow_module_level=True,
+    )
+
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+C10D_BACKEND = "spyreccl"
+_GROUP_NAME = "default"
+
+
+class BroadcastCompiledModule(torch.nn.Module):
+    """Module that performs broadcast using functional collective ops."""
+
+    def __init__(self, src_rank: int = 0, group_name: str = _GROUP_NAME) -> None:
+        super().__init__()
+        self._src_rank = src_rank
+        self._group_name = group_name
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = torch.ops._c10d_functional.broadcast(x, self._src_rank, self._group_name)
+        return torch.ops._c10d_functional.wait_tensor(y)
+
+
+class TestBroadcastCompiled(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up the distributed process group once for the whole test class."""
+        torch.spyre._impl._lazy_init()
+
+        if not dist.distributed_c10d.is_backend_available(C10D_BACKEND):
+            raise RuntimeError(f"Error: Missing the C10 Backend {C10D_BACKEND}")
+        if C10D_BACKEND != dist.get_default_backend_for_device("spyre"):
+            raise RuntimeError(
+                f"Error: Missing a C10 Backend for 'spyre'! Expected {C10D_BACKEND}"
+            )
+
+        if not dist.is_initialized():
+            dist.init_process_group(f"cpu:gloo,spyre:{C10D_BACKEND}")
+
+        c10d._register_process_group(_GROUP_NAME, dist.group.WORLD)
+
+        cls.comm_size = dist.get_world_size()
+        cls.comm_rank = dist.get_rank()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Destroy the distributed process group after all tests complete."""
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def setUp(self):
+        """Reset compiler caches before each test."""
+        super().setUp()
+        torch.compiler.reset()
+
+    def test_broadcast_compiled_fp32(self):
+        """Verify compiled broadcast works with fp32."""
+        x = torch.ones((128,), dtype=torch.float32, device=DEVICE)
+        module = BroadcastCompiledModule()
+        compiled_module = torch.compile(module)
+        result = compiled_module(x)
+
+        expected = torch.ones((128,), dtype=torch.float32)
+        self.assertTrue(
+            torch.allclose(result.to("cpu"), expected),
+            f"Rank {self.comm_rank}: broadcast result incorrect",
+        )
+
+    def test_broadcast_compiled_fp16(self):
+        """Verify compiled broadcast preserves fp16 and correctness."""
+        x = torch.ones((256,), dtype=torch.float16, device=DEVICE)
+        module = BroadcastCompiledModule()
+        compiled_module = torch.compile(module)
+        result = compiled_module(x)
+
+        self.assertEqual(result.dtype, torch.float16)
+        self.assertEqual(result.shape, x.shape)
+        expected = torch.ones((256,), dtype=torch.float16)
+        self.assertTrue(
+            torch.allclose(result.to("cpu"), expected),
+            f"Rank {self.comm_rank}: broadcast result incorrect",
+        )
+
+    def test_broadcast_compiled_with_interleaved_compute(self):
+        """Verify compute between broadcast_async and wait_work compiles correctly."""
+
+        class BroadcastWithCompute(torch.nn.Module):
+            def __init__(self, src_rank=0, group_name=_GROUP_NAME):
+                super().__init__()
+                self._src_rank = src_rank
+                self._group_name = group_name
+
+            def forward(self, x, y):
+                bcast = torch.ops._c10d_functional.broadcast(
+                    x, self._src_rank, self._group_name
+                )
+                # Compute placed between async broadcast and wait
+                z = y * 2.0
+                result = torch.ops._c10d_functional.wait_tensor(bcast)
+                return result + z
+
+        x = torch.ones((128,), dtype=torch.float32, device=DEVICE)
+        y = torch.ones((128,), dtype=torch.float32, device=DEVICE)
+        module = BroadcastWithCompute()
+        compiled_module = torch.compile(module)
+        result = compiled_module(x, y)
+
+        expected = torch.ones((128,), dtype=torch.float32) * 3.0
+        self.assertTrue(
+            torch.allclose(result.to("cpu"), expected),
+            f"Rank {self.comm_rank}: broadcast with interleaved compute incorrect",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -139,6 +139,7 @@ def enable_spyre_compile_fx_wrapper():
 
 def _light_autoload():
     from . import decompositions  # noqa: F401
+    from . import distributed as _distributed_init  # noqa: F401  registers spyre::broadcast_async/wait_work
 
     enable_spyre_compile_fx_wrapper()
 

--- a/torch_spyre/_inductor/distributed/__init__.py
+++ b/torch_spyre/_inductor/distributed/__init__.py
@@ -1,0 +1,1 @@
+from . import spyre_library as spyre_library

--- a/torch_spyre/_inductor/distributed/spyre_library.py
+++ b/torch_spyre/_inductor/distributed/spyre_library.py
@@ -1,0 +1,24 @@
+import torch
+
+# This provides:
+# 1. Proper schema registration
+# 2. Automatic fake kernel registration
+# 3. Better integration with torch.compile
+# 4. C++ implementation via TORCH_LIBRARY_IMPL in spyre_distributed.cpp
+# This file only registers the abstract (fake/meta) kernels needed by torch.compile
+# for shape inference during tracing.
+
+
+@torch.library.register_fake("spyre::broadcast_async")
+def _(x: torch.Tensor, src_rank: int = 0, group_name: str = "default") -> torch.Tensor:
+    """Fake implementation for shape inference during compilation.
+
+    Broadcast preserves shape, dtype, and stride.
+    """
+    return torch.empty_strided(x.shape, x.stride(), dtype=x.dtype, device=x.device)
+
+
+@torch.library.register_fake("spyre::wait_work")
+def _(x: torch.Tensor) -> torch.Tensor:
+    """Fake implementation — pass through the tensor."""
+    return x

--- a/torch_spyre/_inductor/ir.py
+++ b/torch_spyre/_inductor/ir.py
@@ -33,6 +33,9 @@ from torch._inductor.virtualized import V
 import sympy
 from torch.utils._ordered_set import OrderedSet
 import torch._inductor.ir as ir
+from torch_spyre._inductor.logging_utils import get_inductor_logger
+
+logger = get_inductor_logger("ir")
 
 
 @ir_dataclass
@@ -438,6 +441,125 @@ class SpyreEmptyFallback(ir.ExternKernel):
             layout,
             [],
             (),
+            op_overload=op_overload,
+        )
+        self.name = V.graph.register_buffer(self)
+        V.graph.register_operation(self)
+
+
+class BroadcastAsyncFallback(ir.ExternKernel):
+    """IR node for spyre.broadcast_async — emits a runtime call to async broadcast.
+
+    This starts the broadcast operation asynchronously and returns immediately,
+    allowing computation to proceed while communication is in progress.
+    """
+
+    def codegen(self, wrapper: PythonWrapperCodegen) -> None:
+        """Generate code to call torch.ops.spyre.broadcast_async at runtime."""
+        # Get input tensor name
+        input_tensor = self.inputs[0]
+        input_name = input_tensor.codegen_reference()
+
+        # Get constant args (src_rank, group_name)
+        src_rank, group_name = self.constant_args
+
+        # Generate the async call
+        output_name = self.get_name()
+        generated_code = f"{output_name} = torch.ops.spyre.broadcast_async({input_name}, {src_rank}, '{group_name}')"
+
+        logger.debug(
+            "Codegen broadcast_async: %s -> %s (src=%s, group='%s')",
+            input_name,
+            output_name,
+            src_rank,
+            group_name,
+        )
+
+        wrapper.writeline(generated_code)
+
+    def should_allocate(self) -> bool:
+        return True
+
+    def get_mutation_names(self) -> Sequence[str]:
+        return []
+
+    def get_unbacked_symbol_defs(self) -> OrderedSet[sympy.Symbol]:
+        return OrderedSet()
+
+    def __init__(
+        self,
+        op_overload: torch._ops.OpOverload,
+        x: IRNode,
+        src_rank: int,
+        group_name: str,
+    ) -> None:
+        # Async broadcast returns a tensor with the same layout as input
+        x_device = x.get_device()
+        x_dtype = x.get_dtype()
+        x_size = x.get_size()
+        x_stride = x.get_stride()
+        layout = FixedLayout(x_device, x_dtype, x_size, x_stride)
+        super().__init__(
+            None,
+            layout,
+            [x],
+            (src_rank, group_name),
+            python_kernel_name="torch.ops.spyre.broadcast_async",
+            op_overload=op_overload,
+        )
+        self.name = V.graph.register_buffer(self)
+        V.graph.register_operation(self)
+
+
+class WaitWorkFallback(ir.ExternKernel):
+    """IR node for spyre.wait_work — emits a runtime call to synchronize async operation.
+
+    This blocks until the async broadcast operation completes and returns the
+    same in-place-mutated buffer. No allocation is needed (should_allocate() =
+    False) because the result lives in the input tensor's buffer.
+    """
+
+    def codegen(self, wrapper: PythonWrapperCodegen) -> None:
+        # Get input tensor name (the tensor from broadcast_async)
+        input_tensor = self.inputs[0]
+        input_name = input_tensor.codegen_reference()
+
+        print(f"  Input tensor: {input_name}")
+
+        # Generate the wait call
+        output_name = self.get_name()
+        generated_code = f"{output_name} = torch.ops.spyre.wait_work({input_name})"
+
+        logger.debug("Codegen wait_work: %s -> %s", input_name, output_name)
+
+        wrapper.writeline(generated_code)
+
+    def should_allocate(self) -> bool:
+        return False
+
+    def get_mutation_names(self) -> Sequence[str]:
+        return [self.inputs[0].get_name()]
+
+    def get_unbacked_symbol_defs(self) -> OrderedSet[sympy.Symbol]:
+        return OrderedSet()
+
+    def __init__(
+        self,
+        op_overload: torch._ops.OpOverload,
+        x: IRNode,
+    ) -> None:
+        # Wait returns the same tensor (pass-through)
+        x_device = x.get_device()
+        x_dtype = x.get_dtype()
+        x_size = x.get_size()
+        x_stride = x.get_stride()
+        layout = FixedLayout(x_device, x_dtype, x_size, x_stride)
+        super().__init__(
+            None,
+            layout,
+            [x],
+            (),  # No constant args
+            python_kernel_name="torch.ops.spyre.wait_work",
             op_overload=op_overload,
         )
         self.name = V.graph.register_buffer(self)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -33,7 +33,13 @@ from .constants import (
 )
 import torch_spyre._inductor.customops  # noqa: F401
 from torch_spyre.ops.fallbacks import fallback_ops
-from .ir import SpyreReduction, SpyreConstantFallback, SpyreEmptyFallback
+from .ir import (
+    SpyreReduction,
+    SpyreConstantFallback,
+    SpyreEmptyFallback,
+    BroadcastAsyncFallback,
+    WaitWorkFallback,
+)
 from torch_spyre._C import get_elem_in_stick
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
@@ -1371,3 +1377,59 @@ def lower_prod_dim(x, dim, keepdim=False):
         return result
 
     return with_int64_fallback(_prod_dim_impl, x)
+
+
+# ============================================================================
+# Direct c10d Lowerings
+# ============================================================================
+@register_spyre_lowering(torch.ops._c10d_functional.broadcast.default)
+def lower_c10d_broadcast_async(tensor, src_rank, group_name):
+    """
+    Direct lowering for _c10d_functional.broadcast using ASYNC pattern.
+
+    Creates an async broadcast operation that returns immediately without blocking.
+    This provides the infrastructure for potential communication-compute overlap,
+    though actual overlap depends on scheduler decisions.
+
+    Flow:
+      _c10d_functional.broadcast → This lowering → BroadcastAsyncFallback
+      → Generated code: torch.ops.spyre.broadcast_async() → C++ → spyre-comms (non-blocking)
+    """
+    logger.debug(
+        "Lowering _c10d_functional.broadcast to BroadcastAsyncFallback "
+        "(src_rank=%s, group_name='%s')",
+        src_rank,
+        group_name,
+    )
+
+    tensor.realize()
+    return ir.TensorBox.create(
+        BroadcastAsyncFallback(
+            torch.ops.spyre.broadcast_async.default,
+            tensor,
+            src_rank,
+            group_name,
+        )
+    )
+
+
+@register_spyre_lowering(torch.ops._c10d_functional.wait_tensor.default)
+def lower_c10d_wait_tensor_async(tensor):
+    """
+    Direct lowering for _c10d_functional.wait_tensor using ASYNC pattern.
+
+    Synchronizes on the async broadcast operation, blocking until communication completes.
+
+    Flow:
+      _c10d_functional.wait_tensor → This lowering → WaitWorkFallback
+      → Generated code: torch.ops.spyre.wait_work() → C++ → work->wait()
+    """
+    logger.debug("Lowering _c10d_functional.wait_tensor to WaitWorkFallback")
+
+    tensor.realize()
+    return ir.TensorBox.create(
+        WaitWorkFallback(
+            torch.ops.spyre.wait_work.default,
+            tensor,
+        )
+    )

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -60,7 +60,12 @@ from .constants import (
     STAGGERED_EAS,
     TOPK_OPS,
 )
-from .ir import FixedTiledLayout, SpyreConstantFallback
+from .ir import (
+    FixedTiledLayout,
+    SpyreConstantFallback,
+    BroadcastAsyncFallback,
+    WaitWorkFallback,
+)
 from .pass_utils import (
     compute_restickify_target_layout,
     concretize_expr,
@@ -1439,6 +1444,11 @@ def propagate_spyre_tensor_layouts(
             if op.get_layout().device.type == DEVICE_NAME:
                 op.layouts = [generic_layout(op)]
                 op.restick_cost_fn = AnyInNode.from_args()
+        elif isinstance(op, (BroadcastAsyncFallback, WaitWorkFallback)):
+            input_name = op.inputs[0].get_name()
+            input_buf = V.graph.get_buffer(input_name)
+            op.layouts = list(input_buf.layouts)
+            op.restick_cost_fn = AnyInNode.from_args()
         elif isinstance(op, ExternKernel):
             logger.warning(f"unhandled node type {type(op)}")
         else:

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -17,8 +17,12 @@ import dataclasses
 import math
 import itertools
 from sympy import Expr, Integer, Symbol, divisors
-from .ir import SpyreConstantFallback, SpyreEmptyFallback
-
+from .ir import (
+    SpyreConstantFallback,
+    SpyreEmptyFallback,
+    BroadcastAsyncFallback,
+    WaitWorkFallback,
+)
 from torch._inductor.ir import (
     ComputedBuffer,
     DeviceCopy,
@@ -1423,6 +1427,9 @@ def _iter_computed_buffers(operations: list[Operation]):
             if isinstance(op, (SpyreConstantFallback, SpyreEmptyFallback, DeviceCopy)):
                 # Work division not supported on allocation/constant kernels, nor
                 # on DeviceCopy.
+                pass
+            elif isinstance(op, (BroadcastAsyncFallback, WaitWorkFallback)):
+                # Work division not supported on broadcast kernels
                 pass
             else:
                 logger.warning(f"unhandled node type {type(op)}")

--- a/torch_spyre/csrc/distributed/spyre_distributed.cpp
+++ b/torch_spyre/csrc/distributed/spyre_distributed.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2025 The Torch-Spyre Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/ATen.h>
+#include <c10/core/ScalarType.h>
+#include <torch/library.h>
+
+#include <flex/flex.hpp>
+#include <memory>
+#include <mutex>
+#include <spyre_comms.hpp>
+#include <spyre_comms_tensor.hpp>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "../logging.h"
+#include "../spyre_allocator.h"
+#include "../spyre_stream.h"
+#include "../spyre_tensor_impl.h"
+
+namespace spyre {
+
+// Structure to hold pending async work
+struct PendingWork {
+  std::shared_ptr<spyre_comms::WorkSchedule> work;
+};
+
+// Global map to track pending async operations
+// Key: SharedOwnerCtx* (stable per-allocation identity, never reused), Value:
+// PendingWork
+static std::unordered_map<spyre::SharedOwnerCtx*, PendingWork>
+    pending_work_map_;
+static std::mutex work_map_mutex_;
+
+// Helper to convert PyTorch ScalarType to spyre_comms TensorDataTypeEnum
+spyre_comms::TensorDataTypeEnum torch_dtype_to_spyre_comms(
+    c10::ScalarType dtype) {
+  switch (dtype) {
+    case c10::ScalarType::Float:
+      return spyre_comms::TensorDataTypeEnum::float32;
+    case c10::ScalarType::Double:
+      return spyre_comms::TensorDataTypeEnum::float64;
+    case c10::ScalarType::Half:
+      return spyre_comms::TensorDataTypeEnum::float16;
+    case c10::ScalarType::BFloat16:
+      return spyre_comms::TensorDataTypeEnum::bfloat16;
+    case c10::ScalarType::Int:
+      return spyre_comms::TensorDataTypeEnum::int32;
+    case c10::ScalarType::Long:
+      return spyre_comms::TensorDataTypeEnum::int64;
+    case c10::ScalarType::Short:
+      return spyre_comms::TensorDataTypeEnum::int16;
+    case c10::ScalarType::Char:
+      return spyre_comms::TensorDataTypeEnum::int8;
+    case c10::ScalarType::Byte:
+      return spyre_comms::TensorDataTypeEnum::uint8;
+    case c10::ScalarType::Bool:
+      return spyre_comms::TensorDataTypeEnum::boolean;
+    default:
+      TORCH_CHECK(false, "Unsupported dtype for spyre_comms: ", dtype);
+  }
+}
+
+// Helper to get CompositeAddress pointer from a Spyre tensor
+// NOTE: The returned pointer is valid only as long as the tensor's storage
+// context remains valid. Caller must keep the tensor alive.
+const flex::CompositeAddress* get_composite_address(const at::Tensor& tensor) {
+  TORCH_CHECK(tensor.is_privateuseone(),
+              "Tensor must be on Spyre device for distributed operations");
+
+  TORCH_CHECK(tensor.is_contiguous(),
+              "Tensor must be contiguous for distributed operations");
+
+  auto* spyre_impl =
+      static_cast<SpyreTensorImpl*>(tensor.unsafeGetTensorImpl());
+  TORCH_CHECK(spyre_impl != nullptr, "SpyreTensorImpl is null");
+
+  auto& storage = spyre_impl->storage();
+  auto* data_ptr = storage.data_ptr().get();
+  TORCH_CHECK(data_ptr != nullptr, "Storage data pointer is null");
+
+  auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
+  TORCH_CHECK(ctx != nullptr, "SharedOwnerCtx is null");
+
+  // Return a pointer to the CompositeAddress inside the context
+  return &ctx->composite_addr;
+}
+
+// Async broadcast implementation - returns immediately
+at::Tensor spyre_broadcast_async_impl(const at::Tensor& input, int64_t src_rank,
+                                      const std::string& group_name) {
+  DEBUGINFO("spyre::broadcast_async called with src_rank=", src_rank,
+            ", group=", group_name);
+
+  // Get world context
+  auto context = spyre_comms::get_world_context();
+  if (context == nullptr) {
+    DEBUGINFO("Initializing spyre-comms library");
+    spyre_comms::initialize_library(spyre::GlobalRuntime::get(),
+                                    spyre::getDefaultStreamRuntimeHandle());
+    context = spyre_comms::get_world_context();
+    TORCH_CHECK(context != nullptr, "Failed to get spyre-comms world context");
+  }
+
+  // Validate src_rank is in bounds
+  TORCH_CHECK(
+      src_rank >= 0 && src_rank < static_cast<int64_t>(context->getSize()),
+      "src_rank out of range: ", src_rank, " (world size is ",
+      context->getSize(), ")");
+
+  // Create output tensor
+  at::Tensor output = at::empty_like(input);
+  TORCH_CHECK(output.nbytes() > 0,
+              "Tensor must have non-zero size for broadcast");
+
+  // Get SharedOwnerCtx for map key (stable per-allocation identity)
+  auto* ctx = static_cast<spyre::SharedOwnerCtx*>(
+      output.storage().data_ptr().get_context());
+  TORCH_CHECK(ctx != nullptr, "SharedOwnerCtx is null for output tensor");
+
+  // Convert PyTorch tensor metadata to spyre_comms format
+  spyre_comms::TensorDataTypeEnum dtype =
+      torch_dtype_to_spyre_comms(input.scalar_type());
+
+  std::vector<int64_t> shape_vec;
+  for (int64_t i = 0; i < input.dim(); i++) {
+    shape_vec.push_back(input.size(i));
+  }
+  spyre_comms::TensorShape shape(shape_vec);
+  spyre_comms::TensorInfo tensor_info(dtype, shape);
+
+  // Copy input to output if we're the source rank
+  int current_rank = context->getRank();
+  if (current_rank == src_rank) {
+    output.copy_(input);
+  }
+
+  // Create spyre_comms Tensor with device address
+  spyre_comms::Tensor buffer_tensor(tensor_info);
+  buffer_tensor.SetSpyreDeviceAddressBorrowed(&ctx->composite_addr);
+
+  // Start broadcast (non-blocking)
+  auto work_schedule = context->broadcast(
+      buffer_tensor, static_cast<spyre_comms::process_id_t>(src_rank));
+  TORCH_CHECK(work_schedule != nullptr,
+              "Broadcast operation failed to create work schedule");
+
+  work_schedule->start();  // Start but DON'T wait
+
+  // Store WorkSchedule in map (do NOT store tensor to avoid allocator
+  // conflicts)
+  {
+    std::lock_guard<std::mutex> lock(work_map_mutex_);
+    TORCH_CHECK(pending_work_map_.find(ctx) == pending_work_map_.end(),
+                "broadcast_async called twice on the same allocation without "
+                "intervening wait_work");
+    pending_work_map_.emplace(ctx, PendingWork{std::move(work_schedule)});
+    DEBUGINFO("Stored PendingWork at ctx=", ctx,
+              ", pending_work_map size=", pending_work_map_.size());
+  }
+
+  return output;  // Return immediately without waiting
+}
+
+// Wait for async operation to complete
+at::Tensor spyre_wait_work_impl(const at::Tensor& tensor) {
+  DEBUGINFO("spyre::wait_work called");
+
+  // Get SharedOwnerCtx for map lookup
+  auto* ctx = static_cast<spyre::SharedOwnerCtx*>(
+      tensor.storage().data_ptr().get_context());
+  TORCH_CHECK(ctx != nullptr,
+              "SharedOwnerCtx is null — is this tensor from broadcast_async?");
+
+  // Extract WorkSchedule under lock, erase map entry, release lock, then wait
+  std::shared_ptr<spyre_comms::WorkSchedule> work_to_wait;
+  {
+    std::lock_guard<std::mutex> lock(work_map_mutex_);
+    auto it = pending_work_map_.find(ctx);
+    TORCH_CHECK(
+        it != pending_work_map_.end(),
+        "No pending async work found for tensor. "
+        "wait_work must be called on a tensor returned from broadcast_async.");
+
+    work_to_wait = std::move(it->second.work);
+    pending_work_map_.erase(it);
+    DEBUGINFO("Extracted and erased PendingWork, map size=",
+              pending_work_map_.size());
+  }
+
+  // Lock released — concurrent wait_work and broadcast_async can now proceed
+  work_to_wait->wait();
+  DEBUGINFO("WorkSchedule wait completed");
+
+  // Return the input tensor (already has the broadcasted data)
+  return tensor;
+}
+
+}  // namespace spyre
+
+// Define the spyre namespace and operations
+TORCH_LIBRARY(spyre, m) {
+  m.def(
+      "broadcast_async(Tensor input, int src_rank, str group_name) -> Tensor");
+  // wait_work mutates the tensor in-place (fills in the broadcasted data)
+  m.def("wait_work(Tensor(a!) tensor) -> Tensor(a)");
+}
+
+// Register the implementations with PyTorch's dispatcher
+TORCH_LIBRARY_IMPL(spyre, PrivateUse1, m) {
+  m.impl("broadcast_async", &spyre::spyre_broadcast_async_impl);
+  m.impl("wait_work", &spyre::spyre_wait_work_impl);
+}


### PR DESCRIPTION
# Problem Statement 

As workloads scale across multiple AIUs, collective communication becomes an increasingly important component of execution. Today, collective operations are handled outside the Torch-Spyre compiler flow, limiting compiler visibility into communication and preventing future communication-aware optimizations.

This work explores making collectives first-class operations within the Torch-Spyre compilation pipeline by preserving communication operations through compilation and routing them through the Spyre communication stack.

### Overview

This prototype lowers functional collectives directly into Torch-Spyre compiler IR and dispatches them through spyre-comms, rather than relying on the standard distributed execution path. I have used one functional collective - broadcast as an example

Instead of:

```
FX Graph
   ↓
_c10d_functional collective
   ↓
External distributed runtime path
```

the communication operation remains visible throughout compilation:

```
FX Graph
   ↓
Torch-Spyre Lowering
   ↓
Spyre IR
   ↓
Generated Runtime Call
   ↓
spyre-comms
```

## Implementation Details: 

### Key files changed:
torch_spyre/_inductor/lowering.py: Registers async lowering functions for broadcast and wait_tensor

torch_spyre/_inductor/ir.py: Defines SpyreBroadcastAsyncFallback and SpyreWaitWorkFallback IR nodes

torch_spyre/_inductor/distributed/spyre_library.py: Custom op registration for broadcast_async and wait_work with fake implementations

torch_spyre/csrc/distributed/spyre_distributed.cpp: C++ async implementation with PendingWork tracking:

torch_spyre/_inductor/distributed/kernels.py: Eager mode placeholders for c10d ops

examples/test_c10d_async_lowering.py: Demo showing automatic async broadcast lowering

Related to Internal Spyre-comms epic - lowering of collectives to prevent device idle time

## Impact:

This prototype establishes compiler-visible collectives as a foundation for future communication-aware optimizations.

Specifically, it enables:

1. Compiler visibility into collective communication operations
2. Native routing of collectives through spyre-comms
3. Async communication primitives (broadcast_async, wait_work)
4. Runtime WorkSchedule tracking infrastructure
5. Future work on communication scheduling, synchronization strategies, and compute/communication overlap

At this stage, the focus is architectural enablement rather than performance optimization. Subsequent work will build on this foundation to explore scheduling and synchronization improvements aimed at reducing communication-related idle time in multi-AIU workloads.

## Special notes for your reviewer:

### To execute demo:

TORCH_COMPILE_DEBUG=1 torchrun --nproc-per-node=2 docs/source/user_guide/examples/broadcast_demo_multirank.py

<details>
  <summary>Tracing result (output_code.py generated):</summary>

```
    def call(self, args):
        arg0_1, arg1_1 = args
        args.clear()
        assert_size_stride(arg0_1, (8, 8), (8, 1))
        assert_size_stride(arg1_1, (8, 8), (8, 1))
        buf7 = spyre_constant_tensor(2, torch.device("spyre:0"), torch.float32)
        buf0 = spyre_empty_with_layout((8, 8), (8, 1), torch.float32, SpyreTensorLayout(device_size=[1, 8, 32], stride_map =[32, 8, 1], device_dtype=DataFormats.IEEE_FP32))
        # [Provenance debug handles] sdsc_fused_add_0:1
        sdsc_fused_add_0.run(arg0_1, buf0)
        del arg0_1
        buf1 = torch.ops.spyre.broadcast_async(buf0, 0, 'default')
        del buf0
        buf2 = torch.ops.spyre.wait_work(buf1)
        del buf1
        buf6 = spyre_empty_with_layout((8, 8), (8, 1), torch.float32, SpyreTensorLayout(device_size=[1, 8, 32], stride_map =[32, 8, 1], device_dtype=DataFormats.IEEE_FP32))
        # [Provenance debug handles] sdsc_fused_add_mul_1:2
        sdsc_fused_add_mul_1.run(buf2, buf7, arg1_1, buf6)
        del arg1_1
        return (buf6, )
```
</details>





The compilation output demonstrates that torch.ops._c10d_functional.broadcast is now directly lowered to torch.ops.spyre.broadcast.default through Inductor's lowering mechanism. The IR codegen phase generates the appropriate runtime call, which dispatches to the C++ implementation and executes via the spyre-comms library.


