### PR TITLE
Integrating upstream test cases for profiler and kineto API to be spyre specific

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -117,6 +117,8 @@ jobs:
             config: torch_spyre_tests/test_regex_config.yaml
           - name: Test Spyre
             config: torch_spyre_tests/test_spyre_config.yaml
+          - name: Test Spyre
+            config: torch_spyre_tests/test_execution_trace_config.yaml
           - name: Test Spyre Lazy Silent
             config: torch_spyre_tests/test_spyre_lazy_silent_config.yaml
           - name: Test Stream

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -117,7 +117,7 @@ jobs:
             config: torch_spyre_tests/test_regex_config.yaml
           - name: Test Spyre
             config: torch_spyre_tests/test_spyre_config.yaml
-          - name: Test Spyre
+          - name: Test Execution Trace
             config: torch_spyre_tests/test_execution_trace_config.yaml
           - name: Test Spyre Lazy Silent
             config: torch_spyre_tests/test_spyre_lazy_silent_config.yaml

--- a/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/profiler/tests/profiler/test_execution_trace.py
+      unlisted_test_mode: mandatory_success
+

--- a/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_execution_trace_config.yaml
@@ -1,5 +1,5 @@
 test_suite_config:
   files:
-    - path: ${TORCH_DEVICE_ROOT}/tests/profiler/tests/profiler/test_execution_trace.py
+    - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_execution_trace.py
       unlisted_test_mode: mandatory_success
 

