### PR TITLE
Create CoarseTileInfo to group ir.Operation additions and include it in formatted IR output.

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -53,6 +53,7 @@ from torch_spyre._inductor.codegen.compute_ops import (
     generate_sdsc,
 )
 from torch_spyre._inductor.codegen.superdsc import SDSCArgs, SDSCSpec, compile_op_spec
+from torch_spyre._inductor.loop_info import CoarseTileInfo
 from torch_spyre._inductor.coarse_tile import coarse_tile, _divide_ranges
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
 from torch_spyre._inductor.scheduler import (
@@ -379,6 +380,33 @@ def _make_tiled_json(idx: int, sym_id: int) -> dict:
             ],
         }
     }
+
+
+# ===========================================================================
+# 0. CoarseTileInfo dataclass
+# ===========================================================================
+
+
+class TestCoarseTileInfo(unittest.TestCase):
+    def test_fields(self):
+        info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[0]],
+        )
+        self.assertEqual(info.loop_group_id, (0,))
+        self.assertEqual(info.loop_count, [Integer(4)])
+        self.assertEqual(info.loop_tiled_dims, [[0]])
+
+    def test_nested(self):
+        info = CoarseTileInfo(
+            loop_group_id=(0, 0),
+            loop_count=[Integer(4), Integer(2)],
+            loop_tiled_dims=[[0], [1]],
+        )
+        self.assertEqual(info.loop_group_id, (0, 0))
+        self.assertEqual(info.loop_count, [Integer(4), Integer(2)])
+        self.assertEqual(info.loop_tiled_dims, [[0], [1]])
 
 
 # ===========================================================================

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -161,8 +161,7 @@ def _make_op(data, name="op0"):
     op.layout = MagicMock()
     op.get_operation_name.return_value = name
     op.get_name.return_value = name
-    del op.loop_group_id
-    del op.loop_count
+    del op.loop_info
     return op
 
 
@@ -221,7 +220,7 @@ def _make_scheduler():
 
 
 def _make_ir_op(loop_group_id=None, loop_count=None, name="op"):
-    """Return a fake ir.Operation optionally stamped with loop attributes.
+    """Return a fake ir.Operation optionally stamped with loop_info.
 
     loop_count must be a list of trip counts (one per nesting level), matching
     the contract stamped by coarse_tile().  A bare Expr is accepted as a
@@ -230,11 +229,14 @@ def _make_ir_op(loop_group_id=None, loop_count=None, name="op"):
     op = MagicMock()
     op.name = name
     if loop_group_id is not None:
-        op.loop_group_id = loop_group_id
-        op.loop_count = loop_count if isinstance(loop_count, list) else [loop_count]
+        counts = loop_count if isinstance(loop_count, list) else [loop_count]
+        op.loop_info = CoarseTileInfo(
+            loop_group_id=loop_group_id,
+            loop_count=counts,
+            loop_tiled_dims=[],
+        )
     else:
-        del op.loop_group_id
-        del op.loop_count
+        del op.loop_info
     return op
 
 
@@ -621,9 +623,7 @@ class TestCoarseTile(unittest.TestCase):
         op = _make_op(data, "op0")
         original = list(data.ranges)
         coarse_tile([op], [])
-        self.assertFalse(
-            hasattr(op, "loop_group_id") and op.loop_group_id != MagicMock()
-        )
+        self.assertFalse(hasattr(op, "loop_info") and op.loop_info != MagicMock())
         self.assertEqual(data.ranges, original)
 
     def test_non_computed_buffer_skipped(self):
@@ -634,7 +634,7 @@ class TestCoarseTile(unittest.TestCase):
             [op_extern, op_computed],
             [([op_extern, op_computed], [(0, Integer(2))])],
         )
-        self.assertEqual(op_computed.loop_group_id, (0,))
+        self.assertEqual(op_computed.loop_info.loop_group_id, (0,))
         self.assertEqual(data.ranges[0], Integer(8))
 
     def test_symbolic_count(self):
@@ -643,7 +643,7 @@ class TestCoarseTile(unittest.TestCase):
         data = _make_pointwise([n])
         op = _make_hinted_op(data, "op0", hints=((0, 0),))
         coarse_tile([op], [([op], [(0, k)])])
-        self.assertEqual(op.loop_count, [k])
+        self.assertEqual(op.loop_info.loop_count, [k])
         self.assertEqual(simplify(data.ranges[0] - n / k), 0)
 
     def test_non_contiguous_group_raises(self):
@@ -683,9 +683,9 @@ class TestCoarseTileNested(unittest.TestCase):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
         coarse_tile([op], [([op], [(1, Integer(4)), (2, Integer(2))])])
-        self.assertEqual(op.loop_group_id, (0, 0))
-        self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
-        self.assertEqual(op.loop_tiled_dims, [[0], [1]])
+        self.assertEqual(op.loop_info.loop_group_id, (0, 0))
+        self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
+        self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [1]])
 
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
@@ -715,14 +715,14 @@ class TestCoarseTileNested(unittest.TestCase):
                 ([op1], [(2, Integer(4)), (3, Integer(2))]),
             ],
         )
-        self.assertEqual(op0.loop_group_id, (0,))
-        self.assertEqual(op0.loop_count, [Integer(4)])
-        self.assertEqual(op0.loop_tiled_dims, [[0]])
+        self.assertEqual(op0.loop_info.loop_group_id, (0,))
+        self.assertEqual(op0.loop_info.loop_count, [Integer(4)])
+        self.assertEqual(op0.loop_info.loop_tiled_dims, [[0]])
         self.assertEqual(d0.ranges[0], Integer(16))
         self.assertEqual(d0.ranges[1], Integer(32))
-        self.assertEqual(op1.loop_group_id, (1, 0))
-        self.assertEqual(op1.loop_count, [Integer(4), Integer(2)])
-        self.assertEqual(op1.loop_tiled_dims, [[0], [1]])
+        self.assertEqual(op1.loop_info.loop_group_id, (1, 0))
+        self.assertEqual(op1.loop_info.loop_count, [Integer(4), Integer(2)])
+        self.assertEqual(op1.loop_info.loop_tiled_dims, [[0], [1]])
         self.assertEqual(d1.ranges[0], Integer(32))
         self.assertEqual(d1.ranges[1], Integer(32))
 
@@ -731,8 +731,8 @@ class TestCoarseTileNested(unittest.TestCase):
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 0)))
         coarse_tile([op], [([op], [(1, Integer(4)), (2, Integer(2))])])
         self.assertEqual(data.ranges[0], Integer(32))
-        self.assertEqual(op.loop_count, [Integer(4), Integer(2)])
-        self.assertEqual(op.loop_tiled_dims, [[0], [0]])
+        self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
+        self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [0]])
 
 
 # ===========================================================================
@@ -1617,9 +1617,11 @@ def _make_tiled_op(name, ranges, loop_group_id, loop_count, loop_tiled_dims):
     op.data = data
     op.get_operation_name.return_value = name
     op.get_name.return_value = name
-    op.loop_group_id = loop_group_id
-    op.loop_count = list(loop_count)
-    op.loop_tiled_dims = [list(d) for d in loop_tiled_dims]
+    op.loop_info = CoarseTileInfo(
+        loop_group_id=loop_group_id,
+        loop_count=list(loop_count),
+        loop_tiled_dims=[list(d) for d in loop_tiled_dims],
+    )
     op.get_read_writes.return_value = _make_rw_with_reads()
     op.origins = OrderedSet()
     return op
@@ -1637,7 +1639,7 @@ def _make_consumer_op(name, reads_buf):
     op.data = data
     op.get_operation_name.return_value = name
     op.get_name.return_value = name
-    del op.loop_group_id
+    del op.loop_info
     op.get_read_writes.return_value = _make_rw_with_reads(reads_buf)
     op.origins = OrderedSet()
     return op
@@ -1655,9 +1657,11 @@ def _make_inside_consumer_op(name, reads_buf, loop_group_id):
     op.data = data
     op.get_operation_name.return_value = name
     op.get_name.return_value = name
-    op.loop_group_id = loop_group_id
-    op.loop_count = [Integer(4)]
-    op.loop_tiled_dims = [[0]]
+    op.loop_info = CoarseTileInfo(
+        loop_group_id=loop_group_id,
+        loop_count=[Integer(4)],
+        loop_tiled_dims=[[0]],
+    )
     op.get_read_writes.return_value = _make_rw_with_reads(reads_buf)
     op.origins = OrderedSet()
     return op
@@ -1799,9 +1803,11 @@ def _make_tiled_reduction_op(
     op.data = data
     op.get_operation_name.return_value = name
     op.get_name.return_value = name
-    op.loop_group_id = loop_group_id
-    op.loop_count = list(loop_count)
-    op.loop_tiled_dims = [list(d) for d in loop_tiled_dims]
+    op.loop_info = CoarseTileInfo(
+        loop_group_id=loop_group_id,
+        loop_count=list(loop_count),
+        loop_tiled_dims=[list(d) for d in loop_tiled_dims],
+    )
     op.get_read_writes.return_value = _make_rw_with_reads()
     op.origins = OrderedSet()
     return op
@@ -1866,7 +1872,11 @@ class TestTiledSymsForSchedNode(unittest.TestCase):
 
         ir_op = MagicMock()
         ir_op.data.ranges = [Integer(r) for r in host_ranges]
-        ir_op.loop_tiled_dims = [[1]]
+        ir_op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[1]],
+        )
 
         snode = MagicMock(spec=SchedulerNode)
         snode.node = ir_op

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -65,6 +65,7 @@ from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
 from .logging_utils import get_inductor_logger
+from .loop_info import CoarseTileInfo
 from .propagate_hints import get_op_hints
 from .pass_utils import op_out_coords
 
@@ -298,7 +299,8 @@ def _check_reduction_tiling_safety(op: ComputedBuffer) -> None:
     assert isinstance(data, Reduction)
 
     n_output_dims = len(data.ranges)
-    loop_tiled_dims: list[list[int]] = getattr(op, "loop_tiled_dims", [])
+    loop_info = getattr(op, "loop_info", None)
+    loop_tiled_dims: list[list[int]] = loop_info.loop_tiled_dims if loop_info else []
     for dims_list in loop_tiled_dims:
         for d in dims_list:
             if d >= n_output_dims:
@@ -317,9 +319,10 @@ def _propagate_tiled_op(
     if isinstance(op.data, Reduction):
         _check_reduction_tiling_safety(op)
 
-    loop_group_id = getattr(op, "loop_group_id", None)
-    if loop_group_id is None:
+    loop_info = getattr(op, "loop_info", None)
+    if loop_info is None:
         return
+    loop_group_id = loop_info.loop_group_id
 
     buf_name = op.get_name()
     outside_consumers, is_graph_output = _find_outside_consumers(
@@ -328,7 +331,7 @@ def _propagate_tiled_op(
 
     # If no dims were tiled (loop_tiled_dims all empty), the op is loop-invariant —
     # mark per_tile_fixed so the unroller reuses the same address each tile.
-    if all(not dims for dims in getattr(op, "loop_tiled_dims", [[]])):
+    if all(not dims for dims in loop_info.loop_tiled_dims):
         from .ir import FixedTiledLayout
 
         if isinstance(op.layout, FixedTiledLayout):
@@ -357,7 +360,8 @@ def _propagate_tiled_op(
         i
         for i, o in enumerate(operations)
         if isinstance(o, ComputedBuffer)
-        and getattr(o, "loop_group_id", (None,))[0] == outer_key
+        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
+        == outer_key
     )
     full_buf = _allocate_full_buffer(op, full_ranges, operations, group_start_idx)
 
@@ -422,8 +426,8 @@ def _find_outside_consumers(
             continue
         if not _reads_buffer(op, buf_name):
             continue
-        gid = getattr(op, "loop_group_id", None)
-        if gid is None or gid[0] != outer_key:
+        li = getattr(op, "loop_info", None)
+        if li is None or li.loop_group_id[0] != outer_key:
             consumers.append(op)
 
     is_graph_output = buf_name in _graph_output_names()
@@ -440,8 +444,8 @@ def _has_inside_consumers(
     for op in operations:
         if not isinstance(op, ComputedBuffer):
             continue
-        gid = getattr(op, "loop_group_id", None)
-        if gid is None or gid[0] != outer_key:
+        li = getattr(op, "loop_info", None)
+        if li is None or li.loop_group_id[0] != outer_key:
             continue
         if _reads_buffer(op, buf_name):
             return True
@@ -469,8 +473,8 @@ def _compute_full_ranges(op: ComputedBuffer) -> list[Expr]:
     ranges by multiplying each tiled dimension back by its loop_count.
     """
     full_ranges = list(op.data.ranges)
-    loop_count: list[Expr] = op.loop_count
-    loop_tiled_dims: list[list[int]] = op.loop_tiled_dims
+    loop_count: list[Expr] = op.loop_info.loop_count
+    loop_tiled_dims: list[list[int]] = op.loop_info.loop_tiled_dims
     for count, dims in zip(loop_count, loop_tiled_dims):
         for d in dims:
             if 0 <= d < len(full_ranges):
@@ -605,9 +609,7 @@ def _insert_copy_op(
     copy_buf.operation_name = copy_name
 
     # Stamp with the same loop metadata so this op is inside the same loop.
-    copy_buf.loop_group_id = tiled_op.loop_group_id  # type: ignore[attr-defined]
-    copy_buf.loop_count = tiled_op.loop_count  # type: ignore[attr-defined]
-    copy_buf.loop_tiled_dims = tiled_op.loop_tiled_dims  # type: ignore[attr-defined]
+    copy_buf.loop_info = tiled_op.loop_info  # type: ignore[attr-defined]
 
     V.graph.name_to_buffer[copy_name] = copy_buf
 
@@ -725,9 +727,11 @@ def _stamp_group(
             op_tiled_dims.append(effective)
             _divide_ranges(op, count, effective)
 
-        op.loop_group_id = nested_group_id  # type: ignore[attr-defined]
-        op.loop_count = counts  # type: ignore[attr-defined]
-        op.loop_tiled_dims = op_tiled_dims  # type: ignore[attr-defined]
+        op.loop_info = CoarseTileInfo(  # type: ignore[attr-defined]
+            loop_group_id=nested_group_id,
+            loop_count=counts,
+            loop_tiled_dims=op_tiled_dims,
+        )
 
         logger.debug(
             "coarse_tile: stamped %s loop_group_id=%s loop_count=%s loop_tiled_dims=%s",

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -1,0 +1,74 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coarse-tiling loop metadata attached to ir.Operation objects.
+
+``CoarseTileInfo`` is stamped onto ``ComputedBuffer`` ops by ``coarse_tile()``
+and consumed by the scheduler, kernel codegen, and buffer-propagation pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import sympy
+
+if TYPE_CHECKING:
+    from torch._inductor.ir import ComputedBuffer
+
+
+@dataclass
+class CoarseTileInfo:
+    """Loop metadata stamped on a ``ComputedBuffer`` by the coarse-tiling pass.
+
+    Attributes
+    ----------
+    loop_group_id:
+        Tuple encoding the nesting path, e.g. ``(0,)`` for an outermost
+        group, ``(0, 0)`` for a nested group inside group 0.
+    loop_count:
+        List of trip counts, one per nesting level from outermost to
+        innermost.  ``len(loop_count) == len(loop_group_id)`` always holds.
+    loop_tiled_dims:
+        List of lists, one sub-list per nesting level.  Each sub-list
+        contains the ``data.ranges`` positional indices that are tiled at
+        that level.  An empty sub-list means the op is loop-invariant at
+        that level.
+    """
+
+    loop_group_id: tuple[int, ...]
+    loop_count: list[sympy.Expr]
+    loop_tiled_dims: list[list[int]]
+
+
+# ---------------------------------------------------------------------------
+# Op-metadata helpers
+# ---------------------------------------------------------------------------
+
+_SPYRE_METADATA_ATTRS = (
+    "dim_hints",
+    "loop_info",
+)
+
+
+def copy_op_metadata(src: "ComputedBuffer", dst: "ComputedBuffer") -> None:
+    """Copy all Spyre pass metadata from src to dst.
+
+    Call this whenever a pass reconstructs a ComputedBuffer to ensure
+    dim_hints and coarse-tiling attrs are not silently dropped.
+    """
+    for attr in _SPYRE_METADATA_ATTRS:
+        if hasattr(src, attr):
+            setattr(dst, attr, getattr(src, attr))

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -23,9 +23,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import sympy
-
 if TYPE_CHECKING:
+    import sympy
     from torch._inductor.ir import ComputedBuffer
 
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -43,6 +43,7 @@ from .codegen.superdsc import (
 from .constants import BATCH_MATMUL_OP, ELIDED_COPY_BACK_ATTR
 from .ir import FixedTiledLayout, SpyreConstantFallback
 from .logging_utils import get_inductor_logger
+from .loop_info import _SPYRE_METADATA_ATTRS, copy_op_metadata  # noqa: F401
 from .views import compute_coordinates, matching_dim
 
 logger = get_inductor_logger("pass_utils")
@@ -461,25 +462,6 @@ def copy_fx_custom_meta(src: "torch.fx.Node", dst: "torch.fx.Node") -> None:
     """
     if "custom" in src.meta:
         dst.meta["custom"] = src.meta["custom"]
-
-
-_SPYRE_METADATA_ATTRS = (
-    "dim_hints",
-    "loop_group_id",
-    "loop_count",
-    "loop_tiled_dims",
-)
-
-
-def copy_op_metadata(src: ComputedBuffer, dst: ComputedBuffer) -> None:
-    """Copy all Spyre pass metadata from src to dst.
-
-    Call this whenever a pass reconstructs a ComputedBuffer to ensure
-    dim_hints and coarse-tiling attrs are not silently dropped.
-    """
-    for attr in _SPYRE_METADATA_ATTRS:
-        if hasattr(src, attr):
-            setattr(dst, attr, getattr(src, attr))
 
 
 def replace_computed_buffer_body(

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -43,7 +43,7 @@ from .codegen.superdsc import (
 from .constants import BATCH_MATMUL_OP, ELIDED_COPY_BACK_ATTR
 from .ir import FixedTiledLayout, SpyreConstantFallback
 from .logging_utils import get_inductor_logger
-from .loop_info import _SPYRE_METADATA_ATTRS, copy_op_metadata  # noqa: F401
+from .loop_info import copy_op_metadata
 from .views import compute_coordinates, matching_dim
 
 logger = get_inductor_logger("pass_utils")

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -89,6 +89,10 @@ def _format_operations(operations: list[Operation]) -> str:
                     splits, write_index, read_index, it_space
                 )
                 buf.write(f"\n  op_it_space_splits={readable_splits}")
+            if dim_hints := getattr(op, "dim_hints", None):
+                buf.write(f"\n  dim_hints={dim_hints}")
+            if loop_info := getattr(op, "loop_info", None):
+                buf.write(f"\n  loop_info={loop_info}")
             buf.write(f"\n  {op.data}")
         buf.write("\n\n")
     return buf.getvalue()

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -67,8 +67,11 @@ def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -
     ir_op = sched_node.node
     if ir_op is None:
         return []
-    raw = getattr(ir_op, "loop_tiled_dims", None)
-    if raw is None or not raw:
+    loop_info = getattr(ir_op, "loop_info", None)
+    if loop_info is None:
+        return []
+    raw = loop_info.loop_tiled_dims
+    if not raw:
         return []
     dims_per_level: list[list[int]] = raw
     if depth >= len(dims_per_level):
@@ -99,8 +102,8 @@ class CountedLoopSchedulerNode(FusedSchedulerNode):
     """A group of SchedulerNodes to be executed inside a counted outer loop.
 
     Produced by build_loop_scheduler_nodes from SchedulerNodes whose
-    underlying ir.Operation has been stamped with loop_group_id and
-    loop_count attributes by the coarse-tiling IR pass.
+    underlying ir.Operation has been stamped with a ``loop_info``
+    (``CoarseTileInfo``) attribute by the coarse-tiling IR pass.
 
     loop_count is the trip count of the loop that directly contains this
     group's operations.  For nested loops, the snodes may themselves
@@ -145,9 +148,9 @@ def _loop_group_id(node: BaseSchedulerNode):
     """Return the loop_group_id of the ir.Operation inside node, or None."""
     for snode in node.get_nodes():
         if isinstance(snode, SchedulerNode) and snode.node is not None:
-            gid = getattr(snode.node, "loop_group_id", None)
-            if gid is not None:
-                return gid
+            loop_info = getattr(snode.node, "loop_info", None)
+            if loop_info is not None:
+                return loop_info.loop_group_id
     return None
 
 
@@ -164,10 +167,10 @@ def _loop_count(node: BaseSchedulerNode, depth: int) -> sympy.Expr:
     """
     for snode in node.get_nodes():
         if isinstance(snode, SchedulerNode) and snode.node is not None:
-            raw = getattr(snode.node, "loop_count", None)
-            if raw is not None:
-                counts: list = raw if isinstance(raw, list) else [raw]
-                gid = getattr(snode.node, "loop_group_id", ())
+            loop_info = getattr(snode.node, "loop_info", None)
+            if loop_info is not None:
+                counts: list = loop_info.loop_count
+                gid = loop_info.loop_group_id
                 # coarse_tile stamps one count per nesting level, so
                 # len(counts) == len(gid) always holds.
                 assert len(counts) == len(gid), (
@@ -231,8 +234,8 @@ def build_loop_scheduler_nodes(
 ) -> list[BaseSchedulerNode]:
     """Pre-fusion pass: wrap loop-group SchedulerNodes into CountedLoopSchedulerNodes.
 
-    Reads loop_group_id and loop_count attributes stamped on ir.Operation
-    objects by the coarse-tiling IR pass.  Nodes without these attributes
+    Reads the ``loop_info`` (``CoarseTileInfo``) attribute stamped on
+    ir.Operation objects by the coarse-tiling IR pass.  Nodes without these attributes
     are passed through unchanged.
 
     loop_group_id is a tuple of ints encoding the nesting path, e.g.

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -455,7 +455,8 @@ class SpyreKernel(Kernel[CSEVariable]):
         # list[list[int]] (nested multi-level, outermost first).  Flatten all
         # levels so that tiled_symbols covers every loop variable from outermost
         # to innermost — matching the loop_vars ordering in bundle.py _emit_specs.
-        raw_tiled_dims: list[list[int]] = getattr(ir_node, "loop_tiled_dims", [])
+        li = getattr(ir_node, "loop_info", None)
+        raw_tiled_dims: list[list[int]] = li.loop_tiled_dims if li is not None else []
         all_tiled_dims = [d for level in raw_tiled_dims for d in level]
         it_space_keys = list(it_space.keys())
         tiled_syms = [


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Consolidates the three bare dynamic attributes stamped on `ir.Operation` objects by the coarse-tiling pass — `loop_group_id`, `loop_count`, and `loop_tiled_dims` — into a single `loop_info: CoarseTileInfo` dataclass attribute.

**New module:** `torch_spyre/_inductor/loop_info.py` introduces the `CoarseTileInfo` dataclass and relocates `_SPYRE_METADATA_ATTRS` / `copy_op_metadata` from `pass_utils.py` (which now re-exports them for backward compatibility).

**Changes by file:**
- `loop_info.py` (new): `CoarseTileInfo` dataclass with `loop_group_id`, `loop_count`, `loop_tiled_dims` fields; `copy_op_metadata`; `_SPYRE_METADATA_ATTRS`.
- `coarse_tile.py`: `_stamp_group` stamps a single `op.loop_info = CoarseTileInfo(...)` instead of three separate attrs; all read sites updated accordingly.
- `pass_utils.py`: removes the local definitions of `_SPYRE_METADATA_ATTRS` and `copy_op_metadata`; imports them from `loop_info`.
- `scheduler.py`: `_loop_group_id`, `_loop_count`, and `_tiled_syms_for_sched_node_at_depth` read via `op.loop_info`; docstrings updated.
- `spyre_kernel.py`: `create_op_spec` reads `loop_tiled_dims` via `op.loop_info`.
- `passes.py`: `_format_operations` now prints `dim_hints` and `loop_info` when present.

No behaviour change — pure structural cleanup.

#### Which issue(s) this PR is related to:

Part of #1358 

#### Special notes for your reviewer:

`copy_op_metadata` was moved from `pass_utils` to `loop_info` because it is the natural owner of the attribute list. `pass_utils` re-exports it so no call-site changes were needed outside this PR.

`_SPYRE_METADATA_ATTRS` now lists `("dim_hints", "loop_info")` — one entry per stamped attribute instead of the previous four — which is the intended simplification.

New log output is:
```
op1: ComputedBuffer
  layout=MutationLayoutSHOULDREMOVE('spyre:0', torch.float16, size=[1024, 4096], stride=[4096, 1])
  op_it_space_splits={d0: 32, d1: 1}
  dim_hints=[DimHint(dim_names=['A'], split_count=2, loop_var=d0, is_reduction=False, hint_id=3), DimHint(dim_names=['B'], split_count=4, loop_var=d1, is_reduction=False, hint_id=4)]
  loop_info=CoarseTileInfo(loop_group_id=(0, 0), loop_count=[2, 4], loop_tiled_dims=[[0], [1]])
  Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0, i1 = index
      tmp0 = ops.load(buf0, i1 + 4096 * i0)
      tmp1 = ops.load(arg2_1, i1 + 4096 * i0)
      tmp2 = tmp0 * tmp1
      return tmp2
  ,
  ranges=[512, 1024],
  origin_node=mul,
  origins=OrderedSet([mul]),
  stack_traces = {,
    File "/home/dgrove/dt-inductor/local-examples/loop_unrolling.py", line 20, in fn,
      z = y * c,
  ,
  }
)
```

#### Does this PR introduce a user-facing change?

No.

#### Additional note: