### PR TITLE
Minimum fix to generate a triton kernel from torch-spyre

### DIFF
--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -181,14 +181,33 @@ def _autoload():
             device=DEVICE_NAME, device_op_overrides=SpyreDeviceOpOverrides()
         )
 
-        from .scheduler import SuperDSCScheduling
         from .wrapper import SpyrePythonWrapperCodegen
 
-        register_backend_for_device(
-            DEVICE_NAME,
-            SuperDSCScheduling,
-            SpyrePythonWrapperCodegen,
-            device_custom_config=config,
-        )
+        import os
+
+        if os.getenv("TORCH_SPYRE_TRITON") == "1":
+            from torch_spyre._inductor_triton import (
+                SpyreTritonPythonWrapperCodegen,
+                SpyreTritonScheduling,
+            )
+            from torch._inductor import config as torch_config
+
+            torch_config.triton.native_matmul = True
+
+            register_backend_for_device(
+                DEVICE_NAME,
+                SpyreTritonScheduling,
+                SpyreTritonPythonWrapperCodegen,
+                device_custom_config=config,
+            )
+        else:
+            from .scheduler import SuperDSCScheduling
+
+            register_backend_for_device(
+                DEVICE_NAME,
+                SuperDSCScheduling,
+                SpyrePythonWrapperCodegen,
+                device_custom_config=config,
+            )
 
         _autoload._ran = True

--- a/torch_spyre/_inductor/choices.py
+++ b/torch_spyre/_inductor/choices.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 
+import os
+
 import torch
 
 from torch._inductor.choices import InductorChoices
+from torch._inductor.codegen.simd import SIMDKernelFeatures
 from torch._inductor.scheduler import BaseSchedulerNode, Scheduler
 
 
@@ -58,3 +61,17 @@ class SpyreHeuristics(InductorChoices):
         shared_data_score: int,
     ) -> bool:
         return False
+
+    @staticmethod
+    def should_use_persistent_reduction(
+        features: SIMDKernelFeatures, cooperative_reduction: bool
+    ) -> bool:
+        """Force persistent reduction to avoid R-block tiling loops in Triton kernels.
+
+        Persistent reduction sets R0_BLOCK = rnumel so no loop over R is generated.
+        """
+        if os.getenv("TORCH_SPYRE_TRITON") == "1":
+            return True
+        return InductorChoices.should_use_persistent_reduction(
+            features, cooperative_reduction
+        )

--- a/torch_spyre/_inductor/constants.py
+++ b/torch_spyre/_inductor/constants.py
@@ -15,6 +15,7 @@
 from torch_spyre._C import ElementArrangement
 
 BATCH_MATMUL_OP = "batchmatmul"
+DOT_REDUCTION_OP = "dot"
 IDENTITY_OP = "identity"
 RESTICKIFY_OP = "ReStickifyOpHBM"
 BATCH_MATMUL_FP8_OP = "batchmatmulfp8"

--- a/torch_spyre/_inductor/patches.py
+++ b/torch_spyre/_inductor/patches.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import contextmanager
+import os
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 
 import torch
 from torch._inductor.graph import GraphLowering
