### PR TITLE
Fix spyre-hint recovery dropping all hints on duplicated nodes

### DIFF
--- a/torch_spyre/_inductor/propagate_hints.py
+++ b/torch_spyre/_inductor/propagate_hints.py
@@ -60,7 +60,7 @@ _hint_counter = 0
 # by call_function node position. Used by recover_spyre_hints to restore
 # meta on nodes renamed by AOT re-tracing (e.g. mm -> mm_default), which
 # drops node.meta["custom"].
-_dim_hints: list[dict[str, Any] | None] = []
+_dim_hints: list[tuple[Any, dict[str, Any] | None]] = []
 
 
 def spyre_hint(**kwargs: Any):
@@ -96,28 +96,62 @@ def get_op_hints(op: Operation) -> dict[int, dict[str, Any]]:
 
 def collect_spyre_hints(graph: torch.fx.Graph) -> None:
     """
-    Snapshot call_function nodes' custom meta by topological position.
+    Snapshot call_function nodes' (target, custom-meta) by topological position.
     Pairs with recover_spyre_hints to survive AOT re-tracing.
+
+    Targets are stored alongside the meta so recovery can re-align even when the
+    node sequence changes between the two passes (e.g. ``x + x`` materializes the
+    shared producer as two identical nodes -> ``add(mm, mm_default)``). The node
+    *name* is renamed by AOT re-tracing (mm -> mm_default) and so is unstable, but
+    the ``target`` OpOverload is preserved and is what we align on.
     """
     global _dim_hints
 
     _dim_hints = [
-        node.meta.get("custom") for node in graph.nodes if node.op == "call_function"
+        (node.target, node.meta.get("custom"))
+        for node in graph.nodes
+        if node.op == "call_function"
     ]
 
 
 def recover_spyre_hints(graph: torch.fx.Graph) -> None:
     """
-    Restore custom meta on AOT-renamed call_function nodes, matching the
-    snapshot taken by collect_spyre_hints by topological position.
+    Restore custom meta on AOT-renamed call_function nodes by aligning the
+    snapshot from collect_spyre_hints against the current graph on ``target``.
+
+    A simple positional zip is not robust: passes running between collect and
+    recover can insert nodes, most commonly by un-sharing a producer feeding a
+    pointwise op (``add(mm, mm)`` becomes two distinct ``aten.mm.default`` nodes).
+    We instead walk both sequences with a single cursor: a node whose target
+    matches the next snapshot entry consumes it; a node whose target repeats the
+    last consumed entry is treated as a duplicate of that computation and inherits
+    the same hint. This keeps alignment intact across such insertions, where the
+    old count check would bail and silently drop every hint.
     """
     nodes = [n for n in graph.nodes if n.op == "call_function"]
-    if len(nodes) != len(_dim_hints):
-        logger.warning("Warning: unable to recover spyre hints")
-        return
-    for node, custom in zip(nodes, _dim_hints):
+
+    cursor = 0
+    last_target = None
+    last_custom = None
+    for node in nodes:
+        custom = None
+        if cursor < len(_dim_hints) and _dim_hints[cursor][0] == node.target:
+            last_target, last_custom = _dim_hints[cursor]
+            custom = last_custom
+            cursor += 1
+        elif node.target == last_target:
+            # Duplicate of the just-consumed snapshot node (same computation,
+            # e.g. the second mm in add(mm, mm)); reuse its hint.
+            custom = last_custom
+
         if not custom:
             continue
         if node.meta.get("custom") is None:
             node.meta["custom"] = {}
         node.meta["custom"].update(custom)
+
+    if cursor != len(_dim_hints):
+        logger.warning(
+            f"Warning: unable to recover spyre hints "
+            f"(matched {cursor}/{len(_dim_hints)} snapshot entries)"
+        )


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

## Summary

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

`recover_spyre_hints` was silently discarding all spyre dimension hints for any graph that reuses a producer's result (e.g. any `x + x`-style pattern). This restores correct hint recovery across that case.

##### Background: what spyre hints are for

`spyre_hint(...)` is a source-level annotation (via `torch.fx.traceback.annotate`) that drives **working-set reduction** through the coarse-tiling pass. A hint names an iteration-space dimension and requests that it be tiled into K chunks.

`coarse_tile` then takes a sequence of operations that share a hinted dimension, splits that dimension into K, and wraps the body in a counted outer loop — i.e. it does the computation piecewise in the time domain (for example, decomposing `x @ y` into a series of matmuls over groups of `x`'s rows). This matters for two reasons:

- Staying within the per-core memory span limit. Each Spyre core has a bounded DDR/HBM access span; tiling shrinks the per-iteration tensors so they fit.
- Enabling scratchpad residency. Smaller per-iteration tensors can be kept in the on-core scratchpad instead of streaming from memory, reducing bandwidth pressure.

The hints flow: `spyre_hint` annotation → `node.meta["custom"]` → `assign_dim_hints` builds `op.dim_hints` (one `DimHint` per hinted dimension) → `coarse_tile` reads `op.dim_hints` to form its loop groups. This loop structure must be established early, before work division sees the iteration space, and preserved through scheduling and codegen so the hardware executes the reduced per-iteration working set.

That is why losing the hints is not cosmetic: when `recover_spyre_hints` drops them, `op.dim_hints` comes back empty, `coarse_tile` cannot form any groups, and the working-set-reduction tiling for that graph is lost.

##### The bug

Spyre hints live in `node.meta["custom"]`. AOT re-tracing renames call_function nodes (`mm` → `mm_default`), dropping their `custom` meta, so `collect_spyre_hints` snapshots it before the re-trace and `recover_spyre_hints` re-attaches it after.

Recovery matched snapshot → graph by positional `zip`, guarded by an exact count check. That assumes the call_function node sequence is identical between the two passes. It does not hold when a producer's result is consumed more than once: the graph un-shares it into multiple identical nodes between collect and recover.

Minimal trigger — `x + x` lowers to `add(mm, mm)`:

| pass | call_function nodes |
|------|---------------------|
| `collect_spyre_hints` | `[mm, add]` (n=2) |
| `recover_spyre_hints` | `[mm, mm_default, add]` (n=3) |

`2 != 3` → the guard returns early → every hint is discarded, with only a `WARNING`. Downstream, `assign_dim_hints` produces empty `op.dim_hints`, so `coarse_tile` cannot form its tiling groups for that graph.

The duplicated nodes are the same computation (identical target and args), so they can and should receive the same hint.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
