### PR TITLE
Inductor: fix missing reset in propagate_named_dims()

### DIFF
--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -314,6 +314,7 @@ def propagate_named_dims(
     operations: list[Operation],
 ) -> None:
     """Propagate named dims from annotated inputs through the op graph."""
+    global _enabled
     if not _enabled:
         return
     if len(V.graph.graph_input_names) > 0:
@@ -399,6 +400,8 @@ def propagate_named_dims(
     logger.info("OPS")
     for op in operations:
         _log_op(op)
+    # Reset _enabled so that it does not leak True into the next compilation
+    _enabled = False
 
 
 def _get_hint_scopes(op) -> list[dict[str, int]]:


### PR DESCRIPTION


#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

The propagate_named_dims() function reads the module-level _enabled flag but don't reset it to avoid leaking True into the next compilation.

#### Which issue(s) this PR is related to:

Fixes #2451

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
