### PR TITLE
feat(test cicd): add --skip-slow flag to skip platform-specific slow tests auto-enabled on non-x86_64 CI runners

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -231,7 +231,18 @@ jobs:
           CONFIG="tests/configs/${{ matrix.suite.config }}"
 
           echo "Running ${{ matrix.suite.name }} tests..."
-          bash tests/run_test.sh "$CONFIG" -v
+
+          _ARCH="$(uname -m)"
+          _SLOW_FLAG=""
+          if [[ "$_ARCH" != "x86_64" ]]; then
+            echo "Non-x86_64 platform (${_ARCH}): passing --skip-slow"
+            _SLOW_FLAG="--skip-slow"
+          fi
+          echo "  Host Platform : ${_ARCH}"
+          echo "  Slow flag: ${_SLOW_FLAG:-none (all tests will run)}"
+          echo "  Command  : bash tests/run_test.sh $CONFIG -v ${_SLOW_FLAG}"
+          bash tests/run_test.sh "$CONFIG" -v ${_SLOW_FLAG}
+
           echo "${{ matrix.suite.name }} tests done"
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR  add --skip-slow flag to skip platform-specific slow tests auto-enabled on non-x86_64 CI runners on torch spyre tests CI file - `.github/workflows/torch_spyre_tests.yaml`