### PR TITLE
enable layernorm and bug fix

### DIFF
--- a/tests/inductor/test_copy_back_elision.py
+++ b/tests/inductor/test_copy_back_elision.py
@@ -40,7 +40,7 @@ def _assert_copy_back_elided(source: str) -> None:
 
 
 def _assert_copy_back_preserved(source: str) -> None:
-    assert "sdsc_fused_copy" in source
+    assert any("copy_" in line for line in source.splitlines() if "sdsc_fused_" in line)
 
 
 @pytest.mark.parametrize("global_stick_optimizer", [True, False])

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -427,6 +427,11 @@ def generate_sdsc(
         affine_strides = [{} for _ in sdsc_spec.args]
 
         def _start_addr_data(tensor):
+            if "lx" in tensor.allocation:
+                return {
+                    f"[{c}, 0, 0]": str(tensor.start_address)
+                    for c in range(sdsc_spec.num_cores)
+                }
             return {
                 f"[{c}, 0, 0]": str(
                     tensor.start_address

--- a/torch_spyre/_inductor/scratchpad/passes.py
+++ b/torch_spyre/_inductor/scratchpad/passes.py
@@ -160,6 +160,15 @@ class CloneInputNodesPass(ScratchpadOptimizationPass):
         graph.name_to_users[buf_name] = users_of_inp
         graph.name_to_users[new_buf_name] = users_of_new_buf
 
+        # Step 3b: Propagate per-core splits to the clone.
+        # Users share the same per_core_view (pre-checked by core_div_mismatch guard).
+        # op_it_space_splits keys are stride-based coefficients, which are layout-
+        # invariant, so the first user's output_splits transfer without re-keying.
+        # Reduction splits are dropped: the clone is Pointwise with no reduction axis.
+        first_user = buf_users[buf_name][0]
+        user_out_splits, _ = getattr(first_user, "op_it_space_splits", ({}, {}))
+        new_com_buf.op_it_space_splits = (user_out_splits, {})
+
         # Step 4: Hack user nodes' inner_fn
         for old_com_buf in buf_users[buf_name]:
             # hack inner_fn with a nameSwapper ops handler and make a new LoopIR

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -29,12 +29,17 @@ OP_OUTPUT_GOOD_FOR_LX_REUSE = [
     # "clone",
     "exp",
     "sub",
-    # "mul",
+    "mul",
+    "mean",
+    "add",
+    "rsqrt",
 ]
 
 OP_GOOD_FOR_LX_INPLACE = [
     "exp",
     "sub",
+    "add",
+    "rsqrt",
 ]
 
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -26,7 +26,7 @@ OP_OUTPUT_GOOD_FOR_LX_REUSE = [
     "max",
     "amax",
     "sum",
-    "clone",
+    # "clone",
     "exp",
     "sub",
     "mul",

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -26,7 +26,7 @@ OP_OUTPUT_GOOD_FOR_LX_REUSE = [
     "max",
     "amax",
     "sum",
-    # "clone",
+    "clone",
     "exp",
     "sub",
     "mul",


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [X] bug
- [X] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

1. Add needed ops for `layernorm` (`rms_norm` in this case) to the "white list" of LX planning
2. fix a bug in `sdsc` codegen where LX address was treated as HBM address (with offset from core to core). Correct LX address should be the base address without offset.
#### Which issue(s) this PR is related to:

Part of #2413 

#### Special notes for your reviewer:
*NOTE: for some unknown reason, layernorm with LX runs slower than without... *
Without LX
```bash
Op: layernorm  Shape: [[1, 512, 4096]]
Metric                             torch-spyre          sendnn tsp/sendnn
----------------------------------------------------------------------
wall_clock_ms.mean_ms                  5.587          10.521     0.531
cpu_ms.mean_ms                         5.496          10.467     0.525
spyre_ms.mean_ms                       0.525           1.123     0.467
kernel_ms.mean_ms                      0.228           0.124     1.839
memory_transfer_ms.mean_ms             0.297           0.999     0.297
pt_util%                               0.000           0.000        N/A
```

With LX (without input cloning and reuse)
```bash
Op: layernorm  Shape: [[1, 512, 4096]]
Metric                             torch-spyre          sendnn tsp/sendnn
----------------------------------------------------------------------
wall_clock_ms.mean_ms                  5.962          10.985     0.543
cpu_ms.mean_ms                         5.863          10.929     0.536
spyre_ms.mean_ms                       0.688           1.159     0.594
kernel_ms.mean_ms                      0.336           0.125     2.688
memory_transfer_ms.mean_ms             0.352           1.034     0.340
pt_util%                               
```

With LX (with input cloning and reuse)
```bash
Op: layernorm  Shape: [[1, 512, 4096]]
Metric                             torch-spyre          sendnn tsp/sendnn
----------------------------------------------------------------------
wall_clock_ms.mean_ms                  5.203           9.544     0.545
cpu_ms.mean_ms                         5.120           9.487     0.540
spyre_ms.mean_ms                       0.495           0.805     0.615
kernel_ms.mean_ms                      0.181           0.121     1.496
memory_transfer_ms.mean_ms             0.314           0.684     0.459
pt_util%                               0.000           0.000        N/A
```

NOTE: we observed 2X performance degradation when using 3D input (1x512x4096) compared to 2D input (512x4096). **Investigations still on-going** But at least with cloning and re-using the input, LX enabled is not too far from baseline. We will keep `rms_norm` enabled for now while investigating the issue.

#### Does this PR introduce a user-facing change?

#### Additional note:
