### PR TITLE
tests: Added Spyre tensor layout checks

### DIFF
--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-with-device-layout.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-with-device-layout.yaml
@@ -1,0 +1,2794 @@
+test_suite_config:
+  global:
+    supported_dtypes:
+      - name: float16
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: float32
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: float64
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: bfloat16
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: int8
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: int16
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: int32
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: int64
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: uint8
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: uint16
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: uint32
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: uint64
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: complex32
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: complex64
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: complex128
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: bool
+        precision:
+          atol: 0.005
+          rtol: 0.005
+      - name: half
+        precision:
+          atol: 0.005
+          rtol: 0.005
+    input_config:
+      seed: 123
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
+      unlisted_test_mode: skip
+      tests:
+        - names:
+            - TestSpyreModelOps::test_model_ops_db
+          mode: xfail
+          tags:
+            - model__granite-3.3-8b-instruct
+          edits:
+            ops:
+              include:
+                - name: torch.nn.functional.embedding
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41]
+                          stride: [41, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                      - tensor:
+                          shape: [49159, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 0
+                      - value: null
+                      - value: 2.0
+                      - value: false
+                      - value: false
+                  description: 'Operation: torch.nn.functional.embedding, Node: inputs_embeds'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.nn.functional.embedding.1
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 12.0
+                  description: 'Operation: torch.mul, Node: inputs_embeds_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.1
+                - name: torch.arange
+                  sample_inputs_func:
+                    args:
+                      - value: 1
+                  description: 'Operation: torch.arange, Node: batch_arange'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.arange.1
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [41]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                      - value: 0
+                  description: 'Operation: torch.add, Node: q_arange'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.1
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [41]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.getitem, Node: q_indices'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.getitem.1
+                - name: torch.le
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1, 41]
+                          stride: [41, 41, 41, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                      - tensor:
+                          shape: [1, 1, 41, 1]
+                          stride: [41, 41, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.le, Node: attention_mask'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.le.1
+                - name: torch.Tensor.expand
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 41, 41]
+                          stride: [1681, 1681, 41, 1]
+                          storage_offset: 0
+                          dtype: torch.bool
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2
+                      - value: 1
+                      - value: -1
+                      - value: 41
+                      - value: 41
+                  description: 'Operation: torch.Tensor.expand, Node: attention_mask_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.expand.1
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [64]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: getitem_4'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.getitem.2
+                - name: torch.Tensor.float
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 64, 1]
+                          stride: [64, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.float, Node: float_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.float.1
+                - name: torch.Tensor.expand
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 64, 1]
+                          stride: [64, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: -1
+                      - value: 1
+                  description: 'Operation: torch.Tensor.expand, Node: expand_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.expand.2
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 64, 1]
+                          stride: [64, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: inv_freq_expanded'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.to.1
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41]
+                          stride: [41, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.getitem, Node: getitem_5'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.getitem.3
+                - name: torch.Tensor.float
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 41]
+                          stride: [41, 41, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                          device_layout:
+                            device_size: [2, 1, 32]
+                            stride_map: [32, -1, 1]
+                            device_dtype: torch.int32
+                  description: 'Operation: torch.Tensor.float, Node: position_ids_expanded'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.float.2_spyre
+                - name: torch.Tensor.float
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 41]
+                          stride: [41, 41, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.float, Node: float_4'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.float.3
+                - name: torch.matmul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 64, 1]
+                          stride: [64, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 41]
+                          stride: [41, 41, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.matmul, Node: matmul'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.matmul.1_spyre
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 64, 41]
+                          stride: [2624, 41, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: freqs'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.transpose.1
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [1, 41, 64]
+                            stride: [2624, 1, 41]
+                            storage_offset: 0
+                            dtype: torch.float32
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 41, 64]
+                            stride: [2624, 1, 41]
+                            storage_offset: 0
+                            dtype: torch.float32
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: emb'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.cat.1
+                - name: torch.Tensor.cos
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 128]
+                          stride: [5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.cos, Node: cos'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.cos.1
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 128]
+                          stride: [5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0
+                  description: 'Operation: torch.mul, Node: cos_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.mul.2
+                - name: torch.Tensor.sin
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 128]
+                          stride: [5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.sin, Node: sin'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.sin.1
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 128]
+                          stride: [5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: cos_2'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.to.2
+                - name: torch._C._log_api_usage_once
+                  sample_inputs_func:
+                    args:
+                      - value: python.nn_module
+                  description: 'Operation: torch._C._log_api_usage_once, Node: _log_api_usage_once'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch._C._log_api_usage_once.1
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: hidden_states'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.to.3_spyre
+                - name: torch.Tensor.pow
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 2
+                  description: 'Operation: torch.Tensor.pow, Node: pow_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.pow.1
+                - name: torch.Tensor.mean
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: -1
+                  description: 'Operation: torch.Tensor.mean, Node: variance'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.mean.1
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 1]
+                          stride: [41, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_2'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.2_spyre
+                - name: torch.rsqrt
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 1]
+                          stride: [41, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.rsqrt, Node: rsqrt'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.rsqrt.1
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 41, 1]
+                          stride: [41, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: hidden_states_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.mul.3
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: to_4'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.to.4
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [4096]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: hidden_states_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.4
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [4096, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: linear'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.1
+                - name: torch.Tensor.view
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: '[1, 41, -1, 128]'
+                  description: 'Operation: torch.Tensor.view, Node: view'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.view.1
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 32, 128]
+                          stride: [167936, 4096, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: query_states'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.transpose.2
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1024, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: linear_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.2_spyre
+                - name: torch.Tensor.view
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 1024]
+                          stride: [41984, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: '[1, 41, -1, 128]'
+                  description: 'Operation: torch.Tensor.view, Node: view_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.view.2
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 8, 128]
+                          stride: [41984, 1024, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: key_states'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.transpose.3
+                - name: torch.Tensor.unsqueeze
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 128]
+                          stride: [5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                  description: 'Operation: torch.Tensor.unsqueeze, Node: cos_3'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.unsqueeze.1
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 41, 128]
+                          stride: [5248, 5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: mul_5'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.5
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: x1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.getitem.4
+                - name: torch.neg
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 41, 64]
+                          stride: [167936, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.neg, Node: neg'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.neg.1
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [1, 32, 41, 64]
+                            stride: [83968, 64, 2048, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 32, 41, 64]
+                            stride: [167936, 128, 4096, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: cat_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.cat.2_spyre
+                  kwargs:
+                    dim: -1
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: q_embed'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.3
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 41, 128]
+                          stride: [41984, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 41, 128]
+                          stride: [5248, 5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: mul_7'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.6
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 41, 128]
+                          stride: [41984, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: x1_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.getitem.5
+                - name: torch.neg
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 41, 64]
+                          stride: [41984, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.neg, Node: neg_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.neg.2
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [1, 8, 41, 64]
+                            stride: [20992, 64, 512, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 8, 41, 64]
+                            stride: [41984, 128, 1024, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: cat_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.cat.3_spyre
+                  kwargs:
+                    dim: -1
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 41, 128]
+                          stride: [41984, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 8, 41, 128]
+                          stride: [41984, 5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: k_embed'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.4_spyre
+                - name: torch.tensor
+                  description: 'Operation: torch.tensor, Node: tensor'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.tensor.1
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [0]
+                            stride: [1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 8, 41, 128]
+                            stride: [41984, 128, 1024, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: keys'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.cat.4
+                - name: torch.Tensor.expand
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 1, 41, 128]
+                          stride: [41984, 5248, 5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 8
+                      - value: 4
+                      - value: 41
+                      - value: 128
+                  description: 'Operation: torch.Tensor.expand, Node: hidden_states_3'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.expand.3
+                - name: torch.Tensor.reshape
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 4, 41, 128]
+                          stride: [41984, 5248, 0, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 32
+                      - value: 41
+                      - value: 128
+                  description: 'Operation: torch.Tensor.reshape, Node: key'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.reshape.1
+                - name: torch.nn.functional.scaled_dot_product_attention
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 5248, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.nn.functional.scaled_dot_product_attention, Node: attn_output'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.scaled_dot_product_attention.1_spyre
+                  kwargs:
+                    dropout_p: 0.0
+                    scale: 0.0078125
+                    is_causal: false
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 41, 128]
+                          stride: [167936, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: transpose_4'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.transpose.4
+                - name: torch.Tensor.contiguous
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 32, 128]
+                          stride: [167936, 4096, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.contiguous, Node: attn_output_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.contiguous.1
+                - name: torch.Tensor.reshape
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 32, 128]
+                          stride: [167936, 4096, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 41
+                      - value: -1
+                  description: 'Operation: torch.Tensor.reshape, Node: reshape_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.reshape.2
+                - name: torch.Tensor.contiguous
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.contiguous, Node: attn_output_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.contiguous.2
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_5'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.5_spyre
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: hidden_states_6'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.to.5
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 1]
+                          stride: [41, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_6'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.6
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [12800, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: linear_4'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.3_spyre
+                - name: torch.nn.functional.silu
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 12800]
+                          stride: [524800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.nn.functional.silu, Node: silu'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.silu.1_spyre
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 12800]
+                          stride: [524800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 41, 12800]
+                          stride: [524800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: mul_12'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.7
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 12800]
+                          stride: [524800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [4096, 12800]
+                          stride: [12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: down_proj'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.4
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_9'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.7
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_15'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.8_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 1]
+                          stride: [41, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_12'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.9_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 41, 4096]
+                            stride_map: [167936, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_19'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.10_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 41, 4096]
+                            stride_map: [167936, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_139'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.11_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 1]
+                          stride: [41, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_86'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.12_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 41, 4096]
+                            stride_map: [167936, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_145'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.13_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 41, 4096]
+                            stride_map: [167936, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_399'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.14_spyre
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: getitem_246'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.getitem.6
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 4096]
+                          stride: [167936, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [49159, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: logits'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.5
+                - name: torch.truediv
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 41, 49159]
+                          stride: [2015519, 49159, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 16.0
+                  description: 'Operation: torch.truediv, Node: logits_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.truediv.1_spyre
+                - name: torch.nn.functional.embedding
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1]
+                          stride: [1, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                      - tensor:
+                          shape: [49159, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 0
+                      - value: null
+                      - value: 2.0
+                      - value: false
+                      - value: false
+                  description: 'Operation: torch.nn.functional.embedding, Node: inputs_embeds'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.nn.functional.embedding.2
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 12.0
+                  description: 'Operation: torch.mul, Node: inputs_embeds_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.8
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                      - value: 41
+                  description: 'Operation: torch.add, Node: q_arange'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.15
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [42]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                      - value: 0
+                  description: 'Operation: torch.add, Node: kv_arange'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.16
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.getitem, Node: q_indices'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.getitem.7
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [42]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.getitem, Node: kv_indices'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.getitem.8
+                - name: torch.le
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1, 42]
+                          stride: [42, 42, 42, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                      - tensor:
+                          shape: [1, 1, 1, 1]
+                          stride: [1, 1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.le, Node: attention_mask'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.le.2
+                - name: torch.Tensor.expand
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1, 42]
+                          stride: [42, 42, 42, 1]
+                          storage_offset: 0
+                          dtype: torch.bool
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2
+                      - value: 1
+                      - value: -1
+                      - value: 1
+                      - value: 42
+                  description: 'Operation: torch.Tensor.expand, Node: attention_mask_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.expand.4
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1]
+                          stride: [1, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.getitem, Node: getitem_5'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.getitem.9
+                - name: torch.Tensor.float
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.int64
+                          device: cuda:0
+                          init: randint
+                          init_args:
+                            high: 2147483647
+                  description: 'Operation: torch.Tensor.float, Node: position_ids_expanded'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.float.4
+                - name: torch.Tensor.float
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.float, Node: float_4'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.float.5
+                - name: torch.matmul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 64, 1]
+                          stride: [64, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.matmul, Node: matmul'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.matmul.2
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 64, 1]
+                          stride: [64, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: freqs'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.transpose.5
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [1, 1, 64]
+                            stride: [64, 1, 1]
+                            storage_offset: 0
+                            dtype: torch.float32
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 1, 64]
+                            stride: [64, 1, 1]
+                            storage_offset: 0
+                            dtype: torch.float32
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: emb'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.cat.5
+                - name: torch.Tensor.cos
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 128]
+                          stride: [128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.cos, Node: cos'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.cos.2
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 128]
+                          stride: [128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0
+                  description: 'Operation: torch.mul, Node: cos_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.mul.9
+                - name: torch.Tensor.sin
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 128]
+                          stride: [128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.sin, Node: sin'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.sin.2
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 128]
+                          stride: [128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: cos_2'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.to.6
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: hidden_states'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.to.7_spyre
+                - name: torch.Tensor.pow
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 2
+                  description: 'Operation: torch.Tensor.pow, Node: pow_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.pow.2
+                - name: torch.Tensor.mean
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: -1
+                  description: 'Operation: torch.Tensor.mean, Node: variance'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.mean.2
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_2'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.17_spyre
+                - name: torch.rsqrt
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.rsqrt, Node: rsqrt'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.rsqrt.2
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: hidden_states_1'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.mul.10
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: to_4'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.Tensor.to.8
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [4096]
+                          stride: [1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: hidden_states_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.11
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [4096, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: linear'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.6
+                - name: torch.Tensor.view
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: '[1, 1, -1, 128]'
+                  description: 'Operation: torch.Tensor.view, Node: view'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.view.3
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 32, 128]
+                          stride: [4096, 4096, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: query_states'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.transpose.6
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1024, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: linear_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.7_spyre
+                - name: torch.Tensor.view
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1024]
+                          stride: [1024, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: '[1, 1, -1, 128]'
+                  description: 'Operation: torch.Tensor.view, Node: view_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.view.4
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 8, 128]
+                          stride: [1024, 1024, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: key_states'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.transpose.7
+                - name: torch.Tensor.unsqueeze
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 128]
+                          stride: [128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                  description: 'Operation: torch.Tensor.unsqueeze, Node: cos_3'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.unsqueeze.2
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 1, 128]
+                          stride: [4096, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 1, 128]
+                          stride: [128, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: mul_5'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.12
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 1, 128]
+                          stride: [4096, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: x1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.getitem.10
+                - name: torch.neg
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 1, 64]
+                          stride: [4096, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.neg, Node: neg'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.neg.3
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [1, 32, 1, 64]
+                            stride: [2048, 64, 64, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 32, 1, 64]
+                            stride: [4096, 128, 4096, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: cat_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.cat.6_spyre
+                  kwargs:
+                    dim: -1
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 1, 128]
+                          stride: [4096, 128, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 32, 1, 128]
+                          stride: [4096, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: q_embed'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.18
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 1, 128]
+                          stride: [1024, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 1, 128]
+                          stride: [128, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: mul_7'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.13
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 1, 128]
+                          stride: [1024, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: x1_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.getitem.11
+                - name: torch.neg
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 1, 64]
+                          stride: [1024, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.neg, Node: neg_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.neg.4
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [1, 8, 1, 64]
+                            stride: [512, 64, 64, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 8, 1, 64]
+                            stride: [1024, 128, 1024, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: cat_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.cat.7_spyre
+                  kwargs:
+                    dim: -1
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 1, 128]
+                          stride: [1024, 128, 1024, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 8, 1, 128]
+                          stride: [1024, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: k_embed'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.19_spyre
+                - name: torch.cat
+                  sample_inputs_func:
+                    args:
+                      - tensor_list:
+                          - shape: [1, 8, 41, 128]
+                            stride: [41984, 128, 1024, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                          - shape: [1, 8, 1, 128]
+                            stride: [1024, 128, 128, 1]
+                            storage_offset: 0
+                            dtype: torch.bfloat16
+                            device: cuda:0
+                            init: rand
+                  description: 'Operation: torch.cat, Node: keys'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.cat.8
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 42, 128]
+                          stride: [43008, 5376, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: getitem_10'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.getitem.12
+                - name: torch.Tensor.expand
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 1, 42, 128]
+                          stride: [43008, 5376, 5376, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 8
+                      - value: 4
+                      - value: 42
+                      - value: 128
+                  description: 'Operation: torch.Tensor.expand, Node: hidden_states_3'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.expand.5
+                - name: torch.Tensor.reshape
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 8, 4, 42, 128]
+                          stride: [43008, 5376, 0, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 32
+                      - value: 42
+                      - value: 128
+                  description: 'Operation: torch.Tensor.reshape, Node: key'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.reshape.3
+                - name: torch.nn.functional.scaled_dot_product_attention
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 1, 128]
+                          stride: [4096, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 32, 42, 128]
+                          stride: [172032, 5376, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 32, 42, 128]
+                          stride: [172032, 5376, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.nn.functional.scaled_dot_product_attention, Node: attn_output'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.scaled_dot_product_attention.2_spyre
+                  kwargs:
+                    dropout_p: 0.0
+                    scale: 0.0078125
+                    is_causal: false
+                - name: torch.Tensor.transpose
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 32, 1, 128]
+                          stride: [4096, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 2
+                  description: 'Operation: torch.Tensor.transpose, Node: transpose_4'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.transpose.8
+                - name: torch.Tensor.contiguous
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 32, 128]
+                          stride: [4096, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.contiguous, Node: attn_output_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.contiguous.3
+                - name: torch.Tensor.reshape
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 32, 128]
+                          stride: [4096, 128, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 1
+                      - value: 1
+                      - value: -1
+                  description: 'Operation: torch.Tensor.reshape, Node: reshape_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.reshape.4
+                - name: torch.Tensor.contiguous
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 128, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.contiguous, Node: attn_output_2'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.contiguous.4
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_5'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.20_spyre
+                - name: torch.Tensor.to
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.Tensor.to, Node: hidden_states_6'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.Tensor.to.9
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_6'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.21
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [12800, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: linear_4'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.8_spyre
+                - name: torch.nn.functional.silu
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 12800]
+                          stride: [12800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.nn.functional.silu, Node: silu'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.silu.2_spyre
+                - name: torch.mul
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 12800]
+                          stride: [12800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 12800]
+                          stride: [12800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.mul, Node: mul_12'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.mul.14
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 12800]
+                          stride: [12800, 12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [4096, 12800]
+                          stride: [12800, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: down_proj'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.9
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_9'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.22
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_15'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.23_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_12'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.24_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 1, 4096]
+                            stride_map: [4096, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_19'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.25_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 1, 4096]
+                            stride_map: [4096, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_139'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.26_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 1]
+                          stride: [1, 1, 1]
+                          storage_offset: 0
+                          dtype: torch.float32
+                          device: cuda:0
+                          init: rand
+                      - value: 1.0e-05
+                  description: 'Operation: torch.add, Node: add_86'
+                  tags:
+                    - fp32operation
+                    - constant
+                    - torch.add.27_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 1, 4096]
+                            stride_map: [4096, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_145'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.28_spyre
+                - name: torch.add
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                          device_layout:
+                            device_size: [1, 1, 4096]
+                            stride_map: [4096, 4096, 1]
+                            device_dtype: torch.bfloat16
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.add, Node: hidden_states_399'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.add.29_spyre
+                - name: torch.getitem
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                  description: 'Operation: torch.getitem, Node: getitem_246'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.getitem.13
+                - name: torch.nn.functional.linear
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 4096]
+                          stride: [4096, 4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - tensor:
+                          shape: [49159, 4096]
+                          stride: [4096, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: null
+                  description: 'Operation: torch.nn.functional.linear, Node: logits'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.nn.functional.linear.10
+                - name: torch.truediv
+                  sample_inputs_func:
+                    args:
+                      - tensor:
+                          shape: [1, 1, 49159]
+                          stride: [49159, 49159, 1]
+                          storage_offset: 0
+                          dtype: torch.bfloat16
+                          device: cuda:0
+                          init: rand
+                      - value: 16.0
+                  description: 'Operation: torch.truediv, Node: logits_1'
+                  tags:
+                    - bf16operation
+                    - constant
+                    - torch.truediv.2_spyre

--- a/tests/models/test_model_ops_v2.py
+++ b/tests/models/test_model_ops_v2.py
@@ -13,26 +13,23 @@
 # limitations under the License.
 
 
+import logging
 import os
 import sys
 from typing import Any, Dict, List, Optional, Set
 
+import pytest
 import regex as re
 import torch
 import torch.nn as nn
-import pytest
 
-from torch.testing._internal.opinfo.core import OpInfo, SampleInput
 from torch.testing._internal.common_device_type import (
-    ops,
     instantiate_device_type_tests,
+    ops,
 )
 from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.opinfo.core import OpInfo, SampleInput
 
-import shared_config
-from op_registry import OP_REGISTRY, OpAdapter
-
-from oot_framework.oot_test_constants import ENV_TEST_CONFIG
 from oot_framework.oot_test_config_models import (
     InputArgTensor,
     InputArgTensorList,
@@ -40,12 +37,20 @@ from oot_framework.oot_test_config_models import (
     OpsNamedItem,
     TestEntry,
 )
+from oot_framework.oot_test_constants import ENV_TEST_CONFIG
 from oot_framework.oot_test_parsing import load_yaml_config, resolve_current_file
 from oot_framework.oot_test_utilities import (
     print_test_tags_oot,
     _format_input_args_shapes,
     _RUNTIME_SHAPES,
 )
+from op_registry import OP_REGISTRY, OpAdapter
+import shared_config
+
+# Logger setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG if os.environ.get("TORCH_SPYRE_DEBUG") else logging.INFO)
+
 # ---------------------------------------------------------------------------
 # ModelOpInfo
 # ---------------------------------------------------------------------------
@@ -407,14 +412,76 @@ class TestSpyreModelOps(TestCase):
             SampleInput=SampleInput,
         )
 
-        def _to_target_device(x: Any) -> Any:
+        def _to_target_device(x: Any, arg_spec: Optional[Any] = None) -> Any:
             if torch.is_tensor(x):
+                if (
+                    arg_spec is not None
+                    and hasattr(arg_spec, "tensor")
+                    and hasattr(arg_spec.tensor, "to_spyre")
+                    and arg_spec.tensor.device_layout is not None
+                ):
+                    logger.debug(
+                        f"[LAYOUT] calling to_spyre() for shape={list(x.shape)}"
+                    )
+                    return arg_spec.tensor.to_spyre(x)
+                logger.debug(f"[PLAIN]  plain .to(device) for shape={list(x.shape)}")
                 return x.to(test_device)
-            if isinstance(x, list):
-                return [t.to(test_device) if torch.is_tensor(t) else t for t in x]
+
+            if isinstance(x, (list, tuple)):
+                # Mirror SampleInput.transform()'s list/tuple recursion, but stay
+                # layout-aware: an InputArgTensorList spec's tensor_list entries
+                # line up positionally with a list OR tuple of tensors here.
+                tensor_specs = getattr(arg_spec, "tensor_list", None)
+                result = []
+                for i, item in enumerate(x):
+                    spec = (
+                        tensor_specs[i]
+                        if tensor_specs is not None and i < len(tensor_specs)
+                        else None
+                    )
+                    result.append(_to_target_device(item, spec))
+                if isinstance(x, tuple):
+                    # type(x)(result) breaks for tuple subclasses whose ctor
+                    # doesn't accept a single iterable -- namedtuples included
+                    # (they need *result, or ._make(result)). Use _make when
+                    # available; otherwise fall back to a plain tuple.
+                    make = getattr(x, "_make", None)
+                    return make(result) if make is not None else tuple(result)
+                return type(x)(result)
+
+            if isinstance(x, dict):
+                # Mirror transform()'s dict recursion. Positional dict args have no
+                # per-key layout spec today (kwargs already forbid tensor/layout
+                # specs — see resolved_kwargs()'s NotImplementedError), so this is
+                # plain-device-move only, but it at least stops CPU tensors from
+                # silently surviving inside a dict.
+                return {k: _to_target_device(v) for k, v in x.items()}
+
             return x
 
-        test_sample: SampleInput = cpu_sample.transform(_to_target_device)
+        # Build test_sample with per-tensor layout awareness
+        test_args = []
+        for i, (cpu_arg, spec_arg) in enumerate(
+            zip(
+                [cpu_sample.input] + list(cpu_sample.args),
+                ops_item.sample_inputs_func.args,
+            )
+        ):
+            test_args.append(_to_target_device(cpu_arg, spec_arg))
+
+        if test_args:
+            test_sample = SampleInput(
+                test_args[0],
+                args=tuple(test_args[1:]),
+                # NOTE: kwargs are plain values only (dim, dtype, keepdim, etc.) — no
+                # current config passes a tensor/device_layout via kwargs, and
+                # resolved_kwargs() will raise if one ever tries to. If that changes,
+                # this needs the same arg_spec-based layout lookup as _to_target_device
+                # uses for positional args above.
+                kwargs={k: _to_target_device(v) for k, v in cpu_sample.kwargs.items()},
+            )
+        else:
+            test_sample = cpu_sample.transform(lambda x: _to_target_device(x))
 
         # Adapter pre-hook (e.g. dropout sets training=False)
         if adapter.pre is not None:

--- a/tests/oot_framework/oot_test_config_models.py
+++ b/tests/oot_framework/oot_test_config_models.py
@@ -6,22 +6,25 @@ Pydantic models for the OOT PyTorch test framework YAML config.
 Used by oot_test_parsing.py to validate and parse the YAML config.
 """
 
+import logging
+import math
+import os
 import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 
 import torch
-from pydantic import BaseModel, field_validator, model_validator  # type: ignore
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator  # type: ignore
 
 from .oot_test_constants import (
+    REL_PATH_TOKENS,
+    DTYPE_STR_MAP,
+    MODE_MANDATORY_SUCCESS,
+    MODE_XFAIL,
     _VALID_DTYPE_STRINGS,
     _VALID_INIT_STRATEGIES,
     _VALID_TEST_MODES,
     _VALID_UNLISTED_MODES,
-    DTYPE_STR_MAP,
-    MODE_MANDATORY_SUCCESS,
-    MODE_XFAIL,
-    REL_PATH_TOKENS,
 )
 from .oot_test_matching import parse_dtype
 from .oot_test_utilities import (
@@ -29,6 +32,24 @@ from .oot_test_utilities import (
     _resolve_dtype_str,
     _resolve_tensor_path,
 )
+
+# Logger setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG if os.environ.get("TORCH_SPYRE_DEBUG") else logging.INFO)
+
+
+def _resolve_device_dtype(device_dtype_str: str):
+    """Resolve a yaml device_dtype string (a torch dtype alias) to a DataFormats member."""
+    from torch_spyre._C import DataFormats, get_device_dtype
+
+    torch_dtype = _resolve_dtype_str(device_dtype_str)
+    device_dtype = get_device_dtype(torch_dtype)
+    if device_dtype == DataFormats.INVALID:
+        raise ValueError(
+            f"dtype {torch_dtype} (from device_dtype {device_dtype_str!r}) has "
+            f"no Spyre device representation."
+        )
+    return device_dtype
 
 
 # ---------------------------
@@ -46,8 +67,34 @@ class InputInitArgs(BaseModel):
     key: Optional[str] = None  # file: key within file (dict/.safetensors)
 
 
+class SpyreTensorLayoutSpec(BaseModel):
+    """Specifies a SpyreTensorLayout to use when transferring a tensor to Spyre.
+
+    Uses explicit device layout specification:
+    - device_size: explicit device size specification (required)
+    - stride_map: explicit stride map specification (required)
+    - device_dtype: device data format (e.g., DataFormats.IEEE_FP32) (optional)
+    """
+
+    device_size: List[int]
+    stride_map: List[int]
+    device_dtype: str
+
+    @model_validator(mode="after")
+    def validate_layout_format(self) -> "SpyreTensorLayoutSpec":
+        """Validate device_size and stride_map have matching lengths."""
+        if len(self.device_size) != len(self.stride_map):
+            raise ValueError(
+                f"device_size length ({len(self.device_size)}) must match "
+                f"stride_map length ({len(self.stride_map)})"
+            )
+        return self
+
+
 class InputTensorSpec(BaseModel):
     """Specification for constructing a single input tensor."""
+
+    model_config = ConfigDict(extra="forbid")
 
     shape: List[int]
     dtype: str
@@ -56,6 +103,7 @@ class InputTensorSpec(BaseModel):
     init_args: InputInitArgs = InputInitArgs()
     stride: Optional[List[int]] = None
     storage_offset: int = 0
+    device_layout: Optional["SpyreTensorLayoutSpec"] = None
 
     @field_validator("dtype")
     @classmethod
@@ -134,6 +182,99 @@ class InputTensorSpec(BaseModel):
         if dtype_override is not None and resolved.is_floating_point:
             return dtype_override
         return resolved
+
+    def to_spyre(self, cpu_tensor: torch.Tensor) -> torch.Tensor:
+        """Transfer a CPU tensor to Spyre with explicit SpyreTensorLayout.
+
+        Uses explicit device_size and stride_map to create the layout.
+        Automatically validates the created layout matches the specification.
+        """
+        from torch_spyre._C import SpyreTensorLayout, get_spyre_tensor_layout
+
+        layout_spec = self.device_layout
+        assert layout_spec is not None, (
+            "to_spyre() should only be called when device_layout is set"
+        )
+
+        shape = list(cpu_tensor.shape)
+        stride = list(cpu_tensor.stride())
+        dtype = cpu_tensor.dtype
+
+        device_size = layout_spec.device_size
+        stride_map = layout_spec.stride_map
+        device_dtype = _resolve_device_dtype(layout_spec.device_dtype)
+
+        logger.debug(
+            "Transferring tensor shape=%s stride=%s dtype=%s to Spyre with "
+            "device_size=%s stride_map=%s device_dtype=%s",
+            shape,
+            stride,
+            dtype,
+            device_size,
+            stride_map,
+            layout_spec.device_dtype,
+        )
+
+        # Build the SpyreTensorLayout from explicit device_size + stride_map
+        stl = SpyreTensorLayout(
+            device_size=device_size,
+            stride_map=stride_map,
+            device_dtype=device_dtype,
+        )
+        logger.debug("Layout created: %s", stl)
+
+        # Step 1: move to device; Step 2: apply custom layout
+        spyre_tensor = cpu_tensor.to("spyre", device_layout=stl)
+
+        # Validate the applied layout
+        actual_layout = get_spyre_tensor_layout(spyre_tensor)
+        logger.debug(
+            "Applied layout: device_size=%s stride_map=%s device_dtype=%s "
+            "(spec: device_size=%s stride_map=%s device_dtype=%s)",
+            list(actual_layout.device_size),
+            list(actual_layout.stride_map),
+            actual_layout.device_dtype,
+            device_size,
+            stride_map,
+            device_dtype,
+        )
+        # The size/stride checks below don't cover dtype,
+        # so a wrong device_dtype from the YAML spec would previously slip
+        # through unnoticed.
+        assert actual_layout.device_dtype == device_dtype, (
+            f"device_dtype mismatch for tensor shape={shape}:\n"
+            f"  expected: {device_dtype}\n"
+            f"  actual:   {actual_layout.device_dtype}"
+        )
+
+        # H2D and D2H use the same stored layout, making the round-trip
+        # self-inverting. Validate layout invariants instead.
+        n_logical = math.prod(shape) if shape else 1
+        n_device = math.prod(device_size) if device_size else 1
+        assert n_device >= n_logical, (
+            f"device_size {device_size} holds {n_device} elements < the "
+            f"tensor's {n_logical} (shape={shape}); a valid device layout "
+            f"only ever pads up, never loses elements."
+        )
+
+        from torch_spyre._C import get_device_dtype
+
+        expected_dd = get_device_dtype(dtype)
+        assert device_dtype == expected_dd, (
+            f"device_dtype {device_dtype} is not the natural device dtype "
+            f"{expected_dd} for tensor dtype {dtype}."
+        )
+
+        roundtrip = spyre_tensor.cpu()
+        assert torch.equal(roundtrip, cpu_tensor), (
+            f"Data mismatch after applying device_layout for tensor shape={shape}:\n"
+            f"  device_size: {device_size}\n"
+            f"  stride_map:  {stride_map}\n"
+            f"This usually means device_size/stride_map is not a valid device "
+            f"layout for this tensor."
+        )
+
+        return spyre_tensor
 
     def build(
         self, *, seed: Optional[int], dtype: Optional[torch.dtype] = None
@@ -667,6 +808,11 @@ class InputsEdits(BaseModel):
         4. pass through as-is
 
         None, bool, and numeric values pass through unchanged.
+
+        A bare ``device_layout`` dict with no ``tensor`` wrapper isn't a shape
+        _parse_input_arg understands (device_layout only exists nested inside
+        an InputTensorSpec), so it's rejected loudly rather than silently
+        passed through as an unbuilt raw dict.
         """
         import ast as _ast
 
@@ -699,6 +845,14 @@ class InputsEdits(BaseModel):
                 elif isinstance(arg, InputArgPy):
                     out[k] = _eval_py_literal(arg.py)
                 continue
+
+            if isinstance(v, dict) and "device_layout" in v:
+                raise NotImplementedError(
+                    f"kwarg {k!r} looks like a device_layout spec ({v!r}) with no "
+                    f"'tensor' wrapper. device_layout only exists inside an "
+                    f"InputTensorSpec — wrap this as "
+                    f"{{'tensor': {{..., 'device_layout': {v!r}}}}} instead."
+                )
 
             if isinstance(v, str):
                 # 1. dtype resolution


### PR DESCRIPTION
#### What type of PR is this?

- [x] feature

#### What this PR does:

Added option to create input spyre tensors with the spyre tensor layout identified during model forwards pass.

#### Which issue(s) this PR is related to:

[#1069](https://github.com/torch-spyre/torch-spyre/issues/1069) - Support actual tensor layouts in model-centric functional verification

#### Special notes for your reviewer:

The correct device_size, stride_map, and device_dtype values for a given op can be obtained by running the CPU compilation layout extraction pipeline [#20](https://github.com/torch-spyre/RFCs/pull/20)

#### Does this PR introduce a user-facing change?

Yes. Test authors can now specify an explicit SpyreTensorLayout for any input tensor directly in the YAML config

#### Additional note:

Reference torch-spyre PR [#2562](https://github.com/torch-spyre/torch-spyre/pull/2562)