### PR TITLE
Fix named-dims pass: synthesis gap and cross-test state leak

### DIFF
--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -523,3 +523,5 @@ def assign_dim_hints(graph: GraphLowering) -> None:
                         f"  split_count={h.split_count}  -> {per_tile} per tile"
                         f"  loop_var={h.loop_var}{reduction_tag}"
                     )
+
+    _named_dims.clear()

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -323,101 +323,103 @@ def _log_op(op: Operation) -> None:
     logger.info("")
 
 
+def _propagate_named_dims_impl(graph: GraphLowering) -> None:
+    operations = graph.operations
+    if graph.graph_input_names:
+        for name, real_input in zip(graph.graph_input_names, V.get_real_inputs()):
+            if isinstance(real_input, torch.Tensor):
+                tb = graph.graph_inputs[name]
+                if (
+                    not isinstance(tb, TensorBox)
+                    or not isinstance(tb.data, StorageBox)
+                    or not isinstance(tb.data.data, InputBuffer)
+                ):
+                    raise Unsupported(
+                        f"graph input {name} is not a TensorBox(StorageBox(InputBuffer))"
+                    )
+                layout = tb.data.data.layout
+                if not isinstance(layout, FixedLayout):
+                    raise Unsupported(f"graph input {name} does not have a FixedLayout")
+                tb._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
+                    named_dims=_named_tensor_dims.get(real_input) or []
+                )
+
+    for op in operations:
+        if op.is_no_op():
+            _set_no_named_dims(op)
+        elif isinstance(op, ComputedBuffer):
+            if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+                continue
+            hint = False
+            for hint_dict in get_op_hints(op).values():
+                if "named_dims" in hint_dict:
+                    hint = True
+                    named_dims = hint_dict["named_dims"]
+                    break
+            if hint:
+                coords = op_out_coords(op)
+                loop_var_dims = {
+                    _lone_sym(coord): [dim_name]
+                    for coord, dim_name in zip(coords, named_dims)
+                    if len(coord.free_symbols) == 1
+                }
+                op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
+                    named_dims=named_dims,
+                    loop_var_dims=loop_var_dims,
+                )
+                continue
+            origins: set = getattr(op.data, "origins", set())
+            aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
+            reduction_type = getattr(op.data, "reduction_type", None)
+            logger.debug(
+                f"\n--- {op.get_operation_name()} ({type(op.data).__name__})"
+                f" aten={aten_ops} reduction_type={reduction_type}"
+            )
+            rw = op.get_read_writes()
+            inputs = [d for d in rw.reads if isinstance(d, MemoryDep)]
+            if logger.isEnabledFor(logging.DEBUG):
+                for dep in inputs:
+                    _log_dep_debug("input", dep)
+                for dep in rw.writes:
+                    if isinstance(dep, MemoryDep):
+                        _log_dep_debug("output", dep)
+            if isinstance(op.data, (Pointwise, Reduction)):
+                _compute_named_dims(op, inputs)
+            else:
+                logger.warning(f"unhandled node type {type(op.data)}")
+                _set_no_named_dims(op)
+        elif isinstance(op, SpyreConstantFallback):
+            _set_no_named_dims(op)
+        else:
+            logger.warning(f"unhandled operation type {type(op)}")
+            _set_no_named_dims(op)
+
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("DECLARED DIMS")
+        for name, size in _named_dims.items():
+            logger.info(f"  {name} = {size}")
+
+        logger.info("INPUT TENSORS")
+        for name in graph.graph_input_names:
+            tb = graph.graph_inputs[name]
+            if isinstance(tb, TensorBox):
+                dp = getattr(tb, "_dim_prop_info", None)
+                logger.info(f"  {name}: named_dims={dp.named_dims if dp else []}")
+
+        logger.info("OPS")
+        for op in operations:
+            _log_op(op)
+
+
 def propagate_named_dims(
     graph: GraphLowering,
 ) -> None:
     """Propagate named dims from annotated inputs through the op graph."""
     global _enabled
-    operations = graph.operations
     if not _enabled:
         return
     try:
-        if graph.graph_input_names:
-            for name, real_input in zip(graph.graph_input_names, V.get_real_inputs()):
-                if isinstance(real_input, torch.Tensor):
-                    tb = graph.graph_inputs[name]
-                    if (
-                        not isinstance(tb, TensorBox)
-                        or not isinstance(tb.data, StorageBox)
-                        or not isinstance(tb.data.data, InputBuffer)
-                    ):
-                        raise Unsupported(
-                            f"graph input {name} is not a TensorBox(StorageBox(InputBuffer))"
-                        )
-                    layout = tb.data.data.layout
-                    if not isinstance(layout, FixedLayout):
-                        raise Unsupported(
-                            f"graph input {name} does not have a FixedLayout"
-                        )
-                    tb._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
-                        named_dims=_named_tensor_dims.get(real_input) or []
-                    )
-
-        for op in operations:
-            if op.is_no_op():
-                _set_no_named_dims(op)
-            elif isinstance(op, ComputedBuffer):
-                if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
-                    continue
-                hint = False
-                for hint_dict in get_op_hints(op).values():
-                    if "named_dims" in hint_dict:
-                        hint = True
-                        named_dims = hint_dict["named_dims"]
-                        break
-                if hint:
-                    coords = op_out_coords(op)
-                    loop_var_dims = {
-                        _lone_sym(coord): [dim_name]
-                        for coord, dim_name in zip(coords, named_dims)
-                        if len(coord.free_symbols) == 1
-                    }
-                    op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
-                        named_dims=named_dims,
-                        loop_var_dims=loop_var_dims,
-                    )
-                    continue
-                origins: set = getattr(op.data, "origins", set())
-                aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
-                reduction_type = getattr(op.data, "reduction_type", None)
-                logger.debug(
-                    f"\n--- {op.get_operation_name()} ({type(op.data).__name__})"
-                    f" aten={aten_ops} reduction_type={reduction_type}"
-                )
-                rw = op.get_read_writes()
-                inputs = [d for d in rw.reads if isinstance(d, MemoryDep)]
-                if logger.isEnabledFor(logging.DEBUG):
-                    for dep in inputs:
-                        _log_dep_debug("input", dep)
-                    for dep in rw.writes:
-                        if isinstance(dep, MemoryDep):
-                            _log_dep_debug("output", dep)
-                if isinstance(op.data, (Pointwise, Reduction)):
-                    _compute_named_dims(op, inputs)
-                else:
-                    logger.warning(f"unhandled node type {type(op.data)}")
-                    _set_no_named_dims(op)
-            elif isinstance(op, SpyreConstantFallback):
-                _set_no_named_dims(op)
-            else:
-                logger.warning(f"unhandled operation type {type(op)}")
-                _set_no_named_dims(op)
-
-        if logger.isEnabledFor(logging.INFO):
-            logger.info("DECLARED DIMS")
-            for name, size in _named_dims.items():
-                logger.info(f"  {name} = {size}")
-
-            logger.info("INPUT TENSORS")
-            for name in graph.graph_input_names:
-                tb = graph.graph_inputs[name]
-                if isinstance(tb, TensorBox):
-                    dp = getattr(tb, "_dim_prop_info", None)
-                    logger.info(f"  {name}: named_dims={dp.named_dims if dp else []}")
-
-            logger.info("OPS")
-            for op in operations:
-                _log_op(op)
+        _propagate_named_dims_impl(graph)
     finally:
         _named_tensor_dims.clear()
         _enabled = False

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -231,7 +231,7 @@ def _compute_named_dims(op, inputs):
     if isinstance(op.data, Reduction):
         reduction_sym = get_reduction_dim(inputs[0], out_coords)
         if reduction_sym not in loop_var_dims:
-            size = int(output_dep.ranges[reduction_sym])
+            size = int(inputs[0].ranges[reduction_sym])
             loop_var_dims[reduction_sym] = [
                 _untracked_name(op.get_name(), reduction_sym, size)
             ]

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -217,24 +217,30 @@ def _set_no_named_dims(op):
 def _compute_named_dims(op, inputs):
     loop_var_dims = get_input_named_dims(inputs, op)
     out_coords = op_out_coords(op)
-    if not isinstance(op.data, Reduction):
-        # For pointwise ops, synthesize names for loop vars not covered by any input.
-        # This handles full/zeros_like: their iteration space defines named dims but
-        # their constant value contributes nothing to loop_var_dims.
-        output_dep = next(iter(op.get_read_writes().writes))
-        for coord in out_coords:
-            if coord.free_symbols:
-                sym = _lone_sym(coord)
-                if sym not in loop_var_dims:
-                    size = int(output_dep.ranges[sym])
-                    loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
+    # Synthesize names for loop vars not covered by any input.
+    # This handles full/zeros_like/constant ops whose iteration space defines
+    # named dims but whose constant value contributes nothing to loop_var_dims.
+    output_dep = next(iter(op.get_read_writes().writes))
+    for coord in out_coords:
+        if coord.free_symbols:
+            sym = _lone_sym(coord)
+            if sym not in loop_var_dims:
+                size = int(output_dep.ranges[sym])
+                loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
+    reduction_named_dims = None
+    if isinstance(op.data, Reduction):
+        reduction_sym = get_reduction_dim(inputs[0], out_coords)
+        if reduction_sym not in loop_var_dims:
+            size = int(output_dep.ranges[reduction_sym])
+            loop_var_dims[reduction_sym] = [
+                _untracked_name(op.get_name(), reduction_sym, size)
+            ]
+        reduction_named_dims = loop_var_dims[reduction_sym]
     named_dims = coords_to_named_dims(out_coords, loop_var_dims)
     op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
         named_dims=named_dims,
         loop_var_dims=loop_var_dims,
-        reduction_named_dims=loop_var_dims[get_reduction_dim(inputs[0], out_coords)]
-        if isinstance(op.data, Reduction)
-        else None,
+        reduction_named_dims=reduction_named_dims,
     )
 
 
@@ -325,91 +331,96 @@ def propagate_named_dims(
     operations = graph.operations
     if not _enabled:
         return
-    if len(graph.graph_input_names) > 0:
-        for name, real_input in zip(graph.graph_input_names, V.get_real_inputs()):
-            if isinstance(real_input, torch.Tensor):
-                tb = graph.graph_inputs[name]
-                if (
-                    not isinstance(tb, TensorBox)
-                    or not isinstance(tb.data, StorageBox)
-                    or not isinstance(tb.data.data, InputBuffer)
-                ):
-                    raise Unsupported(
-                        f"graph input {name} is not a TensorBox(StorageBox(InputBuffer))"
+    try:
+        if graph.graph_input_names:
+            for name, real_input in zip(graph.graph_input_names, V.get_real_inputs()):
+                if isinstance(real_input, torch.Tensor):
+                    tb = graph.graph_inputs[name]
+                    if (
+                        not isinstance(tb, TensorBox)
+                        or not isinstance(tb.data, StorageBox)
+                        or not isinstance(tb.data.data, InputBuffer)
+                    ):
+                        raise Unsupported(
+                            f"graph input {name} is not a TensorBox(StorageBox(InputBuffer))"
+                        )
+                    layout = tb.data.data.layout
+                    if not isinstance(layout, FixedLayout):
+                        raise Unsupported(
+                            f"graph input {name} does not have a FixedLayout"
+                        )
+                    tb._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
+                        named_dims=_named_tensor_dims.get(real_input) or []
                     )
-                layout = tb.data.data.layout
-                if not isinstance(layout, FixedLayout):
-                    raise Unsupported(f"graph input {name} does not have a FixedLayout")
-                tb._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
-                    named_dims=_named_tensor_dims.get(real_input) or []
-                )
 
-    for op in operations:
-        if op.is_no_op():
-            _set_no_named_dims(op)
-        elif isinstance(op, ComputedBuffer):
-            if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
-                continue
-            hint = False
-            for hint_dict in get_op_hints(op).values():
-                if "named_dims" in hint_dict:
-                    hint = True
-                    named_dims = hint_dict["named_dims"]
-                    break
-            if hint:
-                coords = op_out_coords(op)
-                loop_var_dims = {
-                    _lone_sym(coord): [dim_name]
-                    for coord, dim_name in zip(coords, named_dims)
-                    if len(coord.free_symbols) == 1
-                }
-                op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
-                    named_dims=named_dims,
-                    loop_var_dims=loop_var_dims,
-                )
-                continue
-            origins: set = getattr(op.data, "origins", set())
-            aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
-            reduction_type = getattr(op.data, "reduction_type", None)
-            logger.debug(
-                f"\n--- {op.get_operation_name()} ({type(op.data).__name__})"
-                f" aten={aten_ops} reduction_type={reduction_type}"
-            )
-            rw = op.get_read_writes()
-            inputs = [d for d in rw.reads if isinstance(d, MemoryDep)]
-            if logger.isEnabledFor(logging.DEBUG):
-                for dep in inputs:
-                    _log_dep_debug("input", dep)
-                for dep in rw.writes:
-                    if isinstance(dep, MemoryDep):
-                        _log_dep_debug("output", dep)
-            if isinstance(op.data, (Pointwise, Reduction)):
-                _compute_named_dims(op, inputs)
-            else:
-                logger.warning(f"unhandled node type {type(op.data)}")
+        for op in operations:
+            if op.is_no_op():
                 _set_no_named_dims(op)
-        elif isinstance(op, SpyreConstantFallback):
-            _set_no_named_dims(op)
-        else:
-            logger.warning(f"unhandled operation type {type(op)}")
-            _set_no_named_dims(op)
+            elif isinstance(op, ComputedBuffer):
+                if isinstance(op.layout, MutationLayoutSHOULDREMOVE):
+                    continue
+                hint = False
+                for hint_dict in get_op_hints(op).values():
+                    if "named_dims" in hint_dict:
+                        hint = True
+                        named_dims = hint_dict["named_dims"]
+                        break
+                if hint:
+                    coords = op_out_coords(op)
+                    loop_var_dims = {
+                        _lone_sym(coord): [dim_name]
+                        for coord, dim_name in zip(coords, named_dims)
+                        if len(coord.free_symbols) == 1
+                    }
+                    op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
+                        named_dims=named_dims,
+                        loop_var_dims=loop_var_dims,
+                    )
+                    continue
+                origins: set = getattr(op.data, "origins", set())
+                aten_ops = [str(n.target) for n in origins if hasattr(n, "target")]
+                reduction_type = getattr(op.data, "reduction_type", None)
+                logger.debug(
+                    f"\n--- {op.get_operation_name()} ({type(op.data).__name__})"
+                    f" aten={aten_ops} reduction_type={reduction_type}"
+                )
+                rw = op.get_read_writes()
+                inputs = [d for d in rw.reads if isinstance(d, MemoryDep)]
+                if logger.isEnabledFor(logging.DEBUG):
+                    for dep in inputs:
+                        _log_dep_debug("input", dep)
+                    for dep in rw.writes:
+                        if isinstance(dep, MemoryDep):
+                            _log_dep_debug("output", dep)
+                if isinstance(op.data, (Pointwise, Reduction)):
+                    _compute_named_dims(op, inputs)
+                else:
+                    logger.warning(f"unhandled node type {type(op.data)}")
+                    _set_no_named_dims(op)
+            elif isinstance(op, SpyreConstantFallback):
+                _set_no_named_dims(op)
+            else:
+                logger.warning(f"unhandled operation type {type(op)}")
+                _set_no_named_dims(op)
 
-    if logger.isEnabledFor(logging.INFO):
-        logger.info("DECLARED DIMS")
-        for name, size in _named_dims.items():
-            logger.info(f"  {name} = {size}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("DECLARED DIMS")
+            for name, size in _named_dims.items():
+                logger.info(f"  {name} = {size}")
 
-        logger.info("INPUT TENSORS")
-        for name in graph.graph_input_names:
-            tb = graph.graph_inputs[name]
-            if isinstance(tb, TensorBox):
-                dp = getattr(tb, "_dim_prop_info", None)
-                logger.info(f"  {name}: named_dims={dp.named_dims if dp else []}")
+            logger.info("INPUT TENSORS")
+            for name in graph.graph_input_names:
+                tb = graph.graph_inputs[name]
+                if isinstance(tb, TensorBox):
+                    dp = getattr(tb, "_dim_prop_info", None)
+                    logger.info(f"  {name}: named_dims={dp.named_dims if dp else []}")
 
-    for op in operations:
-        _log_op(op)
-    # Reset _enabled so that it does not leak True into the next compilation
-    _enabled = False
+            logger.info("OPS")
+            for op in operations:
+                _log_op(op)
+    finally:
+        _named_tensor_dims.clear()
+        _enabled = False
 
 
 def assign_dim_hints(graph: GraphLowering) -> None:

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -52,6 +52,9 @@ _enabled = False
 
 
 def reset():
+    # Full teardown — do NOT call between propagate_named_dims() and
+    # assign_dim_hints(), as assign_dim_hints() still needs _named_dims.
+    # The two passes split cleanup across their own finally blocks.
     global _enabled
     _named_dims.clear()
     _named_tensor_dims.clear()
@@ -425,22 +428,7 @@ def propagate_named_dims(
         _enabled = False
 
 
-def assign_dim_hints(graph: GraphLowering) -> None:
-    """Combine spyre_hint scope annotations with propagated named dimensions.
-
-    Reads the hint scopes (from spyre_hint() context managers in user code,
-    attached to FX nodes via meta["custom"]) and matches hinted dimension names
-    against the named loop variables on each op.  The named loop variables come
-    from propagate_named_dims(), which propagates name_tensor_dims() annotations
-    through the op graph — that pass must run before this one.
-
-    Produces op.dim_hints: a flat list of DimHint, one per hinted dimension,
-    ordered outermost hint scope first.  Consumed by hints_to_coarse_tile_groups
-    to form coarse tiling groups.
-
-    Deletes op._dim_prop_info when done — those fields are only needed here.
-    """
-    operations = graph.operations
+def _assign_dim_hints_impl(operations: list[Operation]) -> None:
     for op in operations:
         if not isinstance(op, ComputedBuffer):
             continue
@@ -526,4 +514,23 @@ def assign_dim_hints(graph: GraphLowering) -> None:
                         f"  loop_var={h.loop_var}{reduction_tag}"
                     )
 
-    _named_dims.clear()
+
+def assign_dim_hints(graph: GraphLowering) -> None:
+    """Combine spyre_hint scope annotations with propagated named dimensions.
+
+    Reads the hint scopes (from spyre_hint() context managers in user code,
+    attached to FX nodes via meta["custom"]) and matches hinted dimension names
+    against the named loop variables on each op.  The named loop variables come
+    from propagate_named_dims(), which propagates name_tensor_dims() annotations
+    through the op graph — that pass must run before this one.
+
+    Produces op.dim_hints: a flat list of DimHint, one per hinted dimension,
+    ordered outermost hint scope first.  Consumed by hints_to_coarse_tile_groups
+    to form coarse tiling groups.
+
+    Deletes op._dim_prop_info when done — those fields are only needed here.
+    """
+    try:
+        _assign_dim_hints_impl(graph.operations)
+    finally:
+        _named_dims.clear()

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -52,9 +52,6 @@ _enabled = False
 
 
 def reset():
-    # Full teardown — do NOT call between propagate_named_dims() and
-    # assign_dim_hints(), as assign_dim_hints() still needs _named_dims.
-    # The two passes split cleanup across their own finally blocks.
     global _enabled
     _named_dims.clear()
     _named_tensor_dims.clear()
@@ -533,4 +530,4 @@ def assign_dim_hints(graph: GraphLowering) -> None:
     try:
         _assign_dim_hints_impl(graph.operations)
     finally:
-        _named_dims.clear()
+        reset()


### PR DESCRIPTION
## Summary

Fixes two bugs in `propagate_named_dims.py` that caused 6 nightly CI failures (#2513):

- **Bug 1 (deterministic):** The loop-var synthesis fallback was gated to non-reduction ops, so reduction ops with unmapped loop vars (e.g. `full` → reduction) crashed at the `coords_to_named_dims` assert or the `reduction_named_dims` KeyError. Removed the gate and added explicit reduction-var synthesis.
- **Bug 2 (state contamination):** Module-level state (`_named_dims`, `_enabled`) was never fully cleaned up — if the pass threw, `_enabled` stayed `True` and subsequent compilations entered with stale mappings. Wrapped the body in `try/finally: reset()`.

## Test plan

- [x] Bug 1: `pytest tests/inductor/test_inductor_ops.py::TestOps::test_full_value_2 --cpu-compile -p no:randomly -q` — now xfails gracefully (no InductorError crash)
- [x] Bug 2: `pytest tests/inductor/test_coarse_tile_e2e.py tests/inductor/test_inductor_ops.py::TestOps::test_topk_2d_k4_dim_minusone --cpu-compile -p no:randomly -q` — 19 passed (no contamination)
- [x] Full inductor suite: `pytest tests/inductor/ --cpu-compile -p no:randomly -q`

Closes #2513

🤖 Generated with [Claude Code](https://claude.com/claude-code)