### PR TITLE
Fix symbolic dimension bug in dtype conversion

### DIFF
--- a/tests/inductor/test_inductor_dtype_scalars.py
+++ b/tests/inductor/test_inductor_dtype_scalars.py
@@ -364,6 +364,57 @@ class TestDatatypeScalarOperations:
         # For large numbers, atol must be large, but rtol is the real gate
         _compare_modes(execution_mode, large_scalar_mul, x, atol=1e25, rtol=1e-3)
 
+    def test_dtype_conversion_with_symbolic_dimensions(self, execution_mode):
+        """
+        Test dtype conversion with symbolic dimensions (dynamic shapes).
+
+        Regression test for propagate_layouts.py line 167 bug where:
+        - Bug: unaligned = stick_dim_size % in_elems_per_stick
+               if unaligned > 0:  # TypeError: cannot determine truth value of Relational
+        - Fix: unaligned = concretize_expr(stick_dim_size % in_elems_per_stick)
+
+        Without the fix, this test fails with:
+        TypeError: cannot determine truth value of Relational: Mod(s53, 64) > 0
+        """
+        import torch._dynamo as dynamo
+
+        # Reset compilation cache
+        dynamo.reset()
+
+        # Force dynamic shapes to trigger symbolic dimension handling
+        original_config = torch._dynamo.config.assume_static_by_default
+        torch._dynamo.config.assume_static_by_default = False
+
+        try:
+
+            @torch.compile(backend="inductor", dynamic=True)
+            def convert_fp16_to_fp32(x):
+                """Dtype conversion with dynamic shapes forces symbolic dimensions"""
+                return x.to(torch.float32)
+
+            # Use large dimension (4096) to ensure symbolic handling during compilation
+            batch_size = 1
+            seq_len = 128
+            hidden_dim = 4096
+
+            # Create input tensor on Spyre device
+            x = cached_randn(
+                (batch_size, seq_len, hidden_dim),
+                dtype=torch.float16,
+                differentiation="symbolic_dim_fp16_to_fp32",
+            ).to(DEVICE)
+
+            # This triggers dtype conversion with symbolic dimensions
+            result = convert_fp16_to_fp32(x)
+
+            # Verify result
+            assert result.shape == x.shape
+            assert result.dtype == torch.float32
+            assert result.device.type == "spyre"
+        finally:
+            # Reset config
+            torch._dynamo.config.assume_static_by_default = original_config
+
 
 @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")
 @pytest.mark.parametrize("execution_mode", ["eager", "compiled"])

--- a/tests/inductor/test_inductor_dtype_scalars.py
+++ b/tests/inductor/test_inductor_dtype_scalars.py
@@ -15,6 +15,7 @@
 import numpy as np
 import pytest
 import torch
+import torch._dynamo as dynamo
 
 from utils_inductor import DEVICE, cached_randn, compare_with_cpu
 
@@ -364,6 +365,7 @@ class TestDatatypeScalarOperations:
         # For large numbers, atol must be large, but rtol is the real gate
         _compare_modes(execution_mode, large_scalar_mul, x, atol=1e25, rtol=1e-3)
 
+    @torch._dynamo.config.patch(assume_static_by_default=False)
     def test_dtype_conversion_with_symbolic_dimensions(self, execution_mode):
         """
         Test dtype conversion with symbolic dimensions (dynamic shapes).
@@ -375,45 +377,38 @@ class TestDatatypeScalarOperations:
 
         Without the fix, this test fails with:
         TypeError: cannot determine truth value of Relational: Mod(s53, 64) > 0
-        """
-        import torch._dynamo as dynamo
 
