### PR TITLE
Enable coarse tiling by default

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -90,7 +90,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -132,7 +131,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -192,7 +190,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -251,7 +248,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -333,7 +329,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": True,
             "lx_planning": True,
@@ -397,7 +392,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "unroll_loops": True,
             "sencores": 1,
             "lx_planning": True,
@@ -444,7 +438,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -525,7 +518,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -573,7 +565,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -624,7 +615,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -675,7 +665,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -729,7 +718,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
         }
@@ -755,7 +743,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
     # Matmul with row-tiling: tile the M dimension of x @ y
     # ------------------------------------------------------------------
 
-    @config.patch({"coarse_tiling": True})
     def test_hint_matmul_row_tiling(self):
         """spyre_hint(num_tiles_per_dim={"M": 4}) tiles matmul over the row (M) dimension."""
         from torch_spyre._inductor import spyre_hint
@@ -778,7 +765,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             fn, x, y, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
         )
 
-    @config.patch({"coarse_tiling": True})
     def test_hint_flash_attention(self):
         """Flash attention tiled over H (4 slices) and Lk (2 slices) via nested spyre_hints."""
         import math
@@ -846,7 +832,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
             msg=lambda msg: f"compiled spyre <-> cpu mismatch\n\n{msg}\n",
         )
 
-    @config.patch({"coarse_tiling": True})
     def test_hint_h_tiling_elementwise(self):
         """spyre_hint(num_tiles_per_dim={"H": 2}) tiles elementwise multiply over the H dimension.
 
@@ -898,7 +883,6 @@ class TestNamedDimsHint(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
@@ -938,7 +922,6 @@ class TestNamedDimsHint(InductorTestCase):
 
     @config.patch(
         {
-            "coarse_tiling": True,
             "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -40,8 +40,6 @@ core_id_k_fast_emission: bool = (
     os.environ.get("SPYRE_CORE_ID_K_FAST_EMISSION", "1") == "1"
 )
 
-coarse_tiling: bool = os.environ.get("COARSE_TILING", "0") == "1"
-
 # When True, HBM tensor addresses are emitted as runtime symbols (%sym_N
 # constants) in bundle.mlir and resolved via affine.apply for tiled loops.
 # Requires backend compiler support for the sdscbundle symbol table, which is

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -213,7 +213,7 @@ class CustomPreFusionPasses(CustomNodePassBase):
 
     def get_passes(self):
         # build_loop_scheduler_nodes runs unconditionally: it is a no-op when
-        # coarse_tiling=False because no nodes carry loop_group_id attributes.
+        # no ops carry loop_group_id attributes (i.e. no spyre_hint annotations).
         # Running here (before Inductor's fusion pass) ensures CountedLoopSchedulerNodes
         # are visible to SuperDSCScheduling.can_fuse_vertical/horizontal (which return
         # False), so loop groups survive Inductor fusion intact.
@@ -264,9 +264,8 @@ class CustomPreSchedulingPasses(CustomGraphPass):
             chunk_large_tensors(operations)
         propagate_named_dims(operations)
         assign_dim_hints(operations)
-        if config.coarse_tiling:
-            groups = hints_to_coarse_tile_groups(operations)
-            coarse_tile(operations, groups=groups)
+        groups = hints_to_coarse_tile_groups(operations)
+        coarse_tile(operations, groups=groups)
         span_reduction(operations)
         cost_model_ops = cost_model_matmul_division(operations)
         work_distribution(operations, cost_model_ops)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -265,12 +265,15 @@ class CustomPreSchedulingPasses(CustomGraphPass):
         dedup_and_promote_constants(operations)
 
         # Working Set Reduction
+        if config.chunk_large_tensors:
+            # TODO: chunk_large_tensors needs to be integrated with hint-based working set reduction
+            chunk_large_tensors(operations)
+
         propagate_named_dims(operations)
         assign_dim_hints(operations)
         groups = hints_to_coarse_tile_groups(operations)
-        if config.chunk_large_tensors:
-            chunk_large_tensors(operations)
-        coarse_tile(operations, groups=groups)
+        if groups:
+            coarse_tile(operations, groups=groups)
 
         # Core Division and Scratchpad Allocation
         span_reduction(operations)

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -254,18 +254,25 @@ class CustomPreSchedulingPasses(CustomGraphPass):
             logger.info("BEFORE PRE-SCHEDULING\n%s", _format_operations(operations))
 
         deadcode_elimination(operations)
+
+        # Tensor Layout Assignment
         propagate_spyre_tensor_layouts(operations)
         optimize_restickify_locations(operations)
         finalize_layouts(operations)
         insert_restickify(operations)
         insert_bmm_padding(operations)
+
         dedup_and_promote_constants(operations)
-        if config.chunk_large_tensors:
-            chunk_large_tensors(operations)
+
+        # Working Set Reduction
         propagate_named_dims(operations)
         assign_dim_hints(operations)
         groups = hints_to_coarse_tile_groups(operations)
+        if config.chunk_large_tensors:
+            chunk_large_tensors(operations)
         coarse_tile(operations, groups=groups)
+
+        # Core Division and Scratchpad Allocation
         span_reduction(operations)
         cost_model_ops = cost_model_matmul_division(operations)
         work_distribution(operations, cost_model_ops)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md
).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Removes the `coarse_tiling` boolean feature flag and makes the `coarse_tile` IR
pass run unconditionally in `CustomPreSchedulingPasses`.

The pass is already a no-op when no `spyre_hint` annotations are present:
`hints_to_coarse_tile_groups` returns an empty list and `coarse_tile(operations,
groups=[])` does nothing.  Keeping an opt-in flag around a pass that is
harmless when inactive adds unnecessary friction for anyone writing tests or
using the compiler.

Changes:

- **`config.py`** — delete `coarse_tiling: bool = os.environ.get("COARSE_TILING", "0") == "1"`.
- **`passes.py`** — unwrap the `if config.coarse_tiling:` guard so the two-line
  call runs at the same level as the surrounding passes; update the stale
  comment in `CustomPreFusionPasses.get_passes` that still referenced
  `coarse_tiling=False`.
- **`test_coarse_tile_e2e.py`** — strip `"coarse_tiling": True` from 14
  multi-key `@config.patch` decorators and remove the three single-key
  `@config.patch({"coarse_tiling": True})` decorators entirely (the three
  tests they guarded now run unconditionally, which is correct).

Design-doc updates (`coarse_tiling_loops.md` and related docs) are deferred to
a follow-up doc-only PR.

#### Which issue(s) this PR is related to:

Part of #1358 

#### Special notes for your reviewer:

`test_hint_no_tiling_baseline` (which asserts that an unannotated function
produces no `LoopSpec(` in the generated source) has no decorator and required
no change — it was already correct because the pass produces an empty groups
list when there are no hints.

#### Does this PR introduce a user-facing change?

No. The pass previously required `COARSE_TILING=1` (or `config.patch`) to
activate; it now activates automatically when `spyre_hint` annotations are
present.  Workloads without `spyre_hint` annotations see no behaviour change.

#### Additional note:
