### PR TITLE
Minimum fix to generate a triton kernel from torch-spyre

### DIFF
--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -157,14 +157,29 @@ def _autoload():
             device=DEVICE_NAME, device_op_overrides=SpyreDeviceOpOverrides()
         )
 
-        from .scheduler import SuperDSCScheduling
         from .wrapper import SpyrePythonWrapperCodegen
 
-        register_backend_for_device(
-            DEVICE_NAME,
-            SuperDSCScheduling,
-            SpyrePythonWrapperCodegen,
-            device_custom_config=config,
-        )
+        import os
+
+        if os.getenv("TORCH_SPYRE_TRITON") == "1":
+            print("Using SpyreTritonKernel")
+            from .spyre_triton_scheduler import SpyreTritonScheduling
+
+            register_backend_for_device(
+                DEVICE_NAME,
+                SpyreTritonScheduling,
+                # SuperDSCScheduling,
+                SpyrePythonWrapperCodegen,
+                device_custom_config=config,
+            )
+        else:
+            from .scheduler import SuperDSCScheduling
+
+            register_backend_for_device(
+                DEVICE_NAME,
+                SuperDSCScheduling,
+                SpyrePythonWrapperCodegen,
+                device_custom_config=config,
+            )
 
         _autoload._ran = True

--- a/torch_spyre/_inductor/spyre_triton_kernel.py
+++ b/torch_spyre/_inductor/spyre_triton_kernel.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+import sympy
+
+from torch._inductor.codegen.common import CSEVariable
+from torch._inductor.codegen.triton import FixedTritonConfig, TritonKernel
+from torch._inductor.virtualized import StoreMode
+
+
+class SpyreTritonKernel(TritonKernel):
+    def __init__(
+        self,
+        tiling: dict[str, sympy.Expr],
+        min_elem_per_thread=0,
+        optimize_mask=True,
+        fixed_config: Optional[FixedTritonConfig] = None,
+        hint_override: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            tiling,
+            min_elem_per_thread,
+            optimize_mask,
+            fixed_config,
+            hint_override,
+            **kwargs,
+        )
+
+    def __enter__(self):
+        super(TritonKernel, self).__enter__()
+        return self
+
+    def codegen_kernel(self, name=None) -> str:
+        return super().codegen_kernel(name)
+
+    def codegen_body(self):
+        return super().codegen_body()
+
+    def load(self, name: str, index: sympy.Expr):
+        return super().load(name, index)
+
+    def store(
+        self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
+    ) -> None:
+        return super().store(name, index, value, mode)
+
+    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+        return super().store_reduction(name, index, value)

--- a/torch_spyre/_inductor/spyre_triton_scheduler.py
+++ b/torch_spyre/_inductor/spyre_triton_scheduler.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
+from torch._inductor.codegen.triton import TritonScheduling
+
+from torch_spyre._inductor.spyre_triton_kernel import SpyreTritonKernel
+
+
+class SpyreTritonScheduling(TritonScheduling):
+    """
+    Spyre-specific Triton scheduling that uses SpyreTritonKernel.
+    """
+
+    def create_kernel_choices(  # type: ignore[override]
+        self,
+        kernel_features: SIMDKernelFeatures,
+        kernel_args: list[Any],
+        kernel_kwargs: dict[str, Any],
+    ) -> list[Any]:
+        self.kernel_type = SpyreTritonKernel  # type: ignore[assignment]
+        return super().create_kernel_choices(
+            kernel_features, kernel_args, kernel_kwargs
+        )


### PR DESCRIPTION
This fix enables the triton-kernel generation only when an environment variable TORCH_SPYRE_TRITON=1.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR is a minimum set of changes to generate a triton kernel from torch-spyre. When an environment variable TORCH_SPYRE_TRITON is set to 1, SpyreTritonScheduling is registered instead of SuperDSCScheduling, and then a triton kernel is generated through SpyreTritonKernel. This fix is an entry point for the development of a spyre-optimized triton generator. Note that this fix does not enable the execution of the triton kernel.

#### Which issue(s) this PR is related to:

#2482 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
