### PR TITLE
Changed Tensor Allocation from Segment 0 to Segment 1

### DIFF
--- a/torch_spyre/csrc/spyre_allocator.cpp
+++ b/torch_spyre/csrc/spyre_allocator.cpp
@@ -121,7 +121,8 @@ void SpyreAllocator::recordRelease(size_t nbytes, void* data, int device_id) {
 }
 
 c10::DataPtr SpyreAllocator::allocate(size_t nbytes) {
-  flex::AllocationDirective directive(flex::PlacementPolicy::Bind, {0},
+  // Skip segment 0 to avoid EAR underflow. Use segments 1-6 for tensors.
+  flex::AllocationDirective directive(flex::PlacementPolicy::Bind, {1},
                                       std::nullopt, flex::MemoryType::Tensor);
   return SpyreAllocator::allocate(nbytes, directive);
 }


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

- Modified SpyreAllocator::allocate() in torch_spyre/csrc/spyre_allocator.cpp to use region_id {1} instead of {0} for tensor allocations
- Program allocations remain unchanged (still use segment 0, which maps to segment 7)

This avoids the underflow with no memory waste (the runtime already supports only 6 tensor regions) and requires no compiler/runtime coordination on guard sizes.

#### Which issue(s) this PR is related to:

Fixes #2455 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note: