### PR TITLE
Remove config.coarse_tiling_groups_fn and related cleanups

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -22,25 +22,19 @@ No Spyre hardware is required: torch.compile() exercises the full codegen path
 and run_and_get_code() captures the generated source without executing on device.
 launch_kernel is mocked to prevent actual device execution.
 
-Test classes
-------------
-- TestCoarseTileGroupsFnResidual: tests using coarse_tiling_groups_fn that
-  have not yet been ported to spyre_hints (tiled_dims and baseline tests).
-- TestCoarseTileSpyreHints: the primary test class; all new coarse-tiling
-  tests should be added here using the spyre_hint API.
+All coarse-tiling tests use the spyre_hint API (TestCoarseTileSpyreHints).
+Add new tests there using spyre_hint(num_tiles_per_dim=...) annotations.
 """
 
 import sys
 import os
 
-import sympy
 import torch
 import unittest
 from unittest.mock import patch as mock_patch
 
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
-from torch._inductor.ir import ComputedBuffer, Operation
 
 from torch_spyre._inductor import config
 import torch_spyre._inductor.propagate_named_dims as _pnd
@@ -52,194 +46,12 @@ from utils_inductor import compare_with_cpu  # noqa: E402
 _LAUNCH_KERNEL = "torch_spyre.execution.kernel_runner.launch_kernel"
 
 
-# ---------------------------------------------------------------------------
-# Module-level groups-function helpers
-# (must be module-level so they are picklable by the Inductor cache machinery)
-# ---------------------------------------------------------------------------
-
-
-def _groups_all_k4(operations: list[Operation]):
-    """One group: all ComputedBuffers, loop count K=4."""
-    ops = [op for op in operations if isinstance(op, ComputedBuffer)]
-    return [(ops, sympy.Integer(4))] if ops else []
-
-
-def _groups_nested_k2_m4(operations: list[Operation]):
-    """One group: all ops share nested K=2 outer (dim 0) / M=4 inner (dim 1) loops."""
-    ops = [op for op in operations if isinstance(op, ComputedBuffer)]
-    if not ops:
-        return []
-    return [(ops, [(0, sympy.Integer(2), [0]), (0, sympy.Integer(4), [1])])]
-
-
-# ===========================================================================
-# Residual coarse_tiling_groups_fn tests
-#
-# All scenarios have now been ported to TestCoarseTileSpyreHints.
-# These tests are kept until coarse_tiling_groups_fn is removed from the
-# implementation (config.py, passes.py); their hint-based equivalents already
-# exist in TestCoarseTileSpyreHints.
-#
-# See PR 3 to remove coarse_tiling_groups_fn from the implementation and
-# delete this class entirely.
-# ===========================================================================
-
-
-class TestCoarseTileGroupsFnResidual(InductorTestCase):
-    """Residual tests using coarse_tiling_groups_fn.
-
-    All scenarios are now covered by TestCoarseTileSpyreHints.  These tests
-    remain until the coarse_tiling_groups_fn config is removed from the
-    implementation.  See the comment block above for details.
-    """
-
-    def setUp(self):
-        super().setUp()
-        torch.manual_seed(0xAFFE)
-
-    # ------------------------------------------------------------------
-    # Baseline: no tiling flag → LoopSpec must NOT appear
-    # ------------------------------------------------------------------
-
-    def test_no_tiling_baseline(self):
-        x = torch.randn(256, 128, dtype=torch.float16).to("spyre")
-
-        def fn(x):
-            return torch.abs(x)
-
-        cfn = torch.compile(fn)
-        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
-            _, source_codes = run_and_get_code(cfn, x)
-        self.assertTrue(len(source_codes) > 0)
-        # LoopSpec appears as an import even without tiling; check for a call.
-        self.assertNotIn("LoopSpec(", source_codes[0])
-
-    # ------------------------------------------------------------------
-    # generate_bundle receives LoopSpec in the spec tree
-    # ------------------------------------------------------------------
-
-    # test_generate_bundle_receives_loop_spec is disabled: the torch.compile
-    # cache (AOT autograd / fxgraph) is poisoned by earlier tests in the same
-    # session that call generate_bundle directly, causing generate_bundle to be
-    # bypassed on a cache hit.  The essential coverage — that generate_bundle
-    # handles a LoopSpec and emits affine.apply — is provided by
-    # TestCompileOpSpecSymbolMapping.test_generate_bundle_emits_affine_apply_for_tiled_loop
-    # in test_sdsc_tiled_address.py.
-    #
-    # @config.patch({"coarse_tiling": True, "coarse_tiling_groups_fn": _groups_all_k4})
-    # def test_generate_bundle_receives_loop_spec(self): ...
-
-    # Source inspection: unrolling passes LoopSpec through async_compile
-    # with concrete per-iteration HBM addresses in each unrolled OpSpec.
-    # ------------------------------------------------------------------
-
-    @config.patch(
-        {
-            "coarse_tiling": True,
-            "coarse_tiling_groups_fn": _groups_nested_k2_m4,
-            "unroll_loops": True,
-            "lx_planning": True,
-            "allow_all_ops_in_lx_planning": True,
-        }
-    )
-    def test_unrolled_source_calls_sdsc(self):
-        """Nested K=2 × M=4 loop with unroll_loops=True compiles cleanly.
-
-        The generated wrapper passes a LoopSpec to async_compile.sdsc().
-        SpyreAsyncCompile.sdsc() calls unroll_loop_specs internally, replacing
-        the LoopSpec with K_outer × K_inner = 8 flat copies per op before
-        invoking generate_bundle.  The source must still contain LoopSpec (it's
-        part of the sdsc() call-site), and subprocess.run must be called (the
-        dxp_standalone backend invocation after successful unrolling+bundling).
-        """
-        a = torch.randn(1024, 4096, dtype=torch.float16).to("spyre")
-        b = torch.randn(1024, 4096, dtype=torch.float16).to("spyre")
-        c = torch.randn(1024, 4096, dtype=torch.float16).to("spyre")
-
-        def fn(a, b, c):
-            y = a + b
-            z = y * c
-            return z
-
-        cfn = torch.compile(fn)
-        subprocess_calls = []
-
-        def _record_subprocess(*args, **kwargs):
-            subprocess_calls.append(args)
-
-        with (
-            mock_patch(_LAUNCH_KERNEL),
-            mock_patch("subprocess.run", side_effect=_record_subprocess),
-        ):
-            _, source_codes = run_and_get_code(cfn, a, b, c)
-        self.assertTrue(len(source_codes) > 0)
-        src = source_codes[0]
-        # The generated source passes a LoopSpec to async_compile.sdsc().
-        self.assertIn("LoopSpec(", src)
-        # subprocess.run was called — unroll_loop_specs + generate_bundle
-        # completed without error before invoking dxp_standalone.
-        self.assertTrue(
-            len(subprocess_calls) > 0,
-            "Expected subprocess.run to be called (dxp_standalone invocation)",
-        )
-
-    # ------------------------------------------------------------------
-    # Softmax-shaped tiling: reduction + pointwise, unrolled.
-    # ------------------------------------------------------------------
-
-    @config.patch(
-        {
-            "coarse_tiling": True,
-            "coarse_tiling_groups_fn": _groups_all_k4,
-            "unroll_loops": True,
-            "sencores": 1,
-            "lx_planning": True,
-            "allow_all_ops_in_lx_planning": True,
-        }
-    )
-    def test_unrolled_softmax_shaped_execution(self):
-        """Unrolled K=4 tiling of a softmax-shaped pointwise+reduce chain.
-
-        Tiles the batch dimension (dim 0) of a softmax-like computation:
-          max_val = x.amax(dim=-1, keepdim=True)   # reduction (non-tiled dim)
-          x_shifted = x - max_val                   # pointwise broadcast
-          exp_x = x_shifted.exp()                   # pointwise
-          sum_exp = exp_x.sum(dim=-1, keepdim=True) # reduction (non-tiled dim)
-          out = exp_x / sum_exp                     # pointwise broadcast
-
-        The reductions collapse dim 1 (the D dimension); the loop tiles dim 0
-        (the B dimension), so no tiled dim overlaps with the reduction dim.
-        insert_tiling_propagation propagates the reduction outputs to full-sized
-        buffers so outside consumers (later pointwise stages) see the complete
-        batch.  sencores=1 avoids core-division/scratchpad issues.
-        """
-        B, D = 256, 64
-        x = torch.randn(B, D, dtype=torch.float16)
-
-        def softmax_fn(x):
-            max_val = x.amax(dim=-1, keepdim=True)
-            x_shifted = x - max_val
-            exp_x = x_shifted.exp()
-            sum_exp = exp_x.sum(dim=-1, keepdim=True)
-            return exp_x / sum_exp
-
-        compare_with_cpu(
-            softmax_fn,
-            x,
-            run_compile=True,
-            run_eager=False,
-            atol=0.1,
-            rtol=0.1,
-        )
-
-
 # ===========================================================================
 # spyre_hint-driven coarse tiling
 # These tests verify that coarse tiling is driven automatically by
-# spyre_hint(num_tiles_per_dim=...) annotations, without requiring a
-# coarse_tiling_groups_fn.  Named tensor dimensions must be declared and
-# annotated on device tensors for the hint resolver to map dimension names
-# to loop variables.
+# spyre_hint(num_tiles_per_dim=...) annotations.  Named tensor dimensions
+# must be declared and annotated on device tensors for the hint resolver to
+# map dimension names to loop variables.
 # ===========================================================================
 
 

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -164,6 +164,31 @@ def _make_op(data, name="op0"):
     return op
 
 
+def _make_hinted_op(data, name="op0", hints=((0, 0),)):
+    """Return a fake ComputedBuffer with DimHints for use with coarse_tile().
+
+    coarse_tile() reads op.dim_hints to resolve which dimension each spec level
+    tiles.  ``hints`` is a sequence of (hint_id, dim_index) pairs, one per
+    tiling level.  hint_id must match the hint_id in the corresponding group
+    spec triple; dim_index is the index into op.data.ranges to tile.
+    """
+    from torch_spyre._inductor.propagate_hints import DimHint
+
+    op = _make_op(data, name)
+    op.dim_hints = [
+        DimHint(
+            dim_names=[f"dim{dim_index}"],
+            range_size=0,
+            split_count=1,
+            dim_index=dim_index,
+            is_reduction=False,
+            hint_id=hint_id,
+        )
+        for hint_id, dim_index in hints
+    ]
+    return op
+
+
 def _make_non_computed_op(name="extern0"):
     """Return a fake non-ComputedBuffer operation."""
     from torch._inductor.ir import Operation
@@ -540,36 +565,11 @@ class TestDivideRanges(unittest.TestCase):
 
 
 class TestCoarseTile(unittest.TestCase):
-    def _run(self, all_ops, groups, **kwargs):
-        coarse_tile(all_ops, groups, **kwargs)
-
-    def test_single_group_stamps_attributes(self):
-        data = _make_pointwise([Integer(64)])
-        op = _make_op(data, "op0")
-        self._run([op], [([op], Integer(4))])
-        self.assertEqual(op.loop_group_id, (0,))
-        self.assertEqual(op.loop_count, [Integer(4)])
-        self.assertEqual(op.loop_tiled_dims, [[0]])
-        self.assertEqual(data.ranges[0], Integer(16))
-
-    def test_two_groups_get_distinct_ids(self):
-        d0 = _make_pointwise([Integer(32)])
-        d1 = _make_pointwise([Integer(64)])
-        op0 = _make_op(d0, "op0")
-        op1 = _make_op(d1, "op1")
-        self._run([op0, op1], [([op0], Integer(4)), ([op1], Integer(8))])
-        self.assertEqual(op0.loop_group_id, (0,))
-        self.assertEqual(op1.loop_group_id, (1,))
-        self.assertEqual(op0.loop_count, [Integer(4)])
-        self.assertEqual(op1.loop_count, [Integer(8)])
-        self.assertEqual(d0.ranges[0], Integer(8))
-        self.assertEqual(d1.ranges[0], Integer(8))
-
     def test_empty_groups_list_is_noop(self):
         data = _make_pointwise([Integer(32)])
         op = _make_op(data, "op0")
         original = list(data.ranges)
-        self._run([op], [])
+        coarse_tile([op], [])
         self.assertFalse(
             hasattr(op, "loop_group_id") and op.loop_group_id != MagicMock()
         )
@@ -578,8 +578,11 @@ class TestCoarseTile(unittest.TestCase):
     def test_non_computed_buffer_skipped(self):
         op_extern = _make_non_computed_op("extern0")
         data = _make_pointwise([Integer(16)])
-        op_computed = _make_op(data, "op0")
-        self._run([op_extern, op_computed], [([op_extern, op_computed], Integer(2))])
+        op_computed = _make_hinted_op(data, "op0", hints=((0, 0),))
+        coarse_tile(
+            [op_extern, op_computed],
+            [([op_extern, op_computed], [(0, Integer(2), [0])])],
+        )
         self.assertEqual(op_computed.loop_group_id, (0,))
         self.assertEqual(data.ranges[0], Integer(8))
 
@@ -587,8 +590,8 @@ class TestCoarseTile(unittest.TestCase):
         k = Symbol("K", positive=True)
         n = Symbol("N", positive=True)
         data = _make_pointwise([n])
-        op = _make_op(data, "op0")
-        self._run([op], [([op], k)])
+        op = _make_hinted_op(data, "op0", hints=((0, 0),))
+        coarse_tile([op], [([op], [(0, k, [0])])])
         self.assertEqual(op.loop_count, [k])
         self.assertEqual(simplify(data.ranges[0] - n / k), 0)
 
@@ -600,61 +603,14 @@ class TestCoarseTile(unittest.TestCase):
         op1 = _make_op(d1, "op1")
         op2 = _make_op(d2, "op2")
         with self.assertRaises(RuntimeError):
-            self._run([op0, op1, op2], [([op0, op2], Integer(4))])
+            coarse_tile([op0, op1, op2], [([op0, op2], [(0, Integer(4), [0])])])
 
     def test_op_not_in_operations_raises(self):
         data = _make_pointwise([Integer(32)])
         op_known = _make_op(data, "op0")
         op_unknown = _make_op(_make_pointwise([Integer(8)]), "unknown")
         with self.assertRaises(RuntimeError):
-            self._run([op_known], [([op_unknown], Integer(2))])
-
-    def test_multiple_ops_in_single_group(self):
-        d0 = _make_pointwise([Integer(32)])
-        d1 = _make_pointwise([Integer(64)])
-        op0 = _make_op(d0, "op0")
-        op1 = _make_op(d1, "op1")
-        self._run([op0, op1], [([op0, op1], Integer(4))])
-        self.assertEqual(op0.loop_group_id, (0,))
-        self.assertEqual(op1.loop_group_id, (0,))
-        self.assertEqual(d0.ranges[0], Integer(8))
-        self.assertEqual(d1.ranges[0], Integer(16))
-
-    def test_per_group_tiled_dims_override(self):
-        d0 = _make_pointwise([Integer(32), Integer(16)])
-        d1 = _make_pointwise([Integer(8), Integer(64)])
-        op0 = _make_op(d0, "op0")
-        op1 = _make_op(d1, "op1")
-        self._run(
-            [op0, op1],
-            [
-                ([op0], Integer(4)),
-                ([op1], Integer(4), [0, 1]),
-            ],
-        )
-        self.assertEqual(d0.ranges[0], Integer(8))
-        self.assertEqual(d0.ranges[1], Integer(16))
-        self.assertEqual(d1.ranges[0], Integer(2))
-        self.assertEqual(d1.ranges[1], Integer(16))
-
-    def test_non_contiguous_dim_indices(self):
-        data = _make_pointwise([Integer(32), Integer(16), Integer(8)])
-        op = _make_op(data, "op0")
-        self._run([op], [([op], Integer(4), [0, 2])])
-        self.assertEqual(data.ranges[0], Integer(8))
-        self.assertEqual(data.ranges[1], Integer(16))
-        self.assertEqual(data.ranges[2], Integer(2))
-
-    def test_per_group_tiled_dims_none_overrides_kwarg(self):
-        d0 = _make_pointwise([Integer(32), Integer(16)])
-        op0 = _make_op(d0, "op0")
-        self._run(
-            [op0],
-            [([op0], Integer(4), None)],
-            tiled_dims=[0, 1],
-        )
-        self.assertEqual(d0.ranges[0], Integer(8))
-        self.assertEqual(d0.ranges[1], Integer(16))
+            coarse_tile([op_known], [([op_unknown], [(0, Integer(2), [0])])])
 
 
 class TestCoarseTileNested(unittest.TestCase):
@@ -662,37 +618,38 @@ class TestCoarseTileNested(unittest.TestCase):
 
     def test_nested_spec_stamps_list_attributes(self):
         data = _make_pointwise([Integer(256), Integer(128)])
-        op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(2), [1])])])
+        op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
+        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(2), [1])])])
         self.assertEqual(op.loop_group_id, (0, 0))
         self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_tiled_dims, [[0], [1]])
 
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
-        op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(2), [1])])])
+        op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
+        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(2), [1])])])
         self.assertEqual(data.ranges[0], Integer(64))
         self.assertEqual(data.ranges[1], Integer(64))
 
     def test_nested_spec_outer_only_divides_outer_dim(self):
         data = _make_pointwise([Integer(32), Integer(64), Integer(16)])
-        op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(8), [1])])])
+        op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
+        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(8), [1])])])
         self.assertEqual(data.ranges[0], Integer(8))
         self.assertEqual(data.ranges[1], Integer(8))
         self.assertEqual(data.ranges[2], Integer(16))
 
-    def test_flat_and_nested_groups_coexist(self):
+    def test_single_and_nested_groups_coexist(self):
+        """Group 0: single-level spec tiling dim 0.  Group 1: two-level nested spec."""
         d0 = _make_pointwise([Integer(64), Integer(32)])
         d1 = _make_pointwise([Integer(128), Integer(64)])
-        op0 = _make_op(d0, "op0")
-        op1 = _make_op(d1, "op1")
+        op0 = _make_hinted_op(d0, "op0", hints=((1, 0),))
+        op1 = _make_hinted_op(d1, "op1", hints=((2, 0), (3, 1)))
         coarse_tile(
             [op0, op1],
             [
-                ([op0], Integer(4)),
-                ([op1], [(0, Integer(4), [0]), (0, Integer(2), [1])]),
+                ([op0], [(1, Integer(4), [0])]),
+                ([op1], [(2, Integer(4), [0]), (3, Integer(2), [1])]),
             ],
         )
         self.assertEqual(op0.loop_group_id, (0,))
@@ -708,8 +665,8 @@ class TestCoarseTileNested(unittest.TestCase):
 
     def test_nested_same_dim_different_counts(self):
         data = _make_pointwise([Integer(256)])
-        op = _make_op(data, "op0")
-        coarse_tile([op], [([op], [(0, Integer(4), [0]), (0, Integer(2), [0])])])
+        op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 0)))
+        coarse_tile([op], [([op], [(1, Integer(4), [0]), (2, Integer(2), [0])])])
         self.assertEqual(data.ranges[0], Integer(32))
         self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_tiled_dims, [[0], [0]])

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -92,8 +92,6 @@ logger = get_inductor_logger("coarse_tile")
 def coarse_tile(
     operations: list[Operation],
     groups: list[tuple],
-    *,
-    tiled_dims: list[int] | None = None,
 ) -> None:
     """Stamp loop_group_id / loop_count on operations and scale their ranges.
 
