### PR TITLE
inductor: add compute_fp8_scale op for dynamic FP8 quantization

### DIFF
--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -458,3 +458,114 @@ def to_dtype_cpu(input: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
 @to_dtype_cpu.register_fake
 def _(input: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     return torch.empty_like(input, dtype=dtype)
+
+
+@torch.library.custom_op("spyre::qfp8ch", mutates_args=(), device_types="spyre")
+def qfp8ch(input: torch.Tensor) -> torch.Tensor:
+    """
+    Channel-wise FP8 format conversion (pointwise, optimized for matmul).
+
+    Converts input tensor to FP8 E4M3 format with channel-wise semantics.
+    This operation ONLY performs format conversion - scaling must be done separately.
+
+    Args:
+        input: Input tensor (FP16/BF16/FP32) to convert to FP8
+               Should already be scaled and clamped
+
+    Returns:
+        FP8 E4M3 tensor (same shape as input)
+
+    Maps to: deeptools Qfp8ch operation
+    """
+    pass
+
+
+@qfp8ch.register_fake
+def _(input: torch.Tensor) -> torch.Tensor:
+    # Output is FP8 with same shape as input
+    return torch.empty(input.size(), dtype=torch.float8_e4m3fn, device=input.device)
+
+
+@torch.library.custom_op(
+    "spyre::quantize_fp8_with_scale", mutates_args=(), device_types="spyre"
+)
+def quantize_fp8_with_scale(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """
+    Quantize FP16 tensor to FP8 using pre-computed scale.
+
+    Performs four steps:
+    1. Compute inverse scale: inv_scale = 1 / scale (reciprocal, POINTWISE on sfp unit)
+    2. Scale the input: x_scaled = x * inv_scale (POINTWISE)
+    3. Clamp to FP8 E4M3 range: x_clamped = clamp(x_scaled, -448, 448) (POINTWISE)
+    4. Convert to FP8 format: x_fp8 = qfp8ch(x_clamped) (POINTWISE format conversion)
+
+    Args:
+        input: Input tensor (FP16) to quantize, shape [batch, seq, hidden]
+        scale: Quantization scale (FP16), shape [batch, seq, 1]
+
+    Returns:
+        FP8 E4M3 tensor (same shape as input)
+
+    Example:
+        >>> x = torch.randn(2, 4, 8, dtype=torch.float16, device='spyre')
+        >>> x_fp8 = torch.ops.spyre.quantize_fp8_with_scale(x, scale)
+
+    Note:
+        - Uses reciprocal operation (hardware sfp unit) for 1/scale computation
+    """
+    pass
+
+
+@quantize_fp8_with_scale.register_fake
+def _(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    # Output is FP8 with same shape as input
+    return torch.empty(input.size(), dtype=torch.float8_e4m3fn, device=input.device)
+
+
+@torch.library.custom_op(
+    "spyre::dequantize_fp8_with_scale", mutates_args=(), device_types="spyre"
+)
+def dequantize_fp8_with_scale(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:  # type: ignore[empty-body]
+    """
+    Dequantize FP8 tensor to FP16 using pre-computed scale.
+    Performs two steps:
+    1. Convert FP8 to FP16: x_fp16 = fp8todl16(x) (dtype conversion)
+    2. Scale the output: x_scaled = x_fp16 * scale (POINTWISE)
+    Args:
+        input: Input tensor (FP8) to dequantize, shape [batch, seq, hidden]
+        scale: Dequantization scale (FP16), shape [batch, seq, 1]
+    Returns:
+        FP16 tensor (same shape as input)
+    Example:
+        >>> @torch.compile(backend='inductor')
+        >>> def dequant(x_fp8, scale):
+        >>>     return torch.ops.spyre.dequantize_fp8_with_scale(x_fp8, scale)
+    Note:
+        - MUST use torch.compile(backend='inductor') - does not work in eager mode
+        - Uses fp8todl16 operation for FP8→FP16 conversion
+        - Scale must be FP16, NOT FP32
+    """
+    pass
+
+
+@dequantize_fp8_with_scale.register_fake
+def _(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    # Output is FP16 with same shape as input
+    return torch.empty(input.size(), dtype=torch.float16, device=input.device)
+
+
+@torch.library.custom_op(
+    "spyre::compute_fp8_scale", mutates_args=(), device_types="spyre"
+)
+def compute_fp8_scale(input: torch.Tensor) -> torch.Tensor:  # type: ignore[empty-body]
+    """
+    Compute per-tensor FP8 quantization scale from FP16 input.
+    scale = max(|input|) / FP8_MAX  where FP8_MAX = 448.0
+    Returns a scalar FP16 tensor.
+    """
+    pass
+
+
+@compute_fp8_scale.register_fake
+def _(input: torch.Tensor) -> torch.Tensor:
+    return torch.empty((), dtype=torch.float16, device=input.device)

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -692,6 +692,25 @@ def sub_with_alpha(
         return torch.sub(self, scaled_other)
 
 
+# Register decomposition for custom spyre op (not aten, so use decomp.register_decomposition directly)
+@decomp.register_decomposition(
+    [torch.ops.spyre.dequantize_fp8_with_scale], spyre_decompositions
+)
+def dequantize_fp8_with_scale_decomp(
+    input: torch.Tensor, scale: torch.Tensor
+) -> torch.Tensor:
+    """
+    Decompose dequantize_fp8_with_scale into:
+    1. FP8→FP16 conversion using .to() (triggers fp8todl16 via dtype_ops)
+    2. Multiply by scale
+
+    This decomposition is executed during compilation and removes the custom op
+    from the graph before lowering.
+    """
+    x_fp16 = input.to(torch.float16)
+    return x_fp16 * scale
+
+
 @register_spyre_decomposition([torch.ops.aten.where.ScalarOther])
 def where_scalar_other_decomp(condition, self, other):
     other_t = torch.full_like(self, other)
@@ -736,3 +755,18 @@ def where_scalar_decomp(condition, self, other):
 # called directly; outside (eager mode) the pre-compiled wrapper is used.
 # Note: This has to stay at the end of the file.
 _register_spyre_dispatchkey_kernels_permanently()
+
+
+@decomp.register_decomposition(
+    [torch.ops.spyre.compute_fp8_scale], spyre_decompositions
+)
+def compute_fp8_scale_decomp(input: torch.Tensor) -> torch.Tensor:
+    """
+    Decompose compute_fp8_scale into:
+    1. abs(input)
+    2. amax over all dims
+    3. divide by FP8_MAX (448.0)
+    """
+    FP8_MAX = torch.tensor(448.0, dtype=torch.float16, device=input.device)
+    abs_max = torch.amax(input.abs())
+    return (abs_max / FP8_MAX).to(torch.float16)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -326,6 +326,25 @@ def lower_scaled_mm(
 
     result.realize()
 
+    # Apply activation scale (per-token)
+    if scale_a is not None:
+        scale_a.realize()
+        result = lowering.mul(result, scale_a)
+        result.realize()
+
+    # Apply weight scale (per-channel)
+    if scale_b is not None:
+        scale_b.realize()
+        result = lowering.mul(result, scale_b)
+        result.realize()
+
+    if bias is not None:
+        logger.warning("bias parameter in _scaled_mm is not yet supported")
+    if scale_result is not None:
+        logger.warning("scale_result parameter in _scaled_mm is not yet supported")
+    if use_fast_accum:
+        logger.warning("use_fast_accum parameter in _scaled_mm is not yet supported")
+
     if logger.isEnabledFor(logging.DEBUG):
         result_buf = V.graph.get_buffer(result.get_name())
         logger.debug(


### PR DESCRIPTION
- Add spyre::compute_fp8_scale custom op that computes amax(|x|)/448 on-device for dynamic FP8 quantization scale computation
- Decompose into abs + amax + div (all existing Spyre ops, no new hardware op needed)
- Remove Unsupported guards for scale_a/scale_b in lower_scaled_mm so output can be multiplied by dequantization scales
- Fix indentation in lower_scaled_mm scale application comment

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
