### PR TITLE
Keep buffers read by extern kernels out of LX planning

### DIFF
--- a/tests/inductor/test_inductor_ops_lx_planning.py
+++ b/tests/inductor/test_inductor_ops_lx_planning.py
@@ -132,8 +132,6 @@ POINTWISE_TEST_FAILURES = [
     "test_einsum_einsum_67x255_255x128",
     "test_einsum_einsum_67x256_256x128",
     "test_einsum_einsum_67x67_67x67",
-    "test_fallback_1d",
-    "test_fallback_2d",
     "test_fallback_3d",
     # torch.flatten tests - Contiguous access pattern with span of 4 elements
     # within 64-wide padded stick not supported. Requires Mod(d0, ELEMS_PER_STICK)
@@ -176,11 +174,6 @@ POINTWISE_TEST_FAILURES = [
     "test_pad_3d_dim1_right",
     "test_pad_3d_last_dim_right",
     "test_pad_4d_dim0_left",
-    "test_pointwise_binary_op_int64_add_1d",
-    "test_pointwise_binary_op_int64_maximum_1d",
-    "test_pointwise_binary_op_int64_minimum_1d",
-    "test_pointwise_binary_op_int64_mul_1d",
-    "test_pointwise_binary_op_int64_sub_1d",
     "test_qkv_attn_paths_fms_decode_gqa",
     "test_reduce_edge_multidim_keepdim0_sum_large_2d_dim_01_all",
     "test_reduce_edge_multidim_keepdim1_sum_large_2d_dim_01_all",
@@ -286,9 +279,6 @@ REDUCTION_TEST_FAILURES = [
     "test_einsum_einsum_67x255_255x128",
     "test_einsum_einsum_67x256_256x128",
     "test_einsum_einsum_67x67_67x67",
-    "test_fallback_1d",
-    "test_fallback_2d",
-    "test_fallback_3d",
     # torch.flatten tests - Contiguous access pattern with span of 4 elements
     # within 64-wide padded stick not supported. Requires Mod(d0, ELEMS_PER_STICK)
     # support for partially-filled contiguous regions. See PR #1866.
@@ -326,11 +316,6 @@ REDUCTION_TEST_FAILURES = [
     "test_pad_3d_dim1_right",
     "test_pad_3d_last_dim_right",
     "test_pad_4d_dim0_left",
-    "test_pointwise_binary_op_int64_add_1d",
-    "test_pointwise_binary_op_int64_maximum_1d",
-    "test_pointwise_binary_op_int64_minimum_1d",
-    "test_pointwise_binary_op_int64_mul_1d",
-    "test_pointwise_binary_op_int64_sub_1d",
     "test_permute_4d_0_3_1_2",
     "test_permute_4d_0_m2_m1_1",
     "test_pointwise_binary_op_add_67x71x256_67x71x256",

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional
 
 from torch._inductor.ir import (
-    ComputedBuffer, 
+    ComputedBuffer,
     ExternKernel,
     Operation,
     MutationLayoutSHOULDREMOVE,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -17,7 +17,12 @@ import math
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
-from torch._inductor.ir import ComputedBuffer, Operation, MutationLayoutSHOULDREMOVE
+from torch._inductor.ir import (
+    ComputedBuffer, 
+    ExternKernel,
+    Operation,
+    MutationLayoutSHOULDREMOVE,
+)
 from torch._inductor.graph import GraphLowering
 
 from torch_spyre._inductor.pass_utils import (
@@ -100,6 +105,12 @@ class ScratchpadAllocator(ABC):
         for op in graph.operations:
             if not self._op_output_good_for_lx_reuse(op):
                 drop_list.add(op.name)
+
+        # file out buffers read by extern kernels (e.g. eager fallbacks):
+        # these are accessed host-side and must stay in HBM
+        for op in graph.operations:
+            if isinstance(op, ExternKernel):
+                drop_list.update(dep.name for dep in op.get_read_writes().reads)
 
         # filter out core division mismatches
         drop_list.update(


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Buffers consumed by extern kernels (e.g. eager fallbacks) are read on the host, so they must remain in HBM. The scratchpad planner only excluded graph inputs and outputs, so a fused kernel output consumed by a fallback could be pinned to LX. The buffer was then removed from the kernel arg list and the wrapper never allocated it, leaving a dangling reference in the generated code:

    sdsc_fused_add_0.run(buf1, buf3)
    buf5 = torch.ops.spyre.to_dtype_cpu.default(buf4, torch.int64)
    NameError: name 'buf4' is not defined

This affected all int64 binary ops (upcast fp32 -> kernel -> downcast) and CPU fallback chains like exp -> sin -> exp.

Drop buffers read by ExternKernel ops from LX planning candidates, mirroring HBM pool planning, which already counts only compute-node reads.

Un-skip the fallback and int64 binary op tests in both LX planning two-op wrap classes. test_fallback_3d stays skipped (pointwise): fp16 numerical mismatch (1/32768 elements), unrelated to this fix.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
