### PR TITLE
Detect indirect access for gather like patterns

### DIFF
--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -218,6 +218,8 @@ jobs:
             config: torch_spyre_tests/inductor/test_unroll_loop_specs_config.yaml
           - name: Inductor Work Division Hint
             config: torch_spyre_tests/inductor/test_work_division_hint_config.yaml
+          - name: Inductor Detect Indirect Access Pattern
+            config: torch_spyre_tests/inductor/test_detect_indirect_access_pattern_config.yaml
           # Tensor tests
           - name: Tensor Coordinates
             config: torch_spyre_tests/tensors/test_coordinates_config.yaml

--- a/tests/configs/torch_spyre_tests/inductor/test_detect_indirect_access_pattern_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_detect_indirect_access_pattern_config.yaml
@@ -1,0 +1,4 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/indirect_access/test_detect_indirect_access.py
+      unlisted_test_mode: mandatory_success

--- a/tests/indirect_access/test_detect_indirect_access.py
+++ b/tests/indirect_access/test_detect_indirect_access.py
@@ -1,0 +1,248 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for detect_indirect_access.py"""
+
+import unittest
+from unittest.mock import Mock, patch
+from sympy import Symbol
+
+from torch._inductor.dependencies import MemoryDep
+from torch_spyre._inductor.detect_indirect_access import (
+    detect_indirect_access,
+    _find_indirect_pattern,
+    _mark_indirect_access,
+)
+
+
+class TestFindIndirectPattern(unittest.TestCase):
+    """Test _find_indirect_pattern function"""
+
+    def test_no_reads(self):
+        """Test with empty reads list"""
+        result = _find_indirect_pattern([])
+        self.assertEqual(result, (None, None))
+
+    def test_single_read(self):
+        """Test with single read (need at least 2 for indirect access)"""
+        read = Mock()
+        read.index = Mock()
+        read.index.free_symbols = set()
+
+        result = _find_indirect_pattern([read])
+        self.assertEqual(result, (None, None))
+
+    def test_no_tmp_variables(self):
+        """Test with multiple reads but no tmp variables in index"""
+        read1 = Mock()
+        read1.index = Mock()
+        read1.index.free_symbols = {Symbol("x"), Symbol("y")}
+
+        read2 = Mock()
+        read2.index = Mock()
+        read2.index.free_symbols = {Symbol("z")}
+
+        result = _find_indirect_pattern([read1, read2])
+        self.assertEqual(result, (None, None))
+
+    def test_indirect_pattern_detected(self):
+        """Test when indirect pattern is detected"""
+        # First read - index tensor (no tmp in index)
+        read1 = Mock(spec=MemoryDep)
+        read1.index = Mock()
+        read1.index.free_symbols = {Symbol("x")}
+
+        # Second read - value tensor (has tmp in index)
+        read2 = Mock(spec=MemoryDep)
+        read2.index = Mock()
+        read2.index.free_symbols = {Symbol("tmp0"), Symbol("y")}
+
+        result = _find_indirect_pattern([read1, read2])
+        # read1 is index (pos 0), read2 is value (pos 1)
+        self.assertEqual(result, (0, 1))
+
+    def test_indirect_pattern_reversed_order(self):
+        """Test when value tensor comes before index tensor"""
+        # First read - value tensor (has tmp in index)
+        read1 = Mock(spec=MemoryDep)
+        read1.index = Mock()
+        read1.index.free_symbols = {Symbol("tmp0")}
+
+        # Second read - index tensor (no tmp in index)
+        read2 = Mock(spec=MemoryDep)
+        read2.index = Mock()
+        read2.index.free_symbols = {Symbol("x")}
+
+        result = _find_indirect_pattern([read1, read2])
+        # read2 is index (pos 1), read1 is value (pos 0)
+        self.assertEqual(result, (1, 0))
+
+    def test_multiple_tmp_variables(self):
+        """Test with multiple tmp variables"""
+        read1 = Mock(spec=MemoryDep)
+        read1.index = Mock()
+        read1.index.free_symbols = {Symbol("x")}
+
+        read2 = Mock(spec=MemoryDep)
+        read2.index = Mock()
+        read2.index.free_symbols = {Symbol("tmp0"), Symbol("tmp1")}
+
+        result = _find_indirect_pattern([read1, read2])
+        self.assertEqual(result, (0, 1))
+
+
+class TestMarkIndirectAccess(unittest.TestCase):
+    """Test _mark_indirect_access function"""
+
+    def test_mark_indirect_access_basic(self):
+        """Test basic marking of indirect access"""
+        # Create mock operation
+        op = Mock()
+        op.get_name = Mock(return_value="test_op")
+        op.data = Mock()
+        op.data.op_info = None
+
+        # Create mock reads as MemoryDep instances
+        read1 = Mock(spec=MemoryDep)
+        read1.name = "index_tensor"
+
+        read2 = Mock(spec=MemoryDep)
+        read2.name = "value_tensor"
+
+        reads = [read1, read2]
+
+        # Mark indirect access: index at pos 0, value at pos 1
+        _mark_indirect_access(op, reads, index_tensor_pos=0, value_tensor_pos=1)
+
+        # Verify op_info was set correctly
+        self.assertIsNotNone(op.data.op_info)
+        self.assertEqual(op.data.op_info["op"], "identity")
+        self.assertEqual(
+            op.data.op_info["index_args"], [1]
+        )  # Index is second after reordering
+        self.assertEqual(
+            op.data.op_info["tensor_names"], ["value_tensor", "index_tensor"]
+        )  # Reordered: value first
+        self.assertEqual(
+            op.data.op_info["index_value_pairs"],
+            [{"index_arg": 1, "value_arg": 0}],  # After reordering
+        )
+
+    def test_mark_indirect_access_with_extra_tensors(self):
+        """Test marking with additional tensors"""
+        op = Mock()
+        op.get_name = Mock(return_value="test_op")
+        op.data = Mock()
+        op.data.op_info = None
+
+        read1 = Mock(spec=MemoryDep)
+        read1.name = "index_tensor"
+
+        read2 = Mock(spec=MemoryDep)
+        read2.name = "value_tensor"
+
+        read3 = Mock(spec=MemoryDep)
+        read3.name = "extra_tensor"
+
+        reads = [read1, read2, read3]
+
+        _mark_indirect_access(op, reads, index_tensor_pos=0, value_tensor_pos=1)
+
+        # Verify tensor_names includes all tensors with value and index first
+        self.assertEqual(
+            op.data.op_info["tensor_names"],
+            ["value_tensor", "index_tensor", "extra_tensor"],
+        )
+
+
+class TestDetectIndirectAccess(unittest.TestCase):
+    """Test detect_indirect_access function"""
+
+    def test_empty_operations(self):
+        """Test with empty operations list"""
+        # Should not raise any errors
+        detect_indirect_access([])
+
+    def test_non_computed_buffer(self):
+        """Test with non-ComputedBuffer operation"""
+        op = Mock()
+        op.__class__.__name__ = "SomeOtherOp"
+
+        # Should skip this operation
+        detect_indirect_access([op])
+
+    def test_operation_with_existing_op_info(self):
+        """Test operation that already has indirect access metadata"""
+        from torch._inductor.ir import ComputedBuffer, Pointwise
+
+        op = Mock(spec=ComputedBuffer)
+        op.data = Mock(spec=Pointwise)
+        # Set op_info with index_args to indicate indirect access
+        op.data.op_info = {"index_args": [0], "existing": "info"}
+
+        # Should skip this operation (already has indirect access)
+        detect_indirect_access([op])
+
+        # op_info should remain unchanged
+        self.assertEqual(op.data.op_info, {"index_args": [0], "existing": "info"})
+
+    def test_operation_with_single_read(self):
+        """Test operation with only one read (need at least 2)"""
+        from torch._inductor.ir import ComputedBuffer, Pointwise
+
+        op = Mock(spec=ComputedBuffer)
+        op.data = Mock(spec=Pointwise)
+        op.data.op_info = None
+
+        read_writes = Mock()
+        read_writes.reads = [Mock()]
+        op.get_read_writes = Mock(return_value=read_writes)
+
+        # Should skip this operation
+        detect_indirect_access([op])
+
+    @patch("torch_spyre._inductor.detect_indirect_access._mark_indirect_access")
+    @patch("torch_spyre._inductor.detect_indirect_access._find_indirect_pattern")
+    def test_indirect_pattern_detected_and_marked(
+        self, mock_find_pattern, mock_mark_access
+    ):
+        """Test when indirect pattern is detected and marked"""
+        from torch._inductor.ir import ComputedBuffer, Pointwise
+
+        # Setup mock operation
+        op = Mock(spec=ComputedBuffer)
+        op.data = Mock(spec=Pointwise)
+        op.data.op_info = None
+
+        read1 = Mock()
+        read2 = Mock()
+        read_writes = Mock()
+        read_writes.reads = [read1, read2]
+        op.get_read_writes = Mock(return_value=read_writes)
+
+        # Mock pattern detection to return valid positions
+        mock_find_pattern.return_value = (0, 1)
+
+        # Run detection
+        detect_indirect_access([op])
+
+        # Verify pattern was searched for
+        mock_find_pattern.assert_called_once_with([read1, read2])
+
+        # Verify marking was called
+        mock_mark_access.assert_called_once_with(op, [read1, read2], 0, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_spyre/_inductor/detect_indirect_access.py
+++ b/torch_spyre/_inductor/detect_indirect_access.py
@@ -1,0 +1,126 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Detect and mark indirect access patterns in Pointwise operations.
+
+This pass identifies operations where one tensor is loaded and its value
+is used as an index to load from another tensor (indirect access pattern).
+"""
+
+import logging
+from torch._inductor.ir import ComputedBuffer, Pointwise, Operation
+from torch._inductor.dependencies import MemoryDep
+from .logging_utils import get_inductor_logger
+from .indirect_access import is_indirect_access_operation
+
+logger = get_inductor_logger("detect_indirect_access")
+
+
+def detect_indirect_access(operations: list[Operation]) -> None:
+    """
+    Detect indirect access patterns in Pointwise operations and mark them
+    with appropriate op_info metadata.
+
+    An indirect access pattern is detected when:
+    1. A Pointwise operation has multiple loads
+    2. One load's result is used in the index expression of another load
+
+    When detected, we add op_info with:
+    - index_args: list of positions of index tensors
+    - index_value_pairs: mapping of which index accesses which value tensor
+    """
+    for op in operations:
+        if not isinstance(op, ComputedBuffer) or not isinstance(op.data, Pointwise):
+            continue
+
+        # Skip if operation already has indirect access metadata
+        if is_indirect_access_operation(op):
+            continue
+
+        # Get read dependencies - need at least 2 for indirect access
+        reads = op.get_read_writes().reads
+        if len(reads) < 2:
+            continue
+
+        # Detect indirect access pattern by looking for tmp variables in index expressions
+        index_tensor_pos, value_tensor_pos = _find_indirect_pattern(reads)
+
+        if index_tensor_pos is not None and value_tensor_pos is not None:
+            _mark_indirect_access(op, reads, index_tensor_pos, value_tensor_pos)
+
+
+def _find_indirect_pattern(reads) -> tuple[int | None, int | None]:
+    """
+    Find indirect access pattern in read dependencies.
+
+    Returns:
+        Tuple of (index_tensor_pos, value_tensor_pos) or (None, None) if not found
+    """
+    for i, read in enumerate(reads):
+        if not isinstance(read, MemoryDep):
+            continue
+
+        # Check if index expression contains tmp variables (loaded values)
+        index_expr = read.index
+        for symbol in index_expr.free_symbols:
+            if str(symbol).startswith("tmp"):
+                # Current read is value tensor (indexed by loaded value)
+                value_tensor_pos = i
+                # Find index tensor (first other MemoryDep)
+                for j, other_read in enumerate(reads):
+                    if j != i and isinstance(other_read, MemoryDep):
+                        return j, value_tensor_pos
+    return None, None
+
+
+def _mark_indirect_access(
+    op, reads, index_tensor_pos: int, value_tensor_pos: int
+) -> None:
+    """Mark operation with indirect access metadata."""
+    all_tensor_names = [read.name for read in reads if isinstance(read, MemoryDep)]
+
+    # Reorder tensor_names to match custom op: [value, index, ...]
+    # This ensures the OpSpec args are in the correct order
+    value_name = all_tensor_names[value_tensor_pos]
+    index_name = all_tensor_names[index_tensor_pos]
+
+    tensor_names = [value_name, index_name]
+    # Add any remaining tensors
+    for name in all_tensor_names:
+        if name not in tensor_names:
+            tensor_names.append(name)
+
+    # Update positions based on new ordering
+    new_value_pos = 0  # Value is now first
+    new_index_pos = 1  # Index is now second
+
+    op_info = {
+        "op": "identity",
+        "index_args": [new_index_pos],
+        "index_value_pairs": [{"index_arg": new_index_pos, "value_arg": new_value_pos}],
+        "tensor_names": tensor_names,
+    }
+
+    # Pointwise is frozen dataclass - use object.__setattr__ to bypass
+    if not hasattr(op.data, "op_info") or op.data.op_info is None:
+        object.__setattr__(op.data, "op_info", {})
+    op.data.op_info.update(op_info)
+
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            f"Detected indirect access in {op.get_name()}: "
+            f"tensor_names={tensor_names} (reordered: value first, index second), "
+            f"index_arg={new_index_pos}, value_arg={new_value_pos}"
+        )