@@ -122,8 +123,18 @@ def enable_spyre_context(
 
     GraphLowering._update_scheduler = _spyre_update_scheduler  # type: ignore[method-assign]
 
+    if os.getenv("TORCH_SPYRE_TRITON") == "1":
+        from torch_spyre._inductor_triton.spyre_triton_patches import (
+            spyre_triton_patches,
+        )
+
+        spyre_triton_patches_cm: AbstractContextManager = spyre_triton_patches()
+    else:
+        spyre_triton_patches_cm = nullcontext()
+
     with (
         spyre_data_types(),
+        spyre_triton_patches_cm,
         enable_spyre_lowerings(),
         enable_spyre_decompositions(decomps=decomps) as spyre_context_decompositions,
         V.set_real_inputs(example_inputs),

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -55,6 +55,7 @@ from .constants import (
     BATCH_MATMUL_OP,
     COPY_BACK_CANDIDATE_ATTR,
     DEVICE_NAME,
+    DOT_REDUCTION_OP,
     ELIDED_COPY_BACK_ATTR,
     REDUCTIONS_NON_STICK_DIM_ONLY,
     STAGGERED_EAS,
@@ -1058,7 +1059,10 @@ def compute_layouts(
     if len(args) > 1 and isinstance(data, Pointwise):
         return _multi_arg_pointwise_layouts(op, output, output_dep, args)
 
-    if isinstance(data, Reduction) and data.reduction_type == BATCH_MATMUL_OP:
+    if isinstance(data, Reduction) and data.reduction_type in (
+        BATCH_MATMUL_OP,
+        DOT_REDUCTION_OP,
+    ):
         return _matmul_layouts(op, output, output_dep, args)
 
     if isinstance(data, Reduction) and data.reduction_type == "exx2":

--- a/torch_spyre/_inductor_triton/__init__.py
+++ b/torch_spyre/_inductor_triton/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .async_compile import SpyreTritonAsyncCompile
+from .spyre_triton_patches import SpyreTritonPatches, spyre_triton_patches
+from .spyre_triton_kernel import SpyreTritonKernel
+from .spyre_triton_scheduler import SpyreTritonScheduling
+from .spyre_triton_wrapper import SpyreTritonPythonWrapperCodegen
+
+__all__ = [
+    "SpyreTritonAsyncCompile",
+    "SpyreTritonPatches",
+    "SpyreTritonKernel",
+    "SpyreTritonPythonWrapperCodegen",
+    "SpyreTritonScheduling",
+    "spyre_triton_patches",
+]

--- a/torch_spyre/_inductor_triton/async_compile.py
+++ b/torch_spyre/_inductor_triton/async_compile.py
@@ -1,0 +1,56 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from torch._inductor.codecache import PyCodeCache
+from torch._inductor.runtime.triton_compat import (
+    ASTSource,
+    GPUTarget,
+    cc_warp_size,
+    triton,
+)
+
+
+class SpyreTritonAsyncCompile:
+    """Async compilation interface for Spyre Triton kernels."""
+
+    def triton(self, kernel_name: str, source_code: str, device_str: str) -> None:
+        cat = getattr(PyCodeCache.load(source_code), kernel_name)
+        cfg = cat.configs[0]
+        compile_meta = cat.triton_meta
+        compile_meta["device_type"] = cat.device_props.type
+        compile_meta["cc"] = cat.device_props.cc
+        compile_meta["constants"].update(cfg.kwargs)
+        compile_args = (
+            ASTSource(
+                cat.fn,
+                compile_meta["signature"],
+                compile_meta["constants"],
+                compile_meta["configs"][0],
+            ),
+        )
+        target = GPUTarget(
+            compile_meta["device_type"],
+            compile_meta["cc"],
+            cc_warp_size(compile_meta["cc"]),
+        )
+        compile_kwargs = {
+            "target": target,
+        }
+        _ = triton.compile(*compile_args, **compile_kwargs)
+        return None
+
+    def wait(self, scope: dict[str, Any]) -> None:
+        pass

--- a/torch_spyre/_inductor_triton/spyre_triton_kernel.py
+++ b/torch_spyre/_inductor_triton/spyre_triton_kernel.py
@@ -1,0 +1,65 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import sympy
+
+from torch._inductor.codegen.common import CSEVariable
+from torch._inductor.codegen.triton import (
+    FixedTritonConfig,
+    TritonKernel,
+)
+from torch._inductor.virtualized import StoreMode
+
+
+class SpyreTritonKernel(TritonKernel):
+    def __init__(
+        self,
+        tiling: dict[str, sympy.Expr],
+        min_elem_per_thread=0,
+        optimize_mask=True,
+        fixed_config: Optional[FixedTritonConfig] = None,
+        hint_override: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            tiling,
+            min_elem_per_thread,
+            optimize_mask,
+            fixed_config,
+            hint_override,
+            **kwargs,
+        )
+
+    def __enter__(self):
+        super(TritonKernel, self).__enter__()
+        return self
+
+    def codegen_kernel(self, name=None) -> str:
+        return super().codegen_kernel(name)
+
+    def codegen_body(self):
+        return super().codegen_body()
+
+    def load(self, name: str, index: sympy.Expr):
+        return super().load(name, index)
+
+    def store(
+        self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
+    ) -> None:
+        return super().store(name, index, value, mode)
+
+    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+        return super().store_reduction(name, index, value)

--- a/torch_spyre/_inductor_triton/spyre_triton_patches.py
+++ b/torch_spyre/_inductor_triton/spyre_triton_patches.py
@@ -1,0 +1,115 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any
+
+import torch
+from torch._inductor import config
+from torch._inductor.utils import get_current_backend
+from torch._inductor.virtualized import V
+from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
+
+
+def _patched_use_native_matmul(mat1, mat2) -> bool:
+    """use_native_matmul with spyre added to supported device types.
+
+    Identical to the upstream function except the device type check includes
+    "spyre" alongside "cuda" and "xpu".
+    """
+    if not config.triton.native_matmul:
+        return False
+    if (
+        config.triton.enable_persistent_tma_matmul
+        and torch.utils._triton.has_triton_tma_device()
+    ):
+        raise AssertionError("native matmul doesn't support tma codegen yet")
+    if config.triton.use_block_ptr:
+        raise AssertionError("native matmul doesn't support block_ptr codegen yet")
+    device_type = mat1.get_device().type
+    if not (
+        device_type in ("cuda", "xpu", "spyre")
+        and get_current_backend(device_type) == "triton"
+    ):
+        return False
+    triton_supported_dtype = [
+        torch.int8,
+        torch.uint8,
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ]
+    if mat1.dtype not in triton_supported_dtype:
+        return False
+    if mat2.dtype not in triton_supported_dtype:
+        return False
+    m, k, n = mat1.get_size()[-2], mat1.get_size()[-1], mat2.get_size()[-1]
+    if any(map(has_free_unbacked_symbols, [m, k, n])):
+        return False
+    if (
+        V.graph.sizevars.statically_known_leq(m, 1)
+        or V.graph.sizevars.statically_known_leq(k, 1)
+        or V.graph.sizevars.statically_known_leq(n, 1)
+    ):
+        return False
+    return True
+
+
+def _load_module(name: str) -> ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        parts = name.rsplit(".", 1)
+        parent = __import__(parts[0], fromlist=[parts[1]])
+        mod = getattr(parent, parts[1])
+    return mod
+
+
+class SpyreTritonPatches:
+    """Patches PyTorch Inductor functions to add Spyre device support."""
+
+    def patch(self) -> list[tuple[ModuleType, Any]]:
+        """Monkey-patch use_native_matmul in all modules that hold a local binding.
+
+        mm.py and bmm.py each do `from mm_common import use_native_matmul`, so
+        patching only mm_common would leave their local references stale.
+
+        Returns:
+            List of (module, original_function) pairs for restoration.
+        """
+        targets = [
+            "torch._inductor.kernel.mm_common",
+            "torch._inductor.kernel.mm",
+            "torch._inductor.kernel.bmm",
+        ]
+        saved = []
+        for name in targets:
+            mod = _load_module(name)
+            orig = getattr(mod, "use_native_matmul", None)
+            if orig is not None:
+                setattr(mod, "use_native_matmul", _patched_use_native_matmul)
+                saved.append((mod, orig))
+        return saved
+
+
+@contextmanager
+def spyre_triton_patches():
+    """Context manager to apply Spyre-specific monkey patches for Triton compilation."""
+    saved = SpyreTritonPatches().patch()
+    try:
+        yield
+    finally:
+        for mod, orig in saved:
+            mod.use_native_matmul = orig

--- a/torch_spyre/_inductor_triton/spyre_triton_scheduler.py
+++ b/torch_spyre/_inductor_triton/spyre_triton_scheduler.py
@@ -1,0 +1,37 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
+from torch._inductor.codegen.triton import TritonScheduling
+
+from .spyre_triton_kernel import SpyreTritonKernel
+
+
+class SpyreTritonScheduling(TritonScheduling):
+    """
+    Spyre-specific Triton scheduling that uses SpyreTritonKernel.
+    """
+
+    def create_kernel_choices(  # type: ignore[override]
+        self,
+        kernel_features: SIMDKernelFeatures,
+        kernel_args: list[Any],
+        kernel_kwargs: dict[str, Any],
+    ) -> list[Any]:
+        self.kernel_type = SpyreTritonKernel  # type: ignore[assignment]
+        return super().create_kernel_choices(
+            kernel_features, kernel_args, kernel_kwargs
+        )

--- a/torch_spyre/_inductor_triton/spyre_triton_wrapper.py
+++ b/torch_spyre/_inductor_triton/spyre_triton_wrapper.py
@@ -1,0 +1,53 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from torch._inductor.codegen.wrapper import SubgraphPythonWrapperCodegen
+from torch._inductor.ir import GraphPartitionSignature
+
+from torch_spyre._inductor.wrapper import (
+    PythonWrapperCodegen,
+    SpyrePythonWrapperCodegen,
+)
+
+
+class SpyreTritonPythonWrapperCodegen(SpyrePythonWrapperCodegen):
+    """Wrapper codegen for the Spyre Triton path.
+
+    Overrides create() so Inductor instantiates this class (not the base),
+    and injects a SpyreTritonAsyncCompile import into the generated wrapper.
+    """
+
+    @staticmethod
+    def create(
+        is_subgraph: bool,
+        subgraph_name: Optional[str],
+        parent_wrapper: Optional[PythonWrapperCodegen],
+        partition_signatures: Optional[GraphPartitionSignature] = None,
+    ):
+        if is_subgraph:
+            assert subgraph_name is not None
+            assert parent_wrapper is not None
+            return SubgraphPythonWrapperCodegen(
+                subgraph_name, parent_wrapper, partition_signatures
+            )
+        return SpyreTritonPythonWrapperCodegen()
+
+    def write_header(self) -> None:
+        super().write_header()
+        self.header.writeline(
+            "from torch_spyre._inductor_triton.async_compile import SpyreTritonAsyncCompile"
+        )
+        self.header.writeline("async_compile = SpyreTritonAsyncCompile()")


### PR DESCRIPTION
This fix enables the triton-kernel generation only when an environment variable TORCH_SPYRE_TRITON=1.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR is a minimum set of changes to generate a triton kernel from torch-spyre. When an environment variable TORCH_SPYRE_TRITON is set to 1, SpyreTritonScheduling is registered instead of SuperDSCScheduling, and then a triton kernel is generated through SpyreTritonKernel. This fix is an entry point for the development of a spyre-optimized triton generator. Note that this fix does not enable the execution of the triton kernel.

#### Which issue(s) this PR is related to:

#2482 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional note:
