### PR TITLE
Narrow MLP prefill optimization so attention matmuls are skipped

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -78,9 +78,11 @@ from torch_spyre._inductor.spyre_kernel import (
     _codegen_op_spec_list,
     _iter_op_specs,
     _preserve_shared_weight_unit_bmm_dim,
-    _shared_weight_unit_bmm_info_from_sizes,
 )
-from torch_spyre._inductor.temp_passes import bmm_unflatten_pass
+from torch_spyre._inductor.temp_passes import (
+    _mark_static_unit_batch_bmm,
+    mark_direct_unit_bmm_pass,
+)
 
 _FP16 = DataFormats.SEN169_FP16
 
@@ -1198,7 +1200,7 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         bmm.meta["val"] = SimpleNamespace(shape=out_shape)
         graph.output(bmm)
 
-        bmm_unflatten_pass.apply(fx.GraphModule({}, graph).graph)
+        _mark_static_unit_batch_bmm(bmm, x, y)
         graph.lint()
         return bmm.meta.get("custom") or {}
 
@@ -1274,29 +1276,41 @@ class TestSharedWeightUnitBmmLayout(unittest.TestCase):
         )
 
     def test_shared_weight_marker_requires_stick_aligned_dims(self):
+        m, k, n = 2, 128, 64
         self.assertEqual(
-            self._static_bmm_custom_meta(
-                (1, 512, 4096), (1, 4096, 12800), (1, 512, 12800)
-            )[SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY],
+            self._static_bmm_custom_meta((1, m, k), (1, k, n), (1, m, n))[
+                SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY
+            ],
             {"batch_dim": 0},
         )
         self.assertNotIn(
             SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
-            self._static_bmm_custom_meta(
-                (4, 512, 4096), (4, 4096, 12800), (4, 512, 12800)
-            ),
-        )
-        self.assertIsNone(
-            _shared_weight_unit_bmm_info_from_sizes(
-                [4, 512, 4096], [4, 4096, 12800], [4, 512, 12800]
-            )
+            self._static_bmm_custom_meta((4, m, k), (4, k, n), (4, m, n)),
         )
         self.assertNotIn(
             SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
-            self._static_bmm_custom_meta((1, 55, 2), (1, 2, 99), (1, 55, 99)),
+            self._static_bmm_custom_meta((1, m, 2), (1, 2, n), (1, m, n)),
         )
-        self.assertIsNone(
-            _shared_weight_unit_bmm_info_from_sizes([1, 55, 2], [2, 99], [1, 55, 99])
+
+    def test_mark_direct_unit_bmm_pass_does_not_mark_reshape_inputs(self):
+        m, k, n = 2, 64, 128
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        x_view = graph.call_function(
+            torch.ops.aten.reshape.default, args=(x, (1, m, k))
+        )
+        y_view = graph.call_function(
+            torch.ops.aten.reshape.default, args=(y, (1, k, n))
+        )
+        bmm = graph.call_function(torch.ops.aten.bmm.default, args=(x_view, y_view))
+        graph.output(bmm)
+
+        mark_direct_unit_bmm_pass(graph)
+        graph.lint()
+        self.assertNotIn(
+            SHARED_WEIGHT_UNIT_BMM_CUSTOM_META_KEY,
+            bmm.meta.get("custom") or {},
         )
 
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -40,6 +40,7 @@ from .logging_utils import get_inductor_logger
 from .padding import insert_bmm_padding
 from .temp_passes import (
     bmm_unflatten_pass,
+    mark_direct_unit_bmm_pass,
     mm_to_bmm_pass,
     convert_constant_with_graph_node,
 )
@@ -209,6 +210,7 @@ class CustomPostPasses(_SpyreGraphPassPipeline):
                 recover_spyre_hints,
                 convert_constant_with_graph_node,
                 mm_to_bmm_pass.apply,
+                mark_direct_unit_bmm_pass,
                 bmm_unflatten_pass.apply,
             ]
         )

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -60,63 +60,6 @@ import logging
 logger = get_inductor_logger("spyre_kernel")
 
 