@@ -104,17 +102,12 @@ def coarse_tile(
         CustomPreSchedulingPasses).  Modified in-place when
         insert_tiling_propagation inserts new buffer/copy ops.
     groups:
-        Sequence of ``(ops, spec[, tiled_dims])`` tuples.  ``spec`` is either:
-
-        * A scalar ``loop_count`` (with optional third element ``tiled_dims``)
-          for a flat single-level loop — tile all ops in ``ops`` by that count.
-        * A list of ``(hint_id, loop_count, tiled_dims)`` triples for nested
-          loops — outermost first.  The ops end up in the innermost loop body;
-          each level's count and dims are stamped on the op and the
-          corresponding iteration ranges are divided.
-    tiled_dims:
-        Default ``tiled_dims`` for flat groups that do not supply their own.
-        ``None`` means tile only dimension 0.  Ignored for nested-spec groups.
+        Sequence of ``(ops, spec)`` tuples produced by
+        ``hints_to_coarse_tile_groups``.  ``spec`` is a list of
+        ``(hint_id, loop_count, tiled_dims)`` triples for nested loops —
+        outermost first.  The ops end up in the innermost loop body; each
+        level's count and dims are stamped on the op and the corresponding
+        iteration ranges are divided.
     """
     op_to_position: dict[str, int] = {
         op.get_operation_name(): i for i, op in enumerate(operations)
@@ -122,17 +115,8 @@ def coarse_tile(
 
     for group_idx, group in enumerate(groups):
         group_ops = group[0]
-        spec = group[1]
+        levels: list[tuple[int, Expr, list[int]]] = group[1]
         group_id: tuple[int, ...] = (group_idx,)
-
-        if isinstance(spec, list):
-            # Nested spec: list of (hint_id, loop_count, tiled_dims) triples.
-            levels: list[tuple[int, Expr, list[int]]] = spec
-        else:
-            # Flat spec: scalar loop_count with optional tiled_dims override.
-            flat_tiled = group[2] if len(group) > 2 else tiled_dims
-            effective_dims: list[int] = [0] if flat_tiled is None else flat_tiled
-            levels = [(0, spec, effective_dims)]
 
         _stamp_group(group_ops, group_id, levels, op_to_position)
 
@@ -603,13 +587,10 @@ def _stamp_group(
             )
             continue
 
-        # Two ways to drive coarse tiling: (1) a config-supplied groups function
-        # that assigns the same dims to every op in the group, and (2) spyre_hint
-        # annotations where each op carries its own dim_hints with per-op
-        # dim_index values (ops in the same group can have different iteration
-        # spaces, e.g. a broadcast op may lack the tiled dimension entirely).
-        # Use the op's own dim_index when dim_hints are present; fall back to
-        # spec_dims otherwise, or when the op has no matching dim for a level.
+        # Each op carries its own dim_hints with per-op dim_index values (ops in
+        # the same group can have different iteration spaces, e.g. a broadcast op
+        # may lack the tiled dimension entirely).  Use the op's own dim_index;
+        # fall back to empty when the op has no matching dim for a level.
         op_hints = getattr(op, "dim_hints", [])
         hint_id_to_dim_index: dict[int, int] = {
             h.hint_id: h.dim_index
@@ -618,10 +599,8 @@ def _stamp_group(
         }
         op_tiled_dims: list[list[int]] = []
         for hint_id, count, spec_dims in levels:
-            dim_index = hint_id_to_dim_index.get(hint_id) if op_hints else None
-            if not op_hints:
-                effective = spec_dims  # flat/legacy: no dim_hints, use spec directly
-            elif dim_index is not None:
+            dim_index = hint_id_to_dim_index.get(hint_id)
+            if dim_index is not None:
                 effective = [dim_index]  # use this op's own dim_index
             else:
                 effective = []  # op has no dim for this level — loop-invariant

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -14,7 +14,7 @@
 
 import os
 import sys
-from typing import Callable, Literal, Optional
+from typing import Literal
 
 from torch.utils._config_module import install_config_module
 
@@ -56,19 +56,6 @@ bundle_hbm_symbols: bool = os.environ.get("BUNDLE_HBM_SYMBOLS", "0") == "1"
 # before generate_bundle runs.  Set to False to pass LoopSpecs through intact
 # (used with bundle_hbm_symbols=True for the scf.for / affine.apply path).
 unroll_loops: bool = os.environ.get("UNROLL_LOOPS", "1") == "1"
-
-# Optional callable injected by callers to compute coarse-tiling groups.
-# Signature: (list[Operation]) -> list[tuple[list[Operation], sympy.Expr[, list[int]]]]
-# Each tuple is (ops, loop_count) or (ops, loop_count, tiled_dims).
-# tiled_dims overrides the default per-group (None = tile outermost dim only).
-# When None and coarse_tiling is True, groups are derived from spyre_hint
-# annotations via hints_to_coarse_tile_groups (a no-op if no hints are present).
-# When set, this callable overrides the hint-derived groups entirely.
-# Must be a module-level named function (not a lambda) for Inductor cache pickling.
-# This is intended to be used for interim testing of the coarse-tiling transformation
-# until the working set reduction annotation framework is being developed.
-# It will be removed once the full-fledged annotation mechanism is available.
-coarse_tiling_groups_fn: Optional[Callable] = None
 
 # Layout solver class used by default in scratchpad.allocator.DefaultAllocator.
 # Options:

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -262,8 +262,6 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         assign_dim_hints(operations)
         if config.coarse_tiling:
             groups = hints_to_coarse_tile_groups(operations)
-            if config.coarse_tiling_groups_fn is not None:
-                groups = config.coarse_tiling_groups_fn(operations)
             coarse_tile(operations, groups=groups)
         span_reduction(operations)
         k_fast_ops = (

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -70,7 +70,7 @@ def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -
     raw = getattr(ir_op, "loop_tiled_dims", None)
     if raw is None or not raw:
         return []
-    dims_per_level: list = raw if isinstance(raw[0], list) else [raw]
+    dims_per_level: list[list[int]] = raw
     if depth >= len(dims_per_level):
         return []
     it_space = iteration_space(sched_node)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -449,15 +449,11 @@ class SpyreKernel(Kernel[CSEVariable]):
         }
 
         # If this op is inside a coarse-tiling loop, identify which iteration-space
-        # symbols are tiled by the enclosing loop(s).  loop_tiled_dims on the IR
-        # node is either a flat list[int] (legacy single-level) or a
-        # list[list[int]] (nested multi-level, outermost first).  We flatten all
+        # symbols are tiled by the enclosing loop(s).  loop_tiled_dims is a
+        # list[list[int]] (nested multi-level, outermost first).  Flatten all
         # levels so that tiled_symbols covers every loop variable from outermost
         # to innermost — matching the loop_vars ordering in bundle.py _emit_specs.
-        raw_tiled_dims = getattr(ir_node, "loop_tiled_dims", [])
-        if raw_tiled_dims and not isinstance(raw_tiled_dims[0], list):
-            # Legacy flat list — wrap in a single-level list.
-            raw_tiled_dims = [raw_tiled_dims]
+        raw_tiled_dims: list[list[int]] = getattr(ir_node, "loop_tiled_dims", [])
         all_tiled_dims = [d for level in raw_tiled_dims for d in level]
         it_space_keys = list(it_space.keys())
         tiled_syms = [


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This is the third and final PR in the `coarse_tiling_groups_fn` cleanup:

- **PR 1:** Ported the bulk of the test suite to `spyre_hints`, consolidated
  residual test classes.
- **PR 2:** Ported the last test (`test_per_group_tiled_dims`) using
  sub-dimension naming; all `coarse_tiling_groups_fn` tests eliminated.
- **PR 3 (this PR):** Removes `coarse_tiling_groups_fn` from the
  implementation and cleans up the dead code it left behind.

**Commit 1 — remove config, implementation, and residual tests**
(`cleanup: remove coarse_tiling_groups_fn config, implementation, and residual tests`)

- **`config.py`**: Deleted `coarse_tiling_groups_fn: Optional[Callable] = None`
  and its 11-line comment block. Ruff also cleaned up the now-unused
  `Optional` and `Callable` imports.
- **`passes.py`**: Deleted the `if config.coarse_tiling_groups_fn is not None:`
  override branch. `hints_to_coarse_tile_groups()` is now the sole code path
  for building tiling groups.
- **`test_coarse_tile_e2e.py`**: Deleted `TestCoarseTileGroupsFnResidual`,
  both remaining `_groups_*` module-level helpers, and the now-unused `sympy`,
  `ComputedBuffer`, `Operation` imports. Updated the module docstring and
  section comment. `TestCoarseTileSpyreHints` is now the only test class.

**Commit 2 — remove flat/legacy dead-code paths**
(`cleanup: remove flat/legacy dead-code paths from coarse_tile, spyre_kernel, scheduler`)

With `coarse_tiling_groups_fn` gone, tiling groups now exclusively come from
`hints_to_coarse_tile_groups()`, which always produces nested specs of the form
`(hint_id, loop_count, [dim_index])`. Several code paths that existed only to
handle the old flat/scalar calling convention (`(ops, loop_count)` or
`(ops, loop_count, tiled_dims)`) are now unreachable:

- **`coarse_tile.py`**: Removed the `tiled_dims` parameter from `coarse_tile()`
  and the flat-spec `else` branch in the main loop. Removed the `if not
  op_hints:` fallback branch in `_stamp_group()` (the hints path always
  populates `dim_hints`) and the stale two-calling-convention comment above it.
- **`spyre_kernel.py`**: Removed the `not isinstance(raw_tiled_dims[0], list)`
  legacy-wrap guard — `loop_tiled_dims` is now always `list[list[int]]`.
- **`scheduler.py`**: Removed the same `isinstance` ternary in
  `_tiled_syms_for_sched_node_at_depth()`.

Net across both commits: −209 lines in tests, −42 lines in implementation.
16 coarse-tiling tests pass.

#### Which issue(s) this PR is related to:

Part of #1358 

<!--
No issue — planned three-part cleanup, final step.
-->

#### Special notes for your reviewer:

The `for d in dims` loops in `coarse_tile.py` that iterate over per-level
`tiled_dims` lists were intentionally kept. They already work correctly with
the single-element lists the hint path produces, and flattening them to
`dims[0]` would be a more invasive refactor with no practical benefit.

Similarly, `_group_spec()` and `_find_spec_op()` in `temp_passes.py` were
kept — they're small, clearly scoped helpers that document the conversion from
`DimHint` to the `coarse_tile()` spec format.

#### Does this PR introduce a user-facing change?

No. `coarse_tiling_groups_fn` was never part of the public API — it was an
internal interim config field with a comment marking it for removal. The
`spyre_hints` API (`spyre_hint`, `declare_tensor_dim`, `name_tensor_dims`) is
unchanged.

#### Additional note:

The `coarse_tiling_groups_fn` cleanup is now complete. The coarse-tiling
pipeline is exclusively driven by `spyre_hint(num_tiles_per_dim=...)` context
managers, with groups formed automatically by `hints_to_coarse_tile_groups()`
in `temp_passes.py`.