--- a/tests/profiler/test_execution_trace.py
+++ b/tests/profiler/test_execution_trace.py
@@ -1,0 +1,212 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+import torch
+from typing import Any
+from torch.profiler import profile
+from torch.testing._internal.common_utils import (
+    skipIfHpu,
+    skipIfTorchDynamo,
+    TestCase,
+)
+import json
+from torch.autograd import _record_function_with_args_enter , _record_function_with_args_exit
+import tempfile
+import os
+from torch.profiler import ExecutionTraceObserver , supported_activities , record_function , kineto_available
+import json
+
+
+
+Json = dict[str, Any]
+
+class TestExecutionTrace(TestCase):
+    def payload(self,device,use_device=False):
+        u =torch.randn(3,4,5)
+        with torch.no_grad():
+            with torch.profiler.record_function("## TEST 1 ##", "1, 2, 3"):
+                inf_val = float("inf")
+                neg_inf_val = float("-inf")
+                nan_val = float("nan")
+                rf_handle = _record_function_with_args_enter( '## TEST 2 ##',1,False,2.5,[u,u],(u,u),"hello",u,inf_val,neg_inf_val,nan_val)
+
+                x = torch.randn(10,10)
+                if use_device:
+                    x = x.to(device)
+                y = torch.randn(10,10)
+                if use_device:
+                    y = y.to(device)
+
+                z = x + y + x * y + x * y
+                gelu = torch.nn.GELU()
+                m = torch.randn(2)
+                _ = gelu(m)
+                if use_device:
+                    z = z.cpu()
+                _record_function_with_args_exit(rf_handle)
+
+    def get_execution_trace_rf_ids(self, nodes: list[Json]) -> list[int]:
+        """Returns a sorted list of rf_id (record function ids) in execution trace"""
+        def get_rf_id(node):
+            attrs = node["attrs"]
+            for a in attrs:
+                if a["name"] == "rf_id":
+                    return a["value"]
+            
+            return None
+
+        rf_ids = (
+            get_rf_id(n)
+            for n in nodes
+            if n["name"] != "[pytorch|profiler|execution_trace|process]"
+            and n["name"] != "[pytorch|profiler|execution_trace|thread]"
+        )
+
+        print(rf_ids)
+        return sorted(rf_id for rf_id in rf_ids if rf_id is not None)
+    
+    def get_kineto_rf_ids(self, events: list[Json])-> list[int]:
+        """Returns a sorted list of Record function IDs for CPU operators and user annotations"""
+        ops_and_annoations = (
+            e for e in events if e.get("cat" , "") in ["cpu_op", "user_annotation"]
+        )
+
+        return sorted(
+            e.get("args" , "{}").get("Record function id" , -1) for e in ops_and_annoations
+        )
+    
+    def get_execution_trace_root(self,output_file_name)->Json:
+        import gzip 
+
+        nodes = []
+        with(
+            gzip.open(output_file_name)
+            if output_file_name.endswith(".gz")
+            else open(output_file_name)
+        )as f:
+            et_graph = json.load(f)
+            if "nodes" not in et_graph:
+                raise AssertionError(f"Expected 'nodes' in execution trace: {et_graph}")
+            nodes = et_graph["nodes"]
+        
+        return nodes
+            
+
+
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    @skipIfHpu
+    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    @patch.dict(
+        os.environ,
+        {
+            "ENABLE_PYTORCH_EXECUTION_TRACE": "1",
+            "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1",
+        },
+    )
+    def test_execution_trace_env_enabled_with_kineto(self, device="spyre"):
+
+        trace_called_num = 0
+
+        def trace_handler(p):
+            nonlocal trace_called_num
+            trace_called_num += 1
+
+        use_device = device != "cpu"
+
+        with( 
+            # Kineto Trace (kt_file — .kineto.json) A timeline of hardware + system events, intended for visualization in tools like Chrome useful for timi
+            tempfile.NamedTemporaryFile(
+                mode="w+t",suffix=".kineto.json",delete=False
+            ) as kt ,
+            tempfile.NamedTemporaryFile(                      # <-- A graph of operator calls and their data dependencies, capturing the logical execution structure.useful for deep dive data analysis
+                mode="w+t", suffix=".et.json", delete=False
+            ) as et, 
+        ):
+
+            kt_name = kt.name 
+            et_name = et.name 
+        
+        et_observer = ExecutionTraceObserver()
+        et_observer.register_callback(et_name)
+        
+        # Uncomment for debugging
+        # print("Output kineto = ", kt.name)
+        # print("Output ET = ", et.name)
+
+        with profile(
+            activities= supported_activities(),
+            schedule= torch.profiler.schedule(
+                skip_first=3 , wait=1 ,warmup=1 , active=2 , repeat=1
+            ),
+            on_trace_ready=trace_handler,
+            execution_trace_observer=et_observer,
+        )as p:
+            for idx in range(10):
+                with record_function(f"## LOOP {idx} ##"):
+                    self.payload(device, use_device=use_device)
+                p.step()
+
+            p.export_chrome_trace(kt_name)
+
+            et_path = p.execution_trace_observer.get_output_file_path()
+
+            # et_res_path should be an empty directory and for spyre pytorch 2.12 update required verfied
+            #et_res_path = p.execution_trace_observer.get_resources_dir(et_path) 
+            #self.assertTrue(os.path.isdir(et_res_path))
+            #self.assertEqual(len(os.listdir(et_res_path)), 0)
+        
+        #only one cycle has ran 
+        self.assertEqual(trace_called_num , 1)
+        # the path should be set up due to our env variables
+        self.assertTrue(et_path is not None)
+        # Compare the collected Execution Trace and Kineto Trace
+        # in terms of record func
+        nodes = self.get_execution_trace_root(et_path)
+        #print(nodes)
+        loop_count = 0
+        found_root_node = False 
+        for n in nodes:
+            if "name" not in n:
+                raise AssertionError(f"Expected node to have 'name': {n}")
+            if "[pytorch|profiler|execution_trace|process]" in n["name"]:
+                found_root_node = True
+            if n["name"].startswith('## LOOP '):
+                loop_count +=1
+        self.assertTrue(found_root_node)
+        # Since profiler trace is active for 2 iteration
+        self.assertEqual(loop_count , 2)
+
+        # Compare the collected Execution Trace and Kineto Trace
+        # in terms of record func ID (rf_id) and External IDs
+        # both of these should match for the same trace window
+
+        with open(kt_name) as f:
+            kineto = json.load(f)
+            events = kineto["traceEvents"]
+        
+        os.remove(kt_name)
+
+        rf_ids_et = self.get_execution_trace_rf_ids(nodes)
+        rf_ids_kineto = self.get_kineto_rf_ids(events)
+        print(len(rf_ids_kineto) , len(rf_ids_et))
+        self.assertCountEqual(rf_ids_et,rf_ids_kineto)
+        self.assertListEqual(
+            rf_ids_et,
+            rf_ids_kineto,
+            msg = f"ET and kineto rf_id should exactly match\n"
+            f"  rf_ids_et = {rf_ids_et}\n"
+            f" rf_ids_kineto = {rf_ids_kineto}\n"
+        )

--- a/tests/profiler/test_execution_trace.py
+++ b/tests/profiler/test_execution_trace.py
@@ -109,7 +109,7 @@ class TestExecutionTrace(TestCase):
             for e in ops_and_annoations
         )
 
-    def get_execution_trace_root(self, output_file_name) -> Json:
+    def get_execution_trace_root(self, output_file_name):  # returns List[Json]
         import gzip
 
         nodes = []

--- a/tests/profiler/test_execution_trace.py
+++ b/tests/profiler/test_execution_trace.py
@@ -23,30 +23,49 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 import json
-from torch.autograd import _record_function_with_args_enter , _record_function_with_args_exit
+from torch.autograd import (
+    _record_function_with_args_enter,
+    _record_function_with_args_exit,
+)
 import tempfile
 import os
-from torch.profiler import ExecutionTraceObserver , supported_activities , record_function , kineto_available
-import json
-
+from torch.profiler import (
+    ExecutionTraceObserver,
+    supported_activities,
+    record_function,
+    kineto_available,
+)
 
 
 Json = dict[str, Any]
 
+
 class TestExecutionTrace(TestCase):
-    def payload(self,device,use_device=False):
-        u =torch.randn(3,4,5)
+    def payload(self, device, use_device=False):
+        u = torch.randn(3, 4, 5)
         with torch.no_grad():
             with torch.profiler.record_function("## TEST 1 ##", "1, 2, 3"):
                 inf_val = float("inf")
                 neg_inf_val = float("-inf")
                 nan_val = float("nan")
-                rf_handle = _record_function_with_args_enter( '## TEST 2 ##',1,False,2.5,[u,u],(u,u),"hello",u,inf_val,neg_inf_val,nan_val)
+                rf_handle = _record_function_with_args_enter(
+                    "## TEST 2 ##",
+                    1,
+                    False,
+                    2.5,
+                    [u, u],
+                    (u, u),
+                    "hello",
+                    u,
+                    inf_val,
+                    neg_inf_val,
+                    nan_val,
+                )
 
-                x = torch.randn(10,10)
+                x = torch.randn(10, 10)
                 if use_device:
                     x = x.to(device)
-                y = torch.randn(10,10)
+                y = torch.randn(10, 10)
                 if use_device:
                     y = y.to(device)
 
@@ -60,12 +79,13 @@ class TestExecutionTrace(TestCase):
 
     def get_execution_trace_rf_ids(self, nodes: list[Json]) -> list[int]:
         """Returns a sorted list of rf_id (record function ids) in execution trace"""
+
         def get_rf_id(node):
             attrs = node["attrs"]
             for a in attrs:
                 if a["name"] == "rf_id":
                     return a["value"]
-            
+
             return None
 
         rf_ids = (
@@ -77,34 +97,33 @@ class TestExecutionTrace(TestCase):
 
         print(rf_ids)
         return sorted(rf_id for rf_id in rf_ids if rf_id is not None)
-    
-    def get_kineto_rf_ids(self, events: list[Json])-> list[int]:
+
+    def get_kineto_rf_ids(self, events: list[Json]) -> list[int]:
         """Returns a sorted list of Record function IDs for CPU operators and user annotations"""
         ops_and_annoations = (
-            e for e in events if e.get("cat" , "") in ["cpu_op", "user_annotation"]
+            e for e in events if e.get("cat", "") in ["cpu_op", "user_annotation"]
         )
 
         return sorted(
-            e.get("args" , "{}").get("Record function id" , -1) for e in ops_and_annoations
+            e.get("args", "{}").get("Record function id", -1)
+            for e in ops_and_annoations
         )
-    
-    def get_execution_trace_root(self,output_file_name)->Json:
-        import gzip 
+
+    def get_execution_trace_root(self, output_file_name) -> Json:
+        import gzip
 
         nodes = []
-        with(
+        with (
             gzip.open(output_file_name)
             if output_file_name.endswith(".gz")
             else open(output_file_name)
-        )as f:
+        ) as f:
             et_graph = json.load(f)
             if "nodes" not in et_graph:
                 raise AssertionError(f"Expected 'nodes' in execution trace: {et_graph}")
             nodes = et_graph["nodes"]
-        
-        return nodes
-            
 
+        return nodes
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @skipIfHpu
@@ -117,7 +136,6 @@ class TestExecutionTrace(TestCase):
         },
     )
     def test_execution_trace_env_enabled_with_kineto(self, device="spyre"):