-def _is_static_one(value: Any) -> bool:
-    try:
-        return concretize_expr(value) == 1
-    except Exception:
-        return False
-
-
-def _is_static_multiple(value: Any, divisor: int) -> bool:
-    try:
-        return concretize_expr(value) % divisor == 0
-    except Exception:
-        return False
-
-
-def _has_stick_aligned_matmul_dims(k: Any, n: Any) -> bool:
-    return _is_static_multiple(k, 64) and _is_static_multiple(n, 64)
-
-
-def _same_static_size(lhs: Any, rhs: Any) -> bool:
-    try:
-        return concretize_expr(lhs) == concretize_expr(rhs)
-    except Exception:
-        return False
-
-
-def _shared_weight_unit_bmm_info_from_sizes(
-    x_size: Sequence[Any], y_size: Sequence[Any], out_size: Sequence[Any]
-) -> dict[str, int] | None:
-    if len(x_size) != 3 or len(out_size) != 3:
-        return None
-    if not (_is_static_one(x_size[0]) and _is_static_one(out_size[0])):
-        return None
-    if len(y_size) == 2:
-        if not (
-            _same_static_size(x_size[1], out_size[1])
-            and _same_static_size(x_size[2], y_size[0])
-            and _same_static_size(y_size[1], out_size[2])
-        ):
-            return None
-        k_dim, n_dim = x_size[2], y_size[1]
-    elif len(y_size) == 3:
-        if not _is_static_one(y_size[0]):
-            return None
-        if not (
-            _same_static_size(x_size[1], out_size[1])
-            and _same_static_size(x_size[2], y_size[1])
-            and _same_static_size(y_size[2], out_size[2])
-        ):
-            return None
-        k_dim, n_dim = x_size[2], y_size[2]
-    else:
-        return None
-    if not _has_stick_aligned_matmul_dims(k_dim, n_dim):
-        return None
-    return {"batch_dim": 0}
-
-
 class RValue(ABC):
     """
     An RValue is an expression that can appear on the right hand side of an assignment.
@@ -739,12 +682,6 @@ class SpyreKernel(Kernel[CSEVariable]):
                 raise Unsupported(f"invalid {value.op} arguments {value.arguments}")
             x = value.arguments[0]
             y = value.arguments[1]
-            if SHARED_WEIGHT_UNIT_BMM_INFO_KEY not in op_info:
-                shared_weight_info = _shared_weight_unit_bmm_info_from_sizes(
-                    x.layout.size, y.layout.size, dst.layout.size
-                )
-                if shared_weight_info is not None:
-                    op_info[SHARED_WEIGHT_UNIT_BMM_INFO_KEY] = shared_weight_info
             args = [
                 self.create_tensor_arg(True, x.name, x),
                 self.create_tensor_arg(True, y.name, y),

--- a/torch_spyre/_inductor/temp_passes.py
+++ b/torch_spyre/_inductor/temp_passes.py
@@ -95,6 +95,60 @@ def _mark_static_unit_batch_bmm(
     bmm_node.meta["custom"] = custom
 
 
+def _is_direct_unit_bmm_operand(node: torch.fx.Node) -> bool:
+    if not isinstance(node, torch.fx.Node):
+        return False
+    if node.op in ("placeholder", "get_attr"):
+        return True
+    if node.op == "call_function" and node.target == aten.expand.default:
+        base = node.args[0]
+        return isinstance(base, torch.fx.Node) and base.op in (
+            "placeholder",
+            "get_attr",
+        )
+    return False
+
+
+def _mark_direct_static_unit_batch_bmm(
+    bmm_node: torch.fx.Node, lhs_node: torch.fx.Node, rhs_node: torch.fx.Node
+) -> None:
+    """Mark direct rank-3 B=1 BMMs without catching unflattened attention views."""
+    if not _is_direct_unit_bmm_operand(rhs_node):
+        return
+
+    for arg in (lhs_node, rhs_node):
+        if (
+            isinstance(arg, torch.fx.Node)
+            and arg.op == "call_function"
+            and arg.target in _RESHAPE_OPS
+        ):
+            return
+
+    bmm_users = list(bmm_node.users.keys())
+    if len(bmm_users) == 1:
+        output_view = bmm_users[0]
+        if (
+            isinstance(output_view, torch.fx.Node)
+            and output_view.op == "call_function"
+            and output_view.target in _RESHAPE_OPS
+        ):
+            output_shape = output_view.args[1]
+            if isinstance(output_shape, (list, tuple)) and len(output_shape) > 3:
+                return
+
+    _mark_static_unit_batch_bmm(bmm_node, lhs_node, rhs_node)
+
+
+def mark_direct_unit_bmm_pass(graph: torch.fx.Graph) -> None:
+    for node in graph.nodes:
+        if node.op != "call_function" or node.target != aten.bmm.default:
+            continue
+        if len(node.args) != 2:
+            continue
+        lhs_node, rhs_node = node.args
+        _mark_direct_static_unit_batch_bmm(node, lhs_node, rhs_node)
+
+
 @register_graph_pattern(
     CallFunction(aten.mm.default, Arg(), Arg()),
     pass_dict=mm_to_bmm_pass,
@@ -257,8 +311,6 @@ def _unflatten_bmm_batch_dims(
     node = match.nodes[-1]
     graph = node.graph
     lhs_reshape, rhs_reshape = mat1_node, mat2_node
-
-    _mark_static_unit_batch_bmm(node, lhs_reshape, rhs_reshape)
 
     # Both inputs must be reshape/view that collapse batch dims to 3D
     if not _is_batch_collapsing_reshape(lhs_reshape):


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

fixes the Granite e2e regression from the prefill MLP optimization by restricting the shared-weight BMM marker so it no longer marks attention matmuls

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Fixed https://github.com/torch-spyre/torch-spyre/issues/2587

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
