### PR TITLE
Fix flash restickify coarse tiling

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -538,6 +538,40 @@ class TestDivideRanges(unittest.TestCase):
         op = _make_op(MagicMock(spec=Operation))
         _divide_ranges(op, Integer(4), tiled_dims=[0])
 
+    def test_fixed_tiled_layout_preserves_stick_host_dim_after_tiling(self):
+        import torch
+        from torch_spyre._C import SpyreTensorLayout
+        from torch_spyre._inductor.ir import FixedTiledLayout
+
+        data = _make_pointwise([Integer(12), Integer(32), Integer(256), Integer(256)])
+        op = _make_op(data)
+        size = [Integer(12), Integer(32), Integer(256), Integer(256)]
+        stride = [Integer(2097152), Integer(65536), Integer(256), Integer(1)]
+        origin = MagicMock()
+        origin.target = torch.ops.spyre.restickify.default
+        op.origins = OrderedSet([origin])
+        op.layout = FixedTiledLayout(
+            torch.device("spyre"),
+            torch.float16,
+            size,
+            stride,
+            SpyreTensorLayout(
+                [12, 32, 256, 256],
+                [2097152, 65536, 256, 1],
+                torch.float16,
+                [0, 1, 3, 2],
+            ),
+        )
+
+        _divide_ranges(op, Integer(6), tiled_dims=[0])
+        _divide_ranges(op, Integer(8), tiled_dims=[1])
+        _divide_ranges(op, Integer(4), tiled_dims=[3])
+
+        self.assertEqual(
+            op.layout.size, [Integer(2), Integer(4), Integer(256), Integer(64)]
+        )
+        self.assertEqual(list(op.layout.device_layout.stride_map)[-1], 256)
+
 
 class TestCoarseTile(unittest.TestCase):
     def _run(self, all_ops, groups, **kwargs):
@@ -1121,6 +1155,68 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
             has_strides,
             f"Expected non-empty affine_strides; got {affine_strides}.",
         )
+
+    def test_restickify_layouts_fit_fixed_dim_contract(self):
+        c0 = Symbol("c0")
+        c1 = Symbol("c1")
+        c2 = Symbol("c2")
+        c3 = Symbol("c3")
+        z0 = Symbol("z0")
+        z1 = Symbol("z1")
+        op_spec = OpSpec(
+            op="ReStickifyOpHBM",
+            is_reduction=False,
+            iteration_space={
+                c0: (Integer(2), 2),
+                c1: (Integer(4), 4),
+                c2: (Integer(256), 4),
+                c3: (Integer(64), 1),
+                z0: (Integer(1), 1),
+                z1: (Integer(1), 1),
+            },
+            args=[
+                TensorArg(
+                    is_input=True,
+                    arg_index=-1,
+                    device_dtype=_FP16,
+                    device_size=[4, 64, 4, 1, 32, 64],
+                    device_coordinates=[
+                        z0,
+                        c3,
+                        sympify("floor(c2/64)"),
+                        c0,
+                        c1,
+                        sympify("Mod(c2, 64)"),
+                    ],
+                    allocation={"pool": 0x1000},
+                ),
+                TensorArg(
+                    is_input=False,
+                    arg_index=-1,
+                    device_dtype=_FP16,
+                    device_size=[1, 1, 4, 256, 2, 64],
+                    device_coordinates=[
+                        sympify("floor(c3/64)"),
+                        z0,
+                        c1,
+                        c2,
+                        c0,
+                        sympify("Mod(c3, 64)"),
+                    ],
+                    allocation={"pool": 0x2000},
+                ),
+            ],
+            op_info={},
+            tiled_symbols=[c0, c1, c3],
+        )
+
+        sdsc_json, _, _ = compile_op_spec(0, op_spec, [], use_symbols=False)
+        dsc = next(iter(sdsc_json.values()))["dscs_"][0]["ReStickifyOpHBM"]
+        n_dims = [str(k).rstrip("_") for k in dsc["N_"] if str(k) != "name_"]
+
+        self.assertEqual(len(n_dims), 5)
+        for layout in dsc["primaryDsInfo_"].values():
+            self.assertEqual(len(layout["layoutDimOrder_"]), len(n_dims))
 
     def test_generate_bundle_emits_affine_apply_for_tiled_loop(self):
         op_spec = _make_tiled_op_spec()

--- a/tests/inductor/test_inductor_fx_passes.py
+++ b/tests/inductor/test_inductor_fx_passes.py
@@ -219,6 +219,21 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             result = concretize_index(index, loop_vars)
             assert result == index, f"Expected {index}, got {result}"
 
+    def test_restickify_device_size_substick_target_uses_one_outer_stick(self):
+        from torch_spyre._inductor.pass_utils import restickify_device_size
+
+        result = restickify_device_size(
+            old_device_size=[4, 64, 4, 2, 64],
+            old_sd_outer_dim=3,
+            old_sd_host_size=2,
+            new_sd_outer_dim=1,
+            new_sd_host_size=32,
+            stick_size=64,
+        )
+
+        assert result[3] == 1
+        assert all(size > 0 for size in result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -669,6 +669,14 @@ def _divide_ranges(
     if not ranges:
         return
 
+    from torch._inductor.ir import FixedLayout, FlexibleLayout
+
+    layout = getattr(op, "layout", None)
+    is_restickify = any(
+        getattr(origin, "target", None) is torch.ops.spyre.restickify.default
+        for origin in getattr(op, "origins", [])
+    )
+
     for i in tiled_dims:
         if i < 0 or i >= len(ranges):
             continue
@@ -690,11 +698,8 @@ def _divide_ranges(
     object.__setattr__(data, "ranges", ranges)
 
     # Sync layout.size, layout.stride, and layout.device_layout with the new ranges.
-    from torch._inductor.ir import FixedLayout, FlexibleLayout
-
     from .ir import FixedTiledLayout
 
-    layout = getattr(op, "layout", None)
     if not (isinstance(layout, FixedLayout) and len(layout.size) == len(ranges)):
         return
 
@@ -704,32 +709,39 @@ def _divide_ranges(
             new_size[i] = ranges[i]
     layout.size = new_size
 
-    # Recompute contiguous strides for the smaller buffer.
-    layout.stride = list(FlexibleLayout.contiguous_strides(new_size))
-
-    # Rebuild SpyreTensorLayout for the new host size, preserving the
-    # within-stick dimension.  stride_map[-1] is the element stride of the
-    # within-stick host dimension in the original layout; match it against the
-    # new contiguous strides to identify which host dim remains the stick dim.
+    # Rebuild SpyreTensorLayout for the new host size, preserving the original
+    # within-stick host dimension.  The old stick stride may disappear after
+    # tiling changes the contiguous host strides, so resolve the dimension
+    # before recomputing strides.
     if not isinstance(layout, FixedTiledLayout):
+        layout.stride = list(FlexibleLayout.contiguous_strides(new_size))
         return
     orig_stl = layout.device_layout
     sm_last = int(list(orig_stl.stride_map)[-1])
+    old_strides_ints = [int(s) for s in layout.stride]
+    within_stick_dim = next(
+        (i for i, s in enumerate(old_strides_ints) if s == sm_last), None
+    )
+
+    # Recompute contiguous strides for the smaller buffer.
+    layout.stride = list(FlexibleLayout.contiguous_strides(new_size))
     new_strides_ints = [int(s) for s in layout.stride]
     new_size_ints = [int(s) for s in new_size]
-    within_stick_dim = next(
-        (i for i, s in enumerate(new_strides_ints) if s == sm_last), None
-    )
     if within_stick_dim is None:
         # Fall back to last dim (covers the common contiguous fp16 case where
         # sm_last == 1 and the last stride is also 1).
         within_stick_dim = len(new_size_ints) - 1
     ndim = len(new_size_ints)
     dim_order = [i for i in range(ndim) if i != within_stick_dim] + [within_stick_dim]
+    stl_strides_ints = (
+        old_strides_ints
+        if is_restickify and sm_last not in new_strides_ints
+        else new_strides_ints
+    )
     from torch_spyre._C import SpyreTensorLayout
 
     layout.device_layout = SpyreTensorLayout(
-        new_size_ints, new_strides_ints, layout.dtype, dim_order
+        new_size_ints, stl_strides_ints, layout.dtype, dim_order
     )
 
 

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -22,6 +22,7 @@ from torch._inductor.virtualized import V
 from torch_spyre._C import DataFormats
 from torch_spyre._inductor.constants import (
     IDENTITY_OP,
+    RESTICKIFY_OP,
     INPUT_DIM_LABELS,
     OUTPUT_DIM_LABELS,
     LAYOUT_LABELS,
@@ -338,7 +339,7 @@ def _create_sdsc_tensors(
         max_dim_sizes: dict = {}
         reduced_dims: list = []
         if use_op_dims and dim_order != dims and not _is_topk(op_spec.op):
-            reduced_dims = [d for d in op_dim_order if d not in dim_order]
+            reduced_dims = [d for d in dims if d not in dim_order]
             dim_order = dim_order + reduced_dims
 
         if op_stick_dim is None:
@@ -526,14 +527,41 @@ def _extend_matmul_k_to_padded(
         sdsc_iteration_space[k_sym] = k_padded
 
 
+def _restickify_drop_dims(op_spec: OpSpec) -> set[Symbol]:
+    if op_spec.op != RESTICKIFY_OP or len(op_spec.iteration_space) <= 5:
+        return set()
+
+    drop: set[Symbol] = set()
+    extra = len(op_spec.iteration_space) - 5
+    for sym, (size, split) in reversed(op_spec.iteration_space.items()):
+        if extra == 0:
+            break
+        if size == 1 and split == 1:
+            drop.add(sym)
+            extra -= 1
+    if extra != 0:
+        raise RuntimeError(
+            f"ReStickifyOpHBM SDSC requires at most 5 dimensions, got "
+            f"{len(op_spec.iteration_space)} and could not drop {extra} size-1 dimensions"
+        )
+    return drop
+
+
 def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
     is_matmul = _is_matmul(op_spec.op)
-    ndim = len(op_spec.iteration_space)
+    dropped_dims = _restickify_drop_dims(op_spec)
+    effective_iteration_space = {
+        sym: value
+        for sym, value in op_spec.iteration_space.items()
+        if sym not in dropped_dims
+    }
+    ndim = len(effective_iteration_space)
 
     dim_labels = _get_op_dim_labels(ndim, is_matmul)
-    symbol_mapping = {
-        sym: Symbol(dim_labels[i]) for i, sym in enumerate(op_spec.iteration_space)
-    }
+    symbol_mapping = {sym: Integer(0) for sym in dropped_dims}
+    symbol_mapping.update(
+        {sym: Symbol(dim_labels[i]) for i, sym in enumerate(effective_iteration_space)}
+    )
     logger.debug(
         "symbol mapping: %s",
         ", ".join(f"{k} -> {v}" for k, v in symbol_mapping.items()),
@@ -541,17 +569,18 @@ def parse_op_spec(op_spec: OpSpec) -> tuple["SDSCSpec", "dict"]:
 
     sdsc_iteration_space = {
         symbol_mapping[sym]: _concretize_for_sdsc(size)
-        for sym, (size, _) in op_spec.iteration_space.items()
+        for sym, (size, _) in effective_iteration_space.items()
     }
 
     dim_splits = {
-        symbol_mapping[dim]: value[-1] for dim, value in op_spec.iteration_space.items()
+        symbol_mapping[dim]: value[-1]
+        for dim, value in effective_iteration_space.items()
     }
     num_cores = math.prod(dim_splits.values())
 
     work_slices = {
         symbol_mapping[sym]: wk_slice
-        for sym, (_, wk_slice) in op_spec.iteration_space.items()
+        for sym, (_, wk_slice) in effective_iteration_space.items()
     }
 
     ref_arg = _ref_arg(op_spec)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -316,13 +316,11 @@ def restickify_device_size(
 ) -> list:
     """Computes the new device size after a restickify is performed
     moving the stick from old_sd to new_sd."""
-    assert new_sd_host_size % stick_size == 0, (
-        f"Cannot move stick to dimension with size {new_sd_host_size}: "
-        f"without padding since not a multiple of stick_size={stick_size}"
-    )
     new_device_size = list(old_device_size)
     new_device_size[-1] = stick_size
-    new_device_size[old_sd_outer_dim] = new_sd_host_size // stick_size
+    new_device_size[old_sd_outer_dim] = (
+        new_sd_host_size + stick_size - 1
+    ) // stick_size
     new_device_size[new_sd_outer_dim] = old_sd_host_size
     return new_device_size
 
@@ -376,8 +374,6 @@ def compute_restickify_target_layout(
     if not candidates:
         return None
     new_sd_outer_dim = candidates[0]
-    if host_size[new_sd] % stick_size != 0:
-        return None
     device_size = restickify_device_size(
         list(stl.device_size),
         old_sd_outer_dim,

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -490,6 +490,7 @@ def align_tensors(
         coordinates.append(
             (var % dim_size if var is not None else sympy.S.Zero) + offset
         )
+        size = [sympy.S.One if s == 0 else s for s in size]
         new_tensors.append({"size": size, "coordinates": coordinates})
 
     # decide desired rank for all tensors

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -60,6 +60,13 @@ aten = torch.ops.aten
 spyreop = torch.ops.spyre
 
 
+def _is_restickify_op(op: ComputedBuffer) -> bool:
+    return any(
+        getattr(origin, "target", None) is spyreop.restickify.default
+        for origin in getattr(op, "origins", [])
+    )
+
+
 @dataclasses.dataclass
 class TensorDep:
     """Bundles a MemoryDep with its FixedTiledLayout and pre-computes device coordinates."""
@@ -768,6 +775,8 @@ def span_reduction(operations: list[Operation]) -> None:
     for op in _iter_computed_buffers(operations):
         rw = op.get_read_writes()
         args = get_mem_deps_from_rw(rw)
+        if _is_restickify_op(op):
+            continue
         if isinstance(op.data, Pointwise):
             divide_pointwise_op(op, args, max_cores, span_reduction_pass)
         elif isinstance(op.data, Reduction):
@@ -789,6 +798,8 @@ def work_distribution(
             continue
         rw = op.get_read_writes()
         args = get_mem_deps_from_rw(rw)
+        if _is_restickify_op(op):
+            continue
         if isinstance(op.data, Pointwise):
             divide_pointwise_op(op, args, max_cores, work_distribution_pass)
         elif isinstance(op.data, Reduction):


### PR DESCRIPTION
## Summary

Fix flash attention compilation failures caused by coarse tiling interactions with restickify layouts.

The main issue was that coarse tiling rebuilt FixedTiledLayout.device_layout from the per-tile contiguous strides. For restickify outputs, the original within-stick host dimension can disappear from the tiled stride set, causing the restickified tensor to use the wrong stick dimension. That later produced invalid SDSCs for the downstream batchmatmul.

This PR:
- preserves the original restickify stick host dimension when coarse tiling updates tiled layouts
- skips work-division splitting for restickify layout-conversion ops
- normalizes ReStickifyOpHBM SDSC lowering to the backend's fixed 5D contract
- keeps non-matmul SDSC tensor layouts rank-complete when a tensor omits dimensions present in the op iteration space
- adds focused regressions for the restickify coarse-tiling layout and SDSC dimension contract

## Testing

- timeout 180s python -m pytest -q tests/inductor/test_coarse_tiling.py::TestDivideRanges::test_fixed_tiled_layout_preserves_stick_host_dim_after_tiling tests/inductor/test_coarse_tiling.py::TestCompileOpSpecSymbolMapping::test_restickify_layouts_fit_fixed_dim_contract -s
- timeout 180s python -m py_compile torch_spyre/_inductor/coarse_tile.py torch_spyre/_inductor/work_division.py torch_spyre/_inductor/codegen/superdsc.py torch_spyre/_inductor/pass_utils.py torch_spyre/_inductor/views.py

Additional validation:
- test_scripts/test_flash.py no longer hits the previous sdsc_15 batchmatmul mapping failure or the sdsc14_ReStickifyOpHBM DDL failure.
- Direct dxp_standalone on the generated flash bundle compiled through all 3456 SDSCs, then timed out in the final bundle stage after 1800s.