### PR TITLE
inductor: add compute_fp8_scale op for dynamic FP8 quantization

### DIFF
--- a/torch_spyre/_inductor/customops.py
+++ b/torch_spyre/_inductor/customops.py
@@ -458,3 +458,20 @@ def to_dtype_cpu(input: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
 @to_dtype_cpu.register_fake
 def _(input: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     return torch.empty_like(input, dtype=dtype)
+
+
+@torch.library.custom_op(
+    "spyre::compute_fp8_scale", mutates_args=(), device_types="spyre"
+)
+def compute_fp8_scale(input: torch.Tensor) -> torch.Tensor:  # type: ignore[empty-body]
+    """
+    Compute per-tensor FP8 quantization scale from FP16 input.
+    scale = max(|input|) / FP8_MAX  where FP8_MAX = 448.0
+    Returns a scalar FP16 tensor.
+    """
+    pass
+
+
+@compute_fp8_scale.register_fake
+def _(input: torch.Tensor) -> torch.Tensor:
+    return torch.empty((), dtype=torch.float16, device=input.device)

--- a/torch_spyre/_inductor/decompositions.py
+++ b/torch_spyre/_inductor/decompositions.py
@@ -691,7 +691,6 @@ def sub_with_alpha(
         scaled_other = torch.mul(other, alpha)
         return torch.sub(self, scaled_other)
 
-
 @register_spyre_decomposition([torch.ops.aten.where.ScalarOther])
 def where_scalar_other_decomp(condition, self, other):
     other_t = torch.full_like(self, other)
@@ -736,3 +735,18 @@ def where_scalar_decomp(condition, self, other):
 # called directly; outside (eager mode) the pre-compiled wrapper is used.
 # Note: This has to stay at the end of the file.
 _register_spyre_dispatchkey_kernels_permanently()
+
+
+@decomp.register_decomposition(
+    [torch.ops.spyre.compute_fp8_scale], spyre_decompositions
+)
+def compute_fp8_scale_decomp(input: torch.Tensor) -> torch.Tensor:
+    """
+    Decompose compute_fp8_scale into:
+    1. abs(input)
+    2. amax over all dims
+    3. divide by FP8_MAX (448.0)
+    """
+    FP8_MAX = torch.tensor(448.0, dtype=torch.float16, device=input.device)
+    abs_max = torch.amax(input.abs())
+    return (abs_max / FP8_MAX).to(torch.float16)

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -249,12 +249,11 @@ def lower_scaled_mm(
     out_dtype=None,
     use_fast_accum=False,
 ):
-    if scale_a is not None:
-        raise Unsupported("scale_a parameter in _scaled_mm is not yet supported")
-    if scale_b is not None:
-        raise Unsupported("scale_b parameter in _scaled_mm is not yet supported")
+    
     if bias is not None:
-        raise Unsupported("bias parameter in _scaled_mm is not yet supported")
+        bias.realize()
+        result = lowering.add(result, bias)
+        result.realize()
     if scale_result is not None:
         raise Unsupported("scale_result parameter in _scaled_mm is not yet supported")
     if use_fast_accum:

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -337,8 +337,6 @@ def lower_scaled_mm(
         result = lowering.mul(result, scale_b)
         result.realize()
 
-    if bias is not None:
-        logger.warning("bias parameter in _scaled_mm is not yet supported")
     if scale_result is not None:
         logger.warning("scale_result parameter in _scaled_mm is not yet supported")
     if use_fast_accum:

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -326,6 +326,25 @@ def lower_scaled_mm(
 
     result.realize()
 
+    # Apply activation scale (per-token)
+    if scale_a is not None:
+        scale_a.realize()
+        result = lowering.mul(result, scale_a)
+        result.realize()
+
+    # Apply weight scale (per-channel)
+    if scale_b is not None:
+        scale_b.realize()
+        result = lowering.mul(result, scale_b)
+        result.realize()
+
+    if bias is not None:
+        logger.warning("bias parameter in _scaled_mm is not yet supported")
+    if scale_result is not None:
+        logger.warning("scale_result parameter in _scaled_mm is not yet supported")
+    if use_fast_accum:
+        logger.warning("use_fast_accum parameter in _scaled_mm is not yet supported")
+
     if logger.isEnabledFor(logging.DEBUG):
         result_buf = V.graph.get_buffer(result.get_name())
         logger.debug(


### PR DESCRIPTION
- Add spyre::compute_fp8_scale custom op that computes amax(|x|)/448 on-device for dynamic FP8 quantization scale computation
- Decompose into abs + amax + div (all existing Spyre ops, no new hardware op needed)
- Remove Unsupported guards for scale_a/scale_b in lower_scaled_mm so output can be multiplied by dequantization scales
- Fix indentation in lower_scaled_mm scale application comment

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