-        # Reset compilation cache
+        Note: This test verifies the symbolic dimension fix works (no TypeError during
+        compilation). Full numerical correctness testing is blocked by Issue #2185
+        ("anywhere valid" coordinate bug in dtype conversions causing data corruption).
+        """
+        # Reset compilation cache to ensure clean state
         dynamo.reset()
 
-        # Force dynamic shapes to trigger symbolic dimension handling
-        original_config = torch._dynamo.config.assume_static_by_default
-        torch._dynamo.config.assume_static_by_default = False
+        def convert_fp16_to_fp32(x):
+            """Dtype conversion with dynamic shapes forces symbolic dimensions"""
+            return x.to(torch.float32)
 
-        try:
+        # Use large dimensions to ensure symbolic dimension handling is triggered
+        batch_size = 1
+        seq_len = 128
+        hidden_dim = 4096
 
-            @torch.compile(backend="inductor", dynamic=True)
-            def convert_fp16_to_fp32(x):
-                """Dtype conversion with dynamic shapes forces symbolic dimensions"""
-                return x.to(torch.float32)
+        # Create input tensor
+        x = cached_randn(
+            (batch_size, seq_len, hidden_dim),
+            dtype=torch.float16,
+            differentiation="symbolic_dim_fp16_to_fp32",
+        )
 
-            # Use large dimension (4096) to ensure symbolic handling during compilation
-            batch_size = 1
-            seq_len = 128
-            hidden_dim = 4096
-
-            # Create input tensor on Spyre device
-            x = cached_randn(
-                (batch_size, seq_len, hidden_dim),
-                dtype=torch.float16,
-                differentiation="symbolic_dim_fp16_to_fp32",
-            ).to(DEVICE)
-
-            # This triggers dtype conversion with symbolic dimensions
-            result = convert_fp16_to_fp32(x)
-
-            # Verify result
-            assert result.shape == x.shape
-            assert result.dtype == torch.float32
-            assert result.device.type == "spyre"
-        finally:
-            # Reset config
-            torch._dynamo.config.assume_static_by_default = original_config
+        # Test that compilation succeeds without TypeError
+        # (the bug we're fixing would cause: TypeError: cannot determine truth value of Relational)
+        result = _run_spyre(execution_mode, convert_fp16_to_fp32, x)
+        
+        # Verify basic properties (shape, dtype, device)
+        assert result.shape == x.shape, f"Shape mismatch: {result.shape} != {x.shape}"
+        assert result.dtype == torch.float32, f"Dtype mismatch: {result.dtype} != torch.float32"
+        assert result.device.type == "spyre", f"Device mismatch: {result.device.type} != spyre"
 
 
 @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")

--- a/tests/inductor/test_inductor_dtype_scalars.py
+++ b/tests/inductor/test_inductor_dtype_scalars.py
@@ -404,11 +404,15 @@ class TestDatatypeScalarOperations:
         # Test that compilation succeeds without TypeError
         # (the bug we're fixing would cause: TypeError: cannot determine truth value of Relational)
         result = _run_spyre(execution_mode, convert_fp16_to_fp32, x)
-        
+
         # Verify basic properties (shape, dtype, device)
         assert result.shape == x.shape, f"Shape mismatch: {result.shape} != {x.shape}"
-        assert result.dtype == torch.float32, f"Dtype mismatch: {result.dtype} != torch.float32"
-        assert result.device.type == "spyre", f"Device mismatch: {result.device.type} != spyre"
+        assert result.dtype == torch.float32, (
+            f"Dtype mismatch: {result.dtype} != torch.float32"
+        )
+        assert result.device.type == "spyre", (
+            f"Device mismatch: {result.device.type} != spyre"
+        )
 
 
 @pytest.mark.filterwarnings("ignore::torch_spyre.ops.fallbacks.FallbackWarning")

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -837,7 +837,7 @@ def _per_core_view_on_buf(
     has_partial_reduction = any(n > 1 for n in coeff_splits[1].values())
     splits_by_stride: dict[int, tuple[int, "sympy.Symbol"]] = {}
     for sym, split in per_sym.items():
-        host_stride = int(dep.index.coeff(sym))
+        host_stride = concretize_expr(dep.index.coeff(sym))
         if split <= 1 or host_stride == 0:
             continue
         splits_by_stride[host_stride] = (int(split), sym)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -166,7 +166,7 @@ def _single_arg_op_layout(
 
             in_elems_per_stick = get_elem_in_stick(in_layout.dtype)
             stick_dim_size = in_layout.size[-1]
-            unaligned = stick_dim_size % in_elems_per_stick
+            unaligned = concretize_expr(stick_dim_size % in_elems_per_stick)
 
             if unaligned > 0:
                 outer_sizes = [concretize_expr(s) for s in output.size[:-1]]


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup


#### What this PR does:
This PR fixes two related bugs that prevented operations from working with dynamic shapes (symbolic dimensions) when using `torch.compile(dynamic=True)`.

**Problem 1: Layout Propagation (propagate_layouts.py)**
The layout propagation code attempted to evaluate a symbolic expression (`Mod(s53, 64)`) in a boolean context, which is not supported by SymPy and caused a TypeError.

**Solution 1:**
Wrapped the modulo operation result with `concretize_expr()` to evaluate symbolic expressions to concrete values before the boolean comparison. This is consistent with the pattern used elsewhere in the same file (lines 170-171).

**Problem 2: Scratchpad Allocator (pass_utils.py)**
The scratchpad allocator attempted to convert symbolic coefficients (e.g., `s53`, `128*s53`) to integers during buffer stride analysis, which caused a TypeError.

**Solution 2:**
Wrapped the coefficient with concretize_expr() to evaluate symbolic expressions to concrete values before integer conversion. This follows the same pattern as the propagate_layouts.py fix and is consistent with how symbolic expressions are handled throughout the codebase.**Impact:**

**Impact:**
- Enables dtype conversion operations to work with dynamic shapes
- Fixes scratchpad allocation for operations with symbolic dimensions
- Critical for FP8 quantization pipeline with variable batch sizes/sequence lengths
- Generic fix that benefits all operations using dynamic shapes, not just FP8


#### Which issue(s) this PR is related to:
Fixes #2510

The tests in PR https://github.com/torch-spyre/torch-spyre/pull/2401 are failing due to these issues https://github.com/torch-spyre/torch-spyre/actions/runs/27002123094/job/79684888136?pr=2401 that will be resolved by this PR.

<img width="933" height="548" alt="Screenshot 2026-06-05 at 5 13 30 PM" src="https://github.com/user-attachments/assets/f4102972-5b84-4a82-bd3a-796bf99f8fca" />

## Special notes for your reviewer:
Two minimal, surgical changes using the same concretize_expr() pattern:

- **propagate_layouts.py (line 167)**: Added concretize_expr() wrapper
   - Same pattern already used on lines 170-171 in the same function
- **pass_utils.py** (line 833): Added concretize_expr() wrapper
   - Consistent with propagate_layouts.py fix
   - Follows established pattern for symbolic expression handling

New regression test covers both eager and compiled execution modes with large dimensions (4096) to ensure symbolic handling

**Test results:**
   ```bash
   tests/inductor/test_inductor_dtype_scalars.py::TestDatatypeScalarOperations::test_dtype_conversion_with_symbolic_dimensions[eager] PASSED [50%]
   tests/inductor/test_inductor_dtype_scalars.py::TestDatatypeScalarOperations::test_dtype_conversion_with_symbolic_dimensions[compiled] PASSED [100%]
   =========================================================== 2 passed in 7.91s ===========================================================
   ```
   
## Does this PR introduce a user-facing change?

Yes - Users can now use `torch.compile(dynamic=True)` with dtype conversion operations without encountering TypeError. This is particularly important for:
- Models with variable batch sizes or sequence lengths
- FP8 quantization workflows with dynamic shapes
- Any operation that goes through scratchpad allocation with symbolic dimensions

## Additional note:

These bugs were discovered during FP8 dequantization development but represent fundamental issues with symbolic shape handling in two different passes. The fixes ensure torch-spyre can handle dynamic shapes correctly across all operations.

Error 1 manifested as:
```
File "torch_spyre/_inductor/propagate_layouts.py", line 169, in _single_arg_op_layout
    if unaligned > 0:
       ^^^^^^^^^^^^^
TypeError: cannot determine truth value of Relational: Mod(s53, 64) > 0
```

Error 2 manifested as:
```
File "torch_spyre/_inductor/pass_utils.py", line 833, in _per_core_view_on_buf
    host_stride = int(dep.index.coeff(sym))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
torch._inductor.exc.InductorError: TypeError: Cannot convert symbols to int
```

After the fixes, symbolic expressions are properly handled in both locations by using `concretize_expr()` to evaluate them to concrete values before:

 - Boolean comparisons (propagate_layouts.py)
 - Integer conversions (pass_utils.py)

Both fixes follow the same pattern and allow the compilation pipeline to proceed normally with dynamic shapes.