-
         trace_called_num = 0
 
         def trace_handler(p):
@@ -126,34 +144,33 @@ class TestExecutionTrace(TestCase):
 
         use_device = device != "cpu"
 
-        with( 
+        with (
             # Kineto Trace (kt_file — .kineto.json) A timeline of hardware + system events, intended for visualization in tools like Chrome useful for timi
             tempfile.NamedTemporaryFile(
-                mode="w+t",suffix=".kineto.json",delete=False
-            ) as kt ,
-            tempfile.NamedTemporaryFile(                      # <-- A graph of operator calls and their data dependencies, capturing the logical execution structure.useful for deep dive data analysis
+                mode="w+t", suffix=".kineto.json", delete=False
+            ) as kt,
+            tempfile.NamedTemporaryFile(  # <-- A graph of operator calls and their data dependencies, capturing the logical execution structure.useful for deep dive data analysis
                 mode="w+t", suffix=".et.json", delete=False
-            ) as et, 
+            ) as et,
         ):
+            kt_name = kt.name
+            et_name = et.name
 
-            kt_name = kt.name 
-            et_name = et.name 
-        
         et_observer = ExecutionTraceObserver()
         et_observer.register_callback(et_name)
-        
+
         # Uncomment for debugging
         # print("Output kineto = ", kt.name)
         # print("Output ET = ", et.name)
 
         with profile(
-            activities= supported_activities(),
-            schedule= torch.profiler.schedule(
-                skip_first=3 , wait=1 ,warmup=1 , active=2 , repeat=1
+            activities=supported_activities(),
+            schedule=torch.profiler.schedule(
+                skip_first=3, wait=1, warmup=1, active=2, repeat=1
             ),
             on_trace_ready=trace_handler,
             execution_trace_observer=et_observer,
-        )as p:
+        ) as p:
             for idx in range(10):
                 with record_function(f"## LOOP {idx} ##"):
                     self.payload(device, use_device=use_device)
@@ -164,30 +181,30 @@ class TestExecutionTrace(TestCase):
             et_path = p.execution_trace_observer.get_output_file_path()
 
             # et_res_path should be an empty directory and for spyre pytorch 2.12 update required verfied
-            #et_res_path = p.execution_trace_observer.get_resources_dir(et_path) 
-            #self.assertTrue(os.path.isdir(et_res_path))
-            #self.assertEqual(len(os.listdir(et_res_path)), 0)
-        
-        #only one cycle has ran 
-        self.assertEqual(trace_called_num , 1)
+            # et_res_path = p.execution_trace_observer.get_resources_dir(et_path)
+            # self.assertTrue(os.path.isdir(et_res_path))
+            # self.assertEqual(len(os.listdir(et_res_path)), 0)
+
+        # only one cycle has ran
+        self.assertEqual(trace_called_num, 1)
         # the path should be set up due to our env variables
         self.assertTrue(et_path is not None)
         # Compare the collected Execution Trace and Kineto Trace
         # in terms of record func
         nodes = self.get_execution_trace_root(et_path)
-        #print(nodes)
+        # print(nodes)
         loop_count = 0
-        found_root_node = False 
+        found_root_node = False
         for n in nodes:
             if "name" not in n:
                 raise AssertionError(f"Expected node to have 'name': {n}")
             if "[pytorch|profiler|execution_trace|process]" in n["name"]:
                 found_root_node = True
-            if n["name"].startswith('## LOOP '):
-                loop_count +=1
+            if n["name"].startswith("## LOOP "):
+                loop_count += 1
         self.assertTrue(found_root_node)
         # Since profiler trace is active for 2 iteration
-        self.assertEqual(loop_count , 2)
+        self.assertEqual(loop_count, 2)
 
         # Compare the collected Execution Trace and Kineto Trace
         # in terms of record func ID (rf_id) and External IDs
