### PR TITLE
Optimize prefill MLP for 3d BMM

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -41,8 +41,10 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from sympy import Integer, Symbol, simplify, sympify  # noqa: F401
+from sympy import Integer, Mod, Symbol, floor, simplify, sympify  # noqa: F401
 
+import torch
+from torch import fx
 from torch._inductor.utils import IndentedBuffer
 from torch.utils._ordered_set import OrderedSet
 
@@ -53,7 +55,16 @@ from torch_spyre._inductor.codegen.compute_ops import (
     _tiled_byte_stride,
     generate_sdsc,
 )
-from torch_spyre._inductor.codegen.superdsc import SDSCArgs, SDSCSpec, compile_op_spec
+from torch_spyre._inductor.codegen.superdsc import (
+    SDSCArgs,
+    SDSCSpec,
+    compile_op_spec,
+    parse_op_spec,
+)
+from torch_spyre._inductor.constants import (
+    SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
+    SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
+)
 from torch_spyre._inductor.loop_info import CoarseTileInfo
 from torch_spyre._inductor.coarse_tile import coarse_tile, _divide_ranges
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg, UnimplementedOp
@@ -63,7 +74,13 @@ from torch_spyre._inductor.scheduler import (
     _loop_group_id,
     build_loop_scheduler_nodes,
 )
-from torch_spyre._inductor.spyre_kernel import _codegen_op_spec_list, _iter_op_specs
+from torch_spyre._inductor.spyre_kernel import (
+    _codegen_op_spec_list,
+    _iter_op_specs,
+    _preserve_shared_weight_unit_bmm_dim,
+    _shared_weight_unit_bmm_info_from_sizes,
+)
+from torch_spyre._inductor.temp_passes import bmm_unflatten_pass
 
 _FP16 = DataFormats.SEN169_FP16
 
@@ -1168,6 +1185,119 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
         self.assertIn("affine.apply", mlir)
         self.assertIn("affine_map", mlir)
         self.assertIn("scf.for", mlir)
