### PR TITLE
docs(getting-started): refresh key_concepts and intro article

### DIFF
--- a/docs/source/_static/images/getting-started/ir-levels.svg
+++ b/docs/source/_static/images/getting-started/ir-levels.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 320" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#444"/>
+    </marker>
+    <style>
+      .torch    { fill: #e6f0ff; stroke: #2c5aa0; stroke-width: 1.5; }
+      .kernel   { fill: #fff7e0; stroke: #b88a00; stroke-width: 1.5; }
+      .runtime  { fill: #d6efd6; stroke: #2d7a2d; stroke-width: 1.5; }
+      .label    { fill: #222; }
+      .name     { font-weight: 600; }
+      .sub      { fill: #555; font-size: 11px; font-style: italic; }
+      .arrow    { stroke: #444; stroke-width: 1.5; fill: none; }
+      .title    { fill: #222; font-size: 16px; font-weight: 700; }
+      .legend   { fill: #444; font-size: 11px; }
+      .producer { fill: #555; font-size: 11px; font-style: italic; }
+    </style>
+  </defs>
+
+  <!-- Title -->
+  <text x="410" y="34" text-anchor="middle" class="title">IR levels in the torch-spyre pipeline</text>
+  <text x="410" y="54" text-anchor="middle" class="sub">Each box is a distinct IR. Labels above the arrows name the pass that produces the next IR.</text>
+
+  <!-- Producer labels above arrows -->
+  <text class="producer" x="158" y="135" text-anchor="middle">Dynamo</text>
+  <text class="producer" x="316" y="135" text-anchor="middle">AOTAutograd</text>
+  <text class="producer" x="474" y="135" text-anchor="middle">Inductor</text>
+  <text class="producer" x="632" y="135" text-anchor="middle">codegen</text>
+  <text class="producer" x="775" y="135" text-anchor="middle">prepare</text>
+  <text class="producer" x="775" y="148" text-anchor="middle">Kernel</text>
+
+  <!-- Box 1: Torch IR -->
+  <rect class="torch" x="20" y="160" width="140" height="80" rx="8"/>
+  <text class="label name" x="90" y="190" text-anchor="middle">Torch IR</text>
+  <text class="label" x="90" y="210" text-anchor="middle">FX graph</text>
+  <text class="sub" x="90" y="228" text-anchor="middle">PyTorch dynamic ops</text>
+
+  <!-- Box 2: ATen IR -->
+  <rect class="torch" x="178" y="160" width="140" height="80" rx="8"/>
+  <text class="label name" x="248" y="190" text-anchor="middle">ATen IR</text>
+  <text class="label" x="248" y="210" text-anchor="middle">post-AOT</text>
+  <text class="sub" x="248" y="228" text-anchor="middle">decomposed primitives</text>
+
+  <!-- Box 3: LoopLevel IR -->
+  <rect class="torch" x="336" y="160" width="140" height="80" rx="8"/>
+  <text class="label name" x="406" y="190" text-anchor="middle">LoopLevel IR</text>
+  <text class="label" x="406" y="210" text-anchor="middle">scheduler</text>
+  <text class="sub" x="406" y="228" text-anchor="middle">Inductor IR + Spyre passes</text>
+
+  <!-- Box 4: SuperDSC / KTIR -->
+  <rect class="kernel" x="494" y="160" width="140" height="80" rx="8"/>
+  <text class="label name" x="564" y="190" text-anchor="middle">SuperDSC</text>
+  <text class="label name" x="564" y="208" text-anchor="middle">/ KTIR</text>
+  <text class="sub" x="564" y="226" text-anchor="middle">kernel descriptor</text>
+
+  <!-- Box 5: SpyreCode JobPlan -->
+  <rect class="runtime" x="652" y="160" width="148" height="80" rx="8"/>
+  <text class="label name" x="726" y="190" text-anchor="middle">SpyreCode</text>
+  <text class="label name" x="726" y="208" text-anchor="middle">JobPlan</text>
+  <text class="sub" x="726" y="226" text-anchor="middle">runtime contract</text>
+
+  <!-- Arrows between boxes -->
+  <path class="arrow" d="M 160 200 L 178 200" marker-end="url(#arr)"/>
+  <path class="arrow" d="M 318 200 L 336 200" marker-end="url(#arr)"/>
+  <path class="arrow" d="M 476 200 L 494 200" marker-end="url(#arr)"/>
+  <path class="arrow" d="M 634 200 L 652 200" marker-end="url(#arr)"/>
+
+  <!-- Trailing arrow into device -->
+  <path class="arrow" d="M 800 200 L 815 200" marker-end="url(#arr)"/>
+
+  <!-- Legend -->
+  <rect class="torch" x="60" y="280" width="14" height="14"/>
+  <text class="legend" x="80" y="292">PyTorch / Inductor IR</text>
+  <rect class="kernel" x="240" y="280" width="14" height="14"/>
+  <text class="legend" x="260" y="292">Spyre kernel IR</text>
+  <rect class="runtime" x="430" y="280" width="14" height="14"/>
+  <text class="legend" x="450" y="292">runtime container</text>
+
+  <!-- Bottom note -->
+  <text class="sub" x="410" y="312" text-anchor="middle">Production today: SuperDSC. KTIR is the planned successor; both lower into the same JobPlan at the runtime boundary.</text>
+</svg>

--- a/docs/source/architecture/dataflow_architecture.md
+++ b/docs/source/architecture/dataflow_architecture.md
@@ -155,6 +155,8 @@ The IBM Spyre Accelerator chip (left) and IBM Telum II processor (right). *Image
 |---------|--------|
 | Cores | 32 AI accelerator cores |
 | Technology | 5 nm |
+| LX scratchpad | 2 MB per core (SRAM, shared between corelets) |
+| Per-core memory span | 256 MB addressable contiguous device memory |
 | Memory per card | Up to 128 GB LPDDR5 |
 | Peak performance | >300 TOPS per card |
 | Supported data types | int4, int8, fp8, fp16 |

--- a/docs/source/architecture/spyre_accelerator.md
+++ b/docs/source/architecture/spyre_accelerator.md
@@ -26,6 +26,8 @@ Some of the key features of the Spyre device are listed below:
 * Each card supports up to 128 GB of LPDDR5 memory, with ensembles of up to eight cards delivering 1 TB memory and massive AI performance.
 * It delivers exceptional AI compute, exceeding 300 TOPS per card, while consuming just 75W.
 * PCIe gen5 x16 host interface (PCIe form factor card).
+* Each core has a 2 MB LX scratchpad (SRAM), shared between the two corelets within the core.
+* Each core has a 256 MB limit on the contiguous device-memory span it can address. This is a hardware constraint on the addressable range, distinct from the 2 MB LX scratchpad capacity.
 
 ### Core microarchitecture
 

--- a/docs/source/getting_started/how_torch_spyre_works.md
+++ b/docs/source/getting_started/how_torch_spyre_works.md
@@ -669,11 +669,20 @@ Spyre hardware. There is no emulated mode yet.*
 
 The extension points exist. These are PrivateUse1, the scheduler pass hooks, the TorchInductor
 backend registration, and a custom `TensorImpl`. We built everything out-of-tree, but we still
-monkey-patch a few internal APIs where the extension points are incomplete. The three patches
-cover dtype computation maps, fusion patterns, and compile_fx wrapping. The device registration
-layer is well documented. `torch.accelerator` and OpenReg give a clear starting point. The
-deeper hooks, which are the scheduler passes and codegen, are less well documented. For those,
-we spent a lot of time reading the source code of other backends to figure out the patterns.
+monkey-patch a small number of internal APIs where the extension points are incomplete. The
+patches fall into two groups: import-time patches in
+[`_monkey_patch.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_monkey_patch.py)
+that extend Dynamo guards and the FxGraph cache key to track `SpyreTensorLayout` plus a few
+`torch.Tensor` and `torch.empty` overrides for tiled-layout awareness, and compilation-scoped
+patches in
+[`_inductor/patches.py`](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/patches.py)
+that adjust the computation-dtype map, fusion patterns, the scheduler-passes injection, and a
+realization heuristic. Each patch corresponds to a missing upstream extension point.
+
+The device registration layer is well documented. `torch.accelerator` and OpenReg give a clear
+starting point. The deeper hooks, which are the scheduler passes and codegen, are less well
+documented. For those, we spent a lot of time reading the source code of other backends to
+figure out the patterns.
 
 Staying out-of-tree was worth the discipline it imposed. Every time we were tempted to edit a
 core file directly, the constraint pushed us toward finding the proper hook instead. That is not
@@ -691,25 +700,36 @@ layout propagation, view semantics, and error messaging across dozens of operati
 
 ## What is next
 
-**KTIR.** We are transitioning from SuperDSC to an MLIR-based IR that is designed as a
-community specification rather than a Spyre-specific format. The
-[KTIR RFC](https://github.com/torch-spyre/rfcs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md) is
-available in our public repository.
+**KTIR.** The Kernel Tile IR specification is published as
+[RFC 0682](https://github.com/torch-spyre/rfcs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md) and
+two open-source companion projects are up: a CPU interpreter at
+[torch-spyre/ktir-cpu](https://github.com/torch-spyre/ktir-cpu) and an MLIR parser at
+[torch-spyre/ktir-mlir-frontend](https://github.com/torch-spyre/ktir-mlir-frontend). The
+remaining work is the backend lowering path that lets KTIR replace SuperDSC in the production
+flow. See the [KTIR page](../compiler/ktir.md) for the design.
 
-**Scratchpad optimization.** We are designing and building a `ScratchPadAllocator` that plans
-what data lives in the 2 MB LX scratchpad and what stays in DDR. This is the Spyre equivalent of
-what a GPU cache does implicitly. Without it, compute units stall while they wait for data.
+**Scratchpad optimization.** The scratchpad planner is in-tree under
+`torch_spyre/_inductor/scratchpad/`. The default greedy solver has shipped along with first-fit
+and best-fit variants, an in-place reuse pass, a clone-input pre-pass, and a multi-core layout
+mode. A graph-aware co-optimisation pass that aligns work-division splits with LX placement is
+in proof-of-concept form. See [Scratchpad planning](../compiler/scratchpad_planning.md).
+
+**Distributed inference.** The `spyreccl` torch.distributed backend is implemented under
+`csrc/distributed/`. Synchronous `send`, `recv`, `broadcast`, `barrier`, `gather`, `allgather`,
+`reduce`, and `allreduce` work today. The remaining work is async support and the missing
+collectives (`scatter`, `reduce_scatter`, `alltoall`). See
+[Runtime — Multi-card and distributed execution](../runtime/index.md).
+
+**Profiling.** `torch.profiler` integration via `ProfilerActivity.PrivateUse1` is implemented
+in the in-progress `SpyreActivityProfiler` Kineto bridge. The memory APIs
+(`torch.spyre.memory.memory_allocated` and friends) are available today, and
+`aiu-trace-analyzer` post-processes traces with PT-utilisation metrics. The
+[profiling RFC 0601](https://github.com/torch-spyre/rfcs/blob/main/0601-SpyreProfilingToolkit/0601-SpyreProfilingToolkitRFC.md)
+covers the full plan; current state is summarised on the
+[Profiling page](../user_guide/profiling/index.md).
 
 **Broader model and serving coverage.** Llama 3.1 8B, vision models, and speech models are
 next. We are also integrating with vLLM as a platform plugin alongside CUDA and ROCm.
-
-**Distributed inference.** We are extending `torch.compile` to generate collective operations
-for multi-card Spyre configurations, using the standard PyTorch distributed communication APIs.
-
-**Profiling.** We are building `torch.profiler` integration through `ProfilerActivity.PrivateUse1`
-so that transfer latency, scratchpad pressure, and pipeline utilization are visible to users.
-Early scaffolding is in place. See our
-[profiling RFC](https://github.com/torch-spyre/rfcs/blob/main/0601-SpyreProfilingToolkit/0601-SpyreProfilingToolkitRFC.md).
 
 **Upstream contributions.** We plan to contribute a generalized `FixedTiledLayout` for Inductor,
 OpenReg primitives for standardized out-of-tree backend testing, and documented CI patterns for
@@ -750,6 +770,7 @@ used. The tables are organized by the challenge that each hook addresses.
 | `SpyreTensorImpl` | `at::TensorImpl` | Carries tiled layout metadata alongside the PyTorch tensor | Adds `SpyreTensorLayout` with device-side tiled size, a stride map from host dims to device dims, and device dtype. `BYTES_IN_STICK=128` (64 fp16 elements) |
 | `SpyreHooksInterface` | `PrivateUse1HooksInterface` | Reports device availability and primary context status | Queried by PyTorch runtime during device enumeration |
 | `SpyreStream` | `torch.cuda.Stream` semantics | Asynchronous execution and CPU↔Spyre overlap | Implements `torch.spyre.Stream`, `current_stream()`, `synchronize()`; enables pipelining batch N+1's input transfer behind batch N's compute |
+| `SpyreCCLBackend` | `c10d::Backend` (registered as `"spyreccl"`) | Multi-card collective communication via `torch.distributed` | `init_process_group(backend="spyreccl")`. Implements synchronous `send`, `recv`, `broadcast`, `barrier`, `gather`, `allgather`, `reduce`, `allreduce`. Reuses the rank's flex runtime instance and default stream. |
 
 Initialization is lazy and thread-safe. Importing `torch_spyre` registers the device name and
 module. `flex::initializeRuntime()` starts only on the first device use.
@@ -785,11 +806,14 @@ would require invasive core changes. Deferring to codegen is too late.
 | Decompositions | Registered in `enable_spyre_context()` | Layer 4 ops not natively available | `logical_not` → `eq(input, ne(input, input))` (bool), `addmm` → `matmul+scale+add`, `linear` → `matmul+add` (with weight transpose), `rms_norm` → `spyre::rms_norm`, `layer_norm` → `spyre::layer_norm`, `gelu` → `spyre::gelu`, `softplus` → `spyre::softplus`, `topk` → `spyre::topkvalue`/`spyre::topkindex`, `max.dim` → split value/index decomp, `scaled_dot_product_attention` → explicit Q·K^T·V, `cat`, `constant_pad_nd`, `ones` → `spyre::ones_scalar+expand+clone`, `new_ones`, `full` → `spyre::full`, `bitwise_not`, `bitwise_and` |
 | CPU fallback (auto-transfer) | PyTorch fallback dispatch | Infrequent ops that are off the critical path | `embedding`, `arange`, `sin`, `cos`, `tril`, `triu`, `isin`, `normal_`, `argmax`, `bitwise_or`, `bitwise_xor`, int64 variants of `max`. Data auto-transfers to the CPU, executes, and returns to Spyre. Transparent to the model. |
 
-### Profiling (in progress)
+### Profiling
 
 | Component | PyTorch Hook | Purpose | Key Detail |
 |---|---|---|---|
-| kineto-spyre extension | `ProfilerActivity.PrivateUse1` | Spyre-specific metrics in `torch.profiler` | Target metrics are transfer latency, scratchpad pressure, pipeline utilization, and inter-core communication overhead. Early scaffolding is in place. See the [profiling RFC](https://github.com/torch-spyre/rfcs/blob/main/0601-SpyreProfilingToolkit/0601-SpyreProfilingToolkitRFC.md). |
+| `torch.spyre.memory.*` | `torch.accelerator.memory` re-export | Per-device memory queries | `memory_allocated`, `max_memory_allocated`, `reset_peak_memory_stats`, `memory_stats` — all available today. |
+| `aiu-smi` | Standalone CLI / sampler | Power, thermal, PT-utilisation, DDR / PCIe / RDMA bandwidth | Available in PF and VF mode (Z/LinuxONE rollout in progress for VF). Public release tracked in [#1335](https://github.com/torch-spyre/torch-spyre/issues/1335). |
+| `aiu-trace-analyzer` | Trace post-processor | Adds derived metrics (PT-Util %) to Chrome / Perfetto traces | Available with some known gaps. |
+| `SpyreActivityProfiler` (Kineto bridge) | `ProfilerActivity.PrivateUse1` | Device-side kernel timing into `torch.profiler` traces | In progress in [#1856](https://github.com/torch-spyre/torch-spyre/pull/1856). The full design is in [profiling RFC 0601](https://github.com/torch-spyre/rfcs/blob/main/0601-SpyreProfilingToolkit/0601-SpyreProfilingToolkitRFC.md). |
 
 ---
 

--- a/docs/source/getting_started/how_torch_spyre_works.md
+++ b/docs/source/getting_started/how_torch_spyre_works.md
@@ -706,7 +706,7 @@ two open-source companion projects are up: a CPU interpreter at
 [torch-spyre/ktir-cpu](https://github.com/torch-spyre/ktir-cpu) and an MLIR parser at
 [torch-spyre/ktir-mlir-frontend](https://github.com/torch-spyre/ktir-mlir-frontend). The
 remaining work is the backend lowering path that lets KTIR replace SuperDSC in the production
-flow. See the [KTIR page](../compiler/ktir.md) for the design.
+flow.
 
 **Scratchpad optimization.** The scratchpad planner is in-tree under
 `torch_spyre/_inductor/scratchpad/`. The default greedy solver has shipped along with first-fit

--- a/docs/source/getting_started/key_concepts.md
+++ b/docs/source/getting_started/key_concepts.md
@@ -263,8 +263,9 @@ Each box is a distinct IR. The pass between two boxes is named above the arrow: 
   and the compute op. Artifacts are cached through the standard
   `torch.compile` cache.
 - **KTIR** is the planned successor, an MLIR-based dialect designed as a
-  community specification for dataflow accelerators. See the
-  [KTIR page](../compiler/ktir.md).
+  community specification for dataflow accelerators. See
+  [RFC 0682](https://github.com/torch-spyre/rfcs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md)
+  for the specification.
 - **SpyreCode** is the runtime-side contract: a `JobPlan` of ordered
   steps (host-to-device transfers, compute, host-side program
   correction, device-to-host transfers) that `SpyreStream::launch`

--- a/docs/source/getting_started/key_concepts.md
+++ b/docs/source/getting_started/key_concepts.md
@@ -246,15 +246,37 @@ two IR levels: the FX graph (before Inductor lowering) and the
 LoopLevel IR (before codegen). Gray boxes are PyTorch-standard.
 :::
 
-Two terms appear throughout the compiler docs:
+### IR levels
 
-- **SuperDSC** is the current Spyre IR. It is JSON. One artifact per
-  scheduled kernel encodes the per-core schedule, tensor descriptors,
+The compilation flow runs through several IRs in sequence:
+
+```text
+Torch IR (FX graph) → ATen IR (post-AOTAutograd) → LoopLevel IR (Inductor)
+                            → SuperDSC / KTIR  → SpyreCode JobPlan (runtime)
+```
+
+- **SuperDSC** is the current Spyre kernel IR. It is JSON. One artifact
+  per scheduled kernel encodes the per-core schedule, tensor descriptors,
   and the compute op. Artifacts are cached through the standard
   `torch.compile` cache.
-- **KTIR** is the planned successor, an MLIR-based dialect designed as
-  a community specification for dataflow accelerators. See the
-  [KTIR RFC](https://github.com/torch-spyre/rfcs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md).
+- **KTIR** is the planned successor, an MLIR-based dialect designed as a
+  community specification for dataflow accelerators. See the
+  [KTIR page](../compiler/ktir.md).
+- **SpyreCode** is the runtime-side contract: a `JobPlan` of ordered
+  steps (host-to-device transfers, compute, host-side program
+  correction, device-to-host transfers) that `SpyreStream::launch`
+  consumes. SpyreCode is the runtime interface that turns a compiled
+  kernel IR into device execution. See [Runtime](../runtime/index.md).
+
+### Named dimensions and tiling hints
+
+Working set reduction is driven by **named dimensions**. User code
+declares dimension names with `declare_tensor_dim`, attaches them to
+input tensors with `name_tensor_dims`, and tiles them inside a
+`with spyre_hint(tiles={...}):` scope. Hints are lexically scoped, can
+be nested, and compose by intersection of the op's iteration dimensions
+with each enclosing hint's tile dict. Full details and examples are in
+[Working Set Reduction](../compiler/working_set_reduction.md).
 
 For the full pipeline reference, see
 [Compiler Architecture](../compiler/architecture.md) and
@@ -314,9 +336,60 @@ Constraints that show up as compile-time errors or unexpected behavior:
 | **No HW scalar immediates** | Scalar constants in the FX graph are rewritten to size-1 tensors via `spyre::constant`. |
 | **Indivisible reduction dims** | Some reduction dimensions cannot be split across cores; work distribution honors this. |
 | **Static shapes** | Dynamic shapes are work-in-progress. Shape-polymorphic models may recompile per shape. |
-| **Per-core memory limit** | Each core's tensor footprint must fit its addressable device memory range (separate from the 2 MB LX). |
+| **Per-core memory span (256 MB)** | Each core's contiguous device-memory footprint must fit within 256 MB of addressable range. Separate from the 2 MB LX scratchpad capacity. |
 | **fp16 default** | fp32 is down-cast to fp16 with a warning; set `TORCH_SPYRE_DOWNCAST_WARN=0` to suppress. |
 | **`SENCORES=32`** | Default core count; lowering it for debugging changes work-division decisions. |
+
+---
+
+## 11. Streams
+
+Each Spyre device exposes asynchronous execution through stream
+primitives that match the `torch.cuda.Stream` API:
+
+```python
+import torch
+
+s = torch.spyre.Stream()
+with torch.spyre.stream(s):
+    out = compiled(x.to("spyre"))
+torch.spyre.synchronize()
+```
+
+Streams are FIFO: operations submitted to the same stream complete
+in order, while operations on different streams may execute
+concurrently when the hardware allows it. Each device keeps a fixed
+pool of streams (32 low-priority, 32 high-priority) plus a default
+stream (`stream 0`). Priority is binary, not graded.
+
+Full reference: [Runtime — Streams](../runtime/index.md).
+
+---
+
+## 12. Distributed execution
+
+Multiple Spyre cards on the same host coordinate through the
+`spyreccl` torch.distributed backend:
+
+```python
+import torch
+import torch.distributed as dist
+
+dist.init_process_group(backend="cpu:gloo,spyre:spyreccl")
+DEVICE = torch.device(f"spyre:{os.getenv('RANK', '0')}")
+
+x = torch.zeros(1024, dtype=torch.float16, device=DEVICE)
+dist.broadcast(x, src=0)
+```
+
+The model is one-device-per-process. Each rank attaches to a single
+Spyre device. Implemented synchronous collectives include `send`,
+`recv`, `broadcast`, `barrier`, `gather`, `allgather`, `reduce`, and
+`allreduce`. The underlying transport library is closed-source IBM
+code. Only the public adapter (`SpyreCCLBackend` in
+`csrc/distributed/`) is in-tree.
+
+Full reference: [Runtime — Multi-card and distributed execution](../runtime/index.md).
 
 ---
 

--- a/docs/source/getting_started/key_concepts.md
+++ b/docs/source/getting_started/key_concepts.md
@@ -250,10 +250,13 @@ LoopLevel IR (before codegen). Gray boxes are PyTorch-standard.
 
 The compilation flow runs through several IRs in sequence:
 
-```text
-Torch IR (FX graph) → ATen IR (post-AOTAutograd) → LoopLevel IR (Inductor)
-                            → SuperDSC / KTIR  → SpyreCode JobPlan (runtime)
-```
+:::{figure} ../_static/images/getting-started/ir-levels.svg
+:alt: Five IRs left-to-right with the producing pass labelled above each arrow
+:width: 100%
+:align: center
+
+Each box is a distinct IR. The pass between two boxes is named above the arrow: Dynamo, AOTAutograd, Inductor, codegen, and prepareKernel.
+:::
 
 - **SuperDSC** is the current Spyre kernel IR. It is JSON. One artifact
   per scheduled kernel encodes the per-core schedule, tensor descriptors,


### PR DESCRIPTION
## Summary

Several changes to the introductory sections and the blog post to reflect the changes in the stack. 

- **`getting_started/key_concepts.md`** — adds new §11 Streams
  (`torch.spyre.Stream`, FIFO semantics, stream pool) and §12
  Distributed execution (`spyreccl` backend with init example and
  supported synchronous collectives). Expands §7 Compilation
  pipeline with an IR-levels diagram (FX → ATen → LoopLevel →
  SuperDSC/KTIR → SpyreCode JobPlan), a named-dimensions paragraph,
  and a SpyreCode runtime-contract paragraph. §10 Hardware
  constraints checklist row updated with the explicit 256 MB span
  value.
- **`getting_started/how_torch_spyre_works.md`** — rewrites the
  "What is next" section so each item describes current state plus
  what is still ahead (KTIR, scratchpad, distributed, profiling).
  Replaces the stale "three patches" monkey-patch claim with the
  two-group breakdown that matches the actual files
  (`_monkey_patch.py` and `_inductor/patches.py`). Adds a
  `SpyreCCLBackend` row to the Challenge 1 appendix table and
  refreshes the Profiling appendix with current status of memory
  APIs, aiu-smi, aiu-trace-analyzer, and the in-progress Kineto
  bridge.
- **`architecture/spyre_accelerator.md`** — adds the 2 MB LX
  scratchpad and the 256 MB per-core addressable memory span to
  Key features.
- **`architecture/dataflow_architecture.md`** — adds matching rows
  to the Spyre Architecture Highlights table.

## Cross-references

A few cross-links on docs in earlier PRs. They resolve once the referenced PRs merge:

- `key_concepts.md §7` links to `compiler/ktir.md` (#2545)
- `key_concepts.md §12` links to runtime distributed-execution
  details (#2543)
- `how_torch_spyre_works.md "What is next"` references scratchpad
  solver content (#2541)


## Test plan

- [x] `make html` builds clean, no new warnings.
- [x] No metaphors or fragments in new content.
- [x] Cross-links to existing docs (WSR, runtime, scratchpad) resolve
  in local preview.
- [x] Architecture-table rows match the source claims (2 MB LX,
  256 MB span).