### PR TITLE
Consolidate `bundle_hbm_symbols` and `bundle_symbolic_args` — into a single `bundle_symbolic_args` flag.

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -90,7 +90,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -131,7 +130,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -190,7 +188,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -248,7 +245,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -329,7 +325,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": True,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -438,7 +433,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -518,7 +512,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -565,7 +558,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -615,7 +607,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -665,7 +656,6 @@ class TestCoarseTileSpyreHints(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -883,7 +873,6 @@ class TestNamedDimsHint(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,
@@ -922,7 +911,6 @@ class TestNamedDimsHint(InductorTestCase):
 
     @config.patch(
         {
-            "bundle_hbm_symbols": True,
             "unroll_loops": False,
             "lx_planning": True,
             "allow_all_ops_in_lx_planning": True,

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -347,6 +347,7 @@ def _fake_compile_op_spec(
     op_spec: OpSpec,
     symbols: list,
     symbol_id_offset: int = 0,
+    use_symbols: bool = False,
 ):
     """Stub that returns (json, [], [], []) — no real SDSC compilation."""
     return {f"{idx}_{op_spec.op}": {"op": op_spec.op}}, [], [], []
@@ -913,6 +914,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
+            use_symbols=True,
         )
         self.assertEqual(len(affine_strides), 1)
         self.assertIn(s, affine_strides[0])
@@ -929,6 +931,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
+            use_symbols=True,
         )
         self.assertEqual(len(symbols), 1)
         self.assertEqual(symbols[0], start)
@@ -943,6 +946,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
+            use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
         node = top_val["dscs_"][0]["add"]["scheduleTree_"][0]
@@ -991,6 +995,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=5,
             tiled_symbols=[s],
+            use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
         node = top_val["dscs_"][0]["add"]["scheduleTree_"][0]
@@ -1035,6 +1040,7 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
+            use_symbols=True,
         )
         self.assertEqual(len(symbols), 2)
         self.assertEqual(symbols[0], 0x1000)
@@ -1080,7 +1086,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_produce_two_stride_entries(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
         hbm_strides = [d for d in affine_strides if len(d) > 0]
         self.assertGreater(len(hbm_strides), 0)
         for tensor_strides in hbm_strides:
@@ -1089,7 +1095,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_strides_are_positive(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
         for tensor_strides in affine_strides:
             for sym, stride in tensor_strides.items():
                 self.assertGreater(stride, 0)
@@ -1099,7 +1105,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
     def test_affine_strides_non_empty_for_tiled_op(self):
         op_spec = _make_tiled_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
         has_strides = any(len(d) > 0 for d in affine_strides)
         self.assertTrue(
             has_strides,
@@ -1110,7 +1116,9 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
         op_spec = _make_tiled_op_spec()
         loop = LoopSpec(count=Integer(4), body=[op_spec])
         tmpdir = tempfile.mkdtemp()
-        generate_bundle("test_kernel", tmpdir, [loop], unroll_loops=False)
+        generate_bundle(
+            "test_kernel", tmpdir, [loop], unroll_loops=False, symbolic_args=True
+        )
 
         with open(os.path.join(tmpdir, "bundle.mlir")) as f:
             mlir = f.read()
@@ -1283,7 +1291,7 @@ class TestGenerateBundleMlirSnapshot(unittest.TestCase):
             "\t\t%c1 = arith.constant 1 : index\n"
             "\t\t%loop_bound_0 = arith.constant 8 : index\n"
             "\t\tscf.for %i_0 = %c0 to %loop_bound_0 step %c1 {\n"
-            '\t\t\tsdscbundle.sdsc_execute () {sdsc_filename="sdsc_0.json", "symbol_ids"=[]}\n'
+            '\t\t\tsdscbundle.sdsc_execute () {sdsc_filename="sdsc_0.json"}\n'
             "\t\t}\n"
             "\t\treturn\n"
             "\t}\n"
@@ -1297,7 +1305,7 @@ class TestGenerateBundleMlirSnapshot(unittest.TestCase):
         expected = (
             "module {\n"
             "\tfunc.func @sdsc_bundle() {\n"
-            '\t\tsdscbundle.sdsc_execute () {sdsc_filename="sdsc_0.json", "symbol_ids"=[]}\n'
+            '\t\tsdscbundle.sdsc_execute () {sdsc_filename="sdsc_0.json"}\n'
             "\t\treturn\n"
             "\t}\n"
             "}\n"
@@ -1315,14 +1323,20 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
             "torch_spyre._inductor.codegen.bundle.compile_op_spec",
             side_effect=fake_compile,
         ):
-            generate_bundle("test_kernel", self.tmpdir, specs, unroll_loops=False)
+            generate_bundle(
+                "test_kernel",
+                self.tmpdir,
+                specs,
+                unroll_loops=False,
+                symbolic_args=True,
+            )
         return _read_mlir(self.tmpdir)
 
     def test_tiled_tensor_emits_affine_apply(self):
         s = self._s
         stride = 16384
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return _make_tiled_json(idx, sym_id), [0x1000], [{s: stride}], []
@@ -1342,7 +1356,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         self.assertIn('"symbol_ids"=[-1]', mlir)
 
     def test_non_tiled_tensor_in_loop_no_affine_apply(self):
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x2000)
             return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
@@ -1360,7 +1374,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         s = self._s
         stride = 8192
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x3000)
             return _make_tiled_json(idx, sym_id), [0x3000], [{s: stride}], []
@@ -1377,7 +1391,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
     def test_affine_apply_inside_scf_for(self):
         s = self._s
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x4000)
             return _make_tiled_json(idx, sym_id), [0x4000], [{s: 512}], []
@@ -1396,7 +1410,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
     def test_tiled_snapshot(self):
         s = self._s
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
@@ -1437,20 +1451,26 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
             "torch_spyre._inductor.codegen.bundle.compile_op_spec",
             side_effect=fake_compile,
         ):
-            generate_bundle("test_kernel", self.tmpdir, specs, unroll_loops=False)
+            generate_bundle(
+                "test_kernel",
+                self.tmpdir,
+                specs,
+                unroll_loops=False,
+                symbolic_args=True,
+            )
         return _read_mlir(self.tmpdir)
 
     def _fake_compile_two_strides(self, outer_stride, inner_stride):
         s0, s1 = self.s0, self.s1
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return (
                 _make_tiled_json(idx, sym_id),
                 [0x1000],
                 [{s0: outer_stride, s1: inner_stride}],
-                [SymbolKind.kernel(0)],
+                [],
             )
 
         return fake_compile
@@ -1866,7 +1886,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def test_func_signature_has_params_for_tensor_args(self):
         a = self._make_op_spec_with_hbm_args("a", [0, 1])
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             for i, arg in enumerate(op_spec.args):
                 symbols.append(arg.allocation["hbm"])
             ids = [-(symbol_id_offset + i + 1) for i in range(len(op_spec.args))]
@@ -1921,7 +1941,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def test_sdsc_execute_uses_extracted_names(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(op_spec.args[0].allocation["hbm"])
             return (
@@ -1960,7 +1980,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         call_count = [0]
         values = [0x400000000, 0x0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -1981,22 +2001,13 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
 
     def test_symbolic_args_false_no_params(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
-
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
-            sym_id = -(symbol_id_offset + 1)
-            symbols.append(op_spec.args[0].allocation["hbm"])
-            return (
-                _make_tiled_json(idx, sym_id),
-                [op_spec.args[0].allocation["hbm"]],
-                [{}],
-                [SymbolKind.kernel(0)],
-            )
-
-        mlir = self._bundle([a], symbolic_args=False, fake_compile=fake)
-
+        # When symbolic_args=False, use_symbols=False: no symbols registered,
+        # sdsc_execute has no operands.
+        mlir = self._bundle([a], symbolic_args=False)
         self.assertIn("func.func @sdsc_bundle()", mlir)
         self.assertNotIn("input_arg", mlir)
-        self.assertIn("arith.constant 17179869184", mlir)
+        self.assertNotIn("%sym_", mlir)
+        self.assertIn("sdsc_execute () {sdsc_filename=", mlir)
 
     def test_multi_sdsc_two_tensor_args_snapshot(self):
         """Two tensor args on first op; remaining ops use arith.constant symbols."""
@@ -2020,7 +2031,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         ]
         sym_counts = [2, 3, 2, 2, 3]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             i = call_count[0]
             call_count[0] += 1
             n = sym_counts[i]
@@ -2081,7 +2092,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         base = 0x400000000  # SEGMENT_OFFSETS[1], arg_index=0
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(base)
@@ -2107,7 +2118,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         call_count = [0]
         pool_values = [0, 2048, 0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -2215,6 +2226,7 @@ class TestSymbolKind(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
+            use_symbols=True,
         )
         self.assertEqual(len(kinds), 2)
         self.assertIsInstance(kinds[0], SymbolKind)
@@ -2232,7 +2244,7 @@ class TestSymbolKind(unittest.TestCase):
 
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
             i = call_count[0]
             call_count[0] += 1
             base = 0x400000000

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -347,7 +347,6 @@ def _fake_compile_op_spec(
     op_spec: OpSpec,
     symbols: list,
     symbol_id_offset: int = 0,
-    use_symbols: bool = True,
 ):
     """Stub that returns (json, [], [], []) — no real SDSC compilation."""
     return {f"{idx}_{op_spec.op}": {"op": op_spec.op}}, [], [], []
@@ -914,7 +913,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
-            use_symbols=True,
         )
         self.assertEqual(len(affine_strides), 1)
         self.assertIn(s, affine_strides[0])
@@ -931,7 +929,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
-            use_symbols=True,
         )
         self.assertEqual(len(symbols), 1)
         self.assertEqual(symbols[0], start)
@@ -946,7 +943,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
-            use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
         node = top_val["dscs_"][0]["add"]["scheduleTree_"][0]
@@ -964,7 +960,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[],
-            use_symbols=True,
         )
         self.assertEqual(affine_strides, [{}])
 
@@ -981,7 +976,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
-            use_symbols=True,
         )
         self.assertEqual(symbols, [])
         self.assertEqual(local_sym_values, [])
@@ -997,7 +991,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=5,
             tiled_symbols=[s],
-            use_symbols=True,
         )
         top_val = next(iter(sdsc_json.values()))
         node = top_val["dscs_"][0]["add"]["scheduleTree_"][0]
@@ -1042,7 +1035,6 @@ class TestGenerateSdscTiledSymbols(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
-            use_symbols=True,
         )
         self.assertEqual(len(symbols), 2)
         self.assertEqual(symbols[0], 0x1000)
@@ -1088,7 +1080,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_produce_two_stride_entries(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         hbm_strides = [d for d in affine_strides if len(d) > 0]
         self.assertGreater(len(hbm_strides), 0)
         for tensor_strides in hbm_strides:
@@ -1097,7 +1089,7 @@ class TestCompileOpSpecTwoTiledSymbols(unittest.TestCase):
     def test_two_tiled_symbols_strides_are_positive(self):
         op_spec = self._make_3d_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         for tensor_strides in affine_strides:
             for sym, stride in tensor_strides.items():
                 self.assertGreater(stride, 0)
@@ -1107,7 +1099,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
     def test_affine_strides_non_empty_for_tiled_op(self):
         op_spec = _make_tiled_op_spec()
         symbols: list[int] = []
-        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols, use_symbols=True)
+        _, _, affine_strides, _ = compile_op_spec(0, op_spec, symbols)
         has_strides = any(len(d) > 0 for d in affine_strides)
         self.assertTrue(
             has_strides,
@@ -1118,9 +1110,7 @@ class TestCompileOpSpecSymbolMapping(unittest.TestCase):
         op_spec = _make_tiled_op_spec()
         loop = LoopSpec(count=Integer(4), body=[op_spec])
         tmpdir = tempfile.mkdtemp()
-        generate_bundle(
-            "test_kernel", tmpdir, [loop], use_symbols=True, unroll_loops=False
-        )
+        generate_bundle("test_kernel", tmpdir, [loop], unroll_loops=False)
 
         with open(os.path.join(tmpdir, "bundle.mlir")) as f:
             mlir = f.read()
@@ -1148,9 +1138,7 @@ class TestGenerateBundleMlir(unittest.TestCase):
         self.patch.stop()
 
     def _bundle(self, specs):
-        generate_bundle(
-            "test_kernel", self.tmpdir, specs, use_symbols=True, unroll_loops=False
-        )
+        generate_bundle("test_kernel", self.tmpdir, specs, unroll_loops=False)
         return _read_mlir(self.tmpdir)
 
     def test_flat_ops_no_loop(self):
@@ -1208,9 +1196,7 @@ class TestGenerateBundleMlir(unittest.TestCase):
         a = _make_minimal_op_spec("a")
         b = _make_minimal_op_spec("b")
         loop = LoopSpec(count=Integer(2), body=[a, b])
-        generate_bundle(
-            "test_kernel", self.tmpdir, [loop], use_symbols=True, unroll_loops=False
-        )
+        generate_bundle("test_kernel", self.tmpdir, [loop], unroll_loops=False)
         written = sorted(f for f in os.listdir(self.tmpdir) if f.endswith(".json"))
         self.assertEqual(len(written), 2)
 
@@ -1283,9 +1269,7 @@ class TestGenerateBundleMlirSnapshot(unittest.TestCase):
         self.patch.stop()
 
     def _bundle(self, specs):
-        generate_bundle(
-            "test_kernel", self.tmpdir, specs, use_symbols=True, unroll_loops=False
-        )
+        generate_bundle("test_kernel", self.tmpdir, specs, unroll_loops=False)
         return _read_mlir(self.tmpdir)
 
     def test_single_loop_snapshot(self):
@@ -1331,16 +1315,14 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
             "torch_spyre._inductor.codegen.bundle.compile_op_spec",
             side_effect=fake_compile,
         ):
-            generate_bundle(
-                "test_kernel", self.tmpdir, specs, use_symbols=True, unroll_loops=False
-            )
+            generate_bundle("test_kernel", self.tmpdir, specs, unroll_loops=False)
         return _read_mlir(self.tmpdir)
 
     def test_tiled_tensor_emits_affine_apply(self):
         s = self._s
         stride = 16384
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return _make_tiled_json(idx, sym_id), [0x1000], [{s: stride}], []
@@ -1360,7 +1342,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         self.assertIn('"symbol_ids"=[-1]', mlir)
 
     def test_non_tiled_tensor_in_loop_no_affine_apply(self):
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x2000)
             return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
@@ -1378,7 +1360,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
         s = self._s
         stride = 8192
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x3000)
             return _make_tiled_json(idx, sym_id), [0x3000], [{s: stride}], []
@@ -1395,7 +1377,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
     def test_affine_apply_inside_scf_for(self):
         s = self._s
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x4000)
             return _make_tiled_json(idx, sym_id), [0x4000], [{s: 512}], []
@@ -1414,7 +1396,7 @@ class TestGenerateBundleMlirWithAffineStrides(unittest.TestCase):
     def test_tiled_snapshot(self):
         s = self._s
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
@@ -1455,15 +1437,13 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
             "torch_spyre._inductor.codegen.bundle.compile_op_spec",
             side_effect=fake_compile,
         ):
-            generate_bundle(
-                "test_kernel", self.tmpdir, specs, use_symbols=True, unroll_loops=False
-            )
+            generate_bundle("test_kernel", self.tmpdir, specs, unroll_loops=False)
         return _read_mlir(self.tmpdir)
 
     def _fake_compile_two_strides(self, outer_stride, inner_stride):
         s0, s1 = self.s0, self.s1
 
-        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake_compile(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(0x1000)
             return (
@@ -1535,28 +1515,6 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
             "}\n"
         )
         self.assertEqual(mlir, expected)
-
-
-class TestGenerateBundleUnrollPath(unittest.TestCase):
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-
-    def test_non_tiled_loop_without_use_symbols_ok(self):
-        with patch(
-            "torch_spyre._inductor.codegen.bundle.compile_op_spec",
-            side_effect=_fake_compile_op_spec,
-        ):
-            op = _make_minimal_op_spec("a")
-            loop = LoopSpec(count=Integer(2), body=[op])
-            generate_bundle("test_kernel", self.tmpdir, [loop], use_symbols=False)
-
-    def test_flat_op_without_use_symbols_ok(self):
-        with patch(
-            "torch_spyre._inductor.codegen.bundle.compile_op_spec",
-            side_effect=_fake_compile_op_spec,
-        ):
-            op = _make_minimal_op_spec("a")
-            generate_bundle("test_kernel", self.tmpdir, [op], use_symbols=False)
 
 
 # ===========================================================================
@@ -1873,7 +1831,6 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 specs,
-                use_symbols=True,
                 unroll_loops=False,
                 symbolic_args=symbolic_args,
             )
@@ -1909,7 +1866,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def test_func_signature_has_params_for_tensor_args(self):
         a = self._make_op_spec_with_hbm_args("a", [0, 1])
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             for i, arg in enumerate(op_spec.args):
                 symbols.append(arg.allocation["hbm"])
             ids = [-(symbol_id_offset + i + 1) for i in range(len(op_spec.args))]
@@ -1964,7 +1921,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def test_sdsc_execute_uses_extracted_names(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(op_spec.args[0].allocation["hbm"])
             return (
@@ -2003,7 +1960,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         call_count = [0]
         values = [0x400000000, 0x0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -2025,7 +1982,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
     def test_symbolic_args_false_no_params(self):
         a = self._make_op_spec_with_hbm_args("a", [0])
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             sym_id = -(symbol_id_offset + 1)
             symbols.append(op_spec.args[0].allocation["hbm"])
             return (
@@ -2063,7 +2020,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         ]
         sym_counts = [2, 3, 2, 2, 3]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             n = sym_counts[i]
@@ -2124,7 +2081,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         base = 0x400000000  # SEGMENT_OFFSETS[1], arg_index=0
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
             symbols.append(base)
@@ -2150,7 +2107,7 @@ class TestGenerateBundleMlirSymbolicArgs(unittest.TestCase):
         call_count = [0]
         pool_values = [0, 2048, 0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             sym_id = -(symbol_id_offset + 1)
@@ -2258,7 +2215,6 @@ class TestSymbolKind(unittest.TestCase):
             symbols,
             symbol_id_offset=0,
             tiled_symbols=[s],
-            use_symbols=True,
         )
         self.assertEqual(len(kinds), 2)
         self.assertIsInstance(kinds[0], SymbolKind)
@@ -2276,7 +2232,7 @@ class TestSymbolKind(unittest.TestCase):
 
         call_count = [0]
 
-        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=True):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0):
             i = call_count[0]
             call_count[0] += 1
             base = 0x400000000
@@ -2303,7 +2259,6 @@ class TestSymbolKind(unittest.TestCase):
                 "test_kernel",
                 self.tmpdir,
                 [a, b],
-                use_symbols=True,
                 unroll_loops=False,
                 symbolic_args=True,
             )

--- a/tests/test_launch_jobplan.py
+++ b/tests/test_launch_jobplan.py
@@ -44,9 +44,8 @@ class TestLaunchJobPlan:
         "env_vars",
         [
             {"DUMP_SPYRE_CODE": "1"},
-            {"DUMP_SPYRE_CODE": "1", "BUNDLE_HBM_SYMBOLS": "1"},
         ],
-        ids=["SpyreCode, no symbols", "SpyreCode, fake symbols"],
+        ids=["SpyreCode, no symbols"],
     )
     def test_abs_matches_cpu(self, env_vars):
         """Run compiled abs op with various env settings and compare to CPU."""
@@ -65,9 +64,8 @@ class TestLaunchJobPlan:
         "env_vars",
         [
             {"DUMP_SPYRE_CODE": "1"},
-            {"DUMP_SPYRE_CODE": "1", "BUNDLE_HBM_SYMBOLS": "1"},
         ],
-        ids=["SpyreCode, no symbols", "SpyreCode, fake symbols"],
+        ids=["SpyreCode, no symbols"],
     )
     def test_mul_matches_cpu(self, env_vars):
         """Run compiled mul op with various env settings and compare to CPU."""

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -52,7 +52,6 @@ def generate_bundle(
     kernel_name: str,
     output_dir: str,
     specs: Sequence,
-    use_symbols: bool | None = None,
     unroll_loops: bool | None = None,
     symbolic_args: bool | None = None,
 ):
@@ -60,11 +59,6 @@ def generate_bundle(
 
     ``specs`` is a list of ``OpSpec | LoopSpec`` entries (nested ``LoopSpec``
     entries are supported).
-
-    ``use_symbols`` controls whether HBM tensor addresses are emitted as
-    runtime symbols (``%sym_N`` constants) in ``bundle.mlir`` with
-    ``affine.apply`` indirection.  When ``None`` (the default) the value is
-    read from ``config.bundle_hbm_symbols``.
 
     ``unroll_loops`` controls whether ``LoopSpec`` nodes are fully unrolled
     into flat ``OpSpec`` nodes before bundle generation.  When ``None`` (the
@@ -76,9 +70,13 @@ def generate_bundle(
     independent ``OpSpec`` with concrete per-iteration HBM addresses baked in.
     When ``unroll_loops=False``, ``LoopSpec`` entries are passed through intact
     and produce ``scf.for`` loops in the generated ``bundle.mlir``.
+
+    ``symbolic_args`` controls the function signature of ``@sdsc_bundle``.
+    When ``False`` (default), HBM addresses are baked as concrete integers and
+    ``sdsc_execute`` has no operands.  When ``True``, addresses are emitted as
+    runtime symbols with ``!sdscbundle.input_arg<index>`` parameters.  When
+    ``None``, the value is read from ``config.bundle_symbolic_args``.
     """
-    if use_symbols is None:
-        use_symbols = _spyre_config.bundle_hbm_symbols
     if unroll_loops is None:
         unroll_loops = _spyre_config.unroll_loops
     if symbolic_args is None:
@@ -104,7 +102,6 @@ def generate_bundle(
         sdsc_counter,
         symbol_id_offset_counter,
         output_dir,
-        use_symbols=use_symbols,
     )
 
     # -----------------------------------------------------------------------
@@ -127,12 +124,14 @@ def generate_bundle(
 
     # Build a per-symbol kind list from compiled entries (symbolic_args path only).
     symbol_kinds: list[SymbolKind] = []
-    if symbolic_args and use_symbols:
+    if symbolic_args:
         for _, _, _, local_kinds in compiled:
             symbol_kinds.extend(local_kinds)
 
     # Determine whether a pool parameter is needed (any pool symbol present).
-    has_pool = symbolic_args and use_symbols and any(sk.is_pool for sk in symbol_kinds)
+    has_pool = (
+        symbolic_args and bool(symbol_kinds) and any(sk.is_pool for sk in symbol_kinds)
+    )
     # Indices of kernel-base symbols that become input_arg parameters.
     # Deduplicated by address value: multiple SDSCs may register the same kernel arg
     # address independently (no cross-SDSC dedup in generate_sdsc), so we keep only
@@ -141,7 +140,7 @@ def generate_bundle(
     # kernel_dup_canonical: maps duplicate kernel sym_idx → canonical sym_idx.
     kernel_arg_sym_indices: list[int] = []
     kernel_dup_canonical: dict[int, int] = {}  # duplicate sym_idx → canonical sym_idx
-    if symbolic_args and use_symbols:
+    if symbolic_args:
         seen_kernel_addr: dict[int, int] = {}  # address → canonical sym_idx
         for i, kind_i in enumerate(symbol_kinds):
             if kind_i.kind == "kernel":
@@ -171,7 +170,7 @@ def generate_bundle(
         #   - one !sdscbundle.input_arg<index> param per kernel tensor arg, with a
         #     descriptive formal name %arg_{arg_index}_base_addr; the short form
         #     %arg_{arg_index} is used in the body after input_arg_extract
-        if symbolic_args and use_symbols and (has_pool or kernel_arg_sym_indices):
+        if symbolic_args and (has_pool or kernel_arg_sym_indices):
             params = []
             if has_pool:
                 params.append("%pool_base_addr: !sdscbundle.input_arg<index>")
@@ -206,7 +205,7 @@ def generate_bundle(
         #                         deduped by (arg_index, offset) pair
         #   - "pool"            → arith.addi %pool, <pool_offset>
         #                         deduped by pool offset value
-        #   - anything else     → arith.constant (use_symbols=False or non-symbolic path)
+        #   - anything else     → arith.constant (non-symbolic path)
         # All kernel sym indices to skip during emission (canonical + duplicates).
         kernel_arg_sym_set = set(kernel_arg_sym_indices) | set(kernel_dup_canonical)
         # Map kernel sym_idx → arg_index for SSA name generation.
@@ -279,7 +278,6 @@ def generate_bundle(
             [],
             f,
             indent=2,
-            use_symbols=use_symbols,
             symbolic_args=symbolic_args,
             kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
             sym_canonical=sym_canonical,
@@ -302,7 +300,6 @@ def _compile_specs(
     sdsc_counter: list,
     symbol_id_offset_counter: list,
     output_dir: str,
-    use_symbols: bool = False,
 ) -> None:
     """Recursively compile all OpSpecs in specs depth-first."""
     for entry in specs:
@@ -314,7 +311,6 @@ def _compile_specs(
                 sdsc_counter,
                 symbol_id_offset_counter,
                 output_dir,
-                use_symbols=use_symbols,
             )
         elif isinstance(entry, OpSpec):
             idx = sdsc_counter[0]
@@ -407,7 +403,6 @@ def _emit_specs(
     loop_vars: list,
     f,
     indent: int,
-    use_symbols: bool = False,
     symbolic_args: bool = False,
     kernel_sym_to_arg_idx: dict | None = None,
     sym_canonical: dict | None = None,
@@ -453,7 +448,6 @@ def _emit_specs(
                 loop_vars + [loop_var],
                 f,
                 indent + 1,
-                use_symbols=use_symbols,
                 symbolic_args=symbolic_args,
                 kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
                 sym_canonical=sym_canonical,
@@ -501,18 +495,12 @@ def _emit_specs(
             ]
 
             operand_str = ", ".join(operands)
-            if use_symbols:
-                symbol_ids_str = ", ".join(str(i) for i in symbol_ids)
-                f.write(
-                    f"{tab}sdscbundle.sdsc_execute ({operand_str}) "
-                    f'{{sdsc_filename="{sdsc_filename}", '
-                    f'"symbol_ids"=[{symbol_ids_str}]}}\n'
-                )
-            else:
-                f.write(
-                    f"{tab}sdscbundle.sdsc_execute () "
-                    f'{{sdsc_filename="{sdsc_filename}"}}\n'
-                )
+            symbol_ids_str = ", ".join(str(i) for i in symbol_ids)
+            f.write(
+                f"{tab}sdscbundle.sdsc_execute ({operand_str}) "
+                f'{{sdsc_filename="{sdsc_filename}", '
+                f'"symbol_ids"=[{symbol_ids_str}]}}\n'
+            )
 
 
 def _extract_symbol_ids(sdsc_json: dict) -> list[int]:

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -325,7 +325,6 @@ def _compile_specs(
                     entry,
                     symbols,
                     symbol_id_offset_counter[0],
-                    use_symbols=use_symbols,
                 )
             )
             symbol_id_offset_counter[0] += len(local_sym_values)

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -81,6 +81,7 @@ def generate_bundle(
         unroll_loops = _spyre_config.unroll_loops
     if symbolic_args is None:
         symbolic_args = _spyre_config.bundle_symbolic_args
+    use_symbols = symbolic_args
 
     specs_list: list = unroll_loop_specs(list(specs)) if unroll_loops else list(specs)
 
@@ -102,6 +103,7 @@ def generate_bundle(
         sdsc_counter,
         symbol_id_offset_counter,
         output_dir,
+        use_symbols=use_symbols,
     )
 
     # -----------------------------------------------------------------------
@@ -278,6 +280,7 @@ def generate_bundle(
             [],
             f,
             indent=2,
+            use_symbols=use_symbols,
             symbolic_args=symbolic_args,
             kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
             sym_canonical=sym_canonical,
@@ -300,6 +303,7 @@ def _compile_specs(
     sdsc_counter: list,
     symbol_id_offset_counter: list,
     output_dir: str,
+    use_symbols: bool = False,
 ) -> None:
     """Recursively compile all OpSpecs in specs depth-first."""
     for entry in specs:
@@ -311,6 +315,7 @@ def _compile_specs(
                 sdsc_counter,
                 symbol_id_offset_counter,
                 output_dir,
+                use_symbols=use_symbols,
             )
         elif isinstance(entry, OpSpec):
             idx = sdsc_counter[0]
@@ -321,6 +326,7 @@ def _compile_specs(
                     entry,
                     symbols,
                     symbol_id_offset_counter[0],
+                    use_symbols=use_symbols,
                 )
             )
             symbol_id_offset_counter[0] += len(local_sym_values)
@@ -403,6 +409,7 @@ def _emit_specs(
     loop_vars: list,
     f,
     indent: int,
+    use_symbols: bool = False,
     symbolic_args: bool = False,
     kernel_sym_to_arg_idx: dict | None = None,
     sym_canonical: dict | None = None,
@@ -448,6 +455,7 @@ def _emit_specs(
                 loop_vars + [loop_var],
                 f,
                 indent + 1,
+                use_symbols=use_symbols,
                 symbolic_args=symbolic_args,
                 kernel_sym_to_arg_idx=kernel_sym_to_arg_idx,
                 sym_canonical=sym_canonical,
@@ -495,12 +503,18 @@ def _emit_specs(
             ]
 
             operand_str = ", ".join(operands)
-            symbol_ids_str = ", ".join(str(i) for i in symbol_ids)
-            f.write(
-                f"{tab}sdscbundle.sdsc_execute ({operand_str}) "
-                f'{{sdsc_filename="{sdsc_filename}", '
-                f'"symbol_ids"=[{symbol_ids_str}]}}\n'
-            )
+            if use_symbols:
+                symbol_ids_str = ", ".join(str(i) for i in symbol_ids)
+                f.write(
+                    f"{tab}sdscbundle.sdsc_execute ({operand_str}) "
+                    f'{{sdsc_filename="{sdsc_filename}", '
+                    f'"symbol_ids"=[{symbol_ids_str}]}}\n'
+                )
+            else:
+                f.write(
+                    f"{tab}sdscbundle.sdsc_execute () "
+                    f'{{sdsc_filename="{sdsc_filename}"}}\n'
+                )
 
 
 def _extract_symbol_ids(sdsc_json: dict) -> list[int]:

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -276,29 +276,22 @@ def generate_sdsc(
     symbols: list[int],
     symbol_id_offset: int = 0,
     tiled_symbols=None,
-    use_symbols: bool = False,
 ):
     """Generate SDSC JSON for one OpSpec.
 
     Returns a 4-tuple ``(sdsc_json, base_symbol_values, affine_strides, symbol_kinds)``:
     - ``sdsc_json``: the JSON dict to write to ``sdsc_N.json``
-    - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``;
-      empty when ``use_symbols=False``
+    - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``
     - ``affine_strides``: list (parallel to ``sdsc_spec.args``) of dicts
-      ``{tiled_sym: stride_bytes}`` for tiled HBM tensors; always empty when
-      ``use_symbols=False``.  Used by ``bundle.py`` to emit ``affine.apply``
-      ops inside ``scf.for`` loops.
-    - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``;
-      empty when ``use_symbols=False``.  Classifies each symbol as a kernel base
-      address, per-core derived address, or pool-allocated address.
+      ``{tiled_sym: stride_bytes}`` for tiled HBM tensors.  Used by ``bundle.py``
+      to emit ``affine.apply`` ops inside ``scf.for`` loops.
+    - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``.
+      Classifies each symbol as a kernel base address, per-core derived address,
+      or pool-allocated address.
 
-    When ``use_symbols=False``, HBM tensor addresses are baked directly as
-    concrete integers into the SDSC JSON.  No symbol IDs are registered and
-    ``symbols`` is not modified.
-
-    When ``use_symbols=True``, HBM addresses are registered as negative symbol
-    IDs in the JSON and their values appended to ``symbols``, enabling
-    ``affine.apply`` address computation in ``bundle.mlir`` for tiled loops.
+    HBM addresses are registered as negative symbol IDs in the JSON and their
+    values appended to ``symbols``, enabling ``affine.apply`` address computation
+    in ``bundle.mlir`` for tiled loops.
     """
     if tiled_symbols is None:
         tiled_symbols = []
@@ -322,8 +315,6 @@ def generate_sdsc(
     # that happen to share a base address will emit two separate arith.constant
     # declarations in bundle.mlir.  This keeps symbol IDs contiguous with the
     # symbols list indices: symbols[abs(id)-1] is always the value for id.
-    #
-    # When use_symbols=False this dict stays empty (symbols is not modified).
     local_symbols: dict[int, int] = {}
     # Parallel to local_symbols (insertion order): one SymbolKind per registered symbol.
     local_symbol_kind: list[SymbolKind] = []
@@ -348,95 +339,72 @@ def generate_sdsc(
             arg_index=arg_index,
         )
 
-    if use_symbols:
+    def offset_as_symbol(s, kind: SymbolKind):
+        if s not in local_symbols:
+            local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
+            symbols.append(s)
+            local_symbol_kind.append(kind)
+        return local_symbols[s]
 
-        def offset_as_symbol(s, kind: SymbolKind):
-            if s not in local_symbols:
-                local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
-                symbols.append(s)
-                local_symbol_kind.append(kind)
-            return local_symbols[s]
-
-        # Compute per-tensor affine strides and register base addresses in symbols.
-        # affine_strides[i] is {tiled_sym: stride_bytes} for tensor i (empty if
-        # non-tiled/lx).
-        affine_strides: list[dict] = []
-        for tensor in sdsc_spec.args:
-            if "lx" in tensor.allocation:
-                affine_strides.append({})
-                continue
-            core0_addr = tensor.start_address + core_idx_to_slice_offset(
-                tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-            ) * num_bytes(tensor.data_format)
-            # base_sym_idx: index in global symbols[] where core-0 will be registered.
-            # Used by kernel_derived symbols to reference their base without searching.
-            base_sym_idx = symbol_id_offset + len(local_symbols)
-            tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
-            if not tensor_tiled:
-                # Non-tiled HBM: register per-core addresses.
-                for c in range(sdsc_spec.num_cores):
-                    addr = tensor.start_address + core_idx_to_slice_offset(
-                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                    ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(
-                        addr,
-                        _per_core_kind(
-                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
-                        ),
-                    )
-                affine_strides.append({})
-            else:
-                # Tiled HBM: symbol value = per-core iter-0 base address.
-                # The affine map adds loop_var * tile_stride on top at runtime.
-                strides_for_tensor = {}
-                for s in tensor_tiled:
-                    strides_for_tensor[s] = _tiled_byte_stride(
-                        tensor, s, sdsc_spec.iteration_space
-                    )
-                for c in range(sdsc_spec.num_cores):
-                    addr = tensor.start_address + core_idx_to_slice_offset(
-                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                    ) * num_bytes(tensor.data_format)
-                    offset_as_symbol(
-                        addr,
-                        _per_core_kind(
-                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
-                        ),
-                    )
-                affine_strides.append(strides_for_tensor)
-
-        def _start_addr_data(tensor):
-            # All per-core addresses were already registered by the per-tensor loop
-            # above. Look them up directly rather than re-computing SymbolKind.
-            if "lx" in tensor.allocation:
-                return {
-                    f"[{c}, 0, 0]": str(tensor.start_address)
-                    for c in range(sdsc_spec.num_cores)
-                }
-            result = {}
+    # Compute per-tensor affine strides and register base addresses in symbols.
+    # affine_strides[i] is {tiled_sym: stride_bytes} for tensor i (empty if
+    # non-tiled/lx).
+    affine_strides: list[dict] = []
+    for tensor in sdsc_spec.args:
+        if "lx" in tensor.allocation:
+            affine_strides.append({})
+            continue
+        core0_addr = tensor.start_address + core_idx_to_slice_offset(
+            tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+        ) * num_bytes(tensor.data_format)
+        # base_sym_idx: index in global symbols[] where core-0 will be registered.
+        # Used by kernel_derived symbols to reference their base without searching.
+        base_sym_idx = symbol_id_offset + len(local_symbols)
+        tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
+        if not tensor_tiled:
+            # Non-tiled HBM: register per-core addresses.
             for c in range(sdsc_spec.num_cores):
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                 ) * num_bytes(tensor.data_format)
-                result[f"[{c}, 0, 0]"] = str(local_symbols[addr])
-            return result
-
-    else:
-        # use_symbols=False: bake concrete HBM addresses directly into the JSON,
-        # mirroring the LX tensor path.  symbols and local_symbols are not modified.
-        affine_strides = [{} for _ in sdsc_spec.args]
-
-        def _start_addr_data(tensor):
-            return {
-                f"[{c}, 0, 0]": str(
-                    tensor.start_address
-                    + core_idx_to_slice_offset(
-                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                    )
-                    * num_bytes(tensor.data_format)
+                offset_as_symbol(
+                    addr,
+                    _per_core_kind(c, tensor.arg_index, core0_addr, addr, base_sym_idx),
                 )
+            affine_strides.append({})
+        else:
+            # Tiled HBM: symbol value = per-core iter-0 base address.
+            # The affine map adds loop_var * tile_stride on top at runtime.
+            strides_for_tensor = {}
+            for s in tensor_tiled:
+                strides_for_tensor[s] = _tiled_byte_stride(
+                    tensor, s, sdsc_spec.iteration_space
+                )
+            for c in range(sdsc_spec.num_cores):
+                addr = tensor.start_address + core_idx_to_slice_offset(
+                    tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                ) * num_bytes(tensor.data_format)
+                offset_as_symbol(
+                    addr,
+                    _per_core_kind(c, tensor.arg_index, core0_addr, addr, base_sym_idx),
+                )
+            affine_strides.append(strides_for_tensor)
+
+    def _start_addr_data(tensor):
+        # All per-core addresses were already registered by the per-tensor loop
+        # above. Look them up directly rather than re-computing SymbolKind.
+        if "lx" in tensor.allocation:
+            return {
+                f"[{c}, 0, 0]": str(tensor.start_address)
                 for c in range(sdsc_spec.num_cores)
             }
+        result = {}
+        for c in range(sdsc_spec.num_cores):
+            addr = tensor.start_address + core_idx_to_slice_offset(
+                tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+            ) * num_bytes(tensor.data_format)
+            result[f"[{c}, 0, 0]"] = str(local_symbols[addr])
+        return result
 
     return (
         {
@@ -522,7 +490,7 @@ def generate_sdsc(
                                     else "hbm",
                                     **(
                                         {"isStartAddrSymbolic_": 1}
-                                        if use_symbols and "lx" not in tensor.allocation
+                                        if "lx" not in tensor.allocation
                                         else {}
                                     ),
                                     "layoutDimOrder_": [

--- a/torch_spyre/_inductor/codegen/compute_ops.py
+++ b/torch_spyre/_inductor/codegen/compute_ops.py
@@ -276,22 +276,29 @@ def generate_sdsc(
     symbols: list[int],
     symbol_id_offset: int = 0,
     tiled_symbols=None,
+    use_symbols: bool = False,
 ):
     """Generate SDSC JSON for one OpSpec.
 
     Returns a 4-tuple ``(sdsc_json, base_symbol_values, affine_strides, symbol_kinds)``:
     - ``sdsc_json``: the JSON dict to write to ``sdsc_N.json``
-    - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``
+    - ``base_symbol_values``: list of HBM byte offsets registered in ``symbols``;
+      empty when ``use_symbols=False``
     - ``affine_strides``: list (parallel to ``sdsc_spec.args``) of dicts
-      ``{tiled_sym: stride_bytes}`` for tiled HBM tensors.  Used by ``bundle.py``
-      to emit ``affine.apply`` ops inside ``scf.for`` loops.
-    - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``.
-      Classifies each symbol as a kernel base address, per-core derived address,
-      or pool-allocated address.
+      ``{tiled_sym: stride_bytes}`` for tiled HBM tensors; always empty when
+      ``use_symbols=False``.  Used by ``bundle.py`` to emit ``affine.apply``
+      ops inside ``scf.for`` loops.
+    - ``symbol_kinds``: list of ``SymbolKind`` parallel to ``base_symbol_values``;
+      empty when ``use_symbols=False``.  Classifies each symbol as a kernel base
+      address, per-core derived address, or pool-allocated address.
 
-    HBM addresses are registered as negative symbol IDs in the JSON and their
-    values appended to ``symbols``, enabling ``affine.apply`` address computation
-    in ``bundle.mlir`` for tiled loops.
+    When ``use_symbols=False``, HBM tensor addresses are baked directly as
+    concrete integers into the SDSC JSON.  No symbol IDs are registered and
+    ``symbols`` is not modified.
+
+    When ``use_symbols=True``, HBM addresses are registered as negative symbol
+    IDs in the JSON and their values appended to ``symbols``, enabling
+    ``affine.apply`` address computation in ``bundle.mlir`` for tiled loops.
     """
     if tiled_symbols is None:
         tiled_symbols = []
@@ -339,72 +346,95 @@ def generate_sdsc(
             arg_index=arg_index,
         )
 
-    def offset_as_symbol(s, kind: SymbolKind):
-        if s not in local_symbols:
-            local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
-            symbols.append(s)
-            local_symbol_kind.append(kind)
-        return local_symbols[s]
+    if use_symbols:
 
-    # Compute per-tensor affine strides and register base addresses in symbols.
-    # affine_strides[i] is {tiled_sym: stride_bytes} for tensor i (empty if
-    # non-tiled/lx).
-    affine_strides: list[dict] = []
-    for tensor in sdsc_spec.args:
-        if "lx" in tensor.allocation:
-            affine_strides.append({})
-            continue
-        core0_addr = tensor.start_address + core_idx_to_slice_offset(
-            tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
-        ) * num_bytes(tensor.data_format)
-        # base_sym_idx: index in global symbols[] where core-0 will be registered.
-        # Used by kernel_derived symbols to reference their base without searching.
-        base_sym_idx = symbol_id_offset + len(local_symbols)
-        tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
-        if not tensor_tiled:
-            # Non-tiled HBM: register per-core addresses.
+        def offset_as_symbol(s, kind: SymbolKind):
+            if s not in local_symbols:
+                local_symbols[s] = -(symbol_id_offset + len(local_symbols) + 1)
+                symbols.append(s)
+                local_symbol_kind.append(kind)
+            return local_symbols[s]
+
+        # Compute per-tensor affine strides and register base addresses in symbols.
+        # affine_strides[i] is {tiled_sym: stride_bytes} for tensor i (empty if
+        # non-tiled/lx).
+        affine_strides: list[dict] = []
+        for tensor in sdsc_spec.args:
+            if "lx" in tensor.allocation:
+                affine_strides.append({})
+                continue
+            core0_addr = tensor.start_address + core_idx_to_slice_offset(
+                tensor, core_id_to_wk_slice["0"], sdsc_spec.work_slices
+            ) * num_bytes(tensor.data_format)
+            # base_sym_idx: index in global symbols[] where core-0 will be registered.
+            # Used by kernel_derived symbols to reference their base without searching.
+            base_sym_idx = symbol_id_offset + len(local_symbols)
+            tensor_tiled = [s for s in tiled_symbols if s in tensor.strides]
+            if not tensor_tiled:
+                # Non-tiled HBM: register per-core addresses.
+                for c in range(sdsc_spec.num_cores):
+                    addr = tensor.start_address + core_idx_to_slice_offset(
+                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                    ) * num_bytes(tensor.data_format)
+                    offset_as_symbol(
+                        addr,
+                        _per_core_kind(
+                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
+                        ),
+                    )
+                affine_strides.append({})
+            else:
+                # Tiled HBM: symbol value = per-core iter-0 base address.
+                # The affine map adds loop_var * tile_stride on top at runtime.
+                strides_for_tensor = {}
+                for s in tensor_tiled:
+                    strides_for_tensor[s] = _tiled_byte_stride(
+                        tensor, s, sdsc_spec.iteration_space
+                    )
+                for c in range(sdsc_spec.num_cores):
+                    addr = tensor.start_address + core_idx_to_slice_offset(
+                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                    ) * num_bytes(tensor.data_format)
+                    offset_as_symbol(
+                        addr,
+                        _per_core_kind(
+                            c, tensor.arg_index, core0_addr, addr, base_sym_idx
+                        ),
+                    )
+                affine_strides.append(strides_for_tensor)
+
+        def _start_addr_data(tensor):
+            # All per-core addresses were already registered by the per-tensor loop
+            # above. Look them up directly rather than re-computing SymbolKind.
+            if "lx" in tensor.allocation:
+                return {
+                    f"[{c}, 0, 0]": str(tensor.start_address)
+                    for c in range(sdsc_spec.num_cores)
+                }
+            result = {}
             for c in range(sdsc_spec.num_cores):
                 addr = tensor.start_address + core_idx_to_slice_offset(
                     tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
                 ) * num_bytes(tensor.data_format)
-                offset_as_symbol(
-                    addr,
-                    _per_core_kind(c, tensor.arg_index, core0_addr, addr, base_sym_idx),
-                )
-            affine_strides.append({})
-        else:
-            # Tiled HBM: symbol value = per-core iter-0 base address.
-            # The affine map adds loop_var * tile_stride on top at runtime.
-            strides_for_tensor = {}
-            for s in tensor_tiled:
-                strides_for_tensor[s] = _tiled_byte_stride(
-                    tensor, s, sdsc_spec.iteration_space
-                )
-            for c in range(sdsc_spec.num_cores):
-                addr = tensor.start_address + core_idx_to_slice_offset(
-                    tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-                ) * num_bytes(tensor.data_format)
-                offset_as_symbol(
-                    addr,
-                    _per_core_kind(c, tensor.arg_index, core0_addr, addr, base_sym_idx),
-                )
-            affine_strides.append(strides_for_tensor)
+                result[f"[{c}, 0, 0]"] = str(local_symbols[addr])
+            return result
 
-    def _start_addr_data(tensor):
-        # All per-core addresses were already registered by the per-tensor loop
-        # above. Look them up directly rather than re-computing SymbolKind.
-        if "lx" in tensor.allocation:
+    else:
+        # use_symbols=False: bake concrete HBM addresses directly into the JSON.
+        # symbols and local_symbols are not modified.
+        affine_strides = [{} for _ in sdsc_spec.args]
+
+        def _start_addr_data(tensor):
             return {
-                f"[{c}, 0, 0]": str(tensor.start_address)
+                f"[{c}, 0, 0]": str(
+                    tensor.start_address
+                    + core_idx_to_slice_offset(
+                        tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
+                    )
+                    * num_bytes(tensor.data_format)
+                )
                 for c in range(sdsc_spec.num_cores)
             }
-        result = {}
-        for c in range(sdsc_spec.num_cores):
-            addr = tensor.start_address + core_idx_to_slice_offset(
-                tensor, core_id_to_wk_slice[str(c)], sdsc_spec.work_slices
-            ) * num_bytes(tensor.data_format)
-            result[f"[{c}, 0, 0]"] = str(local_symbols[addr])
-        return result
 
     return (
         {
@@ -490,7 +520,7 @@ def generate_sdsc(
                                     else "hbm",
                                     **(
                                         {"isStartAddrSymbolic_": 1}
-                                        if "lx" not in tensor.allocation
+                                        if use_symbols and "lx" not in tensor.allocation
                                         else {}
                                     ),
                                     "layoutDimOrder_": [

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -650,6 +650,7 @@ def compile_op_spec(
     op_spec: OpSpec,
     symbols: list[int],
     symbol_id_offset: int = 0,
+    use_symbols: bool = False,
 ) -> tuple[Any, list[int], list[dict], list[SymbolKind]]:
     sdsc_spec, symbol_mapping = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)
@@ -664,4 +665,5 @@ def compile_op_spec(
         symbols,
         symbol_id_offset,
         tiled_symbols=tiled_symbols,
+        use_symbols=use_symbols,
     )

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -650,7 +650,6 @@ def compile_op_spec(
     op_spec: OpSpec,
     symbols: list[int],
     symbol_id_offset: int = 0,
-    use_symbols: bool = False,
 ) -> tuple[Any, list[int], list[dict], list[SymbolKind]]:
     sdsc_spec, symbol_mapping = parse_op_spec(op_spec)
     logger.debug("%s", sdsc_spec)

--- a/torch_spyre/_inductor/codegen/superdsc.py
+++ b/torch_spyre/_inductor/codegen/superdsc.py
@@ -665,5 +665,4 @@ def compile_op_spec(
         symbols,
         symbol_id_offset,
         tiled_symbols=tiled_symbols,
-        use_symbols=use_symbols,
     )

--- a/torch_spyre/_inductor/codegen/unroll.py
+++ b/torch_spyre/_inductor/codegen/unroll.py
@@ -14,11 +14,9 @@
 
 """Loop unrolling for coarse-tiling LoopSpec trees.
 
-When ``bundle_hbm_symbols=False`` the backend compiler does not support
-``scf.for`` loops in ``bundle.mlir``.  This module provides
-``unroll_loop_specs``, which fully unrolls a ``list[OpSpec | LoopSpec]`` tree
-into a flat list of ``OpSpec`` entries with concrete per-iteration addresses
-baked into each ``TensorArg.allocation``.
+This module provides ``unroll_loop_specs``, which fully unrolls a
+``list[OpSpec | LoopSpec]`` tree into a flat list of ``OpSpec`` entries
+with concrete per-iteration addresses baked into each ``TensorArg.allocation``.
 
 Whether a tensor's address advances per iteration is determined solely by
 ``TensorArg.per_tile_fixed`` (set by ``insert_tiling_propagation``'s use-def

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -40,21 +40,16 @@ core_id_k_fast_emission: bool = (
     os.environ.get("SPYRE_CORE_ID_K_FAST_EMISSION", "1") == "1"
 )
 
-# When True, HBM tensor addresses are emitted as runtime symbols (%sym_N
-# constants) in bundle.mlir and resolved via affine.apply for tiled loops.
-# Requires backend compiler support for the sdscbundle symbol table, which is
-# still under development.
-bundle_hbm_symbols: bool = os.environ.get("BUNDLE_HBM_SYMBOLS", "0") == "1"
-
-# When True, the generated func.func @sdsc_bundle takes one
-# !sdscbundle.input_arg<index> parameter per tensor argument and extracts
-# each to a local SSA value, rather than emitting arith.constant offsets.
-# Requires bundle_hbm_symbols=True to have any effect.
+# When False (default), HBM tensor addresses are baked as concrete integers
+# into the SDSC JSON and bundle.mlir emits sdsc_execute with no operands.
+# When True, addresses are emitted as runtime symbols with
+# !sdscbundle.input_arg<index> parameters, input_arg_extract ops, and
+# affine.apply indirection for tiled loops.
 bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "0") == "1"
 
 # When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs
 # before generate_bundle runs.  Set to False to pass LoopSpecs through intact
-# (used with bundle_hbm_symbols=True for the scf.for / affine.apply path).
+# for the scf.for / affine.apply path.
 unroll_loops: bool = os.environ.get("UNROLL_LOOPS", "1") == "1"
 
 # Layout solver class used by default in scratchpad.allocator.DefaultAllocator.


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

Consolidates two config flags — `bundle_hbm_symbols` and `bundle_symbolic_args` — into a single `bundle_symbolic_args` flag.

Previously, `bundle_symbolic_args` required `bundle_hbm_symbols=True` as a prerequisite and the middle combination (`bundle_hbm_symbols=True, bundle_symbolic_args=False`) was not a suppor
ted backend target. The two flags are now collapsed into one with two clearly defined modes:

| `bundle_symbolic_args` | Behavior |
|---|---|
| `False` (default) | Concrete HBM addresses baked into SDSC JSON; `sdsc_execute ()` with no operands |
| `True` | Runtime symbols + `!sdscbundle.input_arg<index>` parameters + `input_arg_extract` ops |

**Changes:**
- `config.py`: Delete `bundle_hbm_symbols` and `BUNDLE_HBM_SYMBOLS` env var; update `bundle_symbolic_args` and `unroll_loops` comments to stand alone.
- `codegen/bundle.py`: `generate_bundle` derives `use_symbols = symbolic_args` internally and threads it through `_compile_specs` and `_emit_specs`. The `sdsc_execute` emission restores t
he `if use_symbols` / `else` split.
- `codegen/compute_ops.py`: `generate_sdsc` retains `use_symbols` as an internal parameter (now always driven by the caller); `isStartAddrSymbolic_` is gated on `use_symbols`.
- `codegen/superdsc.py`: `compile_op_spec` retains `use_symbols` and threads it to `generate_sdsc`.
- `codegen/unroll.py`: Remove stale `bundle_hbm_symbols=False` motivation paragraph from module docstring.
- `tests/inductor/test_coarse_tile_e2e.py`: Remove 12 `"bundle_hbm_symbols": True` entries from `@config.patch` dicts (loop-unrolling tests are independent of `bundle_symbolic_args`).
- `tests/inductor/test_coarse_tiling.py`: Remove `TestGenerateBundleUnrollPath` (tested the dead `use_symbols=False`-via-config path); fix `test_symbolic_args_false_no_params` to assert t
he correct concrete-address behavior.
- `tests/test_launch_jobplan.py`: Remove dead `"BUNDLE_HBM_SYMBOLS": "1"` env var entries.

#### Which issue(s) this PR is related to:

Part of #1915 

#### Special notes for your reviewer:

`use_symbols` is kept as an internal parameter rather than being deleted — this is intentional. The parameter is threaded from `generate_bundle` down to `generate_sdsc` to preserve the co
ncrete-address (`False`) path. The public API surface change is only in `config.py` (one flag removed) and `generate_bundle` (one parameter removed).

The `unroll_loops` config is orthogonal to this change and is left untouched.

#### Does this PR introduce a user-facing change?

Yes: `bundle_hbm_symbols` config option and `BUNDLE_HBM_SYMBOLS` environment variable are removed. Users who were setting `BUNDLE_HBM_SYMBOLS=1` should switch to `BUNDLE_SYMBOLIC_ARGS=1` 
(which enables the full symbolic-args path including `input_arg` parameters).

#### Additional note:
