### PR TITLE
Propagate named dimensions cleanup

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -172,16 +172,25 @@ def _make_hinted_op(data, name="op0", hints=((0, 0),)):
     tiles.  ``hints`` is a sequence of (hint_id, dim_index) pairs, one per
     tiling level.  hint_id must match the hint_id in the corresponding group
     spec triple; dim_index is the index into op.data.ranges to tile.
+
+    loop_var uses the cN symbol convention — valid for mock ops where no
+    size-1 dims precede the tiled dimension.
     """
+    import sympy
     from torch_spyre._inductor.propagate_hints import DimHint
 
     op = _make_op(data, name)
+
+    # Build loop_var symbols. coords[i] = cI so _loop_var_to_ranges_pos
+    # resolves correctly for mock ops (no size-1 dims in test data).
+    n_ranges = len(data.ranges)
+    op._test_out_coords = [sympy.Symbol(f"c{i}") for i in range(n_ranges)]
+
     op.dim_hints = [
         DimHint(
             dim_names=[f"dim{dim_index}"],
-            range_size=0,
             split_count=1,
-            dim_index=dim_index,
+            loop_var=sympy.Symbol(f"c{dim_index}"),
             is_reduction=False,
             hint_id=hint_id,
         )
@@ -565,7 +574,22 @@ class TestDivideRanges(unittest.TestCase):
         _divide_ranges(op, Integer(4), tiled_dims=[0])
 
 
+def _mock_op_out_coords(op):
+    """Return pre-built coords stored on op by _make_hinted_op, or empty list."""
+    return getattr(op, "_test_out_coords", [])
+
+
 class TestCoarseTile(unittest.TestCase):
+    def setUp(self):
+        self._patch = patch(
+            "torch_spyre._inductor.coarse_tile.op_out_coords",
+            side_effect=_mock_op_out_coords,
+        )
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+
     def test_empty_groups_list_is_noop(self):
         data = _make_pointwise([Integer(32)])
         op = _make_op(data, "op0")
@@ -582,7 +606,7 @@ class TestCoarseTile(unittest.TestCase):
         op_computed = _make_hinted_op(data, "op0", hints=((0, 0),))
         coarse_tile(
             [op_extern, op_computed],
-            [([op_extern, op_computed], [(0, Integer(2), [0])])],
+            [([op_extern, op_computed], [(0, Integer(2))])],
         )
         self.assertEqual(op_computed.loop_group_id, (0,))
         self.assertEqual(data.ranges[0], Integer(8))
@@ -592,7 +616,7 @@ class TestCoarseTile(unittest.TestCase):
         n = Symbol("N", positive=True)
         data = _make_pointwise([n])
         op = _make_hinted_op(data, "op0", hints=((0, 0),))
-        coarse_tile([op], [([op], [(0, k, [0])])])
+        coarse_tile([op], [([op], [(0, k)])])
         self.assertEqual(op.loop_count, [k])
         self.assertEqual(simplify(data.ranges[0] - n / k), 0)
 
@@ -600,27 +624,39 @@ class TestCoarseTile(unittest.TestCase):
         d0 = _make_pointwise([Integer(32)])
         d1 = _make_pointwise([Integer(32)])
         d2 = _make_pointwise([Integer(32)])
-        op0 = _make_op(d0, "op0")
-        op1 = _make_op(d1, "op1")
-        op2 = _make_op(d2, "op2")
+        op0 = _make_hinted_op(d0, "op0", hints=((0, 0),))
+        op1 = _make_hinted_op(d1, "op1", hints=((0, 0),))
+        op2 = _make_hinted_op(d2, "op2", hints=((0, 0),))
         with self.assertRaises(RuntimeError):
-            coarse_tile([op0, op1, op2], [([op0, op2], [(0, Integer(4), [0])])])
+            coarse_tile([op0, op1, op2], [([op0, op2], [(0, Integer(4))])])
 
     def test_op_not_in_operations_raises(self):
         data = _make_pointwise([Integer(32)])
-        op_known = _make_op(data, "op0")
-        op_unknown = _make_op(_make_pointwise([Integer(8)]), "unknown")
+        op_known = _make_hinted_op(data, "op0", hints=((0, 0),))
+        op_unknown = _make_hinted_op(
+            _make_pointwise([Integer(8)]), "unknown", hints=((0, 0),)
+        )
         with self.assertRaises(RuntimeError):
-            coarse_tile([op_known], [([op_unknown], [(0, Integer(2), [0])])])
+            coarse_tile([op_known], [([op_unknown], [(0, Integer(2))])])
 
 
 class TestCoarseTileNested(unittest.TestCase):
-    """Verify that the nested group format [(hint_id, K1, dims1), ...] works."""
+    """Verify that the nested group format [(hint_id, K1), ...] works."""
+
+    def setUp(self):
+        self._patch = patch(
+            "torch_spyre._inductor.coarse_tile.op_out_coords",
+            side_effect=_mock_op_out_coords,
+        )
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
 
     def test_nested_spec_stamps_list_attributes(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(2), [1])])])
+        coarse_tile([op], [([op], [(1, Integer(4)), (2, Integer(2))])])
         self.assertEqual(op.loop_group_id, (0, 0))
         self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_tiled_dims, [[0], [1]])
@@ -628,14 +664,14 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(2), [1])])])
+        coarse_tile([op], [([op], [(1, Integer(4)), (2, Integer(2))])])
         self.assertEqual(data.ranges[0], Integer(64))
         self.assertEqual(data.ranges[1], Integer(64))
 
     def test_nested_spec_outer_only_divides_outer_dim(self):
         data = _make_pointwise([Integer(32), Integer(64), Integer(16)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(8), [1])])])
+        coarse_tile([op], [([op], [(1, Integer(4)), (2, Integer(8))])])
         self.assertEqual(data.ranges[0], Integer(8))
         self.assertEqual(data.ranges[1], Integer(8))
         self.assertEqual(data.ranges[2], Integer(16))
@@ -649,8 +685,8 @@ class TestCoarseTileNested(unittest.TestCase):
         coarse_tile(
             [op0, op1],
             [
-                ([op0], [(1, Integer(4), [0])]),
-                ([op1], [(2, Integer(4), [0]), (3, Integer(2), [1])]),
+                ([op0], [(1, Integer(4))]),
+                ([op1], [(2, Integer(4)), (3, Integer(2))]),
             ],
         )
         self.assertEqual(op0.loop_group_id, (0,))
@@ -667,7 +703,7 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_same_dim_different_counts(self):
         data = _make_pointwise([Integer(256)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 0)))
-        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(2), [0])])])
+        coarse_tile([op], [([op], [(1, Integer(4)), (2, Integer(2))])])
         self.assertEqual(data.ranges[0], Integer(32))
         self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_tiled_dims, [[0], [0]])

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -168,12 +168,10 @@ def _make_op(data, name="op0"):
 def _make_hinted_op(data, name="op0", hints=((0, 0),)):
     """Return a fake ComputedBuffer with DimHints for use with coarse_tile().
 
-    coarse_tile() reads op.dim_hints to resolve which dimension each spec level
-    tiles.  ``hints`` is a sequence of (hint_id, dim_index) pairs, one per
-    tiling level.  hint_id must match the hint_id in the corresponding group
-    spec triple; dim_index is the index into op.data.ranges to tile.
-
-    loop_var uses the cN symbol convention — valid for mock ops where no
+    ``hints`` is a sequence of ``(hint_id, dim_index)`` pairs, one per tiling
+    level.  Each pair produces a DimHint whose ``loop_var`` is the symbol
+    ``c{dim_index}``, matching the mock output coords built by this helper
+    (``coords[i] = c{i}``).  This convention is valid for mock ops where no
     size-1 dims precede the tiled dimension.
     """
     import sympy

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -15,10 +15,9 @@
 """Coarse-tiling IR pass: stamp loop_group_id / loop_count on ir.Operation objects.
 
 Each group of operations is wrapped in one or more nested counted loops.  For
-every operation in the group the iteration ranges that are divided by each
-loop's trip count are scaled down by that factor; the resulting (smaller)
-per-iteration ranges are what the downstream scheduler and work-division passes
-will see.
+every operation in the group the iteration ranges divided by each loop's trip
+count are scaled down by that factor; the resulting (smaller) per-iteration
+ranges are what the downstream scheduler and work-division passes will see.
 
 A ``loop_group_id`` tuple encodes the nesting path:
   - ``(g,)``       — outermost loop group with index ``g``
@@ -26,31 +25,17 @@ A ``loop_group_id`` tuple encodes the nesting path:
   - etc.
 
 ``loop_count`` is a *list* of trip counts, one per nesting level from outermost
-to innermost.  For a flat (depth-1) group this is a 1-element list ``[K]``.
+to innermost.  For a single-level group this is a 1-element list ``[K]``.
 ``loop_tiled_dims`` is a *list of lists*, one sub-list per nesting level.
 
-Primary entry point — hint-driven (from spyre_hint annotations)::
+Entry point::
 
     groups = hints_to_coarse_tile_groups(operations)
-    coarse_tile(operations, groups=groups)
+    coarse_tile(operations, groups)
 
-Legacy entry point — explicit groups::
-
-    coarse_tile(
-        operations,
-        groups=[
-            ([op_a, op_b], K),             # flat: tile dim 0 by K (default)
-            ([op_c], K2, [0, 1]),           # flat: tile dims 0 and 1 by K2
-            ([op_d], [(0, K3, [0]),
-                      (1, K4, [1])]),       # nested: outer K3 on dim 0, inner K4 on dim 1
-        ],
-    )
-
-``groups`` is a list of ``(ops, spec[, tiled_dims])`` tuples where ``spec`` is
-either:
-  - a scalar ``loop_count`` (flat, optional third element overrides ``tiled_dims``), or
-  - a list of ``(hint_id, count)`` pairs (hints path, from hints_to_coarse_tile_groups),
-  - a list of ``(hint_id, count, tiled_dims)`` triples (legacy path, explicit dims).
+``groups`` is a list of ``(ops, levels)`` tuples where ``levels`` is a list of
+``(hint_id, count)`` pairs, outermost first.  Each op resolves its own tiled
+dimension from its ``loop_var`` in ``dim_hints``.
 
 Each ``ops`` list must be a contiguous sub-sequence of ``operations``.
 
@@ -134,36 +119,29 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
     op has no hint at all.
     """
 
-    def _key(op):
-        resolved = getattr(op, "dim_hints", [])
-        if not resolved:
-            return None
-        return frozenset(h.hint_id for h in resolved)
+    def _flush(groups, current_ops, current_key):
+        if current_ops and current_key is not None:
+            levels = _hints_levels(current_ops)
+            if levels:
+                groups.append((current_ops, levels))
 
-    groups = []
+    groups: list[tuple] = []
     current_ops: list[Operation] = []
     current_key = None
 
     for op in operations:
         if not isinstance(op, ComputedBuffer):
             continue
-        key = _key(op)
+        key = frozenset(h.hint_id for h in getattr(op, "dim_hints", [])) or None
 
         if key is not None and key == current_key:
             current_ops.append(op)
         else:
-            if current_ops and current_key is not None:
-                levels = _hints_levels(current_ops)
-                if levels:
-                    groups.append((current_ops, levels))
+            _flush(groups, current_ops, current_key)
             current_ops = [op] if key is not None else []
             current_key = key
 
-    # Flush the final group.
-    if current_ops and current_key is not None:
-        levels = _hints_levels(current_ops)
-        if levels:
-            groups.append((current_ops, levels))
+    _flush(groups, current_ops, current_key)
 
     if hints_logger.isEnabledFor(logging.INFO):
         # Build an interleaved view: walk operations in order, emit group boundaries
@@ -188,8 +166,8 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
         for o in operations:
             if not isinstance(o, ComputedBuffer):
                 continue
-            g_idx = grouped_to_group_idx.get(id(o))
-            if g_idx is None:
+            op_group_idx = grouped_to_group_idx.get(id(o))
+            if op_group_idx is None:
                 hints = getattr(o, "dim_hints", [])
                 if hints:
                     ids = sorted({h.hint_id for h in hints})
@@ -198,16 +176,16 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
                     reason = "no hints"
                 pending_ungrouped.append(f"{o.get_name()}({reason})")
             else:
-                if g_idx != last_group_idx:
+                if op_group_idx != last_group_idx:
                     if pending_ungrouped:
                         summary_lines.append(
                             f"  ungrouped: [{', '.join(pending_ungrouped)}]"
                         )
                         pending_ungrouped = []
                     summary_lines.append(
-                        f"  group {g_idx} scopes=[{group_hint_descs[g_idx]}]:"
+                        f"  group {op_group_idx} scopes=[{group_hint_descs[op_group_idx]}]:"
                     )
-                    last_group_idx = g_idx
+                    last_group_idx = op_group_idx
                 # Per-op tiling info.
                 tiling_dims = [
                     f"{h.dim_names[0] if h.dim_names else '?'}x{h.split_count}"
@@ -248,32 +226,16 @@ def coarse_tile(
         CustomPreSchedulingPasses).  Modified in-place when
         insert_tiling_propagation inserts new buffer/copy ops.
     groups:
-        Sequence of ``(ops, spec)`` tuples produced by
-        ``hints_to_coarse_tile_groups``.  ``spec`` is a list of
-        ``(hint_id, loop_count, tiled_dims)`` triples for nested loops —
-        outermost first.  The ops end up in the innermost loop body; each
-        level's count and dims are stamped on the op and the corresponding
-        iteration ranges are divided.
+        Sequence of ``(ops, levels)`` tuples produced by
+        ``hints_to_coarse_tile_groups``.  ``levels`` is a list of
+        ``(hint_id, count)`` pairs, outermost first.
     """
     op_to_position: dict[str, int] = {
         op.get_operation_name(): i for i, op in enumerate(operations)
     }
 
-    for group_idx, group in enumerate(groups):
-        group_ops = group[0]
-        levels: list[tuple[int, Expr, list[int]]] = group[1]
+    for group_idx, (group_ops, levels) in enumerate(groups):
         group_id: tuple[int, ...] = (group_idx,)
-
-        if isinstance(spec, list):
-            # Nested spec: either (hint_id, count) pairs from hints path,
-            # or (hint_id, count, tiled_dims) triples from legacy path.
-            levels: list[tuple] = spec
-        else:
-            # Flat spec: scalar loop_count with optional tiled_dims override.
-            flat_tiled = group[2] if len(group) > 2 else tiled_dims
-            effective_dims: list[int] = [0] if flat_tiled is None else flat_tiled
-            levels = [(0, spec, effective_dims)]
-
         _stamp_group(group_ops, group_id, levels, op_to_position)
 
     insert_tiling_propagation(operations, groups)
@@ -311,8 +273,7 @@ def insert_tiling_propagation(
     In both cases the existing tiled_symbols / affine.apply machinery in
     SpyreKernel and bundle.py handles the per-iteration address offset.
     """
-    for group in groups:
-        group_ops: list[Operation] = group[0]
+    for group_ops, _ in groups:
         for op in group_ops:
             if not isinstance(op, ComputedBuffer):
                 continue
@@ -721,11 +682,9 @@ def _stamp_group(
 ) -> None:
     """Stamp loop_group_id / loop_count / loop_tiled_dims and divide ranges.
 
-    ``levels`` is either:
-    - hints path: list of ``(hint_id, count)`` pairs — each op reads its own
-      loop_var from dim_hints to find the correct ranges position.
-    - legacy path: list of ``(hint_id, count, tiled_dims)`` triples — tiled_dims
-      are positional indices applied uniformly to all ops in the group.
+    ``levels`` is a list of ``(hint_id, count)`` pairs, outermost first.
+    Each op resolves its own tiled dimension from its loop_var in dim_hints.
+    Ops that have no matching dim for a level are loop-invariant at that level.
     """
     if not ops:
         return
@@ -744,24 +703,16 @@ def _stamp_group(
             )
             continue
 
-        op_hints = getattr(op, "dim_hints", [])
-        hint_id_to_ranges_pos: dict[int, int] = {}
-        if op_hints:
-            op_out = op_out_coords(op)
-            hint_id_to_ranges_pos = {
-                h.hint_id: pos
-                for h in op_hints
-                if h.loop_var is not None and not h.is_reduction
-                if (pos := _loop_var_to_ranges_pos(op_out, h.loop_var)) is not None
-            }
+        op_out = op_out_coords(op)
+        hint_id_to_ranges_pos: dict[int, int] = {
+            h.hint_id: pos
+            for h in getattr(op, "dim_hints", [])
+            if h.loop_var is not None and not h.is_reduction
+            if (pos := _loop_var_to_ranges_pos(op_out, h.loop_var)) is not None
+        }
         op_tiled_dims: list[list[int]] = []
-        for hint_id, count, *rest in levels:
-            spec_dims = rest[0] if rest else None
-            if spec_dims is not None and not op_hints:
-                # Legacy path: uniform tiled_dims for all ops.
-                effective = spec_dims
-            elif (ranges_pos := hint_id_to_ranges_pos.get(hint_id)) is not None:
-                # Hints path: each op uses its own loop_var.
+        for hint_id, count in levels:
+            if (ranges_pos := hint_id_to_ranges_pos.get(hint_id)) is not None:
                 effective = [ranges_pos]
             else:
                 effective = []  # op has no dim for this level — loop-invariant

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -29,29 +29,28 @@ A ``loop_group_id`` tuple encodes the nesting path:
 to innermost.  For a flat (depth-1) group this is a 1-element list ``[K]``.
 ``loop_tiled_dims`` is a *list of lists*, one sub-list per nesting level.
 
-Usage — flat (single loop)::
+Primary entry point — hint-driven (from spyre_hint annotations)::
+
+    groups = hints_to_coarse_tile_groups(operations)
+    coarse_tile(operations, groups=groups)
+
+Legacy entry point — explicit groups::
 
     coarse_tile(
         operations,
         groups=[
-            ([op_a, op_b], K),            # group 0: tile dim 0 by K (default)
-            ([op_c], K2, [0, 1]),          # group 1: tile dims 0 and 1 by K2
-        ],
-    )
-
-Usage — nested (two independent loops on one op)::
-
-    coarse_tile(
-        operations,
-        groups=[
-            ([op_a], [(K1, [0]), (K2, [1])]),  # outer K1 on dim 0; inner K2 on dim 1
+            ([op_a, op_b], K),             # flat: tile dim 0 by K (default)
+            ([op_c], K2, [0, 1]),           # flat: tile dims 0 and 1 by K2
+            ([op_d], [(0, K3, [0]),
+                      (1, K4, [1])]),       # nested: outer K3 on dim 0, inner K4 on dim 1
         ],
     )
 
 ``groups`` is a list of ``(ops, spec[, tiled_dims])`` tuples where ``spec`` is
 either:
-  - a scalar ``loop_count`` (optionally with a third ``tiled_dims`` element), or
-  - a list of ``(loop_count, tiled_dims)`` pairs for nested loops.
+  - a scalar ``loop_count`` (flat, optional third element overrides ``tiled_dims``), or
+  - a list of ``(hint_id, count)`` pairs (hints path, from hints_to_coarse_tile_groups),
+  - a list of ``(hint_id, count, tiled_dims)`` triples (legacy path, explicit dims).
 
 Each ``ops`` list must be a contiguous sub-sequence of ``operations``.
 
@@ -63,6 +62,7 @@ whose results are consumed outside the loop.
 from __future__ import annotations
 
 
+import logging
 import sympy
 from sympy import Expr
 
@@ -80,8 +80,154 @@ from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
 from .logging_utils import get_inductor_logger
+from .propagate_hints import get_op_hints
+from .propagate_named_dims import op_out_coords, _lone_sym
 
 logger = get_inductor_logger("coarse_tile")
+hints_logger = get_inductor_logger("assign_dim_hints")
+
+
+# ---------------------------------------------------------------------------
+# Hint-driven group construction
+# ---------------------------------------------------------------------------
+
+
+def _loop_var_to_ranges_pos(out_coords: list, sym: sympy.Symbol) -> int | None:
+    """Return the position of loop variable sym in op.data.ranges, or None.
+
+    Looks up sym in the op's output coordinates — the only reliable mapping
+    from a loop variable symbol to its data.ranges position, since dep var
+    numbering skips size-1 dims while data.ranges does not.
+    """
+    for i, coord in enumerate(out_coords):
+        if len(coord.free_symbols) == 1 and _lone_sym(coord) == sym:
+            return i
+    return None
+
+
+def _hints_levels(ops: list[Operation]) -> list[tuple]:
+    """Build (hint_id, K) level pairs from the first hinted op in the group.
+
+    All ops in the group share the same hint IDs and split counts — they are
+    inside the same spyre_hint() scopes, so the counts come from the scope
+    definition, not the op.  Any op with a non-None loop_var is representative.
+    Each op reads its own loop_var from dim_hints in _stamp_group.
+    """
+    for op in ops:
+        levels = [
+            (h.hint_id, sympy.Integer(h.split_count))
+            for h in getattr(op, "dim_hints", [])
+            if h.loop_var is not None and not h.is_reduction
+        ]
+        if levels:
+            return levels
+    return []
+
+
+def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
+    """Build coarse_tile() groups from op.dim_hints (set by assign_dim_hints).
+
+    coarse_tile() requires ops to be grouped: all ops in a group share the same
+    tiling spec and are tiled together inside the same loop nest.  We walk
+    operations in topological order and collect consecutive ops that carry
+    identical hints into one group, breaking whenever the hint changes or an
+    op has no hint at all.
+    """
+
+    def _key(op):
+        resolved = getattr(op, "dim_hints", [])
+        if not resolved:
+            return None
+        return frozenset(h.hint_id for h in resolved)
+
+    groups = []
+    current_ops: list[Operation] = []
+    current_key = None
+
+    for op in operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        key = _key(op)
+
+        if key is not None and key == current_key:
+            current_ops.append(op)
+        else:
+            if current_ops and current_key is not None:
+                levels = _hints_levels(current_ops)
+                if levels:
+                    groups.append((current_ops, levels))
+            current_ops = [op] if key is not None else []
+            current_key = key
+
+    # Flush the final group.
+    if current_ops and current_key is not None:
+        levels = _hints_levels(current_ops)
+        if levels:
+            groups.append((current_ops, levels))
+
+    if hints_logger.isEnabledFor(logging.INFO):
+        # Build an interleaved view: walk operations in order, emit group boundaries
+        # and ungrouped ops so the reader can see what breaks each consecutive run.
+        grouped_to_group_idx = {id(o): i for i, g in enumerate(groups) for o in g[0]}
+        # Pre-compute hint descriptions per group — get_op_hints is called once per
+        # group rather than once per op in the group.
+        group_hint_descs: dict[int, str] = {}
+        for g_idx, (group_ops, group_levels) in enumerate(groups):
+            spec_op = group_ops[0]
+            op_hints = get_op_hints(spec_op)
+            descs = [
+                f"hint_{hint_id}={op_hints[hint_id]}"
+                for hint_id, _ in group_levels
+                if hint_id in op_hints
+            ]
+            group_hint_descs[g_idx] = ", ".join(descs)
+
+        summary_lines = [f"coarse_tile_groups: {len(groups)} group(s) formed"]
+        pending_ungrouped: list[str] = []
+        last_group_idx: int | None = None
+        for o in operations:
+            if not isinstance(o, ComputedBuffer):
+                continue
+            g_idx = grouped_to_group_idx.get(id(o))
+            if g_idx is None:
+                hints = getattr(o, "dim_hints", [])
+                if hints:
+                    ids = sorted({h.hint_id for h in hints})
+                    reason = f"hint_ids={ids}"
+                else:
+                    reason = "no hints"
+                pending_ungrouped.append(f"{o.get_name()}({reason})")
+            else:
+                if g_idx != last_group_idx:
+                    if pending_ungrouped:
+                        summary_lines.append(
+                            f"  ungrouped: [{', '.join(pending_ungrouped)}]"
+                        )
+                        pending_ungrouped = []
+                    summary_lines.append(
+                        f"  group {g_idx} scopes=[{group_hint_descs[g_idx]}]:"
+                    )
+                    last_group_idx = g_idx
+                # Per-op tiling info.
+                tiling_dims = [
+                    f"{h.dim_names[0] if h.dim_names else '?'}x{h.split_count}"
+                    for h in getattr(o, "dim_hints", [])
+                    if h.loop_var is not None and not h.is_reduction
+                ]
+                aten_ops = [
+                    str(n.target)
+                    for n in getattr(o, "origins", [])
+                    if hasattr(n, "target")
+                ]
+                summary_lines.append(
+                    f"      {o.get_name()}  aten={aten_ops}"
+                    + (f"  tiles={tiling_dims}" if tiling_dims else "  (no tiled dims)")
+                )
+        if pending_ungrouped:
+            summary_lines.append(f"  ungrouped: [{', '.join(pending_ungrouped)}]")
+        hints_logger.info("%s", "\n".join(summary_lines))
+
+    return groups
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +263,16 @@ def coarse_tile(
         group_ops = group[0]
         levels: list[tuple[int, Expr, list[int]]] = group[1]
         group_id: tuple[int, ...] = (group_idx,)
+
+        if isinstance(spec, list):
+            # Nested spec: either (hint_id, count) pairs from hints path,
+            # or (hint_id, count, tiled_dims) triples from legacy path.
+            levels: list[tuple] = spec
+        else:
+            # Flat spec: scalar loop_count with optional tiled_dims override.
+            flat_tiled = group[2] if len(group) > 2 else tiled_dims
+            effective_dims: list[int] = [0] if flat_tiled is None else flat_tiled
+            levels = [(0, spec, effective_dims)]
 
         _stamp_group(group_ops, group_id, levels, op_to_position)
 
@@ -560,15 +716,16 @@ def _patch_graph_outputs(old_name: str, new_buf: ComputedBuffer) -> None:
 def _stamp_group(
     ops: list[Operation],
     group_id: tuple[int, ...],
-    levels: list[tuple[int, Expr, list[int]]],
+    levels: list[tuple],
     op_to_position: dict[str, int],
 ) -> None:
     """Stamp loop_group_id / loop_count / loop_tiled_dims and divide ranges.
 
-    ``levels`` is a list of ``(hint_id, loop_count, tiled_dims)`` triples,
-    outermost first.  Each op's ranges are divided using its own dim_hints,
-    matched to the correct level by hint_id so that op-specific dim_index
-    values are used rather than the spec op's indices.
+    ``levels`` is either:
+    - hints path: list of ``(hint_id, count)`` pairs — each op reads its own
+      loop_var from dim_hints to find the correct ranges position.
+    - legacy path: list of ``(hint_id, count, tiled_dims)`` triples — tiled_dims
+      are positional indices applied uniformly to all ops in the group.
     """
     if not ops:
         return
@@ -587,21 +744,25 @@ def _stamp_group(
             )
             continue
 
-        # Each op carries its own dim_hints with per-op dim_index values (ops in
-        # the same group can have different iteration spaces, e.g. a broadcast op
-        # may lack the tiled dimension entirely).  Use the op's own dim_index;
-        # fall back to empty when the op has no matching dim for a level.
         op_hints = getattr(op, "dim_hints", [])
-        hint_id_to_dim_index: dict[int, int] = {
-            h.hint_id: h.dim_index
-            for h in op_hints
-            if h.dim_index is not None and not h.is_reduction
-        }
+        hint_id_to_ranges_pos: dict[int, int] = {}
+        if op_hints:
+            op_out = op_out_coords(op)
+            hint_id_to_ranges_pos = {
+                h.hint_id: pos
+                for h in op_hints
+                if h.loop_var is not None and not h.is_reduction
+                if (pos := _loop_var_to_ranges_pos(op_out, h.loop_var)) is not None
+            }
         op_tiled_dims: list[list[int]] = []
-        for hint_id, count, spec_dims in levels:
-            dim_index = hint_id_to_dim_index.get(hint_id)
-            if dim_index is not None:
-                effective = [dim_index]  # use this op's own dim_index
+        for hint_id, count, *rest in levels:
+            spec_dims = rest[0] if rest else None
+            if spec_dims is not None and not op_hints:
+                # Legacy path: uniform tiled_dims for all ops.
+                effective = spec_dims
+            elif (ranges_pos := hint_id_to_ranges_pos.get(hint_id)) is not None:
+                # Hints path: each op uses its own loop_var.
+                effective = [ranges_pos]
             else:
                 effective = []  # op has no dim for this level — loop-invariant
             op_tiled_dims.append(effective)
@@ -632,7 +793,7 @@ def _divide_ranges(
     op.data.reduction_ranges are left untouched.
 
     ``tiled_dims`` is a list of positional indices into ``data.ranges``.
-    Out-of-bounds indices are silently skipped.
+    All indices must be valid; an out-of-bounds index is a caller bug.
 
     Also updates ``op.layout.size``, ``op.layout.stride``, and
     ``op.layout.device_layout`` so the layout describes the smaller per-tile
@@ -649,15 +810,17 @@ def _divide_ranges(
         return
 
     for i in tiled_dims:
-        if i < 0 or i >= len(ranges):
-            continue
+        assert 0 <= i < len(ranges), (
+            f"coarse_tile: op {op.get_name()!r} tiled dim {i} out of bounds "
+            f"(ranges has {len(ranges)} entries)"
+        )
         r = ranges[i]
         if isinstance(r, (int, sympy.Integer)) and isinstance(
             loop_count, (int, sympy.Integer)
         ):
             if int(r) % int(loop_count) != 0:
                 raise RuntimeError(
-                    f"coarse_tile: op {op.get_name()!r} dimension {i} range {r} "
+                    f"coarse_tile: op {op.get_name()!r} loop var d{i} range {r} "
                     f"is not divisible by loop_count {loop_count}.  All tiled "
                     f"dimensions must be evenly divisible by the loop trip count."
                 )
@@ -679,8 +842,7 @@ def _divide_ranges(
 
     new_size = list(layout.size)
     for i in tiled_dims:
-        if 0 <= i < len(new_size):
-            new_size[i] = ranges[i]
+        new_size[i] = ranges[i]
     layout.size = new_size
 
     # Recompute contiguous strides for the smaller buffer.

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -66,7 +66,7 @@ from torch.utils._ordered_set import OrderedSet
 
 from .logging_utils import get_inductor_logger
 from .propagate_hints import get_op_hints
-from .propagate_named_dims import op_out_coords, _lone_sym
+from .pass_utils import op_out_coords
 
 logger = get_inductor_logger("coarse_tile")
 hints_logger = get_inductor_logger("assign_dim_hints")
@@ -85,7 +85,7 @@ def _loop_var_to_ranges_pos(out_coords: list, sym: sympy.Symbol) -> int | None:
     numbering skips size-1 dims while data.ranges does not.
     """
     for i, coord in enumerate(out_coords):
-        if len(coord.free_symbols) == 1 and _lone_sym(coord) == sym:
+        if len(coord.free_symbols) == 1 and next(iter(coord.free_symbols)) == sym:
             return i
     return None
 
@@ -124,6 +124,12 @@ def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
             levels = _hints_levels(current_ops)
             if levels:
                 groups.append((current_ops, levels))
+            else:
+                hints_logger.warning(
+                    "spyre_hint on [%s]: no op iterates over the hinted dimension "
+                    "— hint ignored",
+                    ", ".join(o.get_name() for o in current_ops),
+                )
 
     groups: list[tuple] = []
     current_ops: list[Operation] = []

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -133,6 +133,12 @@ def get_mem_deps_from_rw(read_writes: ReadWrites) -> list[SchedNodeArg]:
     return res
 
 
+def op_out_coords(op: ComputedBuffer) -> list[sympy.Expr]:
+    """Return host coordinates for the output dep of a ComputedBuffer."""
+    output_dep = next(iter(op.get_read_writes().writes))
+    return host_coordinates(op.get_layout(), output_dep)
+
+
 def host_coordinates(layout: FixedLayout, dep: MemoryDep) -> list[sympy.Expr]:
     # Concretize size/stride so compute_coordinates can use plain ``<``/``>``
     # comparisons.  var_ranges and index stay symbolic so the *output*

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -35,8 +35,8 @@ from .temp_passes import (
     bmm_unflatten_pass,
     mm_to_bmm_pass,
     convert_constant_with_graph_node,
-    hints_to_coarse_tile_groups,
 )
+from .coarse_tile import hints_to_coarse_tile_groups
 from . import config
 from .propagate_hints import (
     collect_spyre_hints,

--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -17,6 +17,7 @@ import dataclasses
 from typing import Any
 
 import regex as re
+import sympy
 
 import torch
 import torch.fx.traceback
@@ -30,9 +31,8 @@ logger = get_inductor_logger("propagate_hints")
 @dataclasses.dataclass
 class DimHint:
     dim_names: list[str]  # e.g. ["A"]
-    range_size: int  # full loop range, e.g. 256; 0 when dim not in iteration space
     split_count: int  # from slices={"A": 4}, e.g. 4
-    dim_index: int | None  # index into op.loop_var_dims / op.data.ranges;
+    loop_var: "sympy.Symbol | None"  # the loop variable (e.g. c0, c1) for this dim;
     # None when op is broadcast w.r.t. this hint scope
     is_reduction: bool
     hint_id: int = 0  # the _hint_N counter value identifying the scope
@@ -49,8 +49,8 @@ class DimHint:
 #       with spyre_hint(slices={"B": 4}):  # inner scope → larger hint ID
 #           y = a + b
 #
-# dim_hints = [DimHint(dim_names=["A"], split_count=2, dim_index=0, ...),
-#                 DimHint(dim_names=["B"], split_count=4, dim_index=1, ...)]
+# dim_hints = [DimHint(dim_names=["A"], split_count=2, loop_var=c0, ...),
+#                 DimHint(dim_names=["B"], split_count=4, loop_var=c1, ...)]
 
 
 _HINT_RE = re.compile(r"^_hint_(\d+)$")

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -243,7 +243,9 @@ def _compute_named_dims(op, inputs):
 
 def _log_dep_debug(label: str, dep: MemoryDep) -> None:
     buf = _get_buffer(dep)
-    layout = buf.get_layout() if buf is not None and hasattr(buf, "get_layout") else None
+    layout = (
+        buf.get_layout() if buf is not None and hasattr(buf, "get_layout") else None
+    )
     dpi = _get_dim_prop_info(dep)
     named_dims = dpi.named_dims if dpi is not None else []
     logger.debug(f"  {label} {dep.name}: named_dims={named_dims}")
@@ -266,7 +268,9 @@ def _log_op_inputs(op: ComputedBuffer) -> None:
             named_dims = dpi.named_dims if dpi is not None else "?"
             buf = _get_buffer(dep)
             host_size = (
-                list(buf.get_layout().size) if buf is not None and hasattr(buf, "get_layout") else "?"
+                list(buf.get_layout().size)
+                if buf is not None and hasattr(buf, "get_layout")
+                else "?"
             )
             logger.info(
                 f"    input {dep.name}: named_dims={named_dims}  host_size={host_size}"
@@ -323,7 +327,7 @@ def propagate_named_dims(
     global _enabled
     if not _enabled:
         return
-    if len(V.graph.graph_input_names) > 0:
+    if V.graph.graph_input_names:
         for name, real_input in zip(V.graph.graph_input_names, V.get_real_inputs()):
             if isinstance(real_input, torch.Tensor):
                 tb = V.graph.graph_inputs[name]
@@ -375,15 +379,16 @@ def propagate_named_dims(
             )
             rw = op.get_read_writes()
             inputs = [d for d in rw.reads if isinstance(d, MemoryDep)]
-            for dep in inputs:
-                _log_dep_debug("input", dep)
-            for dep in rw.writes:
-                if isinstance(dep, MemoryDep):
-                    _log_dep_debug("output", dep)
+            if logger.isEnabledFor(logging.DEBUG):
+                for dep in inputs:
+                    _log_dep_debug("input", dep)
+                for dep in rw.writes:
+                    if isinstance(dep, MemoryDep):
+                        _log_dep_debug("output", dep)
             if isinstance(op.data, (Pointwise, Reduction)):
                 _compute_named_dims(op, inputs)
             else:
-                logger.warning(f"Warning: unhandled node type {type(op.data)}")
+                logger.warning(f"unhandled node type {type(op.data)}")
                 _set_no_named_dims(op)
         elif isinstance(op, SpyreConstantFallback):
             _set_no_named_dims(op)
@@ -391,19 +396,18 @@ def propagate_named_dims(
             logger.warning(f"unhandled operation type {type(op)}")
             _set_no_named_dims(op)
 
-    # LOG THE RESULTS
-    logger.info("DECLARED DIMS")
-    for name, size in _named_dims.items():
-        logger.info(f"  {name} = {size}")
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("DECLARED DIMS")
+        for name, size in _named_dims.items():
+            logger.info(f"  {name} = {size}")
 
-    logger.info("INPUT TENSORS")
-    for name in V.graph.graph_input_names:
-        tb = V.graph.graph_inputs[name]
-        if isinstance(tb, TensorBox):
-            dp = getattr(tb, "_dim_prop_info", None)
-            logger.info(f"  {name}: named_dims={dp.named_dims if dp else []}")
+        logger.info("INPUT TENSORS")
+        for name in V.graph.graph_input_names:
+            tb = V.graph.graph_inputs[name]
+            if isinstance(tb, TensorBox):
+                dp = getattr(tb, "_dim_prop_info", None)
+                logger.info(f"  {name}: named_dims={dp.named_dims if dp else []}")
 
-    logger.info("OPS")
     for op in operations:
         _log_op(op)
     # Reset _enabled so that it does not leak True into the next compilation
@@ -429,21 +433,14 @@ def assign_dim_hints(operations: list[Operation]) -> None:
         if not isinstance(op, ComputedBuffer):
             continue
         dp = getattr(op, "_dim_prop_info", None)
-        if dp is None:
-            # No _dim_prop_info means propagate_named_dims didn't run or
-            # set no info — nothing to delete.
-            op.dim_hints = []  # type: ignore[attr-defined]
-            continue
-        if not dp.loop_var_dims:
-            op.dim_hints = []  # type: ignore[attr-defined]
-            del op._dim_prop_info  # type: ignore[attr-defined]
-            continue
-        op_hints = get_op_hints(op)
+        op_hints = get_op_hints(op) if dp and dp.loop_var_dims else {}
         if not op_hints:
             op.dim_hints = []  # type: ignore[attr-defined]
-            del op._dim_prop_info  # type: ignore[attr-defined]
+            if dp is not None:
+                del op._dim_prop_info  # type: ignore[attr-defined]
             continue
 
+        assert dp is not None  # guaranteed by op_hints check above
         reduction_dims = set(dp.reduction_named_dims or [])
 
         coord_for_name: dict[str, sympy.Symbol] = {}
@@ -457,11 +454,11 @@ def assign_dim_hints(operations: list[Operation]) -> None:
         dim_hints = []
         for hint_id, hint_dict in sorted(op_hints.items()):
             # A hint scope uses exactly one of tiles/slices/num_tiles_per_dim.
-            dims = next(
+            dims: dict[str, int] = next(
                 (
-                    hint_dict.get(k)
+                    v
                     for k in ("tiles", "slices", "num_tiles_per_dim")
-                    if hint_dict.get(k)
+                    if (v := hint_dict.get(k))
                 ),
                 {},
             )

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -32,7 +32,7 @@ from torch._inductor.ir import (
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.virtualized import V
 from .errors import Unsupported
-from .pass_utils import SpyreConstantFallback, host_coordinates, device_coordinates
+from .pass_utils import host_coordinates, device_coordinates, op_out_coords
 from .propagate_hints import DimHint, get_op_hints
 from .views import matching_dim, compute_coordinates
 from torch_spyre._C import SpyreTensorLayout
@@ -144,11 +144,6 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
                 f"continuing using range {actual_range}"
             )
     return result
-
-
-def op_out_coords(op: ComputedBuffer) -> list:
-    output_dep = next(iter(op.get_read_writes().writes))
-    return host_coordinates(op.get_layout(), output_dep)
 
 
 def coords_to_named_dims(coords: list, loop_var_dims: dict) -> list:
@@ -462,6 +457,15 @@ def assign_dim_hints(operations: list[Operation]) -> None:
                 ),
                 {},
             )
+            # TODO: support multiple dimensions per spyre_hint() call.
+            # hint_id_to_ranges_pos in _stamp_group would need to become
+            # dict[int, list[int]] and _hints_levels would need to deduplicate
+            # by hint_id.
+            assert len(dims) <= 1, (
+                f"spyre_hint() argument {list(hint_dict.items())} specifies "
+                f"{len(dims)} dimensions; only one is currently allowed per "
+                f"spyre_hint() call (not yet implemented)"
+            )
             for name, count in dims.items():
                 sym = coord_for_name.get(name)
                 dim_hints.append(
@@ -469,7 +473,7 @@ def assign_dim_hints(operations: list[Operation]) -> None:
                         dim_names=[name],
                         split_count=count,
                         loop_var=sym,
-                        is_reduction=name in reduction_dims and sym is not None,
+                        is_reduction=name in reduction_dims,
                         hint_id=hint_id,
                     )
                 )

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -73,6 +73,16 @@ def _get_buffer(dep):
     return V.graph.get_buffer(dep.name)
 
 
+def _get_dim_prop_info(dep):
+    buf = _get_buffer(dep)
+    if buf is not None:
+        dpi = getattr(buf, "_dim_prop_info", None)
+        if dpi is not None:
+            return dpi
+    tb = V.graph.graph_inputs.get(dep.name)
+    return getattr(tb, "_dim_prop_info", None) if tb is not None else None
+
+
 def _lone_sym(coord: sympy.Expr) -> sympy.Symbol:
     return next(iter(coord.free_symbols))
 
@@ -103,9 +113,8 @@ def _compute_named_layout(named_dims):
 
 def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
     """Map loop vars to named dim names for a single input dep, using named-space coords."""
-    buf = _get_buffer(dep)
-    dp = getattr(buf, "_dim_prop_info", None)
-    buf_named_dims = dp.named_dims if dp is not None else None
+    dpi = _get_dim_prop_info(dep)
+    buf_named_dims = dpi.named_dims if dpi is not None else None
     if not buf_named_dims:
         # Scalar broadcast: constant index, contributes nothing to loop_var_dims
         if not dep.index.free_symbols:
@@ -202,7 +211,6 @@ class _DimPropInfo:
     named_dims: list = dataclasses.field(default_factory=list)
     reduction_named_dims: list | None = None
     loop_var_dims: dict = dataclasses.field(default_factory=dict)
-    loop_var_to_ranges_idx: dict = dataclasses.field(default_factory=dict)
 
 
 def _set_no_named_dims(op):
@@ -227,9 +235,6 @@ def _compute_named_dims(op, inputs):
     op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
         named_dims=named_dims,
         loop_var_dims=loop_var_dims,
-        loop_var_to_ranges_idx={
-            _lone_sym(c): i for i, c in enumerate(out_coords) if c.free_symbols
-        },
         reduction_named_dims=loop_var_dims[get_reduction_dim(inputs[0], out_coords)]
         if isinstance(op.data, Reduction)
         else None,
@@ -237,17 +242,17 @@ def _compute_named_dims(op, inputs):
 
 
 def _log_dep_debug(label: str, dep: MemoryDep) -> None:
-    buf = V.graph.get_buffer(dep.name)
-    layout = buf.get_layout() if hasattr(buf, "get_layout") else None
-    dp = getattr(buf, "_dim_prop_info", None)
-    named_dims = dp.named_dims if dp is not None else []
+    buf = _get_buffer(dep)
+    layout = buf.get_layout() if buf is not None and hasattr(buf, "get_layout") else None
+    dpi = _get_dim_prop_info(dep)
+    named_dims = dpi.named_dims if dpi is not None else []
     logger.debug(f"  {label} {dep.name}: named_dims={named_dims}")
     if layout is not None:
         logger.debug(
             f"    host_size={list(layout.size)}  host_stride={list(layout.stride)}"
         )
         logger.debug(f"    host_coordinates={host_coordinates(layout, dep)}")
-    stl = getattr(buf, "layout", None)
+    stl = getattr(buf, "layout", None) if buf is not None else None
     if isinstance(stl, SpyreTensorLayout):
         logger.debug(f"    device_size={stl.device_size}  stride_map={stl.stride_map}")
         logger.debug(f"    device_coordinates={device_coordinates(stl, dep)}")
@@ -257,10 +262,11 @@ def _log_dep_debug(label: str, dep: MemoryDep) -> None:
 def _log_op_inputs(op: ComputedBuffer) -> None:
     for dep in op.get_read_writes().reads:
         if isinstance(dep, MemoryDep):
+            dpi = _get_dim_prop_info(dep)
+            named_dims = dpi.named_dims if dpi is not None else "?"
             buf = _get_buffer(dep)
-            named_dims = getattr(buf, "named_dims", "?")
             host_size = (
-                list(buf.get_layout().size) if hasattr(buf, "get_layout") else "?"
+                list(buf.get_layout().size) if buf is not None and hasattr(buf, "get_layout") else "?"
             )
             logger.info(
                 f"    input {dep.name}: named_dims={named_dims}  host_size={host_size}"
@@ -404,22 +410,6 @@ def propagate_named_dims(
     _enabled = False
 
 
-def _get_hint_scopes(op) -> list[dict[str, int]]:
-    """Return hint scopes the op is inside, outermost first (sorted by hint ID).
-
-    Each entry is {dim_name: split_count} for one spyre_hint() scope.
-    """
-    scopes = []
-    for _, hint_dict in sorted(get_op_hints(op).items()):
-        scope: dict[str, int] = {}
-        for key in ("tiles", "slices", "num_tiles_per_dim"):
-            if isinstance(hint_dict.get(key), dict):
-                scope.update(hint_dict[key])
-        if scope:
-            scopes.append(scope)
-    return scopes
-
-
 def assign_dim_hints(operations: list[Operation]) -> None:
     """Combine spyre_hint scope annotations with propagated named dimensions.
 
@@ -440,81 +430,53 @@ def assign_dim_hints(operations: list[Operation]) -> None:
             continue
         dp = getattr(op, "_dim_prop_info", None)
         if dp is None:
+            # No _dim_prop_info means propagate_named_dims didn't run or
+            # set no info — nothing to delete.
             op.dim_hints = []  # type: ignore[attr-defined]
             continue
         if not dp.loop_var_dims:
             op.dim_hints = []  # type: ignore[attr-defined]
             del op._dim_prop_info  # type: ignore[attr-defined]
             continue
-        levels = _get_hint_scopes(op)
-        if not levels:
+        op_hints = get_op_hints(op)
+        if not op_hints:
             op.dim_hints = []  # type: ignore[attr-defined]
             del op._dim_prop_info  # type: ignore[attr-defined]
             continue
 
-        hint_id_map = {
-            hint_id: hint_dict
-            for hint_id, hint_dict in sorted(get_op_hints(op).items())
-        }
-        dim_to_level: dict[str, tuple[int, int, int]] = {}
-        for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
-            for key in ("tiles", "slices", "num_tiles_per_dim"):
-                for name, count in (hint_dict.get(key) or {}).items():
-                    dim_to_level[name] = (count, level_idx, hint_id)
-
-        rw = op.get_read_writes()
-        all_ranges = {
-            s: int(v) for dep in [*rw.reads, *rw.writes] for s, v in dep.ranges.items()
-        }
         reduction_dims = set(dp.reduction_named_dims or [])
-        loop_var_dims = dp.loop_var_dims
-        loop_var_to_ranges_idx = dp.loop_var_to_ranges_idx
 
-        unsorted: list[tuple[int, int, DimHint]] = []
-        for i, sym in enumerate(loop_var_dims):
-            nd = named_dims_for_sym(op, sym)
-            hinted_names = [name for name, _ in nd if name in dim_to_level]
-            if not hinted_names:
+        coord_for_name: dict[str, sympy.Symbol] = {}
+        for coord in op_out_coords(op):
+            if not coord.free_symbols:
                 continue
-            split_count, level_idx, hint_id = dim_to_level[hinted_names[0]]
-            ranges_idx = loop_var_to_ranges_idx.get(sym, i)
-            unsorted.append(
+            sym = _lone_sym(coord)
+            for name, _ in named_dims_for_sym(op, sym):
+                coord_for_name[name] = sym
+
+        dim_hints = []
+        for hint_id, hint_dict in sorted(op_hints.items()):
+            # A hint scope uses exactly one of tiles/slices/num_tiles_per_dim.
+            dims = next(
                 (
-                    level_idx,
-                    i,
-                    DimHint(
-                        dim_names=hinted_names,
-                        range_size=all_ranges.get(sym, 0),
-                        split_count=split_count,
-                        dim_index=ranges_idx,
-                        is_reduction=any(
-                            name in reduction_dims for name in hinted_names
-                        ),
-                        hint_id=hint_id,
-                    ),
-                )
+                    hint_dict.get(k)
+                    for k in ("tiles", "slices", "num_tiles_per_dim")
+                    if hint_dict.get(k)
+                ),
+                {},
             )
-        op.dim_hints = [h for _, _, h in sorted(unsorted)]  # type: ignore[attr-defined]
-
-        matched_hint_ids = {h.hint_id for h in op.dim_hints}
-        for level_idx, (hint_id, hint_dict) in enumerate(sorted(hint_id_map.items())):
-            if hint_id in matched_hint_ids:
-                continue
-            for key in ("tiles", "slices", "num_tiles_per_dim"):
-                dims = hint_dict.get(key) or {}
-                if dims:
-                    name, count = next(iter(dims.items()))
-                    op.dim_hints.append(
-                        DimHint(
-                            dim_names=[name],
-                            range_size=0,
-                            split_count=count,
-                            dim_index=None,
-                            is_reduction=False,
-                            hint_id=hint_id,
-                        )
+            for name, count in dims.items():
+                sym = coord_for_name.get(name)
+                dim_hints.append(
+                    DimHint(
+                        dim_names=[name],
+                        split_count=count,
+                        loop_var=sym,
+                        is_reduction=name in reduction_dims and sym is not None,
+                        hint_id=hint_id,
                     )
-                    break
+                )
+        op.dim_hints = dim_hints  # type: ignore[attr-defined]
 
         # Clean up temp intermediates — only dim_hints persists.
         del op._dim_prop_info  # type: ignore[attr-defined]
@@ -528,12 +490,19 @@ def assign_dim_hints(operations: list[Operation]) -> None:
         if ops:
             hints_logger.info("=== assign_dim_hints ===")
             for op in ops:
+                rw = op.get_read_writes()
+                all_ranges = {
+                    s: int(v)
+                    for dep in [*rw.reads, *rw.writes]
+                    for s, v in dep.ranges.items()
+                }
                 hints_logger.info(f"{op.get_operation_name()}:")
                 for h in op.dim_hints:
-                    per_tile = h.range_size // h.split_count if h.range_size else "?"
+                    r = all_ranges.get(h.loop_var, 0) if h.loop_var else 0
+                    per_tile = r // h.split_count if r else "?"
                     reduction_tag = "  [reduction]" if h.is_reduction else ""
                     hints_logger.info(
-                        f"  {h.dim_names}  range={h.range_size}"
+                        f"  {h.dim_names}  range={r}"
                         f"  split_count={h.split_count}  -> {per_tile} per tile"
-                        f"  dim_index={h.dim_index}{reduction_tag}"
+                        f"  loop_var={h.loop_var}{reduction_tag}"
                     )

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -462,11 +462,12 @@ def assign_dim_hints(operations: list[Operation]) -> None:
             # hint_id_to_ranges_pos in _stamp_group would need to become
             # dict[int, list[int]] and _hints_levels would need to deduplicate
             # by hint_id.
-            assert len(dims) <= 1, (
-                f"spyre_hint() argument {list(hint_dict.items())} specifies "
-                f"{len(dims)} dimensions; only one is currently allowed per "
-                f"spyre_hint() call (not yet implemented)"
-            )
+            if len(dims) > 1:
+                raise NotImplementedError(
+                    f"spyre_hint() argument {list(hint_dict.items())} specifies "
+                    f"{len(dims)} dimensions; only one is currently allowed per "
+                    f"spyre_hint() call (not yet implemented)"
+                )
             for name, count in dims.items():
                 sym = coord_for_name.get(name)
                 dim_hints.append(

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -33,6 +33,7 @@ from torch._inductor.dependencies import MemoryDep
 from torch._inductor.virtualized import V
 from .errors import Unsupported
 from .pass_utils import host_coordinates, device_coordinates, op_out_coords
+from .ir import SpyreConstantFallback
 from .propagate_hints import DimHint, get_op_hints
 from .views import matching_dim, compute_coordinates
 from torch_spyre._C import SpyreTensorLayout

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -14,10 +14,7 @@
 
 # This file contains inductor passes that are only needed as temp fixes
 
-import logging
-import sympy
 import torch
-from torch._inductor.ir import ComputedBuffer, Operation
 from torch._inductor.pattern_matcher import (
     Arg,
     CallFunction,
@@ -26,13 +23,11 @@ from torch._inductor.pattern_matcher import (
     register_graph_pattern,
 )
 from .logging_utils import get_inductor_logger
-from .propagate_hints import get_op_hints, DimHint
 from .pass_utils import copy_fx_custom_meta
 
 aten = torch.ops.aten
 
 logger = get_inductor_logger("work_division")
-hints_logger = get_inductor_logger("assign_dim_hints")
 
 _RESHAPE_OPS = (
     aten.view.default,
@@ -257,136 +252,6 @@ def _unflatten_bmm_batch_dims(
                 and not expand_node.users
             ):
                 graph.erase_node(expand_node)
-
-
-def _group_spec(dim_hints: list[DimHint]) -> list[tuple]:
-    """Build the coarse_tile() spec from op.dim_hints.
-
-    Returns a list of (hint_id, K, tiled_dims) tuples, one per hinted dim,
-    outermost first.  Reduction dims are excluded.
-    """
-    return [
-        (h.hint_id, sympy.Integer(h.split_count), [h.dim_index])
-        for h in dim_hints
-        if not h.is_reduction and h.dim_index is not None
-    ]
-
-
-def _find_spec_op(ops: list[Operation]) -> Operation:
-    """Return the first op with a real (non-sentinel) DimHint, or ops[0] as fallback."""
-    return next(
-        (
-            o
-            for o in ops
-            if any(h.dim_index is not None for h in getattr(o, "dim_hints", []))
-        ),
-        ops[0],
-    )
-
-
-def hints_to_coarse_tile_groups(operations: list[Operation]) -> list[tuple]:
-    """Build coarse_tile() groups from op.dim_hints (set by assign_dim_hints).
-
-    coarse_tile() requires ops to be grouped: all ops in a group share the same
-    tiling spec and are tiled together inside the same loop nest.  We walk
-    operations in topological order and collect consecutive ops that carry
-    identical hints into one group, breaking whenever the hint changes or an
-    op has no hint at all.
-    """
-
-    def _key(op):
-        resolved = getattr(op, "dim_hints", [])
-        if not resolved:
-            return None
-        # Key on the set of hint IDs — ops inside the same hint scope(s) group together.
-        return frozenset(h.hint_id for h in resolved)
-
-    groups = []
-    current_ops: list[Operation] = []
-    current_key = None
-
-    for op in operations:
-        if not isinstance(op, ComputedBuffer):
-            continue
-        key = _key(op)
-
-        if key is not None and key == current_key:
-            current_ops.append(op)
-        else:
-            if current_ops and current_key is not None:
-                spec = _group_spec(_find_spec_op(current_ops).dim_hints)
-                if spec:
-                    groups.append((current_ops, spec))
-            current_ops = [op] if key is not None else []
-            current_key = key
-
-    # Flush the final group.
-    if current_ops and current_key is not None:
-        spec = _group_spec(_find_spec_op(current_ops).dim_hints)
-        if spec:
-            groups.append((current_ops, spec))
-
-    if hints_logger.isEnabledFor(logging.INFO):
-        # Build an interleaved view: walk operations in order, emit group boundaries
-        # and ungrouped ops so the reader can see what breaks each consecutive run.
-        grouped_to_group_idx = {id(o): i for i, g in enumerate(groups) for o in g[0]}
-        summary_lines = [f"coarse_tile_groups: {len(groups)} group(s) formed"]
-        pending_ungrouped: list[str] = []
-        last_group_idx: int | None = None
-        for o in operations:
-            if not isinstance(o, ComputedBuffer):
-                continue
-            g_idx = grouped_to_group_idx.get(id(o))
-            if g_idx is None:
-                hints = getattr(o, "dim_hints", [])
-                if hints:
-                    ids = sorted({h.hint_id for h in hints})
-                    reason = f"hint_ids={ids}"
-                else:
-                    reason = "no hints"
-                pending_ungrouped.append(f"{o.get_name()}({reason})")
-            else:
-                if g_idx != last_group_idx:
-                    if pending_ungrouped:
-                        summary_lines.append(
-                            f"  ungrouped: [{', '.join(pending_ungrouped)}]"
-                        )
-                        pending_ungrouped = []
-                    # Emit group header with hint scope info from the spec op.
-                    group_ops = groups[g_idx][0]
-                    spec_op = _find_spec_op(group_ops)
-                    hint_ids = sorted(
-                        {h.hint_id for h in getattr(spec_op, "dim_hints", [])}
-                    )
-                    hint_descs = []
-                    for hid in hint_ids:
-                        hints = get_op_hints(spec_op)
-                        if hid in hints:
-                            hint_descs.append(f"hint_{hid}={hints[hid]}")
-                    summary_lines.append(
-                        f"  group {g_idx} scopes=[{', '.join(hint_descs)}]:"
-                    )
-                    last_group_idx = g_idx
-                # Per-op tiling info.
-                tiling_dims = [
-                    f"{h.dim_names}x{h.split_count}"
-                    for h in getattr(o, "dim_hints", [])
-                    if h.dim_index is not None and not h.is_reduction
-                ]
-                aten_ops = [
-                    str(n.target)
-                    for n in getattr(o, "origins", [])
-                    if hasattr(n, "target")
-                ]
-                summary_lines.append(
-                    f"      {o.get_name()}  aten={aten_ops}"
-                    + (f"  tiles={tiling_dims}" if tiling_dims else "  (no tiled dims)")
-                )
-        if pending_ungrouped:
-            summary_lines.append(f"  ungrouped: [{', '.join(pending_ungrouped)}]")
-        hints_logger.info("%s", "\n".join(summary_lines))
-
-    return groups
 
 
 def convert_constant_with_graph_node(graph: torch.fx.Graph) -> None:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR cleans up the interface between the propagate_named_dims pass and coarse tiling, removing several sources of fragility that had accumulated since the initial implementation.

**DimHint now carries loop_var instead of dim_index**

Previously DimHint.dim_index stored a positional index into op.data.ranges.  We should not be passing indices of things that could be reordered downstream to future passes.   DimHint now carries the loop variable symbol (loop_var) directly.   Coarse Tiling resolves it to a  dim_index but it is kept internal to that pass.  Possible improvements to coarse_tile.py logic is left for a future PR.

**hints_to_coarse_tile_groups moved out of temp_passes.py**

This function logically belongs in coarse_tile.py alongside the rest of the coarse-tiling machinery. Moving it out of temp_passes.py reflects that coarse tiling is no longer an experimental feature driven by a config variable.

**Removed two-case group spec handling**

The old coarse_tile() accepted both a scalar loop_count and a list-of-triples (hint_id, count, tiled_dims) for the group spec, to support both the legacy config-driven path and the hint-driven path. With the config variable removed, only the hint-driven path remains, and the spec format is now uniformly (hint_id, count) pairs. The tiled dimension is resolved per-op from loop_var rather than being carried in the spec.

**Fixed logging bug: named dims showing as ?**

_log_op_inputs was reading named_dims directly off the buffer object (getattr(buf, "named_dims", "?")), which never existed — the data lives in buf._dim_prop_info.named_dims. This always logged ?. Fixed to use the new _get_dim_prop_info helper.

**Other cleanup**
  - op_out_coords moved to pass_utils where it belongs alongside host_coordinates
  - loop_var_to_ranges_idx field removed from _DimPropInfo — redundant now that _loop_var_to_ranges_pos recomputes it from op_out_coords at use time
  - Debug/info logging gated on isEnabledFor to avoid constructing expensive log messages when logging is disabled




#### Which issue(s) this PR is related to:

Part of #2150 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
