### PR TITLE
feat (test framework): add platform host architecture pytest marker to test variants dynamically

### DIFF
--- a/tests/oot_test_base_common.py
+++ b/tests/oot_test_base_common.py
@@ -13,6 +13,7 @@ import pytest  # type: ignore
 import torch
 
 from oot_test_constants import (
+    _DYNAMIC_TAG_PREFIXES,
     DEFAULT_FLOATING_PRECISION,
     ENV_TEST_CONFIG,
     MODE_MANDATORY_SUCCESS,
@@ -43,6 +44,7 @@ from oot_upstream_patcher import (
     _OOTOpMarkerPatcher,
     _OOTPrecisionOverridePatcher,
     _OOTNativeDeviceTypesPatcher,
+    _OOTPlatformMarkerPatcher,
 )
 from oot_test_config_models import (
     OOTTestConfig,
@@ -609,6 +611,9 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
         # Dynamically adds pytest marker to each of modules and dtype passed to @modules
         _OOTModuleMarkerPatcher(test).patch()
 
+        # Attaches platform__<arch> marker
+        _OOTPlatformMarkerPatcher(test).patch()
+
         existing_methods = set(cls.__dict__.keys())
         super().instantiate_test(name, test, generic_cls=generic_cls)
         new_methods = set(cls.__dict__.keys()) - existing_methods
@@ -674,7 +679,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
             # patchers attached to this specific instantiated method, and
             # union them with the variant-specific tags so _XML_INJECT_PY
             # only needs to handle one flat tag list per method.
-            _DYNAMIC_PREFIXES = ("op__", "dtype__", "module__")
+
             existing_fn = cls.__dict__.get(method_name)
             dynamic_tags: List[str] = []
             if existing_fn is not None:
@@ -682,7 +687,7 @@ class TorchTestBase(PrivateUse1TestBase):  # type: ignore[name-defined]  # noqa:
                     {
                         m.name
                         for m in getattr(existing_fn, "pytestmark", [])
-                        if any(m.name.startswith(p) for p in _DYNAMIC_PREFIXES)
+                        if any(m.name.startswith(p) for p in _DYNAMIC_TAG_PREFIXES)
                     }
                 )
 

--- a/tests/oot_test_constants.py
+++ b/tests/oot_test_constants.py
@@ -12,6 +12,8 @@ import torch
 
 DEFAULT_FLOATING_PRECISION: float = 1e-3
 
+_DYNAMIC_TAG_PREFIXES = ("op__", "dtype__", "module__", "platform__")
+
 MODE_MANDATORY_SUCCESS = "mandatory_success"
 MODE_XFAIL = "xfail"
 MODE_XFAIL_STRICT = "xfail_strict"

--- a/tests/oot_test_utilities.py
+++ b/tests/oot_test_utilities.py
@@ -7,6 +7,7 @@ oot_test_utilities.py -- Utility functions for the OOT PyTorch test framework.
 from __future__ import annotations
 
 import ast
+import platform as _platform
 import os
 import sys
 import tempfile
@@ -31,6 +32,12 @@ from oot_test_constants import (
     REL_PATH_TOKENS,
 )
 from oot_test_matching import parse_dtype
+
+# Normalise platform.machine() into a safe marker string once at import time.
+_OOT_PLATFORM_ARCH: str = (
+    re.sub(r"[^a-zA-Z0-9_]", "_", _platform.machine() or "unknown").strip("_")
+    or "unknown"
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/oot_upstream_patcher.py
+++ b/tests/oot_upstream_patcher.py
@@ -23,8 +23,10 @@ would not affect these copies.
 
 from typing import Set, Optional
 import torch
+import regex as re
+import pytest  # type: ignore
 
-from oot_test_utilities import _get_privateuse1_device_type
+from oot_test_utilities import _OOT_PLATFORM_ARCH, _get_privateuse1_device_type
 
 # Resolve the registered backend name once at import time.
 # Used in _OOTModuleListPatcher to strip the device suffix when extracting
@@ -588,6 +590,40 @@ class _OOTPrecisionOverridePatcher:
                 self._underlying_fn.precision_overrides[dtype] = atol
 
 
+class _OOTPlatformMarkerPatcher:
+    """Attaches a pytest marker ``platform__<arch>`` to every test variant.
+
+    Unlike op/dtype/module patchers, the platform tag is the same for every
+    variant in a parametrised test, so we patch the underlying function
+    directly rather than wrapping ``parametrize_fn``.
+
+    The marker is applied BEFORE ``super().instantiate_test()`` so that
+    ``instantiate_test`` copies it onto every generated method via
+    ``@wraps`` / ``pytestmark`` propagation.
+
+    Architecture strings are normalised: non-alphanumeric characters are
+    replaced with ``_`` so the marker is always a valid Python identifier.
+    Examples:
+        x86_64  --> platform__x86_64
+        ppc64le --> platform__ppc64le
+        aarch64 --> platform__aarch64
+    """
+
+    def __init__(self, test: object) -> None:
+        self._underlying_fn = (
+            test.__func__ if hasattr(test, "__func__") else test  # type: ignore[union-attr]
+        )
+
+    def patch(self) -> None:
+        mark = pytest.mark.__getattr__(f"platform__{_OOT_PLATFORM_ARCH}")
+
+        # Attach to pytestmark list so @wraps-based propagation carries it
+        # through every decorator layer that instantiate_test applies later.
+        if not hasattr(self._underlying_fn, "pytestmark"):
+            self._underlying_fn.pytestmark = []
+        self._underlying_fn.pytestmark = list(self._underlying_fn.pytestmark) + [mark]
+
+
 class _OOTOpMarkerPatcher:
     """Patches @ops._parametrize_test to attach pytest markers directly on
     each test_wrapper as it is yielded, before super().instantiate_test()
@@ -614,7 +650,6 @@ class _OOTOpMarkerPatcher:
             return
 
         import pytest
-        import regex as re
 
         original_parametrize_fn = self._underlying_fn.parametrize_fn
 
@@ -682,7 +717,6 @@ class _OOTModuleMarkerPatcher:
             return
 
         import pytest
-        import regex as re
 
         original_parametrize_fn = self._underlying_fn.parametrize_fn
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR add platform host architecture pytest marker to test variants dynamically to be able to be filtered in the dashboard

### Verification of correctness
#### Upstream Pytorch Test View Ops 

<img width="2304" height="554" alt="image" src="https://github.com/user-attachments/assets/6b3b284b-f2be-418f-8842-f8748215a87c" /> <br><br>

#### Torch Spyre MatMul 

<img width="2262" height="1104" alt="image" src="https://github.com/user-attachments/assets/94434170-4fdd-443e-a836-598327395633" /> <br><br>

#### Model Ops Tests Granite 

<img width="2300" height="544" alt="image" src="https://github.com/user-attachments/assets/19fbb318-7e94-4698-9544-21a2b019994d" /> <br><br>


#### Module Tests Granite 

<img width="2088" height="838" alt="image" src="https://github.com/user-attachments/assets/a592d0d6-6f79-4eb8-b2ea-bba9b30c715d" />


