### PR TITLE
Reuse synthetic vars across tensors for dims of size 1

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -2641,6 +2641,11 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "3d2s2": (2, 2, cached_randn((3, 3, 192), dtype=torch.float16)),
             },
         },
+        ("test_slice_synthetic_dims", "test_slice_synthetic_dims_cpu"): {
+            "param_sets": {
+                "5d": (cached_randn((2, 3, 4, 5, 192), dtype=torch.float16),),
+            },
+        },
         ("test_rope_fms", "test_rope_cpu"): {
             "param_sets": {
                 "prefill_bs1": (
@@ -5110,6 +5115,12 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 return op(dim, x[:, start:end])
             elif dim == 2:
                 return op(dim, x[:, :, start:end])
+
+        self.compare_with_cpu(fn, x, clone_inputs=True, run_eager=False)
+
+    def test_slice_synthetic_dims_cpu(self, x):
+        def fn(x):
+            return x[:, 1:2, :, :, :] + x[:, :, 2:3, :, :]
 
         self.compare_with_cpu(fn, x, clone_inputs=True, run_eager=False)
 

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -307,7 +307,7 @@ def normalize_coordinates(
     var_ranges: dict[sympy.Symbol, sympy.Expr],
     size: Sequence[sympy.Expr],
     coordinates: Sequence[sympy.Expr],
-    create_var_fn: Callable[[], sympy.Symbol],
+    synthetic_var_fn: Callable[[], sympy.Symbol],
 ) -> list[Term]:
     """
     Normalize coordinate expressions obtained from compute_coordinates.
@@ -335,7 +335,7 @@ def normalize_coordinates(
             if dim_size > 1 and dim_idx != len(size) - 1:
                 # A non-stick dimension with no variables but size > 1 indicates an elided
                 # dimension with offset/gap. Create a new variable to restore this dimension.
-                var = create_var_fn()
+                var = synthetic_var_fn()
                 var_ranges[var] = 1
                 num = den = mod = sympy.S.One
                 terms.append(Term(num, den, var, mod, dim_size, offset))
@@ -458,15 +458,18 @@ def align_tensors(
     op_it_space_splits = {var: val[1] for var, val in iteration_space.items()}
 
     new_vars: list[sympy.Symbol] = []
-    reused_new_vars: list[sympy.Symbol] = []
+    _synthetic_var_idx: int = 0
 
-    def create_var():
-        if len(reused_new_vars) < len(new_vars):
-            var = new_vars[len(reused_new_vars)]
+    # return a synthetic variable, creating a new variable unless _synthetic_var_idx has been reset
+    # there is no need for distinct synthetic variables for dimensions of size 1 across tensors
+    def synthetic_var():
+        nonlocal _synthetic_var_idx
+        if _synthetic_var_idx < len(new_vars):
+            var = new_vars[_synthetic_var_idx]
         else:
             var = sympy.symbols(f"z{len(new_vars)}")
             new_vars.append(var)
-        reused_new_vars.append(var)
+        _synthetic_var_idx += 1
         return var
 
     all_terms = []  # terms for each tensor
@@ -474,15 +477,15 @@ def align_tensors(
     stick_size = []  # stick size for each tensor
 
     for tensor in tensors:
-        reused_new_vars = []  # restart from z0 for each tensor
+        _synthetic_var_idx = 0  # reuse synthetic_var across tensors
         terms = normalize_coordinates(
-            var_ranges, tensor["size"], tensor["coordinates"], create_var
+            var_ranges, tensor["size"], tensor["coordinates"], synthetic_var
         )
         stick_dim.append(terms[-1].var)
         stick_size.append(terms[-1].dim_size)
         all_terms.append(terms)
 
-    reused_new_vars = new_vars.copy()  # do not reuse vars after this point
+    _synthetic_var_idx = len(new_vars)  # do not reuse synthetic vars after this point
 
     # for each variable collect bounds (den and mod) for all terms involving variable
     # exclude the sick_size resulting from tiling the stick dimension
@@ -526,7 +529,7 @@ def align_tensors(
             new_var_ranges[var] = split[1] // split[0]
             remap[var] = [var]  # reuse variable name for 1st segment
             for i in range(1, len(split) - 1):
-                new_var = create_var()  # create new variable
+                new_var = synthetic_var()  # create new variable
                 new_var_ranges[new_var] = split[i + 1] // split[i]
                 remap[var].append(new_var)
 

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -458,10 +458,15 @@ def align_tensors(
     op_it_space_splits = {var: val[1] for var, val in iteration_space.items()}
 
     new_vars: list[sympy.Symbol] = []
+    reused_new_vars: list[sympy.Symbol] = []
 
     def create_var():
-        var = sympy.symbols(f"z{len(new_vars)}")
-        new_vars.append(var)
+        if len(reused_new_vars) < len(new_vars):
+            var = new_vars[len(reused_new_vars)]
+        else:
+            var = sympy.symbols(f"z{len(new_vars)}")
+            new_vars.append(var)
+        reused_new_vars.append(var)
         return var
 
     all_terms = []  # terms for each tensor
@@ -469,12 +474,15 @@ def align_tensors(
     stick_size = []  # stick size for each tensor
 
     for tensor in tensors:
+        reused_new_vars = []  # restart from z0 for each tensor
         terms = normalize_coordinates(
             var_ranges, tensor["size"], tensor["coordinates"], create_var
         )
         stick_dim.append(terms[-1].var)
         stick_size.append(terms[-1].dim_size)
         all_terms.append(terms)
+
+    reused_new_vars = new_vars  # do not reuse vars after this point
 
     # for each variable collect bounds (den and mod) for all terms involving variable
     # exclude the sick_size resulting from tiling the stick dimension

--- a/torch_spyre/_inductor/views.py
+++ b/torch_spyre/_inductor/views.py
@@ -482,7 +482,7 @@ def align_tensors(
         stick_size.append(terms[-1].dim_size)
         all_terms.append(terms)
 
-    reused_new_vars = new_vars  # do not reuse vars after this point
+    reused_new_vars = new_vars.copy()  # do not reuse vars after this point
 
     # for each variable collect bounds (den and mod) for all terms involving variable
     # exclude the sick_size resulting from tiling the stick dimension


### PR DESCRIPTION
#### What type of PR is this?

- [X] bug

#### What this PR does:

`align_tensors` creates distinct synthetic variables for each sliced dimension where a single element is extracted. This PR ensures these variables are reused across tensors to minimize the number of synthetic dimensions overall.

A test case has been added: `tests/inductor/test_inductor_ops.py::TestOps::test_slice_synthetic_dims_5d`.

#### Which issue(s) this PR is related to:

Issue #2565.