### PR TITLE
feat (test framework): feature to mark slow tests in config based on host platform arch

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
@@ -7,7 +7,14 @@ test_suite_config:
             # k_expr: test_addmm or test_mm_ or test_bmm or test_einsum
             #         or test_matmul or test_large_matmul or test_linear
             #
-            - TestOps::test_(addmm|mm|bmm|einsum|matmul|large_matmul|linear).*
+            - TestOps::test_(addmm|mm|bmm|einsum|matmul|linear).*
           mode: mandatory_success
           tags:
             - ops__inductor-matmul
+        - names:
+            - TestOps::test_large_matmul.*
+          mode: mandatory_success
+          tags:
+            - ops__inductor-matmul
+            - slow_ppc64
+            - slow_s390x

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml
@@ -16,5 +16,5 @@ test_suite_config:
           mode: mandatory_success
           tags:
             - ops__inductor-matmul
-            - slow_ppc64
-            - slow_s390x
+            - slow__plat_ppc64
+            - slow__plat_s390x

--- a/tests/oot_upstream_patcher.py
+++ b/tests/oot_upstream_patcher.py
@@ -605,8 +605,9 @@ class _OOTPlatformMarkerPatcher:
     replaced with ``_`` so the marker is always a valid Python identifier.
     Examples:
         x86_64  --> platform__x86_64
-        ppc64le --> platform__ppc64le
+        ppc64le --> platform__ppc64le (Power PC)
         aarch64 --> platform__aarch64