+
+
+class TestSharedWeightUnitBmmLayout(unittest.TestCase):
+    def _static_bmm_custom_meta(self, x_shape, y_shape, out_shape):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = SimpleNamespace(shape=x_shape)
+        y = graph.placeholder("y")
+        y.meta["val"] = SimpleNamespace(shape=y_shape)
+        bmm = graph.call_function(torch.ops.aten.bmm.default, args=(x, y))
+        bmm.meta["val"] = SimpleNamespace(shape=out_shape)
+        graph.output(bmm)
+
+        bmm_unflatten_pass.apply(fx.GraphModule({}, graph).graph)
+        graph.lint()
+        return bmm.meta.get("custom") or {}
+
+    def test_marked_squeezed_unit_bmm_recovers_sendnn_like_unit_layout(self):
+        c0 = Symbol("c0")
+        c1 = Symbol("c1")
+        c2 = Symbol("c2")
+        input_arg = TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=_FP16,
+            device_size=[512, 64, 1, 64],
+            device_coordinates=[c0, floor(c2 / 64), Integer(0), Mod(c2, 64)],
+            allocation={"hbm": 0},
+            stride_map=[4096, 64, -1, 1],
+        )
+        kernel_arg = TensorArg(
+            is_input=True,
+            arg_index=1,
+            device_dtype=_FP16,
+            device_size=[200, 4096, 64],
+            device_coordinates=[floor(c1 / 64), c2, Mod(c1, 64)],
+            allocation={"hbm": 0x400000000},
+            stride_map=[64, 12800, 1],
+        )
+        output_arg = TensorArg(
+            is_input=False,
+            arg_index=2,
+            device_dtype=_FP16,
+            device_size=[512, 200, 1, 64],
+            device_coordinates=[c0, floor(c1 / 64), Integer(0), Mod(c1, 64)],
+            allocation={"hbm": 0x800000000},
+            stride_map=[12800, 64, -1, 1],
+        )
+        for arg in (input_arg, output_arg):
+            del arg.device_size[-2]
+            del arg.device_coordinates[-2]
+            del arg.stride_map[-2]
+        iteration_space = {
+            c0: (Integer(512), 4),
+            c1: (Integer(12800), 8),
+            c2: (Integer(4096), 1),
+        }
+        args = [input_arg, kernel_arg, output_arg]
+        op_info = {SHARED_WEIGHT_UNIT_BMM_INFO_KEY: {"batch_dim": 0}}
+
+        iteration_space = _preserve_shared_weight_unit_bmm_dim(
+            "batchmatmul", iteration_space, args, op_info
+        )
+        sdsc_spec, _ = parse_op_spec(
+            OpSpec(
+                op="batchmatmul",
+                is_reduction=True,
+                iteration_space=iteration_space,
+                args=args,
+                op_info=op_info,
+            )
+        )
+
+        self.assertEqual(
+            [str(dim) for dim in sdsc_spec.iteration_space],
+            ["x", "mb", "out", "in"],
+        )
+        input_layout = sdsc_spec.layouts[sdsc_spec.args[0].layout]
+        output_layout = sdsc_spec.layouts[sdsc_spec.args[-1].layout]
+        self.assertEqual(
+            [str(dim) for dim in input_layout["dim_order"]],
+            ["mb", "in", "x"],
+        )
+        self.assertEqual(
+            [str(dim) for dim in output_layout["dim_order"]],
+            ["mb", "out", "x"],
+        )
+
+    def test_shared_weight_marker_requires_stick_aligned_dims(self):
+        self.assertEqual(
+            self._static_bmm_custom_meta(
+                (1, 512, 4096), (1, 4096, 12800), (1, 512, 12800)
+            )[SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY],
+            {"batch_dim": 0},
+        )
+        self.assertNotIn(
+            SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
+            self._static_bmm_custom_meta(
+                (4, 512, 4096), (4, 4096, 12800), (4, 512, 12800)
+            ),
+        )
+        self.assertIsNone(
+            _shared_weight_unit_bmm_info_from_sizes(
+                [4, 512, 4096], [4, 4096, 12800], [4, 512, 12800]
+            )
+        )
+        self.assertNotIn(
+            SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
+            self._static_bmm_custom_meta((1, 55, 2), (1, 2, 99), (1, 55, 99)),
+        )
+        self.assertIsNone(
+            _shared_weight_unit_bmm_info_from_sizes([1, 55, 2], [2, 99], [1, 55, 99])
+        )
 
 
 # ===========================================================================

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -34,6 +34,12 @@ COPY_BACK_CANDIDATE_ATTR = "_spyre_copy_back_candidate"
 # compute mutation op from a pure-copy mutation op.
 ELIDED_COPY_BACK_ATTR = "_spyre_writes_copy_back_target"
 
+# FX ``custom`` metadata key for BMMs created from a shared 2D weight whose
+# logical batch dim is statically 1.  The downstream OpSpec key carries the same
+# fact after lowering, where FX metadata is no longer directly available.
+SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY = "_spyre_shared_weight_unit_bmm"
+SHARED_WEIGHT_UNIT_BMM_INFO_KEY = "shared_weight_unit_bmm"
+
 
 SEGMENT_OFFSETS = [
     0x0,

--- a/torch_spyre/_inductor/lowering.py
+++ b/torch_spyre/_inductor/lowering.py
@@ -23,7 +23,13 @@ import torch._inductor.lowering as lowering
 import torch._inductor.ir as ir
 from typing import Any, Callable, Union
 
-from .constants import BATCH_MATMUL_OP, COPY_BACK_CANDIDATE_ATTR, BATCH_MATMUL_FP8_OP
+from .constants import (
+    BATCH_MATMUL_OP,
+    COPY_BACK_CANDIDATE_ATTR,
+    BATCH_MATMUL_FP8_OP,
+    SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
+    SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
+)
 import torch_spyre._inductor.customops  # noqa: F401
 from torch_spyre.ops.fallbacks import fallback_ops
 from .ir import SpyreReduction, SpyreConstantFallback, SpyreEmptyFallback
@@ -43,6 +49,15 @@ _lowerings_nesting = 0
 # The specific spyre lowerings will be registered into this dictionary
 # and merged with the in-tree lowerings when needed
 spyre_lowerings: dict[Union[Callable[..., Any], str], Callable[..., Any]] = {}
+
+
+def _current_fx_custom_meta() -> dict[str, Any]:
+    node = V.get_current_node()
+    meta = getattr(node, "meta", None)
+    if not isinstance(meta, dict):
+        return {}
+    custom = meta.get("custom")
+    return custom if isinstance(custom, dict) else {}
 
 
 def register_spyre_lowering(
@@ -444,11 +459,18 @@ def lower_bmm(x, y):
     else:
         raise Unsupported(f"BMM with input shapes {x.get_size()} and {y.get_size()}")
 
+    custom_meta = _current_fx_custom_meta()
+    op_info = {}
+    if SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY in custom_meta:
+        op_info[SHARED_WEIGHT_UNIT_BMM_INFO_KEY] = custom_meta[
+            SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY
+        ]
+
     if reduction_numel == 1:
         # Reduction degenerates to a pointwise mul
         result = lowering.mul(x, y)
     else:
-        result = Reduction.create(
+        reduction_kwargs = dict(
             reduction_type=BATCH_MATMUL_OP,
             input_node=[x, y],
             device=x.get_device(),
@@ -458,6 +480,10 @@ def lower_bmm(x, y):
             ranges=ranges,
             reduction_ranges=[reduction_numel],
         )
+        if op_info:
+            result = SpyreReduction.create(op_info=op_info, **reduction_kwargs)
+        else:
+            result = Reduction.create(**reduction_kwargs)
 
     result.realize()
 

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -37,6 +37,7 @@ from .constants import (
     IDENTITY_OP,
     RESTICKIFY_OP,
     SEGMENT_OFFSETS,
+    SHARED_WEIGHT_UNIT_BMM_INFO_KEY,
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
@@ -59,6 +60,63 @@ import logging
 logger = get_inductor_logger("spyre_kernel")
 
 
+def _is_static_one(value: Any) -> bool:
+    try:
+        return concretize_expr(value) == 1
+    except Exception:
+        return False
+
+
+def _is_static_multiple(value: Any, divisor: int) -> bool:
+    try:
+        return concretize_expr(value) % divisor == 0
+    except Exception:
+        return False
+
+
+def _has_stick_aligned_matmul_dims(k: Any, n: Any) -> bool:
+    return _is_static_multiple(k, 64) and _is_static_multiple(n, 64)
+
+
+def _same_static_size(lhs: Any, rhs: Any) -> bool:
+    try:
+        return concretize_expr(lhs) == concretize_expr(rhs)
+    except Exception:
+        return False
+
+
+def _shared_weight_unit_bmm_info_from_sizes(
+    x_size: Sequence[Any], y_size: Sequence[Any], out_size: Sequence[Any]
+) -> dict[str, int] | None:
+    if len(x_size) != 3 or len(out_size) != 3:
+        return None
+    if not (_is_static_one(x_size[0]) and _is_static_one(out_size[0])):
+        return None
+    if len(y_size) == 2:
+        if not (
+            _same_static_size(x_size[1], out_size[1])
+            and _same_static_size(x_size[2], y_size[0])
+            and _same_static_size(y_size[1], out_size[2])
+        ):
+            return None
+        k_dim, n_dim = x_size[2], y_size[1]
+    elif len(y_size) == 3:
+        if not _is_static_one(y_size[0]):
+            return None
+        if not (
+            _same_static_size(x_size[1], out_size[1])
+            and _same_static_size(x_size[2], y_size[1])
+            and _same_static_size(y_size[2], out_size[2])
+        ):
+            return None
+        k_dim, n_dim = x_size[2], y_size[2]
+    else:
+        return None
+    if not _has_stick_aligned_matmul_dims(k_dim, n_dim):
+        return None
+    return {"batch_dim": 0}
+
+
 class RValue(ABC):
     """
     An RValue is an expression that can appear on the right hand side of an assignment.
@@ -70,6 +128,74 @@ class TensorAccess(RValue):
     name: str
     index: sympy.Expr
     layout: FixedTiledLayout
+
+
+def _preserve_shared_weight_unit_bmm_dim(
+    op: str,
+    it_space: dict[sympy.Symbol, tuple[sympy.Expr, int]],
+    args: Sequence[TensorArg],
+    op_info: dict[str, Any],
+) -> dict[sympy.Symbol, tuple[sympy.Expr, int]]:
+    # TensorArg layout is normalized in-place below to match the surrounding
+    # OpSpec construction helpers.
+    if SHARED_WEIGHT_UNIT_BMM_INFO_KEY not in op_info:
+        return it_space
+    if op not in [BATCH_MATMUL_OP, BATCH_MATMUL_FP8_OP]:
+        return it_space
+    if len(it_space) != 3 or len(args) < 3:
+        return it_space
+    info = op_info.get(SHARED_WEIGHT_UNIT_BMM_INFO_KEY)
+    if not isinstance(info, dict) or info.get("batch_dim") != 0:
+        return it_space
+
+    unit_sym = sympy.Symbol("_spyre_bmm_unit")
+    suffix = 0
+    while unit_sym in it_space:
+        suffix += 1
+        unit_sym = sympy.Symbol(f"_spyre_bmm_unit_{suffix}")
+
+    def _unit_indices(arg: TensorArg) -> list[int]:
+        return [
+            idx
+            for idx, (size, coord) in enumerate(
+                zip(arg.device_size[:-1], arg.device_coordinates[:-1])
+            )
+            if concretize_expr(size) == 1 and coord == 0
+        ]
+
+    target_args = (args[0], args[-1])
+    unit_idxs_by_arg = [_unit_indices(arg) for arg in target_args]
+
+    if all(len(unit_idxs) == 0 for unit_idxs in unit_idxs_by_arg):
+        for arg in target_args:
+            if len(arg.device_size) < 2:
+                return it_space
+            insert_at = len(arg.device_size) - 1
+            arg.device_size.insert(insert_at, 1)
+            arg.device_coordinates.insert(insert_at, sympy.S.Zero)
+            if arg.stride_map is not None:
+                arg.stride_map.insert(insert_at, -1)
+        unit_idxs_by_arg = [_unit_indices(arg) for arg in target_args]
+
+    if not all(len(unit_idxs) == 1 for unit_idxs in unit_idxs_by_arg):
+        return it_space
+
+    rewrite_targets = [
+        (arg, unit_idxs[0]) for arg, unit_idxs in zip(target_args, unit_idxs_by_arg)
+    ]
+
+    for arg, unit_idx in rewrite_targets:
+        arg.device_coordinates[unit_idx] = unit_sym
+        nonstick = list(range(len(arg.device_size) - 1))
+        order = [unit_idx] + [i for i in reversed(nonstick) if i != unit_idx]
+        order.append(len(arg.device_size) - 1)
+        arg.device_size[:] = [arg.device_size[i] for i in order]
+        arg.device_coordinates[:] = [arg.device_coordinates[i] for i in order]
+        if arg.stride_map is not None and len(arg.stride_map) == len(order):
+            arg.stride_map[:] = [arg.stride_map[i] for i in order]
+
+    logger.info("Preserving shared-weight unit BMM dim %s", unit_sym)
+    return {unit_sym: (sympy.S.One, 1), **it_space}
 
 
 @dataclass
@@ -449,6 +575,9 @@ class SpyreKernel(Kernel[CSEVariable]):
         it_space_extended = {
             k: (v, work_division.get(k, 1)) for k, v in it_space.items()
         }
+        it_space_extended = _preserve_shared_weight_unit_bmm_dim(
+            op, it_space_extended, args, op_info
+        )
 
         # If this op is inside a coarse-tiling loop, identify which iteration-space
         # symbols are tiled by the enclosing loop(s).  loop_tiled_dims is a
@@ -610,6 +739,12 @@ class SpyreKernel(Kernel[CSEVariable]):
                 raise Unsupported(f"invalid {value.op} arguments {value.arguments}")
             x = value.arguments[0]
             y = value.arguments[1]
+            if SHARED_WEIGHT_UNIT_BMM_INFO_KEY not in op_info:
+                shared_weight_info = _shared_weight_unit_bmm_info_from_sizes(
+                    x.layout.size, y.layout.size, dst.layout.size
+                )
+                if shared_weight_info is not None:
+                    op_info[SHARED_WEIGHT_UNIT_BMM_INFO_KEY] = shared_weight_info
             args = [
                 self.create_tensor_arg(True, x.name, x),
                 self.create_tensor_arg(True, y.name, y),
@@ -817,4 +952,8 @@ def simplify_op_spec(op_spec):
                 j = old_sym_to_idx.get(next(iter(syms)))
                 if j is not None and j < len(old_stride_map):
                     new_stride_map[d] = old_stride_map[j]
+            # TODO: consider whether this stick-dim stride preservation should
+            # apply to other op types once another validated case needs it.
+            if SHARED_WEIGHT_UNIT_BMM_INFO_KEY in op_spec.op_info and old_stride_map:
+                new_stride_map[-1] = old_stride_map[-1]
             arg.stride_map = new_stride_map

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -23,6 +23,7 @@ from torch._inductor.pattern_matcher import (
     register_graph_pattern,
 )
 from .logging_utils import get_inductor_logger
+from .constants import SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY
 from .pass_utils import copy_fx_custom_meta
 
 aten = torch.ops.aten
@@ -37,6 +38,61 @@ _RESHAPE_OPS = (
 
 mm_to_bmm_pass = PatternMatcherPass(pass_name="unflatten_mm_to_bmm")
 bmm_unflatten_pass = PatternMatcherPass(pass_name="unflatten_bmm_batch_dims")
+
+
+def _is_static_one(value) -> bool:
+    try:
+        return int(value) == 1
+    except (TypeError, ValueError):
+        return False
+
+
+def _is_static_multiple(value, divisor: int) -> bool:
+    try:
+        return int(value) % divisor == 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _has_stick_aligned_matmul_dims(k, n) -> bool:
+    return _is_static_multiple(k, 64) and _is_static_multiple(n, 64)
+
+
+def _node_shape(node: torch.fx.Node) -> list[int] | None:
+    val = node.meta.get("val")
+    shape = getattr(val, "shape", None)
+    if shape is None:
+        return None
+    return list(shape)
+
+
+def _mark_static_unit_batch_bmm(
+    bmm_node: torch.fx.Node, lhs_node: torch.fx.Node, rhs_node: torch.fx.Node
+) -> None:
+    lhs_shape = _node_shape(lhs_node)
+    rhs_shape = _node_shape(rhs_node)
+    out_shape = _node_shape(bmm_node)
+    if lhs_shape is None or rhs_shape is None or out_shape is None:
+        return
+    if len(lhs_shape) != 3 or len(rhs_shape) != 3 or len(out_shape) != 3:
+        return
+    if not (
+        _is_static_one(lhs_shape[0])
+        and _is_static_one(rhs_shape[0])
+        and _is_static_one(out_shape[0])
+    ):
+        return
+    if not (
+        lhs_shape[1] == out_shape[1]
+        and lhs_shape[2] == rhs_shape[1]
+        and rhs_shape[2] == out_shape[2]
+    ):
+        return
+    if not _has_stick_aligned_matmul_dims(lhs_shape[2], rhs_shape[2]):
+        return
+    custom = dict(bmm_node.meta.get("custom") or {})
+    custom[SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY] = {"batch_dim": 0}
+    bmm_node.meta["custom"] = custom
 
 
 @register_graph_pattern(
@@ -141,6 +197,7 @@ def _unflatten_mm_to_bmm(
         )
         bmm_node.meta["val"] = torch.empty(output_shape, dtype=rhs_dtype, device="meta")
         copy_fx_custom_meta(node, bmm_node)
+        _mark_static_unit_batch_bmm(bmm_node, lhs_input, expanded)
 
     # Replace all uses of mm and output view with the bmm
     node.replace_all_uses_with(bmm_node)
@@ -200,6 +257,8 @@ def _unflatten_bmm_batch_dims(
     node = match.nodes[-1]
     graph = node.graph
     lhs_reshape, rhs_reshape = mat1_node, mat2_node
+
+    _mark_static_unit_batch_bmm(node, lhs_reshape, rhs_reshape)
 
     # Both inputs must be reshape/view that collapse batch dims to 3D
     if not _is_batch_collapsing_reshape(lhs_reshape):

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -648,7 +648,7 @@ _DTYPE_BYTES = 2  # fp16
 _PSUM_PER_ELEM_US = 1.4e-4  # per output element, per K-split ring reduction hop
 _COHORT_LIMIT = 8  # cores sharing a broadcast before it contends for bandwidth
 _BATCH_SPLIT_EXPONENT = 1.4  # batch-split cost grows ~ b ** this (fit to bmm sweeps)
-_TARGET_M_PENALTY_US = 50.0  # tie-break weight, per log2 step off the target m-split
+_TARGET_M_PENALTY_US = 50.0  # tie-break weight when per-core M under-fills PT
 
 
 def _matmul_split_cost(
@@ -688,12 +688,14 @@ def _matmul_split_cost(
     # sum hops around the ring, each touching every output element.
     psum_us = max(0, k - 1) * (B * M * N) * _PSUM_PER_ELEM_US
 
-    # Tie-break: among compute-equivalent splits prefer the m-split that lands
-    # per-core M near the PT sweet spot, penalising log2-distance from it.
-    target_m = max(
-        _M_MIN, min(max_cores // 2, max(1, M // (_TARGET_PT_PASSES * _PT_ROWS)))
-    )
-    target_m_us = abs(math.log2(max(1, m) / target_m)) * _TARGET_M_PENALTY_US
+    # Tie-break: among compute-equivalent splits, penalize only M splits that
+    # make the per-core tile too short to fill the PT pipeline. Larger per-core
+    # M tiles are already compute-equivalent in this model; penalizing them
+    # incorrectly prefers M parallelism over N parallelism for wide projections.
+    if pt_passes >= _TARGET_PT_PASSES:
+        target_m_us = 0.0
+    else:
+        target_m_us = math.log2(_TARGET_PT_PASSES / pt_passes) * _TARGET_M_PENALTY_US
 
     # Splitting batch across cores is strictly worse than tiling it in time on
     # one core (each item is independent), so charge a super-linear b penalty.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Improve Spyre lowering for prefill bmm's by preserving the singleton batch dim through graph rewriting and `OpSpec` construction. This lets equivalent forms like `[1, M, K] @ [K, N]` and `[1, M, K] @ [1, K, N]` use the same efficient layout and schedule, while true `B > 1` batched matmuls stay unchanged.

`LX_PLANNING=0`, bs1/sl512 prefill:

| shape | op | main / sendnn | PR speedup over main | PR / sendnn |
| --- | --- | ---: | ---: | ---: |
| [[1, 512, 4096], [4096, 1024]] | KV-proj | 1.198x | 1.411x | 0.849x |
| [[1, 512, 4096], [4096, 4096]] | QO-proj | 1.564x | 1.761x | 0.888x |
| [[1, 512, 4096], [4096, 12800]] | MLP-gate/up | 3.889x | 3.656x | 1.064x |
| [[1, 512, 4096]] | mlp | 3.780x | 3.120x | 1.211x |

PR moves the torch spyre MLP prefill gap from **3.78x -> 1.21x.** 

Gains comes from keeping the size-1 batch dimension visible as a layout cue and updating the matmul cost model to favor useful output/N parallelism once token/M work is sufficient.

#### Which issue(s) this PR is related to:

#2517 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
