### PR TITLE
Coarse tiling for non-stick reduction dimensions (Stage 1)

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -978,8 +978,8 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
             torch.compile(fn)(x_dev)
 
-    def test_hint_tiled_reduction_sum_correct(self):
-        """x.sum(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+    def test_hint_tiled_reduction_sum_rejects(self):
+        """x.sum(dim=-1) with D hint rejects at compile time with Stage 2 error."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
@@ -1018,8 +1018,8 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
             torch.compile(fn)(a_dev, b_dev)
 
-    def test_hint_tiled_reduction_matmul_correct(self):
-        """torch.matmul tiled over K raises: stick-dim reduction not yet supported."""
+    def test_hint_tiled_reduction_matmul_rejects(self):
+        """torch.matmul with K hint rejects at compile time with Stage 2 error."""
         from torch_spyre._inductor import spyre_hint
 
         M, K, N = 64, 512, 32
@@ -1058,8 +1058,8 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
             torch.compile(fn)(x_dev)
 
-    def test_hint_tiled_reduction_max_correct(self):
-        """x.amax(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+    def test_hint_tiled_reduction_max_rejects(self):
+        """x.amax(dim=-1) with D hint rejects at compile time with Stage 2 error."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
@@ -1094,8 +1094,8 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
             torch.compile(fn)(x_dev)
 
-    def test_hint_tiled_reduction_min_correct(self):
-        """x.amin(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+    def test_hint_tiled_reduction_min_rejects(self):
+        """x.amin(dim=-1) with D hint rejects at compile time with Stage 2 error."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -945,53 +945,46 @@ class TestNamedDimsHint(InductorTestCase):
 class TestCoarseTileReductionE2E(InductorTestCase):
     """E2E tests for coarse-tiling a reduction dimension.
 
-    Each test verifies two things:
-      1. With unroll_loops=False: LoopSpec appears in generated source.
-      2. Numerical correctness via compare_with_cpu (uses default config,
-         which has unroll_loops=True).
+    Stage 1 supports tiling reductions over non-stick dimensions only.
+    Tiling a reduction over the stick dimension (dim=-1 on a [..., D] tensor
+    where D maps to the stick) raises RuntimeError — deferred to Stage 2.
+
+    The tests below verify that the appropriate error is raised for stick-dim
+    reduction tiling, and that LoopSpec is still emitted up to the point where
+    validation fires.
     """
+
+    _STAGE2_MSG = "stick-dim reduction tiling is not yet implemented — Stage 2"
 
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
-    @config.patch(
-        {
-            "unroll_loops": False,
-            "lx_planning": True,
-            "allow_all_ops_in_lx_planning": True,
-        }
-    )
     def test_hint_tiled_reduction_sum_loopspec(self):
-        """x.sum(dim=-1) tiled over the reduction dim emits LoopSpec."""
+        """x.sum(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16) * 0.1
-
-        def fn(x):
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
-                return x.sum(dim=-1)
-
         x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
         _declare_tensor_dim("D", D)
         _name_tensor_dims(x_dev, ["B", "D"])
 
-        cfn = torch.compile(fn)
-        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
-            _, source_codes = run_and_get_code(cfn, x_dev)
-        self.assertTrue(len(source_codes) > 0)
-        self.assertIn("LoopSpec(", source_codes[0])
-        self.assertIn("sympify('4')", source_codes[0])
+        def fn(x):
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.sum(dim=-1)
+
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(x_dev)
 
     def test_hint_tiled_reduction_sum_correct(self):
-        """x.sum(dim=-1) tiled over D produces correct results."""
+        """x.sum(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16) * 0.1
-
+        x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
         _declare_tensor_dim("D", D)
 
@@ -1000,50 +993,40 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.sum(dim=-1)
 
-        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(x_dev)
 
-    @config.patch(
-        {
-            "unroll_loops": False,
-            "lx_planning": True,
-            "allow_all_ops_in_lx_planning": True,
-        }
-    )
     def test_hint_tiled_reduction_matmul_loopspec(self):
-        """torch.matmul tiled over K emits LoopSpec."""
+        """torch.matmul tiled over K raises: stick-dim reduction not yet supported."""
         from torch_spyre._inductor import spyre_hint
 
         M, K, N = 64, 512, 32
         a = torch.randn(M, K, dtype=torch.float16) * 0.01
         b = torch.randn(K, N, dtype=torch.float16) * 0.01
-
-        def fn(a, b):
-            _name_tensor_dims(a, ["M", "K"])
-            _name_tensor_dims(b, ["K", "N"])
-            with spyre_hint(num_tiles_per_dim={"K": 4}):
-                return a @ b
-
         a_dev = a.to("spyre")
         b_dev = b.to("spyre")
         _declare_tensor_dim("M", M)
         _declare_tensor_dim("K", K)
         _declare_tensor_dim("N", N)
 
-        cfn = torch.compile(fn)
-        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
-            _, source_codes = run_and_get_code(cfn, a_dev, b_dev)
-        self.assertTrue(len(source_codes) > 0)
-        self.assertIn("LoopSpec(", source_codes[0])
-        self.assertIn("sympify('4')", source_codes[0])
+        def fn(a, b):
+            _name_tensor_dims(a, ["M", "K"])
+            _name_tensor_dims(b, ["K", "N"])
+            with spyre_hint(num_tiles_per_dim={"K": 4}):
+                return a @ b
+
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(a_dev, b_dev)
 
     def test_hint_tiled_reduction_matmul_correct(self):
-        """torch.matmul tiled over K produces correct results."""
+        """torch.matmul tiled over K raises: stick-dim reduction not yet supported."""
         from torch_spyre._inductor import spyre_hint
 
         M, K, N = 64, 512, 32
         a = torch.randn(M, K, dtype=torch.float16) * 0.01
         b = torch.randn(K, N, dtype=torch.float16) * 0.01
-
+        a_dev = a.to("spyre")
+        b_dev = b.to("spyre")
         _declare_tensor_dim("M", M)
         _declare_tensor_dim("K", K)
         _declare_tensor_dim("N", N)
@@ -1054,46 +1037,34 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             with spyre_hint(num_tiles_per_dim={"K": 4}):
                 return a @ b
 
-        compare_with_cpu(
-            fn, a, b, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
-        )
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(a_dev, b_dev)
 
-    @config.patch(
-        {
-            "unroll_loops": False,
-            "lx_planning": True,
-            "allow_all_ops_in_lx_planning": True,
-        }
-    )
     def test_hint_tiled_reduction_max_loopspec(self):
-        """x.amax(dim=-1) tiled over the reduction dim emits LoopSpec."""
+        """x.amax(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
-
-        def fn(x):
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
-                return x.amax(dim=-1)
-
         x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
         _declare_tensor_dim("D", D)
         _name_tensor_dims(x_dev, ["B", "D"])
 
-        cfn = torch.compile(fn)
-        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
-            _, source_codes = run_and_get_code(cfn, x_dev)
-        self.assertTrue(len(source_codes) > 0)
-        self.assertIn("LoopSpec(", source_codes[0])
+        def fn(x):
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.amax(dim=-1)
+
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(x_dev)
 
     def test_hint_tiled_reduction_max_correct(self):
-        """x.amax(dim=-1) tiled over D produces correct results."""
+        """x.amax(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
         from torch_spyre._inductor import spyre_hint
 
         B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
-
+        x_dev = x.to("spyre")
         _declare_tensor_dim("B", B)
         _declare_tensor_dim("D", D)
 
@@ -1101,43 +1072,101 @@ class TestCoarseTileReductionE2E(InductorTestCase):
             _name_tensor_dims(x, ["B", "D"])
             with spyre_hint(num_tiles_per_dim={"D": 4}):
                 return x.amax(dim=-1)
+
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(x_dev)
+
+    def test_hint_tiled_reduction_min_loopspec(self):
+        """x.amin(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 512
+        x = torch.randn(B, D, dtype=torch.float16)
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(x_dev, ["B", "D"])
+
+        def fn(x):
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.amin(dim=-1)
+
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(x_dev)
+
+    def test_hint_tiled_reduction_min_correct(self):
+        """x.amin(dim=-1) tiled over D raises: stick-dim reduction not yet supported."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 512
+        x = torch.randn(B, D, dtype=torch.float16)
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+
+        def fn(x):
+            _name_tensor_dims(x, ["B", "D"])
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.amin(dim=-1)
+
+        with self.assertRaisesRegex(Exception, self._STAGE2_MSG):
+            torch.compile(fn)(x_dev)
+
+
+class TestCoarseTileReductionDim0E2E(InductorTestCase):
+    """E2E tests for coarse-tiling a reduction over dim=0.
+
+    These reduce a [B, D] tensor over B (dim=0), producing a [D] output where
+    D is on the stick.  This is a simpler case than dim=-1 reductions because
+    the output has a normal stick layout (no column-vector addressing).
+    """
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0xAFFE)
+
+    @config.patch({"lx_planning": False})
+    def test_hint_tiled_reduction_dim0_sum_correct(self):
+        """x.sum(dim=0) tiled over B produces correct results."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 512, 64
+        x = torch.randn(B, D, dtype=torch.float16) * 0.1
+
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+
+        def fn(x):
+            _name_tensor_dims(x, ["B", "D"])
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x.sum(dim=0)
+
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
+
+    @config.patch({"lx_planning": False})
+    def test_hint_tiled_reduction_dim0_max_correct(self):
+        """x.amax(dim=0) tiled over B produces correct results."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 512, 64
+        x = torch.randn(B, D, dtype=torch.float16)
+
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+
+        def fn(x):
+            _name_tensor_dims(x, ["B", "D"])
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x.amax(dim=0)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
 
-    @config.patch(
-        {
-            "unroll_loops": False,
-            "lx_planning": True,
-            "allow_all_ops_in_lx_planning": True,
-        }
-    )
-    def test_hint_tiled_reduction_min_loopspec(self):
-        """x.amin(dim=-1) tiled over the reduction dim emits LoopSpec."""
+    @config.patch({"lx_planning": False})
+    def test_hint_tiled_reduction_dim0_min_correct(self):
+        """x.amin(dim=0) tiled over B produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
-        B, D = 64, 512
-        x = torch.randn(B, D, dtype=torch.float16)
-
-        def fn(x):
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
-                return x.amin(dim=-1)
-
-        x_dev = x.to("spyre")
-        _declare_tensor_dim("B", B)
-        _declare_tensor_dim("D", D)
-        _name_tensor_dims(x_dev, ["B", "D"])
-
-        cfn = torch.compile(fn)
-        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
-            _, source_codes = run_and_get_code(cfn, x_dev)
-        self.assertTrue(len(source_codes) > 0)
-        self.assertIn("LoopSpec(", source_codes[0])
-
-    def test_hint_tiled_reduction_min_correct(self):
-        """x.amin(dim=-1) tiled over D produces correct results."""
-        from torch_spyre._inductor import spyre_hint
-
-        B, D = 64, 512
+        B, D = 512, 64
         x = torch.randn(B, D, dtype=torch.float16)
 
         _declare_tensor_dim("B", B)
@@ -1145,8 +1174,8 @@ class TestCoarseTileReductionE2E(InductorTestCase):
 
         def fn(x):
             _name_tensor_dims(x, ["B", "D"])
-            with spyre_hint(num_tiles_per_dim={"D": 4}):
-                return x.amin(dim=-1)
+            with spyre_hint(num_tiles_per_dim={"B": 4}):
+                return x.amin(dim=0)
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -942,5 +942,214 @@ class TestNamedDimsHint(InductorTestCase):
         self.assertIn("sympify('2')", src, "Expected loop count 2")
 
 
+class TestCoarseTileReductionE2E(InductorTestCase):
+    """E2E tests for coarse-tiling a reduction dimension.
+
+    Each test verifies two things:
+      1. With unroll_loops=False: LoopSpec appears in generated source.
+      2. Numerical correctness via compare_with_cpu (uses default config,
+         which has unroll_loops=True).
+    """
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0xAFFE)
+
+    @config.patch(
+        {
+            "unroll_loops": False,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_hint_tiled_reduction_sum_loopspec(self):
+        """x.sum(dim=-1) tiled over the reduction dim emits LoopSpec."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 128
+        x = torch.randn(B, D, dtype=torch.float16) * 0.1
+
+        def fn(x):
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.sum(dim=-1)
+
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(x_dev, ["B", "D"])
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        self.assertIn("LoopSpec(", source_codes[0])
+        self.assertIn("sympify('4')", source_codes[0])
+
+    def test_hint_tiled_reduction_sum_correct(self):
+        """x.sum(dim=-1) tiled over D produces correct results."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 128
+        x = torch.randn(B, D, dtype=torch.float16) * 0.1
+
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+
+        def fn(x):
+            _name_tensor_dims(x, ["B", "D"])
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.sum(dim=-1)
+
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
+
+    @config.patch(
+        {
+            "unroll_loops": False,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_hint_tiled_reduction_matmul_loopspec(self):
+        """torch.matmul tiled over K emits LoopSpec."""
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 64, 128, 32
+        a = torch.randn(M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(K, N, dtype=torch.float16) * 0.01
+
+        def fn(a, b):
+            _name_tensor_dims(a, ["M", "K"])
+            _name_tensor_dims(b, ["K", "N"])
+            with spyre_hint(num_tiles_per_dim={"K": 4}):
+                return a @ b
+
+        a_dev = a.to("spyre")
+        b_dev = b.to("spyre")
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, a_dev, b_dev)
+        self.assertTrue(len(source_codes) > 0)
+        self.assertIn("LoopSpec(", source_codes[0])
+        self.assertIn("sympify('4')", source_codes[0])
+
+    def test_hint_tiled_reduction_matmul_correct(self):
+        """torch.matmul tiled over K produces correct results."""
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 64, 128, 32
+        a = torch.randn(M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(K, N, dtype=torch.float16) * 0.01
+
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+
+        def fn(a, b):
+            _name_tensor_dims(a, ["M", "K"])
+            _name_tensor_dims(b, ["K", "N"])
+            with spyre_hint(num_tiles_per_dim={"K": 4}):
+                return a @ b
+
+        compare_with_cpu(
+            fn, a, b, run_compile=True, run_eager=False, atol=0.01, rtol=0.01
+        )
+
+    @config.patch(
+        {
+            "unroll_loops": False,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_hint_tiled_reduction_max_loopspec(self):
+        """x.amax(dim=-1) tiled over the reduction dim emits LoopSpec."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 128
+        x = torch.randn(B, D, dtype=torch.float16)
+
+        def fn(x):
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.amax(dim=-1)
+
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(x_dev, ["B", "D"])
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        self.assertIn("LoopSpec(", source_codes[0])
+
+    def test_hint_tiled_reduction_max_correct(self):
+        """x.amax(dim=-1) tiled over D produces correct results."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 128
+        x = torch.randn(B, D, dtype=torch.float16)
+
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+
+        def fn(x):
+            _name_tensor_dims(x, ["B", "D"])
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.amax(dim=-1)
+
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
+
+    @config.patch(
+        {
+            "unroll_loops": False,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_hint_tiled_reduction_min_loopspec(self):
+        """x.amin(dim=-1) tiled over the reduction dim emits LoopSpec."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 128
+        x = torch.randn(B, D, dtype=torch.float16)
+
+        def fn(x):
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.amin(dim=-1)
+
+        x_dev = x.to("spyre")
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+        _name_tensor_dims(x_dev, ["B", "D"])
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x_dev)
+        self.assertTrue(len(source_codes) > 0)
+        self.assertIn("LoopSpec(", source_codes[0])
+
+    def test_hint_tiled_reduction_min_correct(self):
+        """x.amin(dim=-1) tiled over D produces correct results."""
+        from torch_spyre._inductor import spyre_hint
+
+        B, D = 64, 128
+        x = torch.randn(B, D, dtype=torch.float16)
+
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("D", D)
+
+        def fn(x):
+            _name_tensor_dims(x, ["B", "D"])
+            with spyre_hint(num_tiles_per_dim={"D": 4}):
+                return x.amin(dim=-1)
+
+        compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -966,7 +966,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """x.sum(dim=-1) tiled over the reduction dim emits LoopSpec."""
         from torch_spyre._inductor import spyre_hint
 
-        B, D = 64, 128
+        B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16) * 0.1
 
         def fn(x):
@@ -989,7 +989,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """x.sum(dim=-1) tiled over D produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
-        B, D = 64, 128
+        B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16) * 0.1
 
         _declare_tensor_dim("B", B)
@@ -1013,7 +1013,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """torch.matmul tiled over K emits LoopSpec."""
         from torch_spyre._inductor import spyre_hint
 
-        M, K, N = 64, 128, 32
+        M, K, N = 64, 512, 32
         a = torch.randn(M, K, dtype=torch.float16) * 0.01
         b = torch.randn(K, N, dtype=torch.float16) * 0.01
 
@@ -1040,7 +1040,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """torch.matmul tiled over K produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
-        M, K, N = 64, 128, 32
+        M, K, N = 64, 512, 32
         a = torch.randn(M, K, dtype=torch.float16) * 0.01
         b = torch.randn(K, N, dtype=torch.float16) * 0.01
 
@@ -1069,7 +1069,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """x.amax(dim=-1) tiled over the reduction dim emits LoopSpec."""
         from torch_spyre._inductor import spyre_hint
 
-        B, D = 64, 128
+        B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
 
         def fn(x):
@@ -1091,7 +1091,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """x.amax(dim=-1) tiled over D produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
-        B, D = 64, 128
+        B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
 
         _declare_tensor_dim("B", B)
@@ -1115,7 +1115,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """x.amin(dim=-1) tiled over the reduction dim emits LoopSpec."""
         from torch_spyre._inductor import spyre_hint
 
-        B, D = 64, 128
+        B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
 
         def fn(x):
@@ -1137,7 +1137,7 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         """x.amin(dim=-1) tiled over D produces correct results."""
         from torch_spyre._inductor import spyre_hint
 
-        B, D = 64, 128
+        B, D = 64, 512
         x = torch.randn(B, D, dtype=torch.float16)
 
         _declare_tensor_dim("B", B)

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2815,6 +2815,61 @@ class TestStampGroupReductionDim(unittest.TestCase):
         # output ranges untouched
         self.assertEqual(op.data.ranges[0], Integer(128))
 
+    def test_pointwise_op_in_reduction_level_does_not_crash(self):
+        """A Pointwise op co-tiled with a reduction-dim hint must not crash."""
+        from torch_spyre._inductor.coarse_tile import _stamp_group
+        from torch_spyre._inductor.propagate_hints import DimHint
+        from torch._inductor.codegen.common import SymT
+        import torch
+        from torch._inductor.ir import Pointwise, Reduction, ReductionHint
+
+        # Build a real Reduction op to get the reduction symbol
+        real_reduction = Reduction(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda idx, ridx: None,
+            ranges=[Integer(128)],
+            reduction_ranges=[Integer(256)],
+            reduction_type="sum",
+            src_dtype=torch.float16,
+            reduction_hint=ReductionHint.DEFAULT,
+        )
+        rindex = real_reduction._index(real_reduction.reduction_ranges, SymT.R0_INDEX)
+        red_sym = next(iter(rindex[0].free_symbols))
+
+        hint = DimHint(
+            dim_names=["K"],
+            split_count=4,
+            loop_var=red_sym,
+            is_reduction=True,
+            hint_id=0,
+        )
+
+        # Build a Pointwise op (not Reduction) — simulates a relu co-tiled with sum
+        pointwise_data = Pointwise(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda index: None,
+            ranges=[Integer(128)],
+        )
+        from torch._inductor.ir import ComputedBuffer
+
+        pw_op = MagicMock(spec=ComputedBuffer)
+        pw_op.data = pointwise_data
+        pw_op.get_name.return_value = "pw0"
+        pw_op.get_operation_name.return_value = "pw0"
+        pw_op.dim_hints = [hint]
+        layout_mock = MagicMock()
+        layout_mock.size = [Integer(128)]
+        pw_op.layout = layout_mock
+
+        # Must not crash — Pointwise op is loop-invariant on the reduction dim
+        with patch("torch_spyre._inductor.coarse_tile.op_out_coords", return_value=[]):
+            _stamp_group([pw_op], (0,), [(0, Integer(4), True)], {"pw0": 0})
+
+        self.assertEqual(pw_op.loop_info.loop_tiled_dims, [[]])
+        self.assertEqual(pw_op.loop_info.loop_tiled_reduction_dims, [[]])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2871,5 +2871,159 @@ class TestStampGroupReductionDim(unittest.TestCase):
         self.assertEqual(pw_op.loop_info.loop_tiled_reduction_dims, [[]])
 
 
+class TestPropagateTiledReductionOp(unittest.TestCase):
+    """_propagate_tiled_reduction_op inserts fill + combine for tiled reductions."""
+
+    def _make_tiled_reduction(
+        self, name, out_ranges, reduction_ranges, reduction_type="sum", loop_count=4
+    ):
+        """Build a ComputedBuffer mock stamped for reduction-dim tiling."""
+        import torch
+        from torch._inductor.ir import (
+            ComputedBuffer,
+            FixedLayout,  # noqa: F401
+            Reduction,
+            ReductionHint,
+        )
+        from torch._inductor.ir import FlexibleLayout
+        from torch_spyre._C import SpyreTensorLayout
+        from torch_spyre._inductor.ir import FixedTiledLayout
+        from torch_spyre._inductor.loop_info import CoarseTileInfo
+
+        data = Reduction(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda idx, ridx: None,
+            ranges=[Integer(r) for r in out_ranges],
+            reduction_ranges=[Integer(r) for r in reduction_ranges],
+            reduction_type=reduction_type,
+            src_dtype=torch.float16,
+            reduction_hint=ReductionHint.DEFAULT,
+        )
+        size = [Integer(r) for r in out_ranges]
+        strides = list(FlexibleLayout.contiguous_strides(size))
+        device = torch.device("cpu")
+        dtype = torch.float16
+        dim_order = list(range(len(out_ranges)))
+        stl = SpyreTensorLayout(
+            [int(s) for s in size],
+            [int(s) for s in strides] if strides else [1],
+            dtype,
+            dim_order,
+        )
+        layout = FixedTiledLayout(device, dtype, size, strides, stl)
+        op = MagicMock(spec=ComputedBuffer)
+        op.name = name
+        op.data = data
+        op.get_name.return_value = name
+        op.get_operation_name.return_value = name
+        op.get_device.return_value = device
+        op.get_dtype.return_value = dtype
+        op.layout = layout
+        op.origins = OrderedSet()
+        op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(loop_count)],
+            loop_tiled_dims=[[]],
+            loop_tiled_reduction_dims=[[0]],
+        )
+        op.make_loader.return_value = lambda index: None
+        return op
+
+    def test_fill_and_combine_ops_inserted(self):
+        """_propagate_tiled_reduction_op inserts a fill op and a combine op."""
+        from torch._inductor.ir import ComputedBuffer
+        from torch_spyre._inductor.coarse_tile import _propagate_tiled_reduction_op
+
+        op = self._make_tiled_reduction("red0", out_ranges=[32], reduction_ranges=[64])
+        operations = [op]
+
+        fill_buf_mock = MagicMock(spec=ComputedBuffer)
+        fill_buf_mock.get_name.return_value = "coarse_tile_accum_red0"
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile._allocate_full_buffer",
+                return_value=fill_buf_mock,
+            ) as mock_alloc,
+            patch(
+                "torch_spyre._inductor.coarse_tile._find_outside_consumers",
+                return_value=([], False),
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile._graph_output_names",
+                return_value=set(),
+            ),
+            patch("torch_spyre._inductor.coarse_tile.V") as mock_v,
+            patch("torch._inductor.ir.V"),
+        ):
+            mock_v.graph.qualify_name.side_effect = lambda n: n
+            mock_v.graph.name_to_buffer = {}
+            # Simulate _allocate_full_buffer inserting fill_buf_mock into operations
+            mock_alloc.side_effect = lambda *a, **kw: (
+                operations.insert(0, fill_buf_mock) or fill_buf_mock
+            )
+            _propagate_tiled_reduction_op(op, operations)
+
+        # The original op should be marked per_tile_fixed
+        self.assertTrue(op.layout.per_tile_fixed)
+        # A fill init op and combine op should have been inserted
+        # (2 new ops: fill_init Pointwise + combine Pointwise)
+        self.assertGreater(len(operations), 1)
+        names = [
+            o.get_name() if hasattr(o, "get_name") and callable(o.get_name) else ""
+            for o in operations
+        ]
+        self.assertTrue(any("fill" in n or "accum" in n for n in names))
+        self.assertTrue(any("combine" in n for n in names))
+
+    def test_consumers_patched_to_accum_buf(self):
+        """Outside consumers are redirected to read the accumulation buffer."""
+        from torch._inductor.ir import ComputedBuffer
+        from torch_spyre._inductor.coarse_tile import _propagate_tiled_reduction_op
+
+        op = self._make_tiled_reduction("red0", out_ranges=[32], reduction_ranges=[64])
+        consumer = MagicMock(spec=ComputedBuffer)
+        consumer.get_name.return_value = "consumer0"
+        operations = [op, consumer]
+
+        fill_buf_mock = MagicMock(spec=ComputedBuffer)
+        fill_buf_mock.get_name.return_value = "coarse_tile_accum_red0"
+        fill_buf_mock.make_loader.return_value = lambda index: None
+
+        patched_consumers = []
+
+        def fake_patch_consumers(consumers, old, new, ops):
+            patched_consumers.extend(consumers)
+
+        with (
+            patch(
+                "torch_spyre._inductor.coarse_tile._allocate_full_buffer",
+                side_effect=lambda *a, **kw: (
+                    operations.insert(0, fill_buf_mock) or fill_buf_mock
+                ),
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile._find_outside_consumers",
+                return_value=([consumer], False),
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile._patch_consumers",
+                side_effect=fake_patch_consumers,
+            ),
+            patch(
+                "torch_spyre._inductor.coarse_tile._graph_output_names",
+                return_value=set(),
+            ),
+            patch("torch_spyre._inductor.coarse_tile.V") as mock_v,
+            patch("torch._inductor.ir.V"),
+        ):
+            mock_v.graph.qualify_name.side_effect = lambda n: n
+            mock_v.graph.name_to_buffer = {}
+            _propagate_tiled_reduction_op(op, operations)
+
+        self.assertIn(consumer, patched_consumers)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2474,5 +2474,45 @@ class TestSymbolKind(unittest.TestCase):
         self.assertNotIn("input_arg_extract", op1_operand)
 
 
+class TestCoarseTileInfoReductionField(unittest.TestCase):
+    """CoarseTileInfo carries loop_tiled_reduction_dims parallel to loop_tiled_dims."""
+
+    def test_field_present_and_defaults_to_empty(self):
+        from torch_spyre._inductor.loop_info import CoarseTileInfo
+
+        info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[0]],
+        )
+        self.assertEqual(info.loop_tiled_reduction_dims, [])
+
+    def test_field_can_be_set(self):
+        from torch_spyre._inductor.loop_info import CoarseTileInfo
+
+        info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[]],
+            loop_tiled_reduction_dims=[[0]],
+        )
+        self.assertEqual(info.loop_tiled_reduction_dims, [[0]])
+
+    def test_nested_parallel_shape(self):
+        """For a two-level nest, both fields have two sub-lists."""
+        from torch_spyre._inductor.loop_info import CoarseTileInfo
+
+        info = CoarseTileInfo(
+            loop_group_id=(0, 0),
+            loop_count=[Integer(2), Integer(4)],
+            loop_tiled_dims=[[0], []],
+            loop_tiled_reduction_dims=[[], [0]],
+        )
+        self.assertEqual(len(info.loop_tiled_dims), 2)
+        self.assertEqual(len(info.loop_tiled_reduction_dims), 2)
+        self.assertEqual(info.loop_tiled_reduction_dims[0], [])
+        self.assertEqual(info.loop_tiled_reduction_dims[1], [0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -663,7 +663,7 @@ class TestCoarseTile(unittest.TestCase):
         op_computed = _make_hinted_op(data, "op0", hints=((0, 0),))
         coarse_tile(
             _graph([op_extern, op_computed]),
-            [([op_extern, op_computed], [(0, Integer(2))])],
+            [([op_extern, op_computed], [(0, Integer(2), False)])],
         )
         self.assertEqual(op_computed.loop_info.loop_group_id, (0,))
         self.assertEqual(data.ranges[0], Integer(8))
@@ -673,7 +673,7 @@ class TestCoarseTile(unittest.TestCase):
         n = Symbol("N", positive=True)
         data = _make_pointwise([n])
         op = _make_hinted_op(data, "op0", hints=((0, 0),))
-        coarse_tile(_graph([op]), [([op], [(0, k)])])
+        coarse_tile(_graph([op]), [([op], [(0, k, False)])])
         self.assertEqual(op.loop_info.loop_count, [k])
         self.assertEqual(simplify(data.ranges[0] - n / k), 0)
 
@@ -685,7 +685,7 @@ class TestCoarseTile(unittest.TestCase):
         op1 = _make_hinted_op(d1, "op1", hints=((0, 0),))
         op2 = _make_hinted_op(d2, "op2", hints=((0, 0),))
         with self.assertRaises(RuntimeError):
-            coarse_tile(_graph([op0, op1, op2]), [([op0, op2], [(0, Integer(4))])])
+            coarse_tile(_graph([op0, op1, op2]), [([op0, op2], [(0, Integer(4), False)])])
 
     def test_op_not_in_operations_raises(self):
         data = _make_pointwise([Integer(32)])
@@ -694,11 +694,11 @@ class TestCoarseTile(unittest.TestCase):
             _make_pointwise([Integer(8)]), "unknown", hints=((0, 0),)
         )
         with self.assertRaises(RuntimeError):
-            coarse_tile(_graph([op_known]), [([op_unknown], [(0, Integer(2))])])
+            coarse_tile(_graph([op_known]), [([op_unknown], [(0, Integer(2), False)])])
 
 
 class TestCoarseTileNested(unittest.TestCase):
-    """Verify that the nested group format [(hint_id, K1), ...] works."""
+    """Verify that the nested group format [(hint_id, K1, is_reduction), ...] works."""
 
     def setUp(self):
         self._patch = patch(
@@ -713,7 +713,7 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_stamps_list_attributes(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])])
         self.assertEqual(op.loop_info.loop_group_id, (0, 0))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [1]])
@@ -721,14 +721,14 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])])
         self.assertEqual(data.ranges[0], Integer(64))
         self.assertEqual(data.ranges[1], Integer(64))
 
     def test_nested_spec_outer_only_divides_outer_dim(self):
         data = _make_pointwise([Integer(32), Integer(64), Integer(16)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(8))])])
+        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(8), False)])])
         self.assertEqual(data.ranges[0], Integer(8))
         self.assertEqual(data.ranges[1], Integer(8))
         self.assertEqual(data.ranges[2], Integer(16))
@@ -742,8 +742,8 @@ class TestCoarseTileNested(unittest.TestCase):
         coarse_tile(
             _graph([op0, op1]),
             [
-                ([op0], [(1, Integer(4))]),
-                ([op1], [(2, Integer(4)), (3, Integer(2))]),
+                ([op0], [(1, Integer(4), False)]),
+                ([op1], [(2, Integer(4), False), (3, Integer(2), False)]),
             ],
         )
         self.assertEqual(op0.loop_info.loop_group_id, (0,))
@@ -760,7 +760,7 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_same_dim_different_counts(self):
         data = _make_pointwise([Integer(256)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 0)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4)), (2, Integer(2))])])
+        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])])
         self.assertEqual(data.ranges[0], Integer(32))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [0]])
@@ -2757,6 +2757,63 @@ class TestReductionIdentityValues(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             _reduction_identity_value("welford_reduce", torch.float16)
+
+
+class TestStampGroupReductionDim(unittest.TestCase):
+    """_stamp_group populates loop_tiled_reduction_dims for reduction-dim hints."""
+
+    def test_reduction_dim_hint_populates_loop_tiled_reduction_dims(self):
+        """A hint with is_reduction=True causes loop_tiled_reduction_dims to be [[0]]."""
+        from torch_spyre._inductor.coarse_tile import _stamp_group
+        from torch_spyre._inductor.propagate_hints import DimHint
+        from torch._inductor.codegen.common import SymT
+        import torch
+        from torch._inductor.ir import Reduction, ReductionHint
+
+        ranges = [Integer(128)]
+        reduction_ranges = [Integer(256)]
+        real_data = Reduction(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda idx, ridx: None,
+            ranges=ranges,
+            reduction_ranges=reduction_ranges,
+            reduction_type="sum",
+            src_dtype=torch.float16,
+            reduction_hint=ReductionHint.DEFAULT,
+        )
+        rindex = real_data._index(real_data.reduction_ranges, SymT.R0_INDEX)
+        red_sym = next(iter(rindex[0].free_symbols))
+
+        hint = DimHint(
+            dim_names=["K"],
+            split_count=4,
+            loop_var=red_sym,
+            is_reduction=True,
+            hint_id=0,
+        )
+
+        from torch._inductor.ir import ComputedBuffer
+
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = real_data
+        op.get_name.return_value = "red0"
+        op.get_operation_name.return_value = "red0"
+        op.dim_hints = [hint]
+        layout_mock = MagicMock()
+        layout_mock.size = list(ranges)
+        op.layout = layout_mock
+        del op.loop_info
+
+        with patch("torch_spyre._inductor.coarse_tile.op_out_coords", return_value=[]):
+            _stamp_group([op], (0,), [(0, Integer(4), True)], {"red0": 0})
+
+        self.assertEqual(op.loop_info.loop_tiled_dims, [[]])
+        self.assertEqual(op.loop_info.loop_tiled_reduction_dims, [[0]])
+        # reduction_ranges should be divided: 256 / 4 = 64
+        self.assertEqual(op.data.reduction_ranges[0], Integer(64))
+        # output ranges untouched
+        self.assertEqual(op.data.ranges[0], Integer(128))
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2514,5 +2514,115 @@ class TestCoarseTileInfoReductionField(unittest.TestCase):
         self.assertEqual(info.loop_tiled_reduction_dims[1], [0])
 
 
+class TestDivideReductionRanges(unittest.TestCase):
+    """_divide_reduction_ranges divides reduction_ranges, leaves ranges intact."""
+
+    def _make_reduction_op(self, ranges, reduction_ranges, reduction_type="sum"):
+        from torch._inductor.ir import ComputedBuffer, Reduction, ReductionHint
+        import torch
+
+        data = Reduction(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda idx, ridx: None,
+            ranges=list(ranges),
+            reduction_ranges=list(reduction_ranges),
+            reduction_type=reduction_type,
+            src_dtype=torch.float16,
+            reduction_hint=ReductionHint.DEFAULT,
+        )
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = data
+        op.get_name.return_value = "test_op"
+        return op
+
+    def test_basic_halves_reduction_range(self):
+        from torch_spyre._inductor.coarse_tile import _divide_reduction_ranges
+
+        op = self._make_reduction_op(
+            ranges=[Integer(128)], reduction_ranges=[Integer(256)]
+        )
+        _divide_reduction_ranges(op, Integer(2), [0])
+        self.assertEqual(op.data.reduction_ranges[0], Integer(128))
+        self.assertEqual(op.data.ranges[0], Integer(128))  # output ranges untouched
+
+    def test_empty_tiled_dims_is_noop(self):
+        from torch_spyre._inductor.coarse_tile import _divide_reduction_ranges
+
+        op = self._make_reduction_op(
+            ranges=[Integer(128)], reduction_ranges=[Integer(64)]
+        )
+        _divide_reduction_ranges(op, Integer(4), [])
+        self.assertEqual(op.data.reduction_ranges[0], Integer(64))  # unchanged
+
+    def test_not_divisible_raises(self):
+        from torch_spyre._inductor.coarse_tile import _divide_reduction_ranges
+
+        op = self._make_reduction_op(
+            ranges=[Integer(128)], reduction_ranges=[Integer(100)]
+        )
+        with self.assertRaises(RuntimeError, msg="not divisible should raise"):
+            _divide_reduction_ranges(op, Integer(3), [0])
+
+    def test_divides_second_reduction_dim(self):
+        from torch_spyre._inductor.coarse_tile import _divide_reduction_ranges
+
+        op = self._make_reduction_op(
+            ranges=[Integer(32)], reduction_ranges=[Integer(64), Integer(128)]
+        )
+        _divide_reduction_ranges(op, Integer(4), [1])
+        self.assertEqual(op.data.reduction_ranges[0], Integer(64))  # untouched
+        self.assertEqual(op.data.reduction_ranges[1], Integer(32))  # divided
+
+
+class TestLoopVarToReductionRangesPos(unittest.TestCase):
+    """_loop_var_to_reduction_ranges_pos finds the position of a symbol in reduction_ranges."""
+
+    def _make_reduction_op(self, ranges, reduction_ranges):
+        from torch._inductor.ir import ComputedBuffer, Reduction, ReductionHint
+        import torch
+
+        data = Reduction(
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+            inner_fn=lambda idx, ridx: None,
+            ranges=list(ranges),
+            reduction_ranges=list(reduction_ranges),
+            reduction_type="sum",
+            src_dtype=torch.float16,
+            reduction_hint=ReductionHint.DEFAULT,
+        )
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = data
+        op.get_name.return_value = "test_op"
+        return op
+
+    def test_finds_reduction_symbol(self):
+        from torch_spyre._inductor.coarse_tile import _loop_var_to_reduction_ranges_pos
+        from torch._inductor.codegen.common import SymT
+
+        op = self._make_reduction_op(
+            ranges=[Integer(32)], reduction_ranges=[Integer(64)]
+        )
+        # The reduction symbol for a single reduction_ranges entry is r0_0
+        rindex = op.data._index(op.data.reduction_ranges, SymT.R0_INDEX)
+        sym = next(iter(rindex[0].free_symbols))
+        result = _loop_var_to_reduction_ranges_pos(op, sym)
+        self.assertEqual(result, 0)
+
+    def test_returns_none_for_output_symbol(self):
+        from torch_spyre._inductor.coarse_tile import _loop_var_to_reduction_ranges_pos
+        from torch._inductor.codegen.common import SymT
+        from torch._inductor.utils import sympy_index_symbol_with_prefix
+
+        op = self._make_reduction_op(
+            ranges=[Integer(32)], reduction_ranges=[Integer(64)]
+        )
+        # Use an output-dim symbol (i0_0) — should not appear in reduction_ranges
+        output_sym = sympy_index_symbol_with_prefix(SymT.INDEX, 0)
+        result = _loop_var_to_reduction_ranges_pos(op, output_sym)
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -685,7 +685,9 @@ class TestCoarseTile(unittest.TestCase):
         op1 = _make_hinted_op(d1, "op1", hints=((0, 0),))
         op2 = _make_hinted_op(d2, "op2", hints=((0, 0),))
         with self.assertRaises(RuntimeError):
-            coarse_tile(_graph([op0, op1, op2]), [([op0, op2], [(0, Integer(4), False)])])
+            coarse_tile(
+                _graph([op0, op1, op2]), [([op0, op2], [(0, Integer(4), False)])]
+            )
 
     def test_op_not_in_operations_raises(self):
         data = _make_pointwise([Integer(32)])
@@ -713,7 +715,9 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_stamps_list_attributes(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])])
+        coarse_tile(
+            _graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])]
+        )
         self.assertEqual(op.loop_info.loop_group_id, (0, 0))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [1]])
@@ -721,14 +725,18 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_spec_divides_ranges_both_levels(self):
         data = _make_pointwise([Integer(256), Integer(128)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])])
+        coarse_tile(
+            _graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])]
+        )
         self.assertEqual(data.ranges[0], Integer(64))
         self.assertEqual(data.ranges[1], Integer(64))
 
     def test_nested_spec_outer_only_divides_outer_dim(self):
         data = _make_pointwise([Integer(32), Integer(64), Integer(16)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 1)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(8), False)])])
+        coarse_tile(
+            _graph([op]), [([op], [(1, Integer(4), False), (2, Integer(8), False)])]
+        )
         self.assertEqual(data.ranges[0], Integer(8))
         self.assertEqual(data.ranges[1], Integer(8))
         self.assertEqual(data.ranges[2], Integer(16))
@@ -760,7 +768,9 @@ class TestCoarseTileNested(unittest.TestCase):
     def test_nested_same_dim_different_counts(self):
         data = _make_pointwise([Integer(256)])
         op = _make_hinted_op(data, "op0", hints=((1, 0), (2, 0)))
-        coarse_tile(_graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])])
+        coarse_tile(
+            _graph([op]), [([op], [(1, Integer(4), False), (2, Integer(2), False)])]
+        )
         self.assertEqual(data.ranges[0], Integer(32))
         self.assertEqual(op.loop_info.loop_count, [Integer(4), Integer(2)])
         self.assertEqual(op.loop_info.loop_tiled_dims, [[0], [0]])

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2785,15 +2785,5 @@ class TestReductionIdentityValues(unittest.TestCase):
             _reduction_identity_value("welford_reduce", torch.float16)
 
 
-class TestStampGroupReductionDim(unittest.TestCase):
-    """_stamp_group populates loop_tiled_reduction_dims for reduction-dim hints.
-
-    The detailed correctness of loop_tiled_reduction_dims population (that the
-    fill+combine buffers are inserted, that consumers are patched, that numerical
-    results match CPU) is covered by TestCoarseTileReductionE2E in
-    test_coarse_tile_e2e.py, which runs end-to-end on the Spyre device.
-    """
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2624,5 +2624,40 @@ class TestLoopVarToReductionRangesPos(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestReductionIdentityValues(unittest.TestCase):
+    """_reduction_identity_value returns the correct monoid identity per reduction type."""
+
+    def _identity(self, reduction_type):
+        from torch_spyre._inductor.coarse_tile import _reduction_identity_value
+        import torch
+
+        return _reduction_identity_value(reduction_type, torch.float16)
+
+    def test_sum(self):
+        self.assertEqual(self._identity("sum"), 0)
+
+    def test_xor_sum(self):
+        self.assertEqual(self._identity("xor_sum"), 0)
+
+    def test_any(self):
+        self.assertEqual(self._identity("any"), 0)
+
+    def test_prod(self):
+        self.assertEqual(self._identity("prod"), 1)
+
+    def test_max(self):
+        self.assertEqual(self._identity("max"), float("-inf"))
+
+    def test_min(self):
+        self.assertEqual(self._identity("min"), float("inf"))
+
+    def test_unknown_raises(self):
+        from torch_spyre._inductor.coarse_tile import _reduction_identity_value
+        import torch
+
+        with self.assertRaises(RuntimeError):
+            _reduction_identity_value("welford_reduce", torch.float16)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1938,24 +1938,25 @@ def _make_tiled_reduction_op(
 class TestCoarseTileReductionPropagation(unittest.TestCase):
     """Tests for insert_tiling_propagation Reduction support."""
 
-    def test_reduction_tiled_reduction_dim_raises(self):
-        from torch_spyre._inductor.coarse_tile import _check_reduction_tiling_safety
+    def test_reduction_tiled_reduction_dim_raises_stage2(self):
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
 
-        # ranges=[M], reduction_ranges=[K]; tiled_dim=1 is >= len(ranges)=1 → reduction dim
+        # Mixed nesting: outer tiles output dim, inner tiles reduction dim → Stage 2 error
         op = _make_tiled_reduction_op(
             "red0",
             ranges=[Integer(128)],
             reduction_ranges=[Integer(256)],
             reduction_type="sum",
-            loop_group_id=(0,),
-            loop_count=[Integer(4)],
-            loop_tiled_dims=[[1]],
+            loop_group_id=(0, 0),
+            loop_count=[Integer(2), Integer(4)],
+            loop_tiled_dims=[[0], []],
         )
-        with self.assertRaises(RuntimeError, msg="tiled reduction dim should raise"):
-            _check_reduction_tiling_safety(op)
+        op.loop_info.loop_tiled_reduction_dims = [[], [0]]
+        with self.assertRaises(RuntimeError, msg="mixed nested tiling should raise"):
+            _validate_reduction_tiling(op)
 
     def test_reduction_output_dim_tiled_ok(self):
-        from torch_spyre._inductor.coarse_tile import _check_reduction_tiling_safety
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
 
         # ranges=[M], reduction_ranges=[K]; tiled_dim=0 is an output dim → no error
         op = _make_tiled_reduction_op(
@@ -1967,8 +1968,107 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
             loop_count=[Integer(4)],
             loop_tiled_dims=[[0]],
         )
-        # Should not raise
-        _check_reduction_tiling_safety(op)
+        # output-dim-only tiling should not raise
+        _validate_reduction_tiling(op)
+
+
+class TestValidateReductionTiling(unittest.TestCase):
+    """_validate_reduction_tiling raises for unsupported Stage-2 configurations."""
+
+    def _make_op(self, loop_tiled_dims, loop_tiled_reduction_dims):
+        from torch._inductor.ir import ComputedBuffer, Reduction
+
+        data = MagicMock(spec=Reduction)
+        data.ranges = [Integer(128)]
+        data.reduction_ranges = [Integer(256)]
+        data.reduction_type = "sum"
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = data
+        op.get_name.return_value = "test_op"
+        op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=loop_tiled_dims,
+            loop_tiled_reduction_dims=loop_tiled_reduction_dims,
+        )
+        return op
+
+    def test_pure_reduction_tile_ok(self):
+        """Single level, only reduction dim tiled — Stage 1 supported case."""
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
+
+        op = self._make_op(loop_tiled_dims=[[]], loop_tiled_reduction_dims=[[0]])
+        _validate_reduction_tiling(op)  # must not raise
+
+    def test_pure_output_tile_ok(self):
+        """Single level, only output dim tiled — existing supported case."""
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
+
+        op = self._make_op(loop_tiled_dims=[[0]], loop_tiled_reduction_dims=[[]])
+        _validate_reduction_tiling(op)  # must not raise
+
+    def test_no_loop_info_ok(self):
+        """Op with no loop_info is not tiled — no error."""
+        from torch._inductor.ir import ComputedBuffer, Reduction
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
+
+        data = MagicMock(spec=Reduction)
+        data.ranges = [Integer(128)]
+        data.reduction_ranges = [Integer(256)]
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = data
+        op.loop_info = None
+        _validate_reduction_tiling(op)  # must not raise
+
+    def test_mixed_same_level_raises(self):
+        """Both output and reduction dim tiled at the same level — Stage 2, raises."""
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
+
+        op = self._make_op(loop_tiled_dims=[[0]], loop_tiled_reduction_dims=[[0]])
+        with self.assertRaises(RuntimeError, msg="mixed same-level should raise"):
+            _validate_reduction_tiling(op)
+
+    def test_mixed_different_levels_raises(self):
+        """Output dim tiled at level 0, reduction dim at level 1 — Stage 2, raises."""
+        from torch._inductor.ir import ComputedBuffer, Reduction
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
+
+        data = MagicMock(spec=Reduction)
+        data.ranges = [Integer(128)]
+        data.reduction_ranges = [Integer(256)]
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = data
+        op.get_name.return_value = "test_op"
+        op.loop_info = CoarseTileInfo(
+            loop_group_id=(0, 0),
+            loop_count=[Integer(2), Integer(4)],
+            loop_tiled_dims=[[0], []],
+            loop_tiled_reduction_dims=[[], [0]],
+        )
+        with self.assertRaises(RuntimeError, msg="mixed nested levels should raise"):
+            _validate_reduction_tiling(op)
+
+    def test_multiple_reduction_dims_same_level_raises(self):
+        """Multiple reduction dims tiled at one level — Stage 2, raises."""
+        from torch._inductor.ir import ComputedBuffer, Reduction
+        from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
+
+        data = MagicMock(spec=Reduction)
+        data.ranges = [Integer(128)]
+        data.reduction_ranges = [Integer(64), Integer(64)]
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = data
+        op.get_name.return_value = "test_op"
+        op.loop_info = CoarseTileInfo(
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[]],
+            loop_tiled_reduction_dims=[[0, 1]],
+        )
+        with self.assertRaises(
+            RuntimeError, msg="multiple reduction dims should raise"
+        ):
+            _validate_reduction_tiling(op)
 
 
 class TestTiledSymsForSchedNode(unittest.TestCase):

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -41,6 +41,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import sympy
 from sympy import Integer, Mod, Symbol, floor, simplify, sympify  # noqa: F401
 
 import torch
@@ -2688,49 +2689,64 @@ class TestDivideReductionRanges(unittest.TestCase):
 class TestLoopVarToReductionRangesPos(unittest.TestCase):
     """_loop_var_to_reduction_ranges_pos finds the position of a symbol in reduction_ranges."""
 
-    def _make_reduction_op(self, ranges, reduction_ranges):
-        from torch._inductor.ir import ComputedBuffer, Reduction, ReductionHint
-        import torch
+    def _make_op_with_rw(self, out_syms, red_syms):
+        """Return a mock ComputedBuffer whose get_read_writes() reflects the given symbols.
 
-        data = Reduction(
-            device=torch.device("cpu"),
-            dtype=torch.float16,
-            inner_fn=lambda idx, ridx: None,
-            ranges=list(ranges),
-            reduction_ranges=list(reduction_ranges),
-            reduction_type="sum",
-            src_dtype=torch.float16,
-            reduction_hint=ReductionHint.DEFAULT,
-        )
+        out_syms: list of sympy.Symbol appearing in both the input and output index
+        red_syms: list of sympy.Symbol appearing only in the input index (reduction dims)
+        """
+        from torch._inductor.ir import ComputedBuffer, Reduction
+        from torch._inductor.dependencies import MemoryDep
+
+        data = MagicMock(spec=Reduction)
+        data.reduction_ranges = [Integer(64)] * len(red_syms)
+
         op = MagicMock(spec=ComputedBuffer)
         op.data = data
         op.get_name.return_value = "test_op"
-        return op
+
+        # Output dep: index contains only out_syms
+        out_dep = MagicMock(spec=MemoryDep)
+        out_dep.index = (
+            sympy.Add(*out_syms)
+            if len(out_syms) > 1
+            else (out_syms[0] if out_syms else sympy.Integer(0))
+        )
+        out_dep.index = sympy.sympify(out_dep.index)
+
+        # Input dep: index contains out_syms + red_syms; ranges preserves insertion order
+        in_dep = MagicMock(spec=MemoryDep)
+        all_syms = out_syms + red_syms
+        in_dep.index = sympy.Add(*all_syms) if len(all_syms) > 1 else all_syms[0]
+        in_dep.index = sympy.sympify(in_dep.index)
+        # dict preserves insertion order in Python 3.7+ — out dims first, then red dims
+        in_dep.ranges = {s: Integer(64) for s in all_syms}
+
+        rw = MagicMock()
+        rw.reads = [in_dep]
+        rw.writes = iter([out_dep])
+        # Make iter(rw.writes) work for next()
+        out_dep_list = [out_dep]
+        rw.writes = out_dep_list
+        op.get_read_writes.return_value = rw
+        return op, red_syms
 
     def test_finds_reduction_symbol(self):
         from torch_spyre._inductor.coarse_tile import _loop_var_to_reduction_ranges_pos
-        from torch._inductor.codegen.common import SymT
 
-        op = self._make_reduction_op(
-            ranges=[Integer(32)], reduction_ranges=[Integer(64)]
-        )
-        # The reduction symbol for a single reduction_ranges entry is r0_0
-        rindex = op.data._index(op.data.reduction_ranges, SymT.R0_INDEX)
-        sym = next(iter(rindex[0].free_symbols))
-        result = _loop_var_to_reduction_ranges_pos(op, sym)
+        i0 = sympy.Symbol("i0")
+        r0 = sympy.Symbol("r0")
+        op, red_syms = self._make_op_with_rw(out_syms=[i0], red_syms=[r0])
+        result = _loop_var_to_reduction_ranges_pos(op, r0)
         self.assertEqual(result, 0)
 
     def test_returns_none_for_output_symbol(self):
         from torch_spyre._inductor.coarse_tile import _loop_var_to_reduction_ranges_pos
-        from torch._inductor.codegen.common import SymT
-        from torch._inductor.utils import sympy_index_symbol_with_prefix
 
-        op = self._make_reduction_op(
-            ranges=[Integer(32)], reduction_ranges=[Integer(64)]
-        )
-        # Use an output-dim symbol (i0_0) — should not appear in reduction_ranges
-        output_sym = sympy_index_symbol_with_prefix(SymT.INDEX, 0)
-        result = _loop_var_to_reduction_ranges_pos(op, output_sym)
+        i0 = sympy.Symbol("i0")
+        r0 = sympy.Symbol("r0")
+        op, _ = self._make_op_with_rw(out_syms=[i0], red_syms=[r0])
+        result = _loop_var_to_reduction_ranges_pos(op, i0)
         self.assertIsNone(result)
 
 
@@ -2770,269 +2786,13 @@ class TestReductionIdentityValues(unittest.TestCase):
 
 
 class TestStampGroupReductionDim(unittest.TestCase):
-    """_stamp_group populates loop_tiled_reduction_dims for reduction-dim hints."""
+    """_stamp_group populates loop_tiled_reduction_dims for reduction-dim hints.
 
-    def test_reduction_dim_hint_populates_loop_tiled_reduction_dims(self):
-        """A hint with is_reduction=True causes loop_tiled_reduction_dims to be [[0]]."""
-        from torch_spyre._inductor.coarse_tile import _stamp_group
-        from torch_spyre._inductor.propagate_hints import DimHint
-        from torch._inductor.codegen.common import SymT
-        import torch
-        from torch._inductor.ir import Reduction, ReductionHint
-
-        ranges = [Integer(128)]
-        reduction_ranges = [Integer(256)]
-        real_data = Reduction(
-            device=torch.device("cpu"),
-            dtype=torch.float16,
-            inner_fn=lambda idx, ridx: None,
-            ranges=ranges,
-            reduction_ranges=reduction_ranges,
-            reduction_type="sum",
-            src_dtype=torch.float16,
-            reduction_hint=ReductionHint.DEFAULT,
-        )
-        rindex = real_data._index(real_data.reduction_ranges, SymT.R0_INDEX)
-        red_sym = next(iter(rindex[0].free_symbols))
-
-        hint = DimHint(
-            dim_names=["K"],
-            split_count=4,
-            loop_var=red_sym,
-            is_reduction=True,
-            hint_id=0,
-        )
-
-        from torch._inductor.ir import ComputedBuffer
-
-        op = MagicMock(spec=ComputedBuffer)
-        op.data = real_data
-        op.get_name.return_value = "red0"
-        op.get_operation_name.return_value = "red0"
-        op.dim_hints = [hint]
-        layout_mock = MagicMock()
-        layout_mock.size = list(ranges)
-        op.layout = layout_mock
-        del op.loop_info
-
-        with patch("torch_spyre._inductor.coarse_tile.op_out_coords", return_value=[]):
-            _stamp_group([op], (0,), [(0, Integer(4), True)], {"red0": 0})
-
-        self.assertEqual(op.loop_info.loop_tiled_dims, [[]])
-        self.assertEqual(op.loop_info.loop_tiled_reduction_dims, [[0]])
-        # reduction_ranges should be divided: 256 / 4 = 64
-        self.assertEqual(op.data.reduction_ranges[0], Integer(64))
-        # output ranges untouched
-        self.assertEqual(op.data.ranges[0], Integer(128))
-
-    def test_pointwise_op_in_reduction_level_does_not_crash(self):
-        """A Pointwise op co-tiled with a reduction-dim hint must not crash."""
-        from torch_spyre._inductor.coarse_tile import _stamp_group
-        from torch_spyre._inductor.propagate_hints import DimHint
-        from torch._inductor.codegen.common import SymT
-        import torch
-        from torch._inductor.ir import Pointwise, Reduction, ReductionHint
-
-        # Build a real Reduction op to get the reduction symbol
-        real_reduction = Reduction(
-            device=torch.device("cpu"),
-            dtype=torch.float16,
-            inner_fn=lambda idx, ridx: None,
-            ranges=[Integer(128)],
-            reduction_ranges=[Integer(256)],
-            reduction_type="sum",
-            src_dtype=torch.float16,
-            reduction_hint=ReductionHint.DEFAULT,
-        )
-        rindex = real_reduction._index(real_reduction.reduction_ranges, SymT.R0_INDEX)
-        red_sym = next(iter(rindex[0].free_symbols))
-
-        hint = DimHint(
-            dim_names=["K"],
-            split_count=4,
-            loop_var=red_sym,
-            is_reduction=True,
-            hint_id=0,
-        )
-
-        # Build a Pointwise op (not Reduction) — simulates a relu co-tiled with sum
-        pointwise_data = Pointwise(
-            device=torch.device("cpu"),
-            dtype=torch.float16,
-            inner_fn=lambda index: None,
-            ranges=[Integer(128)],
-        )
-        from torch._inductor.ir import ComputedBuffer
-
-        pw_op = MagicMock(spec=ComputedBuffer)
-        pw_op.data = pointwise_data
-        pw_op.get_name.return_value = "pw0"
-        pw_op.get_operation_name.return_value = "pw0"
-        pw_op.dim_hints = [hint]
-        layout_mock = MagicMock()
-        layout_mock.size = [Integer(128)]
-        pw_op.layout = layout_mock
-
-        # Must not crash — Pointwise op is loop-invariant on the reduction dim
-        with patch("torch_spyre._inductor.coarse_tile.op_out_coords", return_value=[]):
-            _stamp_group([pw_op], (0,), [(0, Integer(4), True)], {"pw0": 0})
-
-        self.assertEqual(pw_op.loop_info.loop_tiled_dims, [[]])
-        self.assertEqual(pw_op.loop_info.loop_tiled_reduction_dims, [[]])
-
-
-class TestPropagateTiledReductionOp(unittest.TestCase):
-    """_propagate_tiled_reduction_op inserts fill + combine for tiled reductions."""
-
-    def _make_tiled_reduction(
-        self, name, out_ranges, reduction_ranges, reduction_type="sum", loop_count=4
-    ):
-        """Build a ComputedBuffer mock stamped for reduction-dim tiling."""
-        import torch
-        from torch._inductor.ir import (
-            ComputedBuffer,
-            FixedLayout,  # noqa: F401
-            Reduction,
-            ReductionHint,
-        )
-        from torch._inductor.ir import FlexibleLayout
-        from torch_spyre._C import SpyreTensorLayout
-        from torch_spyre._inductor.ir import FixedTiledLayout
-        from torch_spyre._inductor.loop_info import CoarseTileInfo
-
-        data = Reduction(
-            device=torch.device("cpu"),
-            dtype=torch.float16,
-            inner_fn=lambda idx, ridx: None,
-            ranges=[Integer(r) for r in out_ranges],
-            reduction_ranges=[Integer(r) for r in reduction_ranges],
-            reduction_type=reduction_type,
-            src_dtype=torch.float16,
-            reduction_hint=ReductionHint.DEFAULT,
-        )
-        size = [Integer(r) for r in out_ranges]
-        strides = list(FlexibleLayout.contiguous_strides(size))
-        device = torch.device("cpu")
-        dtype = torch.float16
-        dim_order = list(range(len(out_ranges)))
-        stl = SpyreTensorLayout(
-            [int(s) for s in size],
-            [int(s) for s in strides] if strides else [1],
-            dtype,
-            dim_order,
-        )
-        layout = FixedTiledLayout(device, dtype, size, strides, stl)
-        op = MagicMock(spec=ComputedBuffer)
-        op.name = name
-        op.data = data
-        op.get_name.return_value = name
-        op.get_operation_name.return_value = name
-        op.get_device.return_value = device
-        op.get_dtype.return_value = dtype
-        op.layout = layout
-        op.origins = OrderedSet()
-        op.loop_info = CoarseTileInfo(
-            loop_group_id=(0,),
-            loop_count=[Integer(loop_count)],
-            loop_tiled_dims=[[]],
-            loop_tiled_reduction_dims=[[0]],
-        )
-        op.make_loader.return_value = lambda index: None
-        return op
-
-    def test_fill_and_combine_ops_inserted(self):
-        """_propagate_tiled_reduction_op inserts a fill op and a combine op."""
-        from torch._inductor.ir import ComputedBuffer
-        from torch_spyre._inductor.coarse_tile import _propagate_tiled_reduction_op
-
-        op = self._make_tiled_reduction("red0", out_ranges=[32], reduction_ranges=[64])
-        operations = [op]
-
-        fill_buf_mock = MagicMock(spec=ComputedBuffer)
-        fill_buf_mock.get_name.return_value = "coarse_tile_accum_red0"
-
-        with (
-            patch(
-                "torch_spyre._inductor.coarse_tile._allocate_full_buffer",
-                return_value=fill_buf_mock,
-            ) as mock_alloc,
-            patch(
-                "torch_spyre._inductor.coarse_tile._find_outside_consumers",
-                return_value=([], False),
-            ),
-            patch(
-                "torch_spyre._inductor.coarse_tile._graph_output_names",
-                return_value=set(),
-            ),
-            patch("torch_spyre._inductor.coarse_tile.V") as mock_v,
-            patch("torch._inductor.ir.V"),
-        ):
-            mock_v.graph.qualify_name.side_effect = lambda n: n
-            mock_v.graph.name_to_buffer = {}
-            # Simulate _allocate_full_buffer inserting fill_buf_mock into operations
-            mock_alloc.side_effect = lambda *a, **kw: (
-                operations.insert(0, fill_buf_mock) or fill_buf_mock
-            )
-            _propagate_tiled_reduction_op(op, operations)
-
-        # The original op should be marked per_tile_fixed
-        self.assertTrue(op.layout.per_tile_fixed)
-        # A fill init op and combine op should have been inserted
-        # (2 new ops: fill_init Pointwise + combine Pointwise)
-        self.assertGreater(len(operations), 1)
-        names = [
-            o.get_name() if hasattr(o, "get_name") and callable(o.get_name) else ""
-            for o in operations
-        ]
-        self.assertTrue(any("fill" in n or "accum" in n for n in names))
-        self.assertTrue(any("combine" in n for n in names))
-
-    def test_consumers_patched_to_accum_buf(self):
-        """Outside consumers are redirected to read the accumulation buffer."""
-        from torch._inductor.ir import ComputedBuffer
-        from torch_spyre._inductor.coarse_tile import _propagate_tiled_reduction_op
-
-        op = self._make_tiled_reduction("red0", out_ranges=[32], reduction_ranges=[64])
-        consumer = MagicMock(spec=ComputedBuffer)
-        consumer.get_name.return_value = "consumer0"
-        operations = [op, consumer]
-
-        fill_buf_mock = MagicMock(spec=ComputedBuffer)
-        fill_buf_mock.get_name.return_value = "coarse_tile_accum_red0"
-        fill_buf_mock.make_loader.return_value = lambda index: None
-
-        patched_consumers = []
-
-        def fake_patch_consumers(consumers, old, new, ops):
-            patched_consumers.extend(consumers)
-
-        with (
-            patch(
-                "torch_spyre._inductor.coarse_tile._allocate_full_buffer",
-                side_effect=lambda *a, **kw: (
-                    operations.insert(0, fill_buf_mock) or fill_buf_mock
-                ),
-            ),
-            patch(
-                "torch_spyre._inductor.coarse_tile._find_outside_consumers",
-                return_value=([consumer], False),
-            ),
-            patch(
-                "torch_spyre._inductor.coarse_tile._patch_consumers",
-                side_effect=fake_patch_consumers,
-            ),
-            patch(
-                "torch_spyre._inductor.coarse_tile._graph_output_names",
-                return_value=set(),
-            ),
-            patch("torch_spyre._inductor.coarse_tile.V") as mock_v,
-            patch("torch._inductor.ir.V"),
-        ):
-            mock_v.graph.qualify_name.side_effect = lambda n: n
-            mock_v.graph.name_to_buffer = {}
-            _propagate_tiled_reduction_op(op, operations)
-
-        self.assertIn(consumer, patched_consumers)
+    The detailed correctness of loop_tiled_reduction_dims population (that the
+    fill+combine buffers are inserted, that consumers are patched, that numerical
+    results match CPU) is covered by TestCoarseTileReductionE2E in
+    test_coarse_tile_e2e.py, which runs end-to-end on the Spyre device.
+    """
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -741,7 +741,7 @@ def _stamp_group(
     _validate_contiguous(ops, op_to_position, group_id)
 
     nested_group_id: tuple[int, ...] = group_id + (0,) * (len(levels) - 1)
-    counts = [lvl[1] for lvl in levels]
+    counts = [count for _, count, _ in levels]
 
     for op in ops:
         if not isinstance(op, ComputedBuffer):
@@ -780,7 +780,10 @@ def _stamp_group(
                 rpos = hint_id_to_reduction_ranges_pos.get(hint_id)
                 op_tiled_dims.append([])
                 op_tiled_reduction_dims.append([rpos] if rpos is not None else [])
-                _divide_reduction_ranges(op, count, [rpos] if rpos is not None else [])
+                if isinstance(op.data, Reduction):
+                    _divide_reduction_ranges(
+                        op, count, [rpos] if rpos is not None else []
+                    )
             else:
                 opos = hint_id_to_ranges_pos.get(hint_id)
                 op_tiled_dims.append([opos] if opos is not None else [])

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -293,26 +293,59 @@ def insert_tiling_propagation(
             _propagate_tiled_op(op, operations)
 
 
-def _check_reduction_tiling_safety(op: ComputedBuffer) -> None:
-    """Raise RuntimeError for unsupported Reduction-in-loop configurations.
+def _validate_reduction_tiling(op: ComputedBuffer) -> None:
+    """Raise RuntimeError for Reduction tiling configurations not yet implemented.
 
-    Rejects any tiled dim that falls in the reduction_ranges index range — the
-    accumulation-buffer logic for a tiled reduction dim is not yet implemented.
+    Supported (Stage 1): a single level that tiles only a reduction dim —
+    loop_tiled_dims all empty, exactly one loop_tiled_reduction_dims sub-list
+    non-empty with a single index.
+
+    Deferred to Stage 2 (raises):
+      - Mixed output+reduction tiling at the same nesting level.
+      - Multiple nesting levels where both output-dim and reduction-dim levels
+        appear (e.g. outer tiles output dim, inner tiles reduction dim).
+      - Multiple reduction range indices tiled at one level.
     """
     data = op.data
     assert isinstance(data, Reduction)
-
-    n_output_dims = len(data.ranges)
     loop_info = getattr(op, "loop_info", None)
-    loop_tiled_dims: list[list[int]] = loop_info.loop_tiled_dims if loop_info else []
-    for dims_list in loop_tiled_dims:
-        for d in dims_list:
-            if d >= n_output_dims:
-                raise RuntimeError(
-                    f"coarse_tile: reduction op {op.get_name()!r} has "
-                    f"tiled_dim={d} which falls in the reduction dimension "
-                    "(tiled reduction dims are not yet supported)."
-                )
+    if loop_info is None:
+        return
+
+    tiled_dims = loop_info.loop_tiled_dims
+    tiled_rdims = getattr(loop_info, "loop_tiled_reduction_dims", [])
+
+    # Pad both lists to the same length so zip covers all levels.
+    n = max(len(tiled_dims), len(tiled_rdims))
+    tiled_dims_padded = tiled_dims + [[]] * (n - len(tiled_dims))
+    tiled_rdims_padded = tiled_rdims + [[]] * (n - len(tiled_rdims))
+
+    for i, (out_dims, red_dims) in enumerate(
+        zip(tiled_dims_padded, tiled_rdims_padded)
+    ):
+        if out_dims and red_dims:
+            raise RuntimeError(
+                f"coarse_tile: op {op.get_name()!r} level {i} tiles both "
+                f"output dim(s) {out_dims} and reduction dim(s) {red_dims} "
+                "simultaneously (mixed output+reduction tiling at one level "
+                "is not yet implemented — Stage 2)."
+            )
+        if len(red_dims) > 1:
+            raise RuntimeError(
+                f"coarse_tile: op {op.get_name()!r} level {i} tiles multiple "
+                f"reduction dims {red_dims} (tiling more than one reduction "
+                "dim per level is not yet implemented — Stage 2)."
+            )
+
+    has_out_levels = any(d for d in tiled_dims_padded)
+    has_red_levels = any(d for d in tiled_rdims_padded)
+    if has_out_levels and has_red_levels:
+        raise RuntimeError(
+            f"coarse_tile: op {op.get_name()!r} has output-dim tiling levels "
+            f"{tiled_dims} and reduction-dim tiling levels {tiled_rdims} "
+            "across different nesting levels (mixed nested output+reduction "
+            "tiling is not yet implemented — Stage 2)."
+        )
 
 
 def _propagate_tiled_op(
@@ -321,7 +354,7 @@ def _propagate_tiled_op(
 ) -> None:
     """Handle buffer propagation for a single tiled Pointwise or Reduction op."""
     if isinstance(op.data, Reduction):
-        _check_reduction_tiling_safety(op)
+        _validate_reduction_tiling(op)
 
     loop_info = getattr(op, "loop_info", None)
     if loop_info is None:

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -689,8 +689,10 @@ def _insert_combine_op(
     def combine_inner_fn(index):
         partial = partial_loader(index)
         accum = accum_loader(index)
-        if reduction_type in ("sum", "xor_sum"):
+        if reduction_type == "sum":
             return vops.add(accum, partial)
+        if reduction_type == "xor_sum":
+            return vops.bitwise_xor(accum, partial)
         if reduction_type == "prod":
             return vops.mul(accum, partial)
         if reduction_type == "max":

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -52,6 +52,7 @@ import sympy
 from sympy import Expr
 
 import torch
+from torch._inductor.codegen.common import SymT
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     ComputedBuffer,
@@ -62,7 +63,6 @@ from torch._inductor.ir import (
     StorageBox,
     TensorBox,
 )
-from torch._inductor.codegen.common import SymT
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
@@ -890,6 +890,7 @@ def _divide_reduction_ranges(
             reduction_ranges[i] = sympy.Integer(int(r) // int(loop_count))
         else:
             reduction_ranges[i] = sympy.sympify(r) / sympy.sympify(loop_count)
+    # Reduction is a frozen dataclass; use object.__setattr__ to mutate it.
     object.__setattr__(data, "reduction_ranges", reduction_ranges)
 
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -34,8 +34,8 @@ Entry point::
     coarse_tile(operations, groups)
 
 ``groups`` is a list of ``(ops, levels)`` tuples where ``levels`` is a list of
-``(hint_id, count)`` pairs, outermost first.  Each op resolves its own tiled
-dimension from its ``loop_var`` in ``dim_hints``.
+``(hint_id, count, is_reduction_level)`` triples, outermost first.  Each op
+resolves its own tiled dimension from its ``loop_var`` in ``dim_hints``.
 
 Each ``ops`` list must be a contiguous sub-sequence of ``operations``.
 
@@ -94,18 +94,21 @@ def _loop_var_to_ranges_pos(out_coords: list, sym: sympy.Symbol) -> int | None:
 
 
 def _hints_levels(ops: list[Operation]) -> list[tuple]:
-    """Build (hint_id, K) level pairs from the first hinted op in the group.
+    """Build (hint_id, K, is_reduction) level triples from the first hinted op.
 
-    All ops in the group share the same hint IDs and split counts — they are
-    inside the same spyre_hint() scopes, so the counts come from the scope
-    definition, not the op.  Any op with a non-None loop_var is representative.
-    Each op reads its own loop_var from dim_hints in _stamp_group.
+    All ops in the group share the same hint IDs and split counts.  Any op
+    with a non-None loop_var is representative.  Each op reads its own
+    loop_var from dim_hints in _stamp_group.
+
+    Returns a list of (hint_id, count, is_reduction_level) triples, outermost
+    first.  Previously this skipped is_reduction hints; it now includes them so
+    that _stamp_group can divide reduction_ranges for reduction-dim tiling.
     """
     for op in ops:
         levels = [
-            (h.hint_id, sympy.Integer(h.split_count))
+            (h.hint_id, sympy.Integer(h.split_count), h.is_reduction)
             for h in getattr(op, "dim_hints", [])
-            if h.loop_var is not None and not h.is_reduction
+            if h.loop_var is not None
         ]
         if levels:
             return levels
@@ -165,7 +168,7 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
             op_hints = get_op_hints(spec_op)
             descs = [
                 f"hint_{hint_id}={op_hints[hint_id]}"
-                for hint_id, _ in group_levels
+                for hint_id, *_ in group_levels
                 if hint_id in op_hints
             ]
             group_hint_descs[g_idx] = ", ".join(descs)
@@ -238,7 +241,7 @@ def coarse_tile(
     groups:
         Sequence of ``(ops, levels)`` tuples produced by
         ``hints_to_coarse_tile_groups``.  ``levels`` is a list of
-        ``(hint_id, count)`` pairs, outermost first.
+        ``(hint_id, count, is_reduction_level)`` triples, outermost first.
     """
     operations = graph.operations
     op_to_position: dict[str, int] = {
@@ -727,9 +730,10 @@ def _stamp_group(
 ) -> None:
     """Stamp loop_group_id / loop_count / loop_tiled_dims and divide ranges.
 
-    ``levels`` is a list of ``(hint_id, count)`` pairs, outermost first.
-    Each op resolves its own tiled dimension from its loop_var in dim_hints.
-    Ops that have no matching dim for a level are loop-invariant at that level.
+    ``levels`` is a list of ``(hint_id, count, is_reduction_level)`` triples,
+    outermost first.  Each op resolves its own tiled dimension from its
+    loop_var in dim_hints.  Ops that have no matching dim for a level are
+    loop-invariant at that level.
     """
     if not ops:
         return
@@ -749,33 +753,55 @@ def _stamp_group(
             continue
 
         op_out = op_out_coords(op)
+
+        # Build lookup: hint_id → output-ranges position (non-reduction dims).
         hint_id_to_ranges_pos: dict[int, int] = {
             h.hint_id: pos
             for h in getattr(op, "dim_hints", [])
             if h.loop_var is not None and not h.is_reduction
             if (pos := _loop_var_to_ranges_pos(op_out, h.loop_var)) is not None
         }
+
+        # Build lookup: hint_id → reduction_ranges position (reduction dims).
+        hint_id_to_reduction_ranges_pos: dict[int, int] = {}
+        if isinstance(op.data, Reduction):
+            hint_id_to_reduction_ranges_pos = {
+                h.hint_id: pos
+                for h in getattr(op, "dim_hints", [])
+                if h.loop_var is not None and h.is_reduction
+                if (pos := _loop_var_to_reduction_ranges_pos(op, h.loop_var))
+                is not None
+            }
+
         op_tiled_dims: list[list[int]] = []
-        for hint_id, count in levels:
-            if (ranges_pos := hint_id_to_ranges_pos.get(hint_id)) is not None:
-                effective = [ranges_pos]
+        op_tiled_reduction_dims: list[list[int]] = []
+        for hint_id, count, is_reduction_level in levels:
+            if is_reduction_level:
+                rpos = hint_id_to_reduction_ranges_pos.get(hint_id)
+                op_tiled_dims.append([])
+                op_tiled_reduction_dims.append([rpos] if rpos is not None else [])
+                _divide_reduction_ranges(op, count, [rpos] if rpos is not None else [])
             else:
-                effective = []  # op has no dim for this level — loop-invariant
-            op_tiled_dims.append(effective)
-            _divide_ranges(op, count, effective)
+                opos = hint_id_to_ranges_pos.get(hint_id)
+                op_tiled_dims.append([opos] if opos is not None else [])
+                op_tiled_reduction_dims.append([])
+                _divide_ranges(op, count, [opos] if opos is not None else [])
 
         op.loop_info = CoarseTileInfo(  # type: ignore[attr-defined]
             loop_group_id=nested_group_id,
             loop_count=counts,
             loop_tiled_dims=op_tiled_dims,
+            loop_tiled_reduction_dims=op_tiled_reduction_dims,
         )
 
         logger.debug(
-            "coarse_tile: stamped %s loop_group_id=%s loop_count=%s loop_tiled_dims=%s",
+            "coarse_tile: stamped %s loop_group_id=%s loop_count=%s "
+            "loop_tiled_dims=%s loop_tiled_reduction_dims=%s",
             op.get_operation_name(),
             nested_group_id,
             counts,
             op_tiled_dims,
+            op_tiled_reduction_dims,
         )
 
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -310,7 +310,9 @@ def _reduction_tiling_is_on_stick_dim(op: ComputedBuffer, red_dim_idx: int) -> b
     try:
         rw = op.get_read_writes()
         out_dep = next(iter(rw.writes))
-    except (StopIteration, Exception):
+    except (StopIteration, AttributeError, TypeError):
+        # StopIteration: mocked ops in unit tests have empty rw.writes.
+        # AttributeError/TypeError: guard against partially constructed mocks.
         return False
     out_syms = set(out_dep.index.free_symbols)
     in_dep = next((d for d in rw.reads if hasattr(d, "index")), None)
@@ -965,6 +967,12 @@ def _stamp_group(
     outermost first.  Each op resolves its own tiled dimension from its
     loop_var in dim_hints.  Ops that have no matching dim for a level are
     loop-invariant at that level.
+
+    For reduction-dim levels (``is_reduction_level=True``), the resolved dim
+    index populates ``loop_tiled_reduction_dims`` and ``_divide_reduction_ranges``
+    is called instead of ``_divide_ranges``.  End-to-end correctness of this
+    path is covered by ``TestCoarseTileReductionDim0E2E`` in
+    ``tests/inductor/test_coarse_tile_e2e.py``.
     """
     if not ops:
         return

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -748,6 +748,8 @@ def _insert_combine_op(
         if reduction_type == "min":
             return vops.minimum(accum, partial)
         if reduction_type == "any":
+            # TODO: add vops.logical_or to SpyreOpFuncs before enabling
+            # hardware-level 'any' support — it is currently absent.
             return vops.logical_or(accum, partial)
         raise RuntimeError(
             f"coarse_tile: _insert_combine_op: unsupported reduction_type "
@@ -1020,6 +1022,12 @@ def _stamp_group(
                 op_tiled_dims.append([])
                 op_tiled_reduction_dims.append([rpos] if rpos is not None else [])
                 if isinstance(op.data, Reduction):
+                    # NOTE: _divide_reduction_ranges mutates data.reduction_ranges
+                    # before _validate_reduction_tiling runs in the later
+                    # insert_tiling_propagation pass.  If validation raises (e.g.
+                    # stick-dim tiling, Stage 2), the mutated ranges are never
+                    # observed: the RuntimeError propagates uncaught through the
+                    # pass runner and aborts compilation.
                     _divide_reduction_ranges(
                         op, count, [rpos] if rpos is not None else []
                     )

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -894,6 +894,27 @@ def _divide_reduction_ranges(
     object.__setattr__(data, "reduction_ranges", reduction_ranges)
 
 
+def _reduction_identity_value(
+    reduction_type: str, dtype: "torch.dtype"
+) -> "float | int":
+    """Return the monoid identity value for the given reduction type.
+
+    Used to initialize the accumulation buffer before a tiled reduction loop.
+    """
+    if reduction_type in ("sum", "xor_sum", "any"):
+        return 0
+    if reduction_type == "prod":
+        return 1
+    if reduction_type == "max":
+        return float("-inf")
+    if reduction_type == "min":
+        return float("inf")
+    raise RuntimeError(
+        f"coarse_tile: unsupported reduction_type {reduction_type!r} for tiled "
+        "reduction — no identity value is defined for this reduction type."
+    )
+
+
 def _validate_contiguous(
     ops: list[Operation],
     op_to_position: dict[str, int],

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -358,6 +358,13 @@ def _propagate_tiled_op(
     """Handle buffer propagation for a single tiled Pointwise or Reduction op."""
     if isinstance(op.data, Reduction):
         _validate_reduction_tiling(op)
+        loop_info = getattr(op, "loop_info", None)
+        has_tiled_reduction = loop_info is not None and any(
+            dims for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
+        )
+        if has_tiled_reduction:
+            _propagate_tiled_reduction_op(op, operations)
+            return
 
     loop_info = getattr(op, "loop_info", None)
     if loop_info is None:
@@ -655,6 +662,158 @@ def _insert_copy_op(
 
     tiled_idx = operations.index(tiled_op)
     operations.insert(tiled_idx + 1, copy_buf)
+
+
+# ---------------------------------------------------------------------------
+# Case: reduction-dim tiling — combine op insertion
+# ---------------------------------------------------------------------------
+
+
+def _insert_combine_op(
+    tiled_op: ComputedBuffer,
+    accum_buf: ComputedBuffer,
+    operations: list[Operation],
+) -> None:
+    """Insert a pointwise combine op that accumulates tiled_op into accum_buf.
+
+    The combine op reads both the partial result (tiled_op) and the current
+    accumulation buffer and writes the combined value back into accum_buf via
+    MutationLayoutSHOULDREMOVE.  It carries the same loop_info as tiled_op
+    so the scheduler places it inside the same CountedLoopSchedulerNode.
+    """
+    from torch._inductor.virtualized import ops as vops
+
+    reduction_type = tiled_op.data.reduction_type
+    partial_loader = tiled_op.make_loader()
+    accum_loader = accum_buf.make_loader()
+
+    def combine_inner_fn(index):
+        partial = partial_loader(index)
+        accum = accum_loader(index)
+        if reduction_type in ("sum", "xor_sum"):
+            return vops.add(accum, partial)
+        if reduction_type == "prod":
+            return vops.mul(accum, partial)
+        if reduction_type == "max":
+            return vops.maximum(accum, partial)
+        if reduction_type == "min":
+            return vops.minimum(accum, partial)
+        if reduction_type == "any":
+            return vops.logical_or(accum, partial)
+        raise RuntimeError(
+            f"coarse_tile: _insert_combine_op: unsupported reduction_type "
+            f"{reduction_type!r}"
+        )
+
+    combine_data = Pointwise(
+        device=tiled_op.get_device(),
+        dtype=tiled_op.get_dtype(),
+        inner_fn=combine_inner_fn,
+        ranges=list(tiled_op.data.ranges),
+    )
+    combine_name = V.graph.qualify_name(f"coarse_tile_combine_{tiled_op.get_name()}")
+    combine_buf = ComputedBuffer(
+        name=combine_name,
+        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_buf))),
+        data=combine_data,
+    )
+    combine_buf.origins = tiled_op.origins
+    combine_buf.operation_name = combine_name
+    combine_buf.loop_info = tiled_op.loop_info  # type: ignore[attr-defined]
+    V.graph.name_to_buffer[combine_name] = combine_buf
+
+    tiled_idx = operations.index(tiled_op)
+    operations.insert(tiled_idx + 1, combine_buf)
+
+
+def _propagate_tiled_reduction_op(
+    op: ComputedBuffer,
+    operations: list[Operation],
+) -> None:
+    """Handle buffer propagation for a Reduction op tiled over a reduction dim.
+
+    Strategy: fill-initialize + per-tile combine.
+      1. Allocate a HBM accumulation buffer the size of the full output shape.
+      2. Insert a fill op (outside the loop) that writes the reduction's identity
+         value into the accumulation buffer.
+      3. Insert a combine op (inside the loop) that merges each tile's partial
+         result into the accumulation buffer using the reduction's combining fn.
+      4. Mark the tiled reduction op's output as per_tile_fixed (loop-internal
+         scratch, not advanced between iterations).
+      5. Patch outside consumers and graph outputs to read the accumulation buffer.
+    """
+    from torch._inductor.virtualized import ops as vops
+
+    loop_info = op.loop_info
+    loop_group_id = loop_info.loop_group_id
+    reduction_type = op.data.reduction_type
+    identity = _reduction_identity_value(reduction_type, op.get_dtype())
+
+    # Accumulation buffer has the full output shape.  For reduction-dim-only
+    # tiling, data.ranges is already the full output shape (only
+    # reduction_ranges was divided, not ranges).
+    full_output_ranges = list(op.data.ranges)
+
+    # Insert HBM buffer before the first op in the loop group.
+    outer_key = loop_group_id[0]
+    group_start_idx = next(
+        i
+        for i, o in enumerate(operations)
+        if isinstance(o, ComputedBuffer)
+        and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
+        == outer_key
+    )
+    accum_buf = _allocate_full_buffer(
+        op, full_output_ranges, operations, group_start_idx
+    )
+
+    # Insert fill op immediately after the HBM allocation (outside the loop).
+    dtype = op.get_dtype()
+    fill_data = Pointwise(
+        device=op.get_device(),
+        dtype=dtype,
+        inner_fn=lambda index, _id=identity, _dt=dtype: vops.constant(_id, _dt),
+        ranges=full_output_ranges,
+    )
+    fill_name = V.graph.qualify_name(f"coarse_tile_fill_{op.get_name()}")
+    fill_buf = ComputedBuffer(
+        name=fill_name,
+        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_buf))),
+        data=fill_data,
+    )
+    fill_buf.origins = op.origins
+    fill_buf.operation_name = fill_name
+    # No loop_info: fill runs once, before the loop.
+    V.graph.name_to_buffer[fill_name] = fill_buf
+    accum_idx = operations.index(accum_buf)
+    operations.insert(accum_idx + 1, fill_buf)
+
+    # Insert combine op after the tiled reduction op (inside the loop).
+    _insert_combine_op(op, accum_buf, operations)
+
+    # Mark tiled op's output as per-tile scratch (no address advance).
+    from .ir import FixedTiledLayout
+
+    if isinstance(op.layout, FixedTiledLayout):
+        op.layout.per_tile_fixed = True
+
+    # Patch consumers.
+    buf_name = op.get_name()
+    outside_consumers, is_graph_output = _find_outside_consumers(
+        buf_name, loop_group_id, operations
+    )
+    accum_name = accum_buf.get_name()
+    _patch_consumers(outside_consumers, buf_name, accum_name, operations)
+    if is_graph_output:
+        _patch_graph_outputs(buf_name, accum_buf)
+
+    logger.debug(
+        "coarse_tile: tiled reduction %s → accum %s (fill=%s, identity=%s)",
+        buf_name,
+        accum_name,
+        fill_name,
+        identity,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -52,7 +52,6 @@ import sympy
 from sympy import Expr
 
 import torch
-from torch._inductor.codegen.common import SymT
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
     ComputedBuffer,
@@ -296,14 +295,53 @@ def insert_tiling_propagation(
             _propagate_tiled_op(op, operations)
 
 
+def _reduction_tiling_is_on_stick_dim(op: ComputedBuffer, red_dim_idx: int) -> bool:
+    """Return True if red_dim_idx in reduction_ranges corresponds to the stick dim.
+
+    Uses device_coordinates to find the within-stick coordinate for the primary
+    input, then checks whether the reduction symbol for red_dim_idx appears in
+    that coordinate's free symbols — the same technique used in propagate_layouts.
+    """
+    from .ir import FixedTiledLayout
+    from .pass_utils import device_coordinates
+
+    data = op.data
+    assert isinstance(data, Reduction)
+    try:
+        rw = op.get_read_writes()
+        out_dep = next(iter(rw.writes))
+    except (StopIteration, Exception):
+        return False
+    out_syms = set(out_dep.index.free_symbols)
+    in_dep = next((d for d in rw.reads if hasattr(d, "index")), None)
+    if in_dep is None:
+        return False
+    # reduction_syms: symbols in in_dep.ranges that are absent from the output index,
+    # in dep.ranges order (which matches reduction_ranges order).
+    reduction_syms = [s for s in in_dep.ranges if s not in out_syms]
+    if red_dim_idx >= len(reduction_syms):
+        return False
+    red_sym = reduction_syms[red_dim_idx]
+
+    in_buf = V.graph.get_buffer(in_dep.name)
+    if in_buf is None or not isinstance(in_buf.layout, FixedTiledLayout):
+        return False
+    # device_coordinates[-1] is the within-stick coordinate expression.
+    # If red_sym appears in its free symbols, the reduction is on the stick dim.
+    stick_coord = device_coordinates(in_buf.layout.device_layout, in_dep)[-1]
+    return red_sym in stick_coord.free_symbols
+
+
 def _validate_reduction_tiling(op: ComputedBuffer) -> None:
     """Raise RuntimeError for Reduction tiling configurations not yet implemented.
 
-    Supported (Stage 1): a single level that tiles only a reduction dim —
-    loop_tiled_dims all empty, exactly one loop_tiled_reduction_dims sub-list
-    non-empty with a single index.
+    Supported (Stage 1): a single level that tiles only a non-stick reduction
+    dim — loop_tiled_dims all empty, exactly one loop_tiled_reduction_dims
+    sub-list non-empty with a single index, and that index must not be the
+    within-stick dimension of the primary input.
 
     Deferred to Stage 2 (raises):
+      - Reduction tiling on the stick dimension.
       - Mixed output+reduction tiling at the same nesting level.
       - Multiple nesting levels where both output-dim and reduction-dim levels
         appear (e.g. outer tiles output dim, inner tiles reduction dim).
@@ -323,6 +361,16 @@ def _validate_reduction_tiling(op: ComputedBuffer) -> None:
     tiled_dims_padded = tiled_dims + [[]] * (n - len(tiled_dims))
     tiled_rdims_padded = tiled_rdims + [[]] * (n - len(tiled_rdims))
 
+    has_out_levels = any(d for d in tiled_dims_padded)
+    has_red_levels = any(d for d in tiled_rdims_padded)
+    if has_out_levels and has_red_levels:
+        raise RuntimeError(
+            f"coarse_tile: op {op.get_name()!r} has output-dim tiling levels "
+            f"{tiled_dims} and reduction-dim tiling levels {tiled_rdims} "
+            "across different nesting levels (mixed nested output+reduction "
+            "tiling is not yet implemented — Stage 2)."
+        )
+
     for i, (out_dims, red_dims) in enumerate(
         zip(tiled_dims_padded, tiled_rdims_padded)
     ):
@@ -339,16 +387,14 @@ def _validate_reduction_tiling(op: ComputedBuffer) -> None:
                 f"reduction dims {red_dims} (tiling more than one reduction "
                 "dim per level is not yet implemented — Stage 2)."
             )
-
-    has_out_levels = any(d for d in tiled_dims_padded)
-    has_red_levels = any(d for d in tiled_rdims_padded)
-    if has_out_levels and has_red_levels:
-        raise RuntimeError(
-            f"coarse_tile: op {op.get_name()!r} has output-dim tiling levels "
-            f"{tiled_dims} and reduction-dim tiling levels {tiled_rdims} "
-            "across different nesting levels (mixed nested output+reduction "
-            "tiling is not yet implemented — Stage 2)."
-        )
+        for red_dim_idx in red_dims:
+            if _reduction_tiling_is_on_stick_dim(op, red_dim_idx):
+                raise RuntimeError(
+                    f"coarse_tile: op {op.get_name()!r} level {i} tiles "
+                    f"reduction dim {red_dim_idx} which is the stick dimension "
+                    "of the primary input (stick-dim reduction tiling is not "
+                    "yet implemented — Stage 2)."
+                )
 
 
 def _propagate_tiled_op(
@@ -743,8 +789,6 @@ def _propagate_tiled_reduction_op(
          scratch, not advanced between iterations).
       5. Patch outside consumers and graph outputs to read the accumulation buffer.
     """
-    from torch._inductor.virtualized import ops as vops
-
     loop_info = op.loop_info
     loop_group_id = loop_info.loop_group_id
     reduction_type = op.data.reduction_type
@@ -769,11 +813,31 @@ def _propagate_tiled_reduction_op(
     )
 
     # Insert fill op immediately after the HBM allocation (outside the loop).
+    # Use a SpyreConstantFallback scalar as the fill source so that Spyre's
+    # kernel codegen can express this as an IDENTITY_OP broadcast.  We must
+    # assign a FixedTiledLayout manually here because finalize_layouts has
+    # already run when this pass executes.
     dtype = op.get_dtype()
+    device = op.get_device()
+    from .ir import (
+        FixedTiledLayout,
+        SpyreConstantFallback,
+    )  # deferred: avoids circular import
+    from torch_spyre._C import SpyreTensorLayout  # deferred: avoids circular import
+
+    scalar_op = SpyreConstantFallback(
+        torch.ops.spyre.constant.default, float(identity), dtype, device
+    )
+    # SpyreTensorLayout([], dtype) yields device_size=[1, 64], stride_map=[-1, -1]
+    # — a 0-d broadcast scalar in Spyre's device coordinate system.
+    scalar_stl = SpyreTensorLayout([], dtype)
+    scalar_op.layout = FixedTiledLayout(device, dtype, [], [], scalar_stl)
+    scalar_loader = TensorBox.create(scalar_op).make_loader()
+
     fill_data = Pointwise(
-        device=op.get_device(),
+        device=device,
         dtype=dtype,
-        inner_fn=lambda index, _id=identity, _dt=dtype: vops.constant(_id, _dt),
+        inner_fn=lambda index, _loader=scalar_loader: _loader([]),
         ranges=full_output_ranges,
     )
     fill_name = V.graph.qualify_name(f"coarse_tile_fill_{op.get_name()}")
@@ -787,14 +851,16 @@ def _propagate_tiled_reduction_op(
     # No loop_info: fill runs once, before the loop.
     V.graph.name_to_buffer[fill_name] = fill_buf
     accum_idx = operations.index(accum_buf)
-    operations.insert(accum_idx + 1, fill_buf)
+    # scalar_op was appended to graph.operations by register_operation(); move it
+    # to just after accum_buf, then insert fill_buf after scalar_op.
+    operations.remove(scalar_op)
+    operations.insert(accum_idx + 1, scalar_op)
+    operations.insert(accum_idx + 2, fill_buf)
 
     # Insert combine op after the tiled reduction op (inside the loop).
     _insert_combine_op(op, accum_buf, operations)
 
     # Mark tiled op's output as per-tile scratch (no address advance).
-    from .ir import FixedTiledLayout
-
     if not isinstance(op.layout, FixedTiledLayout):
         raise RuntimeError(
             f"coarse_tile: tiled reduction op {op.get_name()!r} has layout "
@@ -1071,16 +1137,21 @@ def _loop_var_to_reduction_ranges_pos(
 ) -> int | None:
     """Return position of loop variable sym in op.data.reduction_ranges, or None.
 
-    Mirrors _loop_var_to_ranges_pos but searches the reduction index expressions
-    (r0_0, r0_1, ...) instead of the output coords.
+    Uses dep-tracking symbols (d0, d1, ...) rather than SymT.R0_INDEX symbols
+    (r0_0, r0_1, ...) which are a different namespace.  Finds reduction symbols
+    by set-subtracting output index symbols from input index symbols, in
+    dep.ranges order (which matches reduction_ranges order).
     """
-    data = op.data
-    assert isinstance(data, Reduction)
-    rindex = data._index(data.reduction_ranges, SymT.R0_INDEX)
-    for i, coord in enumerate(rindex):
-        if len(coord.free_symbols) == 1 and next(iter(coord.free_symbols)) == sym:
-            return i
-    return None
+    assert isinstance(op.data, Reduction)
+    rw = op.get_read_writes()
+    out_dep = next(iter(rw.writes))
+    out_syms = out_dep.index.free_symbols
+    in_dep = next(d for d in rw.reads if hasattr(d, "index"))
+    reduction_syms = [s for s in in_dep.ranges if s not in out_syms]
+    try:
+        return reduction_syms.index(sym)
+    except ValueError:
+        return None
 
 
 def _divide_reduction_ranges(

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -62,6 +62,7 @@ from torch._inductor.ir import (
     StorageBox,
     TensorBox,
 )
+from torch._inductor.codegen.common import SymT
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
 
@@ -836,6 +837,60 @@ def _divide_ranges(
     layout.device_layout = SpyreTensorLayout(
         new_size_ints, new_strides_ints, layout.dtype, dim_order
     )
+
+
+def _loop_var_to_reduction_ranges_pos(
+    op: ComputedBuffer, sym: sympy.Symbol
+) -> int | None:
+    """Return position of loop variable sym in op.data.reduction_ranges, or None.
+
+    Mirrors _loop_var_to_ranges_pos but searches the reduction index expressions
+    (r0_0, r0_1, ...) instead of the output coords.
+    """
+    data = op.data
+    assert isinstance(data, Reduction)
+    rindex = data._index(data.reduction_ranges, SymT.R0_INDEX)
+    for i, coord in enumerate(rindex):
+        if len(coord.free_symbols) == 1 and next(iter(coord.free_symbols)) == sym:
+            return i
+    return None
+
+
+def _divide_reduction_ranges(
+    op: ComputedBuffer,
+    loop_count: Expr,
+    tiled_dims: list[int],
+) -> None:
+    """Divide the specified reduction_ranges entries of op by loop_count.
+
+    Unlike _divide_ranges, does NOT update op.layout.size/stride — the
+    output buffer shape is determined by data.ranges (non-reduction dims)
+    and is unchanged by reduction-dim tiling.
+    """
+    data = op.data
+    assert isinstance(data, Reduction)
+    if not tiled_dims:
+        return
+    reduction_ranges = list(data.reduction_ranges)
+    for i in tiled_dims:
+        assert 0 <= i < len(reduction_ranges), (
+            f"coarse_tile: op {op.get_name()!r} tiled reduction dim {i} out of bounds "
+            f"(reduction_ranges has {len(reduction_ranges)} entries)"
+        )
+        r = reduction_ranges[i]
+        if isinstance(r, (int, sympy.Integer)) and isinstance(
+            loop_count, (int, sympy.Integer)
+        ):
+            if int(r) % int(loop_count) != 0:
+                raise RuntimeError(
+                    f"coarse_tile: op {op.get_name()!r} reduction dim {i} range {r} "
+                    f"is not divisible by loop_count {loop_count}.  All tiled "
+                    f"reduction dimensions must be evenly divisible by the loop trip count."
+                )
+            reduction_ranges[i] = sympy.Integer(int(r) // int(loop_count))
+        else:
+            reduction_ranges[i] = sympy.sympify(r) / sympy.sympify(loop_count)
+    object.__setattr__(data, "reduction_ranges", reduction_ranges)
 
 
 def _validate_contiguous(

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -356,9 +356,9 @@ def _propagate_tiled_op(
     operations: list[Operation],
 ) -> None:
     """Handle buffer propagation for a single tiled Pointwise or Reduction op."""
+    loop_info = getattr(op, "loop_info", None)
     if isinstance(op.data, Reduction):
         _validate_reduction_tiling(op)
-        loop_info = getattr(op, "loop_info", None)
         has_tiled_reduction = loop_info is not None and any(
             dims for dims in getattr(loop_info, "loop_tiled_reduction_dims", [])
         )
@@ -366,7 +366,6 @@ def _propagate_tiled_op(
             _propagate_tiled_reduction_op(op, operations)
             return
 
-    loop_info = getattr(op, "loop_info", None)
     if loop_info is None:
         return
     loop_group_id = loop_info.loop_group_id
@@ -794,8 +793,13 @@ def _propagate_tiled_reduction_op(
     # Mark tiled op's output as per-tile scratch (no address advance).
     from .ir import FixedTiledLayout
 
-    if isinstance(op.layout, FixedTiledLayout):
-        op.layout.per_tile_fixed = True
+    if not isinstance(op.layout, FixedTiledLayout):
+        raise RuntimeError(
+            f"coarse_tile: tiled reduction op {op.get_name()!r} has layout "
+            f"{type(op.layout).__name__}, expected FixedTiledLayout; "
+            "cannot mark per_tile_fixed"
+        )
+    op.layout.per_tile_fixed = True
 
     # Patch consumers.
     buf_name = op.get_name()

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -20,7 +20,7 @@ and consumed by the scheduler, kernel codegen, and buffer-propagation pass.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -45,11 +45,17 @@ class CoarseTileInfo:
         contains the ``data.ranges`` positional indices that are tiled at
         that level.  An empty sub-list means the op is loop-invariant at
         that level.
+    loop_tiled_reduction_dims:
+        List of lists, one sub-list per nesting level.  Each sub-list
+        contains the ``data.reduction_ranges`` positional indices that are
+        tiled at that level.  An empty sub-list means no reduction dim is
+        tiled at that level.  Parallel to ``loop_tiled_dims``.
     """
 
     loop_group_id: tuple[int, ...]
     loop_count: list[sympy.Expr]
     loop_tiled_dims: list[list[int]]
+    loop_tiled_reduction_dims: list[list[int]] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -447,6 +447,14 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
             sym = _lone_sym(coord)
             for name, _ in named_dims_for_sym(op, sym):
                 coord_for_name[name] = sym
+        # Also map reduction dim names to their loop variable.  Reduction dims
+        # don't appear in output coordinates, so they would never be found by
+        # the output-coord loop above.  dp.loop_var_dims covers all loop vars
+        # (including the reduction dim), so we invert it for reduction names.
+        for sym, names in dp.loop_var_dims.items():
+            for name in names:
+                if name in reduction_dims:
+                    coord_for_name[name] = sym
 
         dim_hints = []
         for hint_id, hint_dict in sorted(op_hints.items()):

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -586,11 +586,27 @@ class SpyreKernel(Kernel[CSEVariable]):
         # to innermost — matching the loop_vars ordering in bundle.py _emit_specs.
         li = getattr(ir_node, "loop_info", None)
         raw_tiled_dims: list[list[int]] = li.loop_tiled_dims if li is not None else []
+        raw_tiled_red_dims: list[list[int]] = (
+            li.loop_tiled_reduction_dims if li is not None else []
+        )
         all_tiled_dims = [d for level in raw_tiled_dims for d in level]
+        all_tiled_red_dims = [d for level in raw_tiled_red_dims for d in level]
         it_space_keys = list(it_space.keys())
         tiled_syms = [
             it_space_keys[i] for i in all_tiled_dims if i < len(it_space_keys)
         ]
+        # For reduction ops tiled over a reduction dimension, it_space (from
+        # reads.ranges) has output-dim symbols first, then reduction-dim symbols.
+        # loop_tiled_reduction_dims indices are 0-based into the reduction portion,
+        # so offset them by the number of output-space symbols.
+        if all_tiled_red_dims:
+            write_dep = next(iter(self.current_node.read_writes.writes), None)
+            n_output_syms = len(write_dep.ranges) if write_dep is not None else 0
+            tiled_syms += [
+                it_space_keys[n_output_syms + r]
+                for r in all_tiled_red_dims
+                if n_output_syms + r < len(it_space_keys)
+            ]
 
         return OpSpec(
             op,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Extends the coarse-tiling IR pass (`coarse_tile.py`) to support tiling a
*non-stick reduction* dimension (Stage 1).  Previously any `spyre_hint` that
named a reduction dim raised `RuntimeError` via `_check_reduction_tiling_safety`.

**Stage 1 scope:** Only non-stick reduction dimensions are supported — i.e.,
the reduction dimension must not be the within-stick (innermost) dimension of
the primary input.  Stick-dim reduction tiling (e.g. `x.sum(dim=-1)` where
`dim=-1` maps to the D/stick dimension) is rejected with a clear error message
and deferred to Stage 2.

**Approach — fill-initialize + per-tile combine:**

1. Before the loop, allocate an HBM accumulation buffer (same shape as the
   op's output) and fill it with the reduction identity value (0 for
   sum/matmul, −∞ for max, +∞ for min, 1 for prod, …).
2. Inside each loop iteration the tiled reduction op writes its partial result
   to a per-tile scratch buffer.
3. Also inside the loop, a new *combine op* (`Pointwise` with
   `MutationLayoutSHOULDREMOVE`) merges the partial result into the
   accumulation buffer using the appropriate binary operator.
4. Consumers outside the loop are patched to read the accumulation buffer.

The fill op uses a `SpyreConstantFallback` scalar loader (same pattern as
`lower_full`) so the identity value has a valid `FixedTiledLayout` without
going through `finalize_layouts`, which has already run by the time
`_maybe_coarse_tile` fires.

The fill op carries no `loop_info` (runs once); the combine op carries the
same `loop_info` as the tiled reduction op so the scheduler wraps them in the
same `CountedLoopSchedulerNode`.

**Data structure changes:**

- `CoarseTileInfo` gains a new optional field `loop_tiled_reduction_dims:
  list[list[int]]`, parallel to `loop_tiled_dims`, recording which
  `data.reduction_ranges` indices are tiled at each nesting level.  Defaults
  to `[]` for backward compatibility.

**Fix in `spyre_kernel.py` — `create_op_spec`:**

`tiled_syms` was computed only from `loop_tiled_dims` (output dims).  For
reduction-dim tiling, `loop_tiled_dims` is empty so the runtime never advanced
the input tensor pointer between tiles.  Fixed by also consulting
`loop_tiled_reduction_dims`: for a `Reduction` op, `iteration_space` returns
`reads.ranges` with output-dim symbols first then reduction-dim symbols; the
number of output symbols is `len(write_dep.ranges)`, and the reduction dim
index is offset by that count.

**Validation — Stage 1 only:**

`_validate_reduction_tiling` (replacing `_check_reduction_tiling_safety`)
allows a single level that tiles only a non-stick reduction dim.  Raises with
a clear message for:
- Stick-dim reduction tiling ("Stage 2")
- Mixed output-dim + reduction-dim tiling at the same nesting level ("Stage 2")
- Output-dim tiling at one level and reduction-dim tiling at another ("Stage 2")
- Multiple reduction-range indices tiled at one level ("Stage 2")

**Bug fix in `propagate_named_dims.py`:**

`assign_dim_hints` previously only scanned output coordinates when building
the `coord_for_name` map, so reduction-dim names (which don't appear in output
coords) always resolved to `loop_var=None` and were silently dropped.  Fixed
by also inverting `dp.loop_var_dims` for names in `reduction_dims`.

**Supported after this PR:**

```python
# dim=0 reduction on [B, D] — B is non-stick, D is stick
with spyre_hint(num_tiles_per_dim={"B": 4}):
    out = x.sum(dim=0)    # ✓ Stage 1: non-stick reduction dim

with spyre_hint(num_tiles_per_dim={"B": 4}):
    out = x.amax(dim=0)   # ✓ Stage 1

with spyre_hint(num_tiles_per_dim={"B": 4}):
    out = x.amin(dim=0)   # ✓ Stage 1
```

**Deferred to Stage 2 (raises `RuntimeError`):**

```python
with spyre_hint(num_tiles_per_dim={"D": 4}):
    out = x.sum(dim=-1)        # ✗ D is the stick dim

with spyre_hint(num_tiles_per_dim={"K": 4}):
    out = torch.matmul(a, b)   # ✗ K is the stick dim for the matmul input
```

#### Which issue(s) this PR is related to:

Part of #2369 

#### Special notes for your reviewer:

- `_hints_levels` now returns 3-tuples `(hint_id, count, is_reduction)`.  All
  existing call sites in `coarse_tile.py` and the test suite have been updated.
  The change is internal to the pass — no external API is affected.

- The `propagate_named_dims.py` bug fix was discovered during E2E testing; it
  is a prerequisite for the feature to work at all.

- `_validate_reduction_tiling` checks cross-level mixed tiling *before* the
  per-level loop so Stage 2 errors are raised before `_reduction_tiling_is_on_stick_dim`
  is called (which requires a real `get_read_writes()` result).

- Stage 2 (stick-dim reduction tiling) is structurally anticipated:
  `loop_tiled_reduction_dims` is already a list-of-lists shaped for
  multi-level nesting.  The only things missing are relaxing the Stage 2
  guard in `_validate_reduction_tiling` and handling the column-vector output
  addressing that stick-dim reductions require.

- `argmin`/`argmax` are not combinable element-wise and will hit
  `_reduction_identity_value`'s `RuntimeError` if a user attempts to tile
  them.  This is intentional for Stage 1.

#### Does this PR introduce a user-facing change?

Yes.  `spyre_hint(num_tiles_per_dim={"B": N})` now works when `B` is a
non-stick reduction dimension (previously raised `RuntimeError`).  No existing
API is changed or removed.  Stick-dim reduction tiling still raises, but now
with a more descriptive "Stage 2" message instead of the generic safety error.

#### Additional note:

162 tests pass (`tests/inductor/test_coarse_tiling.py` +
`tests/inductor/test_coarse_tile_e2e.py`), including 3 new E2E correctness
tests in `TestCoarseTileReductionDim0E2E` (sum/max/min over dim=0).