@@ -196,17 +213,17 @@ class TestExecutionTrace(TestCase):
         with open(kt_name) as f:
             kineto = json.load(f)
             events = kineto["traceEvents"]
-        
+
         os.remove(kt_name)
 
         rf_ids_et = self.get_execution_trace_rf_ids(nodes)
         rf_ids_kineto = self.get_kineto_rf_ids(events)
-        print(len(rf_ids_kineto) , len(rf_ids_et))
-        self.assertCountEqual(rf_ids_et,rf_ids_kineto)
+        print(len(rf_ids_kineto), len(rf_ids_et))
+        self.assertCountEqual(rf_ids_et, rf_ids_kineto)
         self.assertListEqual(
             rf_ids_et,
             rf_ids_kineto,
-            msg = f"ET and kineto rf_id should exactly match\n"
+            msg=f"ET and kineto rf_id should exactly match\n"
             f"  rf_ids_et = {rf_ids_et}\n"
-            f" rf_ids_kineto = {rf_ids_kineto}\n"
+            f" rf_ids_kineto = {rf_ids_kineto}\n",
         )

--- a/tests/profiler/test_execution_trace.py
+++ b/tests/profiler/test_execution_trace.py
@@ -30,7 +30,6 @@ from torch.autograd import (
 import tempfile
 import os
 from torch.profiler import (
-    ExecutionTraceObserver,
     supported_activities,
     record_function,
     kineto_available,
@@ -149,19 +148,11 @@ class TestExecutionTrace(TestCase):
             tempfile.NamedTemporaryFile(
                 mode="w+t", suffix=".kineto.json", delete=False
             ) as kt,
-            tempfile.NamedTemporaryFile(  # <-- A graph of operator calls and their data dependencies, capturing the logical execution structure.useful for deep dive data analysis
-                mode="w+t", suffix=".et.json", delete=False
-            ) as et,
         ):
             kt_name = kt.name
-            et_name = et.name
-
-        et_observer = ExecutionTraceObserver()
-        et_observer.register_callback(et_name)
 
         # Uncomment for debugging
         # print("Output kineto = ", kt.name)
-        # print("Output ET = ", et.name)
 
         with profile(
             activities=supported_activities(),
@@ -169,21 +160,20 @@ class TestExecutionTrace(TestCase):
                 skip_first=3, wait=1, warmup=1, active=2, repeat=1
             ),
             on_trace_ready=trace_handler,
-            execution_trace_observer=et_observer,
         ) as p:
             for idx in range(10):
                 with record_function(f"## LOOP {idx} ##"):
                     self.payload(device, use_device=use_device)
                 p.step()
 
-            p.export_chrome_trace(kt_name)
+        p.export_chrome_trace(kt_name)
 
-            et_path = p.execution_trace_observer.get_output_file_path()
+        et_path = p.execution_trace_observer.get_output_file_path()
 
-            # et_res_path should be an empty directory and for spyre pytorch 2.12 update required verfied
-            # et_res_path = p.execution_trace_observer.get_resources_dir(et_path)
-            # self.assertTrue(os.path.isdir(et_res_path))
-            # self.assertEqual(len(os.listdir(et_res_path)), 0)
+        # et_res_path should be an empty directory and for spyre pytorch 2.12 update required verfied
+        # et_res_path = p.execution_trace_observer.get_resources_dir(et_path)
+        # self.assertTrue(os.path.isdir(et_res_path))
+        # self.assertEqual(len(os.listdir(et_res_path)), 0)
 
         # only one cycle has ran
         self.assertEqual(trace_called_num, 1)
@@ -218,7 +208,6 @@ class TestExecutionTrace(TestCase):
 
         rf_ids_et = self.get_execution_trace_rf_ids(nodes)
         rf_ids_kineto = self.get_kineto_rf_ids(events)
-        print(len(rf_ids_kineto), len(rf_ids_et))
         self.assertCountEqual(rf_ids_et, rf_ids_kineto)
         self.assertListEqual(
             rf_ids_et,

--- a/tests/profiler/test_spyre_profiler.py
+++ b/tests/profiler/test_spyre_profiler.py
@@ -14,6 +14,96 @@
 
 import json
 import pytest
+import unittest
+import torch
+import torch.nn.functional as F
+from torch.profiler import profile, ProfilerActivity
+from torch.testing._internal.common_utils import (
+    skipIfTorchDynamo,
+    TemporaryFileName,
+    TestCase,
+)
+
+
+Test_spyre = None
+if hasattr(torch, "spyre"):
+    Test_spyre = torch.spyre.is_available()
+else:
+    Test_spyre = False
+
+
+class TestSpyreProfiler(TestCase):
+    @unittest.skipUnless(Test_spyre, "requires spyre device")
+    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    def test_basic_profile(self):
+        device = "spyre"
+        x = torch.randn(4, device=device)
+
+        with profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.PrivateUse1],
+            with_stack=True,
+        ) as prof:
+            x *= 2
+
+        names = [e.name for e in prof.events()]
+        self.assertTrue("aten::mul_" in names)
+
+    @unittest.skipUnless(Test_spyre, "require spyre device")
+    def test_event_list(self):
+        device = torch.device("spyre")
+        x, y = (torch.rand((4, 4), dtype=torch.float16).to(device) for _ in range(2))
+
+        with profile(with_stack=True) as prof:
+            z = torch.add(x, y)
+            z = F.gelu(z)
+            z = torch.sum(z)
+
+        event_list = torch.autograd.profiler_util.EventList(prof.events())
+
+        with TemporaryFileName(mode="w+") as fname:
+            event_list.export_chrome_trace(fname)
+            with open(fname) as f:
+                json.load(f)
+
+        event_list.table()
+        prof.export_chrome_trace("../../tests/trace_prof.json")
+        event_list.export_chrome_trace("../../tests/trace_event.json")
+
+    @unittest.skipIf(not Test_spyre, "spyre device required")
+    def test_profiler_timestamp_consistency(self):
+        """Verify that FunctionEvent timestamps can reconstruct Chrome trace ts values."""
+        with profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.PrivateUse1]
+        ) as prof:
+            x = torch.randn(32, 32, device="spyre")
+            torch.add(x, x)
+
+        trace_start_ns = prof.profiler.kineto_results.trace_start_ns()
+
+        with TemporaryFileName(mode="w+") as fname:
+            prof.export_chrome_trace(fname)
+            with open(fname) as f:
+                j = json.load(f)
+
+            base_time_ns = j.get("baseTimeNanoseconds", 0)
+
+            fe_mm = next((e for e in prof.events() if e.name == "aten::add"), None)
+            json_mm = next(
+                (
+                    e
+                    for e in j["traceEvents"]
+                    if e["name"] == "aten::add" and e["ph"] == "X"
+                ),
+                None,
+            )
+
+            absolute_ns = int(fe_mm.time_range.start * 1000) + trace_start_ns
+            recovered_ts = (absolute_ns - base_time_ns) / 1000
+            self.assertEqual(
+                recovered_ts,
+                json_mm["ts"],
+                msg="Recovered Chrome trace ts doesn't match Json for aten::add",
+            )
 
 
 def test_package_importable():

--- a/tests/profiler/test_spyre_profiler.py
+++ b/tests/profiler/test_spyre_profiler.py
@@ -66,8 +66,6 @@ class TestSpyreProfiler(TestCase):
                 json.load(f)
 
         event_list.table()
-        prof.export_chrome_trace("../../tests/trace_prof.json")
-        event_list.export_chrome_trace("../../tests/trace_event.json")
 
     @unittest.skipIf(not Test_spyre, "spyre device required")
     def test_profiler_timestamp_consistency(self):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Integrating upstream test cases for profiler and kineto API to be spyre specific

Please describe your changes

test_spyre_profiler.py : 
     Added basic_test_profile : to check aten ops are working
     Added test_event_list.py : to verify event list can be exported as chrome trace
    Added test_profiler_timestamp_consistency : verifying that timestamp is consistent between exported json chrome    trace and the time stamp from kineto results

test_execution_trace.py : 
     Added test_execution_trace_env_enabled_with_kineto : tThis test verifies that the Execution Trace (ET) and Kineto Trace are both generated correctly when profiling is enabled and that they stay consistent with each other by representing the same execution window

#### Which issue(s) this PR is related to:

Please link relevant issues to help with tracking.
Fixes #1249 
<issue link> https://github.com/torch-spyre/torch-spyre/issues/1249