--- a/torch_spyre/_inductor/indirect_access.py
+++ b/torch_spyre/_inductor/indirect_access.py
@@ -1,0 +1,34 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def is_indirect_access_operation(op) -> bool:
+    """Check if an operation uses indirect access (e.g., gather, scatter, index_select).
+
+    Indirect access operations have op_info with either 'index_args' or 'index_value_pairs'.
+
+    Args:
+        op: Operation to check (typically a ComputedBuffer or SchedulerNode)
+
+    Returns:
+        True if the operation uses indirect access, False otherwise
+    """
+    if not hasattr(op, "data"):
+        return False
+    if not hasattr(op.data, "op_info"):
+        return False
+    if not op.data.op_info:
+        return False
+
+    return "index_args" in op.data.op_info or "index_value_pairs" in op.data.op_info

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -75,6 +75,7 @@ from .deadcode_elimination import deadcode_elimination
 from .dedup_constants import dedup_and_promote_constants
 from .chunk_large_tensors import chunk_large_tensors
 from .coarse_tile import coarse_tile
+from .detect_indirect_access import detect_indirect_access
 
 
 logger = get_inductor_logger("passes")
@@ -315,6 +316,7 @@ class CustomPreSchedulingPasses:
     def __init__(self):
         self.passes = [
             deadcode_elimination,
+            detect_indirect_access,
             #
             # Tensor Layout (Stickification)
             propagate_spyre_tensor_layouts,

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -266,6 +266,11 @@ def _runs(*passes: Callable) -> Callable[[Callable], Callable]:
     return annotate
 
 
+@_runs(detect_indirect_access)
+def _maybe_detect_indirect_access(graph: GraphLowering) -> None:
+    detect_indirect_access(graph.operations)
+
+
 @_runs(chunk_large_tensors)
 def _maybe_chunk_large_tensors(graph: GraphLowering) -> None:
     if config.chunk_large_tensors:
@@ -316,7 +321,7 @@ class CustomPreSchedulingPasses:
     def __init__(self):
         self.passes = [
             deadcode_elimination,
-            detect_indirect_access,
+            _maybe_detect_indirect_access,
             #
             # Tensor Layout (Stickification)
             propagate_spyre_tensor_layouts,

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -62,6 +62,7 @@ from .pass_utils import (
     iter_var_id,
 )
 from .optimize_restickify import AllSameNode, AnyInNode, FixedInOutNode
+from .indirect_access import is_indirect_access_operation
 from .views import matching_dim
 
 # ---------------------------------------------------------------------------
@@ -547,6 +548,28 @@ def _topk_layouts(
     return results
 
 
+def _indirect_access_layouts(
+    op: Operation,
+    output: FixedLayout,
+    output_dep: MemoryDep,
+    args: list[PropArg],
+) -> list[SpyreTensorLayout]:
+    """Compute layouts for indirect access operations (gather, scatter, embedding).
+
+    For indirect access operations, the output layout is determined by the operation's
+    semantics, not by propagating from inputs. Index tensors are used for address
+    computation and value tensors may have different dimensions than the output.
+    """
+    # For indirect access, use generic layout since dimensions may not match
+    # between value tensor and output
+    all_layouts = [generic_layout(op)]
+
+    # Use AnyInNode: indirect access operations handle layout conversion internally
+    # via address computation, so no restickify is needed before them
+    op.restick_cost_fn = AnyInNode.from_args()
+    return all_layouts
+
+
 def compute_layouts(
     op: Operation,
     output: FixedLayout,
@@ -559,6 +582,9 @@ def compute_layouts(
     2. Attach a restick cost function based on the type of op.
     """
     data = op.data
+
+    if is_indirect_access_operation(op):
+        return _indirect_access_layouts(op, output, output_dep, args)
 
     if len(args) > 1 and isinstance(data, Pointwise):
         return _multi_arg_pointwise_layouts(op, output, output_dep, args)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Three components added at the Inductor pre scheduling level:
- _detect_indirect_access.py_ — a new compiler pass that marks gather like operators as indirect access
- _indirect_access.py_ —  detection utilities
- _Changes to propagate_layouts.py_ — a new layout path for detected indirect ops with AnyInNode restickification optimization strategy

The detection pass is registered second in CustomPreSchedulingPasses, immediately after dead-code elimination, before layout propagation runs.

After Inductor lowers the FX graph, gather/index_select/embedding nodes become generic Pointwise operations — indistinguishable from an elementwise add to the compiler. But they must be treated differently at every downstream stage. OpSpec construction and SDSC codegen need to know which tensor is the "value" and which is the "index"
Detection is the single source of truth that controls all of this. Every downstream PR reads from the op_info metadata set here.

#### Which issue(s) this PR is related to:

**Issue :** [1363](https://github.com/torch-spyre/torch-spyre/issues/1363)

**Sub-Issues:** [2466](https://github.com/torch-spyre/torch-spyre/issues/2466)

#### Special notes for your reviewer:
Here are few todos to be taken separately:
	- Pattern matcher uses named buffer for detection. If upstream changes buffer name, this should be reworked.
	- Evolve the detection for scatter like operations.
	- Validate the op data propagation when operations fuse.