+        s390x    --> platform__s390x (IBM Z)
     """
 
     def __init__(self, test: object) -> None:

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -60,6 +60,31 @@ if [[ $# -lt 1 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# --skip-slow / --include-slow flag parsing
+#
+# Controls whether platform-specific slow tests are skipped or run.
+# Default: include all tests (no filtering).
+#
+# --skip-slow    : skip tests tagged slow__plat_<arch> for the current platform.
+#                  On platforms with no slow tag defined, this is a no-op.
+# --include-slow : explicit no-op (default behaviour, for clarity in scripts).
+#
+# Usage:
+#   run_test.sh config.yaml                 # default: all tests run
+#   run_test.sh config.yaml --include-slow  # same, explicit
+#   run_test.sh config.yaml --skip-slow     # skip slow tests on this platform
+# ---------------------------------------------------------------------------
+_SKIP_SLOW=0
+_FILTERED_ARGS=()
+for _arg in "$@"; do
+    case "$_arg" in
+        --skip-slow)    _SKIP_SLOW=1 ;;
+        --include-slow) _SKIP_SLOW=0 ;;
+        *)              _FILTERED_ARGS+=("$_arg") ;;
+    esac
+done
+set -- "${_FILTERED_ARGS[@]+"${_FILTERED_ARGS[@]}"}"
+# ---------------------------------------------------------------------------
 # Multi-config support
 #
 # Collect all leading positional arguments that are YAML files or directories
@@ -327,35 +352,37 @@ echo "  PYTHONPATH                      = $PYTHONPATH"
 echo ""
 
 # ---------------------------------------------------------------------------
-# Auto-inject slow tag filter for non-x86_64 platforms.
+# Platform-specific slow test filtering.
 #
-# On platforms where large matmul tests are prohibitively slow, automatically
-# skip tests tagged slow_<arch> without requiring any flag from the caller.
-# x86_64 is the baseline CI platform -- no filtering applied there.
+# Slow tests are tagged slow__plat_<arch> in the YAML config.
+# Filtering is opt-in: pass --skip-slow to activate.
+# Default behaviour (no flag): all tests run regardless of platform.
 #
 # To mark a test as slow on a platform, add the tag in the YAML config:
-#   tags: [slow_ppc64]   # skipped automatically on ppc64le
-# WARNING: To add a new platform (e.g. x86_64), BOTH steps must be done
-# together in the same PR:
-#   1. Add the case entry here:   x86_64) _PLATFORM_SLOW_TAG="slow__plat_x86_64" ;;
-#   2. Add the tag in YAML:       tags: [slow__plat_x86_64]
-# Adding the case WITHOUT the YAML tags breaks configs where all listed tests
-# are mode:skip — pytest exits 5 (no tests collected) and CI fails.
-# ---------------------------------------------------------------------------
+#   tags: [slow__plat_ppc64]   # skipped on ppc64le when --skip-slow is passed
 # ---------------------------------------------------------------------------
 _machine="$(uname -m 2>/dev/null || true)"
 case "$_machine" in
-    ppc64*) _PLATFORM_SLOW_TAG="slow__plat_ppc64"  ;;
-    s390x*) _PLATFORM_SLOW_TAG="slow__plat_s390x"  ;;
-    aarch64|arm64) _PLATFORM_SLOW_TAG="slow_aarch64" ;;
-    *)      _PLATFORM_SLOW_TAG="" ;;
+    ppc64*)        _PLATFORM_SLOW_TAG="slow__plat_ppc64"   ;;
+    s390x*)        _PLATFORM_SLOW_TAG="slow__plat_s390x"   ;;
+    x86_64*)        _PLATFORM_SLOW_TAG="slow__plat_x86_64"   ;;
+    aarch64|arm64) _PLATFORM_SLOW_TAG="slow__plat_aarch64" ;;
+    *)             _PLATFORM_SLOW_TAG="" ;;
 esac
 
-if [[ -n "$_PLATFORM_SLOW_TAG" ]]; then
-    echo "[torch_oot_device_tests_run] Platform ${_machine}: auto-skipping tests tagged '${_PLATFORM_SLOW_TAG}'"
-    EXTRA_PYTEST_ARGS+=("-m" "not ${_PLATFORM_SLOW_TAG}")
+if [[ $_SKIP_SLOW -eq 1 ]]; then
+    if [[ -n "$_PLATFORM_SLOW_TAG" ]]; then
+        echo "[torch_oot_device_tests_run] --skip-slow: skipping tests tagged '${_PLATFORM_SLOW_TAG}' on ${_machine}"
+        EXTRA_PYTEST_ARGS+=("-m" "not ${_PLATFORM_SLOW_TAG}")
+    else
+        echo "[torch_oot_device_tests_run] --skip-slow: no slow tag defined for ${_machine}, all tests will run"
+    fi
 else
-    echo "[torch_oot_device_tests_run] Platform ${_machine}: no slow tag defined, all tests will run"
+    if [[ -n "$_PLATFORM_SLOW_TAG" ]]; then
+        echo "[torch_oot_device_tests_run] Platform ${_machine}: slow tag '${_PLATFORM_SLOW_TAG}' exists — pass --skip-slow to skip those tests"
+    else
+        echo "[torch_oot_device_tests_run] Platform ${_machine}: no slow tag defined, all tests will run"
+    fi
 fi
 echo ""
 

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -327,6 +327,32 @@ echo "  PYTHONPATH                      = $PYTHONPATH"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Auto-inject slow tag filter for non-x86_64 platforms.
+#
+# On platforms where large matmul tests are prohibitively slow, automatically
+# skip tests tagged slow_<arch> without requiring any flag from the caller.
+# x86_64 is the baseline CI platform -- no filtering applied there.
+#
+# To mark a test as slow on a platform, add the tag in the YAML config:
+#   tags: [slow_ppc64]   # skipped automatically on ppc64le
+# ---------------------------------------------------------------------------
+_machine="$(uname -m 2>/dev/null || true)"
+case "$_machine" in
+    ppc64*) _PLATFORM_SLOW_TAG="slow_ppc64"  ;;
+    s390x*) _PLATFORM_SLOW_TAG="slow_s390x"  ;;
+    aarch64|arm64) _PLATFORM_SLOW_TAG="slow_aarch64" ;;
+    *)      _PLATFORM_SLOW_TAG="" ;;
+esac
+
+if [[ -n "$_PLATFORM_SLOW_TAG" ]]; then
+    echo "[torch_oot_device_tests_run] Platform ${_machine}: auto-skipping tests tagged '${_PLATFORM_SLOW_TAG}'"
+    EXTRA_PYTEST_ARGS+=("-m" "not ${_PLATFORM_SLOW_TAG}")
+else
+    echo "[torch_oot_device_tests_run] Platform ${_machine}: no slow tag defined, all tests will run"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
 # 5. Extract raw file paths from YAML
 # ---------------------------------------------------------------------------
 _extract_file_paths_from_yaml() {

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -338,9 +338,10 @@ echo ""
 # ---------------------------------------------------------------------------
 _machine="$(uname -m 2>/dev/null || true)"
 case "$_machine" in
-    ppc64*) _PLATFORM_SLOW_TAG="slow_ppc64"  ;;
-    s390x*) _PLATFORM_SLOW_TAG="slow_s390x"  ;;
+    ppc64*) _PLATFORM_SLOW_TAG="slow__plat_ppc64"  ;;
+    s390x*) _PLATFORM_SLOW_TAG="slow__plat_s390x"  ;;
     aarch64|arm64) _PLATFORM_SLOW_TAG="slow_aarch64" ;;
+    x86_64)        _PLATFORM_SLOW_TAG="slow__plat_x86_64"  ;;
     *)      _PLATFORM_SLOW_TAG="" ;;
 esac
 

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -335,13 +335,19 @@ echo ""
 #
 # To mark a test as slow on a platform, add the tag in the YAML config:
 #   tags: [slow_ppc64]   # skipped automatically on ppc64le
+# WARNING: To add a new platform (e.g. x86_64), BOTH steps must be done
+# together in the same PR:
+#   1. Add the case entry here:   x86_64) _PLATFORM_SLOW_TAG="slow__plat_x86_64" ;;
+#   2. Add the tag in YAML:       tags: [slow__plat_x86_64]
+# Adding the case WITHOUT the YAML tags breaks configs where all listed tests
+# are mode:skip — pytest exits 5 (no tests collected) and CI fails.
+# ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 _machine="$(uname -m 2>/dev/null || true)"
 case "$_machine" in
     ppc64*) _PLATFORM_SLOW_TAG="slow__plat_ppc64"  ;;
     s390x*) _PLATFORM_SLOW_TAG="slow__plat_s390x"  ;;
     aarch64|arm64) _PLATFORM_SLOW_TAG="slow_aarch64" ;;
-    x86_64)        _PLATFORM_SLOW_TAG="slow__plat_x86_64"  ;;
     *)      _PLATFORM_SLOW_TAG="" ;;
 esac
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Current make tests and pytests tests don't work properly on PowerPC.

Large matmul tests are prohibitively slow on PowerPC hardware. Add tags from config to auto inject `-m not ${_PLATFORM_SLOW_TAG} ` tag to skip tests marked with `- slow__plat_ppc64` and `- slow__plat_s390x` if `--skip-slow` is passed to `run_test.sh`

```yaml
test_suite_config:
  files:
    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_inductor_ops.py
      unlisted_test_mode: skip
      tests:
        - names:
            - TestOps::test_(addmm|mm|bmm|einsum|matmul|linear).*
          mode: mandatory_success
          tags:
            - ops__inductor-matmul
        - names:
            - TestOps::test_large_matmul.*
          mode: mandatory_success
          tags:
            - ops__inductor-matmul
            - slow__plat_ppc64
            - slow__plat_s390x
            
```
---

## Verification of correctness on x86_64 considering symmetrical behaviour across other hosts.

### Tag (slow__plat_x86_64) defined in the yaml and passed `--skip-slow` to skip tests marked with the specific marker
```bash
 bash run_test.sh configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml -v --skip-slow
 ```
 
 #### Debug log (4 large matmul tests skipped --- 48/52 tests collected)
 ```bash
 [torch_oot_device_tests_run] --skip-slow: skipping tests tagged 'slow__plat_x86_64' on x86_64
 ....
 48/52 tests collected (4 deselected) in 35.18s
[torch_oot_device_tests_run] Running serial test
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /dev/shm/torch-spyre-venv/bin/python3
cachedir: .pytest_cache
rootdir: /dev/shm/dt-inductor/torch-spyre-anu-forked
configfile: pyproject.toml
plugins: anyio-4.13.0, xdist-3.8.0
collected 52 items / 4 deselected / 48 selected  

...
============================================================================== 47 passed, 4 deselected, 1 xfailed in 81.96s (0:01:21) ===============================================================================

[torch_oot_device_tests_run] Done. Overall exit code: 0
[torch_oot_device_tests_run] Cleaned up wrapper: /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/test_inductor_ops__oot_wrapper.py
[torch_oot_device_tests_run] Cleaned up wrapper: /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/__oot_conftest_test_inductor_ops.py
[torch_oot_device_tests_run] Cleaned up marker sidecar: /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml.markers.json
                                                                                                                                                                   
```
 
 ### Tag specified  in config but the flag is not passed to `run_test.sh` (Runs all tests -- default behaviour)
 ```bash
  bash run_test.sh configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml -v
  ```
  
  #### Debug logs (all 52 tests collected)
  ```bash
[torch_oot_device_tests_run] Platform x86_64: slow tag 'slow__plat_x86_64' exists — pass --skip-slow to skip those tests
...
...
collected 52 items  
...
===================================================================================== 51 passed, 1 xfailed in 95.27s (0:01:35) ======================================================================================
[torch_oot_device_tests_run] Done. Overall exit code: 0
[torch_oot_device_tests_run] Cleaned up wrapper: /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/test_inductor_ops__oot_wrapper.py
[torch_oot_device_tests_run] Cleaned up wrapper: /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/__oot_conftest_test_inductor_ops.py
[torch_oot_device_tests_run] Cleaned up marker sidecar: /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml.markers.json
```

