### PR TITLE
[test] Improve matmul test stability with Xavier initialization for op-level tests

### DIFF
--- a/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -239,14 +239,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 12]
                           stride: [12, 12, 1]
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -513,14 +513,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -572,14 +572,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -1120,3 +1120,4 @@ test_suite_config:
                     - bf16operation
                     - constant
                     - torch.getitem.6
+cases: []

--- a/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct_spyre.yaml
+++ b/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -233,14 +233,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 12]
                           stride: [12, 12, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -492,14 +492,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -548,14 +548,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -1069,3 +1069,4 @@ test_suite_config:
                   tags:
                     - constant
                     - torch.getitem.6_spyre
+cases: []

--- a/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct_spyre.yaml
+++ b/tests/configs/model_ops_tests/Meta-Llama-3.1-8B-Instruct_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512.yaml
+++ b/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512.yaml
+++ b/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -239,14 +239,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 14]
                           stride: [14, 14, 1]
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -522,14 +522,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
                     forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -581,14 +581,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
                     forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -1237,14 +1237,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in
                     forward, code: attn_output = self.o_proj(attn_output)'
@@ -1283,14 +1283,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [16384, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -1343,14 +1343,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 16384]
                           stride: [16384, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -1384,14 +1384,14 @@ test_suite_config:
                           storage_offset: 66560
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [131072, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -1487,14 +1487,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 1]
                           stride: [1, 1, 1]
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -1761,14 +1761,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
                     forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -1820,14 +1820,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
                     forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -2442,14 +2442,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in
                     forward, code: attn_output = self.o_proj(attn_output)'
@@ -2488,14 +2488,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [16384, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -2548,14 +2548,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 16384]
                           stride: [16384, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -2589,14 +2589,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [131072, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -2604,3 +2604,4 @@ test_suite_config:
                     - bf16operation
                     - constant
                     - torch.nn.functional.linear.12
+cases: []

--- a/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512_spyre.yaml
+++ b/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512_spyre.yaml
+++ b/tests/configs/model_ops_tests/Ministral-3-14B-Instruct-2512_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -233,14 +233,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 14]
                           stride: [14, 14, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -501,14 +501,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
                     forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -557,14 +557,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
                     forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -1181,14 +1181,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in
                     forward, code: attn_output = self.o_proj(attn_output)'
@@ -1225,14 +1225,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [16384, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -1282,14 +1282,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 16384]
                           stride: [16384, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -1321,14 +1321,14 @@ test_suite_config:
                           storage_offset: 66560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [131072, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -1421,14 +1421,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 1]
                           stride: [1, 1, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -1680,14 +1680,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
                     forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -1736,14 +1736,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
                     forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -2328,14 +2328,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in
                     forward, code: attn_output = self.o_proj(attn_output)'
@@ -2372,14 +2372,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [16384, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -2429,14 +2429,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 16384]
                           stride: [16384, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -2468,17 +2468,18 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [131072, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
                     - torch.nn.functional.linear.12_spyre
+cases: []

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -1228,3 +1228,4 @@ test_suite_config:
                     - bf16operation
                     - constant
                     - torch.getitem.7
+cases: []

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -1174,3 +1174,4 @@ test_suite_config:
                   tags:
                     - constant
                     - torch.getitem.7_spyre
+cases: []

--- a/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/configs/model_ops_tests/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/gpt-oss-20b.yaml
+++ b/tests/configs/model_ops_tests/gpt-oss-20b.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -239,14 +239,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 11]
                           stride: [11, 11, 1]
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -490,14 +490,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096]
                           stride: [1]
@@ -554,14 +554,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512]
                           stride: [1]
@@ -1094,14 +1094,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 128]
                           stride: [524288, 8192, 1, 64]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -1349,14 +1349,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 128, 64]
                           stride: [524288, 8192, 64, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -1436,14 +1436,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880]
                           stride: [1]
@@ -1504,14 +1504,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32]
                           stride: [1]
@@ -1869,14 +1869,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [44, 2880, 5760]
                           stride: [16588800, 5760, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -2054,14 +2054,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [44, 2880, 2880]
                           stride: [8294400, 2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -2405,14 +2405,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 2048]
                           stride: [8388608, 131072, 1, 64]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -2599,14 +2599,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 2048, 64]
                           stride: [8388608, 131072, 64, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -2638,14 +2638,14 @@ test_suite_config:
                           storage_offset: 28800
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [201088, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -2741,14 +2741,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 1]
                           stride: [1, 1, 1]
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -2992,14 +2992,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096]
                           stride: [1]
@@ -3056,14 +3056,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512]
                           stride: [1]
@@ -3511,14 +3511,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 128]
                           stride: [524288, 8192, 1, 64]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -3729,14 +3729,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 128, 64]
                           stride: [524288, 8192, 64, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -3816,14 +3816,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880]
                           stride: [1]
@@ -3884,14 +3884,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32]
                           stride: [1]
@@ -4238,14 +4238,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4, 2880, 5760]
                           stride: [16588800, 5760, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -4423,14 +4423,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4, 2880, 2880]
                           stride: [8294400, 2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -4689,14 +4689,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 2048]
                           stride: [8388608, 131072, 1, 64]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -4883,14 +4883,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 2048, 64]
                           stride: [8388608, 131072, 64, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -4922,14 +4922,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [201088, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -4937,3 +4937,4 @@ test_suite_config:
                     - bf16operation
                     - constant
                     - torch.nn.functional.linear.10
+cases: []

--- a/tests/configs/model_ops_tests/gpt-oss-20b.yaml
+++ b/tests/configs/model_ops_tests/gpt-oss-20b.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/gpt-oss-20b_spyre.yaml
+++ b/tests/configs/model_ops_tests/gpt-oss-20b_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/gpt-oss-20b_spyre.yaml
+++ b/tests/configs/model_ops_tests/gpt-oss-20b_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -233,14 +233,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 11]
                           stride: [11, 11, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -469,14 +469,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096]
                           stride: [1]
@@ -530,14 +530,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512]
                           stride: [1]
@@ -1034,14 +1034,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 128]
                           stride: [524288, 8192, 1, 64]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -1271,14 +1271,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 128, 64]
                           stride: [524288, 8192, 64, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -1353,14 +1353,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880]
                           stride: [1]
@@ -1418,14 +1418,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32]
                           stride: [1]
@@ -1767,14 +1767,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [44, 2880, 5760]
                           stride: [16588800, 5760, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -1942,14 +1942,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [44, 2880, 2880]
                           stride: [8294400, 2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -2278,14 +2278,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 2048]
                           stride: [8388608, 131072, 1, 64]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -2462,14 +2462,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 2048, 64]
                           stride: [8388608, 131072, 64, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -2499,14 +2499,14 @@ test_suite_config:
                           storage_offset: 28800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [201088, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -2599,14 +2599,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 1]
                           stride: [1, 1, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -2835,14 +2835,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096]
                           stride: [1]
@@ -2896,14 +2896,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512]
                           stride: [1]
@@ -3319,14 +3319,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 128]
                           stride: [524288, 8192, 1, 64]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -3521,14 +3521,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 128, 64]
                           stride: [524288, 8192, 64, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -3603,14 +3603,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2880]
                           stride: [1]
@@ -3668,14 +3668,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [32]
                           stride: [1]
@@ -4006,14 +4006,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4, 2880, 5760]
                           stride: [16588800, 5760, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -4181,14 +4181,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4, 2880, 2880]
                           stride: [8294400, 2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code:
                     out = torch.bmm(input.unsqueeze(1), weight).squeeze(1)'
                   tags:
@@ -4436,14 +4436,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 64, 2048]
                           stride: [8388608, 131072, 1, 64]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
                     code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
                   tags:
@@ -4620,14 +4620,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 64, 2048, 64]
                           stride: [8388608, 131072, 64, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
                     code: attn_output = torch.matmul(attn_weights, value_states)'
                   tags:
@@ -4657,17 +4657,18 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [201088, 2880]
                           stride: [2880, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward,
                     code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
                   tags:
                     - constant
                     - torch.nn.functional.linear.10_spyre
+cases: []

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -164,14 +164,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L443 in forward,
                     code: queries = self.query(q)'
@@ -188,14 +188,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L444 in forward,
                     code: keys = self.key(k)'
@@ -756,14 +756,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [12800, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L294 in forward,
                     code: out = self.a(self.wg(x)) * self.w1(x)'
@@ -819,14 +819,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 12800]
                           stride: [12800, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L297 in forward,
                     code: return self.w2(out)'
@@ -2166,14 +2166,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [49159, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/models/granite.py#L381 in torch_dynamo_resume_in_forward_at_380,
                     code: preds = self.head(output.to("cpu")).to("cuda")'
@@ -2298,14 +2298,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L443 in forward,
                     code: queries = self.query(q)'
@@ -2322,14 +2322,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L444 in forward,
                     code: keys = self.key(k)'
@@ -2895,14 +2895,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [12800, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L294 in forward,
                     code: out = self.a(self.wg(x)) * self.w1(x)'
@@ -2958,14 +2958,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 12800]
                           stride: [12800, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L297 in forward,
                     code: return self.w2(out)'
@@ -4305,14 +4305,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [49159, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/models/granite.py#L381 in torch_dynamo_resume_in_forward_at_380,
                     code: preds = self.head(output.to("cpu")).to("cuda")'
@@ -14012,3 +14012,4 @@ test_suite_config:
                     dropout_p: 0.0
                     is_causal: false
                     scale: 0.0078125
+cases: []

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -161,14 +161,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L443 in forward,
                     code: queries = self.query(q)'
@@ -184,14 +184,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L444 in forward,
                     code: keys = self.key(k)'
@@ -725,14 +725,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [12800, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L294 in forward,
                     code: out = self.a(self.wg(x)) * self.w1(x)'
@@ -785,14 +785,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 12800]
                           stride: [12800, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L297 in forward,
                     code: return self.w2(out)'
@@ -2090,14 +2090,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [49159, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/models/granite.py#L381 in torch_dynamo_resume_in_forward_at_380,
                     code: preds = self.head(output.to("cpu")).to("cuda")'
@@ -2216,14 +2216,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L443 in forward,
                     code: queries = self.query(q)'
@@ -2239,14 +2239,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/attention.py#L444 in forward,
                     code: keys = self.key(k)'
@@ -2785,14 +2785,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [12800, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L294 in forward,
                     code: out = self.a(self.wg(x)) * self.w1(x)'
@@ -2845,14 +2845,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 12800]
                           stride: [12800, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/modules/feedforward.py#L297 in forward,
                     code: return self.w2(out)'
@@ -4150,14 +4150,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [49159, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cpu
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/foundation-model-stack/foundation-model-stack/blob/eager_spyre/fms/models/granite.py#L381 in torch_dynamo_resume_in_forward_at_380,
                     code: preds = self.head(output.to("cpu")).to("cuda")'
@@ -13536,3 +13536,4 @@ test_suite_config:
                     dropout_p: 0.0
                     is_causal: false
                     scale: 0.0078125
+cases: []

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct-fms_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -256,14 +256,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 41]
                           stride: [41, 41, 1]
                           storage_offset: 0
                           dtype: torch.float32
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -530,14 +530,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -589,14 +589,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.bfloat16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -1154,3 +1154,4 @@ test_suite_config:
                     - bf16operation
                     - constant
                     - torch.truediv.1
+cases: []

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/configs/model_ops_tests/granite-3.3-8b-instruct_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-3.3-8b-instruct_spyre.yaml
@@ -73,7 +73,7 @@ test_suite_config:
       seed: 123
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -249,14 +249,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 41]
                           stride: [41, 41, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378 in forward,
                     code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
                   tags:
@@ -508,14 +508,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -564,14 +564,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'site-packages/accelerate/hooks.py:192 in torch_dynamo_resume_in_new_forward_at_187, code: output = module._old_forward(*args,
                     **kwargs)'
@@ -1101,3 +1101,4 @@ test_suite_config:
                   tags:
                     - constant
                     - torch.truediv.1_spyre
+cases: []

--- a/tests/configs/model_ops_tests/granite-4.0-h-tiny.yaml
+++ b/tests/configs/model_ops_tests/granite-4.0-h-tiny.yaml
@@ -596,14 +596,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [6448, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L639
                     in torch_forward, code: projected_states = self.in_proj(input_states)'
@@ -2563,14 +2563,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 3072]
                           stride: [3072, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L830
                     in torch_forward, code: contextualized_states = self.out_proj(scan_output.to(dtype))  # [batch, seq_len, hidden_size]'
@@ -2639,14 +2639,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [64, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1034
                     in forward, code: logits = self.layer(hidden_states).float()  # [batch_size x seq_len, num_experts]'
@@ -3396,14 +3396,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3417,14 +3417,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3438,14 +3438,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3459,14 +3459,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3480,14 +3480,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3501,14 +3501,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3522,14 +3522,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3543,14 +3543,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3564,14 +3564,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3585,14 +3585,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3606,14 +3606,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3627,14 +3627,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3648,14 +3648,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3669,14 +3669,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3690,14 +3690,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3711,14 +3711,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3732,14 +3732,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3753,14 +3753,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3774,14 +3774,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3795,14 +3795,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3816,14 +3816,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3837,14 +3837,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3858,14 +3858,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3879,14 +3879,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3900,14 +3900,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3921,14 +3921,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3942,14 +3942,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3963,14 +3963,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3984,14 +3984,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4005,14 +4005,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4026,14 +4026,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4047,14 +4047,14 @@ test_suite_config:
                           storage_offset: 38400
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4068,14 +4068,14 @@ test_suite_config:
                           storage_offset: 38400
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4089,14 +4089,14 @@ test_suite_config:
                           storage_offset: 41472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4110,14 +4110,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4131,14 +4131,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4152,14 +4152,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4173,14 +4173,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4194,14 +4194,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4215,14 +4215,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4236,14 +4236,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4257,14 +4257,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4278,14 +4278,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4299,14 +4299,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4320,14 +4320,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4341,14 +4341,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4362,14 +4362,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4383,14 +4383,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4404,14 +4404,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4425,14 +4425,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4446,14 +4446,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4467,14 +4467,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4488,14 +4488,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4509,14 +4509,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4530,14 +4530,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4551,14 +4551,14 @@ test_suite_config:
                           storage_offset: 79872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4572,14 +4572,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4593,14 +4593,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4614,14 +4614,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4635,14 +4635,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4656,14 +4656,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4677,14 +4677,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4698,14 +4698,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4719,14 +4719,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5636,14 +5636,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5657,14 +5657,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5678,14 +5678,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5699,14 +5699,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5720,14 +5720,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5741,14 +5741,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5762,14 +5762,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5783,14 +5783,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5804,14 +5804,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5825,14 +5825,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5846,14 +5846,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5867,14 +5867,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5888,14 +5888,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5909,14 +5909,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5930,14 +5930,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5951,14 +5951,14 @@ test_suite_config:
                           storage_offset: 4096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5972,14 +5972,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5993,14 +5993,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6014,14 +6014,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6035,14 +6035,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6056,14 +6056,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6077,14 +6077,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6098,14 +6098,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6119,14 +6119,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6140,14 +6140,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6161,14 +6161,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6182,14 +6182,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6203,14 +6203,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6224,14 +6224,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6245,14 +6245,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6266,14 +6266,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6287,14 +6287,14 @@ test_suite_config:
                           storage_offset: 12800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6308,14 +6308,14 @@ test_suite_config:
                           storage_offset: 12800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6329,14 +6329,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6350,14 +6350,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6371,14 +6371,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6392,14 +6392,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6413,14 +6413,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6434,14 +6434,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6455,14 +6455,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6476,14 +6476,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6497,14 +6497,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6518,14 +6518,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6539,14 +6539,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6560,14 +6560,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6581,14 +6581,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6602,14 +6602,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6623,14 +6623,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6644,14 +6644,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6665,14 +6665,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6686,14 +6686,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6707,14 +6707,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6728,14 +6728,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6749,14 +6749,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6770,14 +6770,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6791,14 +6791,14 @@ test_suite_config:
                           storage_offset: 26624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6812,14 +6812,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6833,14 +6833,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6854,14 +6854,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6875,14 +6875,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6896,14 +6896,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6917,14 +6917,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6938,14 +6938,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6959,14 +6959,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7473,14 +7473,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2048, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L894
                     in forward, code: hidden_states = self.input_linear(hidden_states)'
@@ -7570,14 +7570,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 1024]
                           stride: [1024, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L897
                     in forward, code: hidden_states = self.output_linear(hidden_states)'
@@ -7593,14 +7593,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7614,14 +7614,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7635,14 +7635,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7656,14 +7656,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7677,14 +7677,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7698,14 +7698,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7719,14 +7719,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7740,14 +7740,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7761,14 +7761,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7782,14 +7782,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7803,14 +7803,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7824,14 +7824,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7845,14 +7845,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7866,14 +7866,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7887,14 +7887,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7908,14 +7908,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7929,14 +7929,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7950,14 +7950,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7971,14 +7971,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7992,14 +7992,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8013,14 +8013,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8034,14 +8034,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8055,14 +8055,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8076,14 +8076,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8097,14 +8097,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8118,14 +8118,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8139,14 +8139,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8160,14 +8160,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8181,14 +8181,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8202,14 +8202,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8223,14 +8223,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8244,14 +8244,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8265,14 +8265,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8286,14 +8286,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8307,14 +8307,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8328,14 +8328,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8349,14 +8349,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8370,14 +8370,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8391,14 +8391,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8412,14 +8412,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8433,14 +8433,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8454,14 +8454,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8475,14 +8475,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8496,14 +8496,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8517,14 +8517,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8538,14 +8538,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8559,14 +8559,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8580,14 +8580,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8601,14 +8601,14 @@ test_suite_config:
                           storage_offset: 79872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8622,14 +8622,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8643,14 +8643,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8664,14 +8664,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8685,14 +8685,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8706,14 +8706,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8727,14 +8727,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8748,14 +8748,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8769,14 +8769,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8790,14 +8790,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8811,14 +8811,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8832,14 +8832,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8853,14 +8853,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8874,14 +8874,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8895,14 +8895,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8916,14 +8916,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9349,14 +9349,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9370,14 +9370,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9391,14 +9391,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9412,14 +9412,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9433,14 +9433,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9454,14 +9454,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9475,14 +9475,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9496,14 +9496,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9517,14 +9517,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9538,14 +9538,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9559,14 +9559,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9580,14 +9580,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9601,14 +9601,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9622,14 +9622,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9643,14 +9643,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9664,14 +9664,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9685,14 +9685,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9706,14 +9706,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9727,14 +9727,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9748,14 +9748,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9769,14 +9769,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9790,14 +9790,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9811,14 +9811,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9832,14 +9832,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9853,14 +9853,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9874,14 +9874,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9895,14 +9895,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9916,14 +9916,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9937,14 +9937,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9958,14 +9958,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9979,14 +9979,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10000,14 +10000,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10021,14 +10021,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10042,14 +10042,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10063,14 +10063,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10084,14 +10084,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10105,14 +10105,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10126,14 +10126,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10147,14 +10147,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10168,14 +10168,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10189,14 +10189,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10210,14 +10210,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10231,14 +10231,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10252,14 +10252,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10273,14 +10273,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10294,14 +10294,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10315,14 +10315,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10336,14 +10336,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10357,14 +10357,14 @@ test_suite_config:
                           storage_offset: 26624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10378,14 +10378,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10399,14 +10399,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10420,14 +10420,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10441,14 +10441,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10462,14 +10462,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10483,14 +10483,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10504,14 +10504,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10525,14 +10525,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10546,14 +10546,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10567,14 +10567,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10588,14 +10588,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10609,14 +10609,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10630,14 +10630,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10651,14 +10651,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10672,14 +10672,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11087,14 +11087,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11108,14 +11108,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11129,14 +11129,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11150,14 +11150,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11171,14 +11171,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11192,14 +11192,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11213,14 +11213,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11234,14 +11234,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11255,14 +11255,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11276,14 +11276,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11297,14 +11297,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11318,14 +11318,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11339,14 +11339,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11360,14 +11360,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11381,14 +11381,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11402,14 +11402,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11423,14 +11423,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11444,14 +11444,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11465,14 +11465,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11486,14 +11486,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11507,14 +11507,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11528,14 +11528,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11549,14 +11549,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11570,14 +11570,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11591,14 +11591,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11612,14 +11612,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11633,14 +11633,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11654,14 +11654,14 @@ test_suite_config:
                           storage_offset: 39936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11675,14 +11675,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11696,14 +11696,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11717,14 +11717,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11738,14 +11738,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11759,14 +11759,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11780,14 +11780,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11801,14 +11801,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11822,14 +11822,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11843,14 +11843,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11864,14 +11864,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11885,14 +11885,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11906,14 +11906,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11927,14 +11927,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11948,14 +11948,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11969,14 +11969,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11990,14 +11990,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12011,14 +12011,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12032,14 +12032,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12053,14 +12053,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12074,14 +12074,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12095,14 +12095,14 @@ test_suite_config:
                           storage_offset: 84480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12116,14 +12116,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12137,14 +12137,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12158,14 +12158,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12179,14 +12179,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12200,14 +12200,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12221,14 +12221,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12242,14 +12242,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12263,14 +12263,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12284,14 +12284,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12305,14 +12305,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12738,14 +12738,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12759,14 +12759,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12780,14 +12780,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12801,14 +12801,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12822,14 +12822,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12843,14 +12843,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12864,14 +12864,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12885,14 +12885,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12906,14 +12906,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12927,14 +12927,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12948,14 +12948,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12969,14 +12969,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12990,14 +12990,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13011,14 +13011,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13032,14 +13032,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13053,14 +13053,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13074,14 +13074,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13095,14 +13095,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13116,14 +13116,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13137,14 +13137,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13158,14 +13158,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13179,14 +13179,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13200,14 +13200,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13221,14 +13221,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13242,14 +13242,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13263,14 +13263,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13284,14 +13284,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13305,14 +13305,14 @@ test_suite_config:
                           storage_offset: 13312
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13326,14 +13326,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13347,14 +13347,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13368,14 +13368,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13389,14 +13389,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13410,14 +13410,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13431,14 +13431,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13452,14 +13452,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13473,14 +13473,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13494,14 +13494,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13515,14 +13515,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13536,14 +13536,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13557,14 +13557,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13578,14 +13578,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13599,14 +13599,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13620,14 +13620,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13641,14 +13641,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13662,14 +13662,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13683,14 +13683,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13704,14 +13704,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13725,14 +13725,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13746,14 +13746,14 @@ test_suite_config:
                           storage_offset: 28160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13767,14 +13767,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13788,14 +13788,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13809,14 +13809,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13830,14 +13830,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13851,14 +13851,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13872,14 +13872,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13893,14 +13893,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13914,14 +13914,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13935,14 +13935,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13956,14 +13956,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14371,14 +14371,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14392,14 +14392,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14413,14 +14413,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14434,14 +14434,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14455,14 +14455,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14476,14 +14476,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14497,14 +14497,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14518,14 +14518,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14539,14 +14539,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14560,14 +14560,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14581,14 +14581,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14602,14 +14602,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14623,14 +14623,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14644,14 +14644,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14665,14 +14665,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14686,14 +14686,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14707,14 +14707,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14728,14 +14728,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14749,14 +14749,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14770,14 +14770,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14791,14 +14791,14 @@ test_suite_config:
                           storage_offset: 39936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14812,14 +14812,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14833,14 +14833,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14854,14 +14854,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14875,14 +14875,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14896,14 +14896,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14917,14 +14917,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14938,14 +14938,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14959,14 +14959,14 @@ test_suite_config:
                           storage_offset: 58368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14980,14 +14980,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15001,14 +15001,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15022,14 +15022,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15043,14 +15043,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15064,14 +15064,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15085,14 +15085,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15106,14 +15106,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15127,14 +15127,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15148,14 +15148,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15169,14 +15169,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15190,14 +15190,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15211,14 +15211,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15232,14 +15232,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15253,14 +15253,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15274,14 +15274,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15295,14 +15295,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15316,14 +15316,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15337,14 +15337,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15358,14 +15358,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15379,14 +15379,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15400,14 +15400,14 @@ test_suite_config:
                           storage_offset: 84480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15421,14 +15421,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15442,14 +15442,14 @@ test_suite_config:
                           storage_offset: 89088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15463,14 +15463,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15484,14 +15484,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15505,14 +15505,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15526,14 +15526,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15959,14 +15959,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15980,14 +15980,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16001,14 +16001,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16022,14 +16022,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16043,14 +16043,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16064,14 +16064,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16085,14 +16085,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16106,14 +16106,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16127,14 +16127,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16148,14 +16148,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16169,14 +16169,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16190,14 +16190,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16211,14 +16211,14 @@ test_suite_config:
                           storage_offset: 9728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16232,14 +16232,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16253,14 +16253,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16274,14 +16274,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16295,14 +16295,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16316,14 +16316,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16337,14 +16337,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16358,14 +16358,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16379,14 +16379,14 @@ test_suite_config:
                           storage_offset: 13312
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16400,14 +16400,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16421,14 +16421,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16442,14 +16442,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16463,14 +16463,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16484,14 +16484,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16505,14 +16505,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16526,14 +16526,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16547,14 +16547,14 @@ test_suite_config:
                           storage_offset: 19456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16568,14 +16568,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16589,14 +16589,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16610,14 +16610,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16631,14 +16631,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16652,14 +16652,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16673,14 +16673,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16694,14 +16694,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16715,14 +16715,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16736,14 +16736,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16757,14 +16757,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16778,14 +16778,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16799,14 +16799,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16820,14 +16820,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16841,14 +16841,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16862,14 +16862,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16883,14 +16883,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16904,14 +16904,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16925,14 +16925,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16946,14 +16946,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16967,14 +16967,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16988,14 +16988,14 @@ test_suite_config:
                           storage_offset: 28160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17009,14 +17009,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17030,14 +17030,14 @@ test_suite_config:
                           storage_offset: 29696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17051,14 +17051,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17072,14 +17072,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17093,14 +17093,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17114,14 +17114,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17529,14 +17529,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17550,14 +17550,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17571,14 +17571,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17592,14 +17592,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17613,14 +17613,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17634,14 +17634,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17655,14 +17655,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17676,14 +17676,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17697,14 +17697,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17718,14 +17718,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17739,14 +17739,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17760,14 +17760,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17781,14 +17781,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17802,14 +17802,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17823,14 +17823,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17844,14 +17844,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17865,14 +17865,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17886,14 +17886,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17907,14 +17907,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17928,14 +17928,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17949,14 +17949,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17970,14 +17970,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17991,14 +17991,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18012,14 +18012,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18033,14 +18033,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18054,14 +18054,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18075,14 +18075,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18096,14 +18096,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18117,14 +18117,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18138,14 +18138,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18159,14 +18159,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18180,14 +18180,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18201,14 +18201,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18222,14 +18222,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18243,14 +18243,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18264,14 +18264,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18285,14 +18285,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18306,14 +18306,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18327,14 +18327,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18348,14 +18348,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18369,14 +18369,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18390,14 +18390,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18411,14 +18411,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18432,14 +18432,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18453,14 +18453,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18474,14 +18474,14 @@ test_suite_config:
                           storage_offset: 84480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18495,14 +18495,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18516,14 +18516,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18537,14 +18537,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18558,14 +18558,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18579,14 +18579,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19012,14 +19012,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19033,14 +19033,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19054,14 +19054,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19075,14 +19075,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19096,14 +19096,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19117,14 +19117,14 @@ test_suite_config:
                           storage_offset: 4096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19138,14 +19138,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19159,14 +19159,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19180,14 +19180,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19201,14 +19201,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19222,14 +19222,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19243,14 +19243,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19264,14 +19264,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19285,14 +19285,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19306,14 +19306,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19327,14 +19327,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19348,14 +19348,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19369,14 +19369,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19390,14 +19390,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19411,14 +19411,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19432,14 +19432,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19453,14 +19453,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19474,14 +19474,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19495,14 +19495,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19516,14 +19516,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19537,14 +19537,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19558,14 +19558,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19579,14 +19579,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19600,14 +19600,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19621,14 +19621,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19642,14 +19642,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19663,14 +19663,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19684,14 +19684,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19705,14 +19705,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19726,14 +19726,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19747,14 +19747,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19768,14 +19768,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19789,14 +19789,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19810,14 +19810,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19831,14 +19831,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19852,14 +19852,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19873,14 +19873,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19894,14 +19894,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19915,14 +19915,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19936,14 +19936,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19957,14 +19957,14 @@ test_suite_config:
                           storage_offset: 28160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19978,14 +19978,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19999,14 +19999,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20020,14 +20020,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20041,14 +20041,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20062,14 +20062,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20477,14 +20477,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L159
                     in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -20533,14 +20533,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L160
                     in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -20734,14 +20734,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20755,14 +20755,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20776,14 +20776,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20797,14 +20797,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20818,14 +20818,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20839,14 +20839,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20860,14 +20860,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20881,14 +20881,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20902,14 +20902,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20923,14 +20923,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20944,14 +20944,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20965,14 +20965,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20986,14 +20986,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21007,14 +21007,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21028,14 +21028,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21049,14 +21049,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21070,14 +21070,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21091,14 +21091,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21112,14 +21112,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21133,14 +21133,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21154,14 +21154,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21175,14 +21175,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21196,14 +21196,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21217,14 +21217,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21238,14 +21238,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21259,14 +21259,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21280,14 +21280,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21301,14 +21301,14 @@ test_suite_config:
                           storage_offset: 38400
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21322,14 +21322,14 @@ test_suite_config:
                           storage_offset: 41472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21343,14 +21343,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21364,14 +21364,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21385,14 +21385,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21406,14 +21406,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21427,14 +21427,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21448,14 +21448,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21469,14 +21469,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21490,14 +21490,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21511,14 +21511,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21532,14 +21532,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21553,14 +21553,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21574,14 +21574,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21595,14 +21595,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21616,14 +21616,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21637,14 +21637,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21658,14 +21658,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21679,14 +21679,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21700,14 +21700,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21721,14 +21721,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21742,14 +21742,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21763,14 +21763,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21784,14 +21784,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21805,14 +21805,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21826,14 +21826,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21847,14 +21847,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21868,14 +21868,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21889,14 +21889,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21910,14 +21910,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21931,14 +21931,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21952,14 +21952,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21973,14 +21973,14 @@ test_suite_config:
                           storage_offset: 93696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22406,14 +22406,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22427,14 +22427,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22448,14 +22448,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22469,14 +22469,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22490,14 +22490,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22511,14 +22511,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22532,14 +22532,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22553,14 +22553,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22574,14 +22574,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22595,14 +22595,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22616,14 +22616,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22637,14 +22637,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22658,14 +22658,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22679,14 +22679,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22700,14 +22700,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22721,14 +22721,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22742,14 +22742,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22763,14 +22763,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22784,14 +22784,14 @@ test_suite_config:
                           storage_offset: 9728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22805,14 +22805,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22826,14 +22826,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22847,14 +22847,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22868,14 +22868,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22889,14 +22889,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22910,14 +22910,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22931,14 +22931,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22952,14 +22952,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22973,14 +22973,14 @@ test_suite_config:
                           storage_offset: 12800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22994,14 +22994,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23015,14 +23015,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23036,14 +23036,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23057,14 +23057,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23078,14 +23078,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23099,14 +23099,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23120,14 +23120,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23141,14 +23141,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23162,14 +23162,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23183,14 +23183,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23204,14 +23204,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23225,14 +23225,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23246,14 +23246,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23267,14 +23267,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23288,14 +23288,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23309,14 +23309,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23330,14 +23330,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23351,14 +23351,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23372,14 +23372,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23393,14 +23393,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23414,14 +23414,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23435,14 +23435,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23456,14 +23456,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23477,14 +23477,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23498,14 +23498,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23519,14 +23519,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23540,14 +23540,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23561,14 +23561,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23582,14 +23582,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23603,14 +23603,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23624,14 +23624,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23645,14 +23645,14 @@ test_suite_config:
                           storage_offset: 31232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24060,14 +24060,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24081,14 +24081,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24102,14 +24102,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24123,14 +24123,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24144,14 +24144,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24165,14 +24165,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24186,14 +24186,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24207,14 +24207,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24228,14 +24228,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24249,14 +24249,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24270,14 +24270,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24291,14 +24291,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24312,14 +24312,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24333,14 +24333,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24354,14 +24354,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24375,14 +24375,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24396,14 +24396,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24417,14 +24417,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24438,14 +24438,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24459,14 +24459,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24480,14 +24480,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24501,14 +24501,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24522,14 +24522,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24543,14 +24543,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24564,14 +24564,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24585,14 +24585,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24606,14 +24606,14 @@ test_suite_config:
                           storage_offset: 58368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24627,14 +24627,14 @@ test_suite_config:
                           storage_offset: 58368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24648,14 +24648,14 @@ test_suite_config:
                           storage_offset: 66048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24669,14 +24669,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24690,14 +24690,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24711,14 +24711,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24732,14 +24732,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24753,14 +24753,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24774,14 +24774,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24795,14 +24795,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24816,14 +24816,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24837,14 +24837,14 @@ test_suite_config:
                           storage_offset: 79872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24858,14 +24858,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24879,14 +24879,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24900,14 +24900,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24921,14 +24921,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24942,14 +24942,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24963,14 +24963,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25396,14 +25396,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25417,14 +25417,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25438,14 +25438,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25459,14 +25459,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25480,14 +25480,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25501,14 +25501,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25522,14 +25522,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25543,14 +25543,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25564,14 +25564,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25585,14 +25585,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25606,14 +25606,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25627,14 +25627,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25648,14 +25648,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25669,14 +25669,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25690,14 +25690,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25711,14 +25711,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25732,14 +25732,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25753,14 +25753,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25774,14 +25774,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25795,14 +25795,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25816,14 +25816,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25837,14 +25837,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25858,14 +25858,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25879,14 +25879,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25900,14 +25900,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25921,14 +25921,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25942,14 +25942,14 @@ test_suite_config:
                           storage_offset: 19456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25963,14 +25963,14 @@ test_suite_config:
                           storage_offset: 19456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25984,14 +25984,14 @@ test_suite_config:
                           storage_offset: 22016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26005,14 +26005,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26026,14 +26026,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26047,14 +26047,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26068,14 +26068,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26089,14 +26089,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26110,14 +26110,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26131,14 +26131,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26152,14 +26152,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26173,14 +26173,14 @@ test_suite_config:
                           storage_offset: 26624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26194,14 +26194,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26215,14 +26215,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26236,14 +26236,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26257,14 +26257,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26278,14 +26278,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26299,14 +26299,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26714,14 +26714,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26735,14 +26735,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26756,14 +26756,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26777,14 +26777,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26798,14 +26798,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26819,14 +26819,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26840,14 +26840,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26861,14 +26861,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26882,14 +26882,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26903,14 +26903,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26924,14 +26924,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26945,14 +26945,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26966,14 +26966,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26987,14 +26987,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27008,14 +27008,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27029,14 +27029,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27050,14 +27050,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27071,14 +27071,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27092,14 +27092,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27113,14 +27113,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27134,14 +27134,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27155,14 +27155,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27176,14 +27176,14 @@ test_suite_config:
                           storage_offset: 41472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27197,14 +27197,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27218,14 +27218,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27239,14 +27239,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27260,14 +27260,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27281,14 +27281,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27302,14 +27302,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27323,14 +27323,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27344,14 +27344,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27365,14 +27365,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27386,14 +27386,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27407,14 +27407,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27428,14 +27428,14 @@ test_suite_config:
                           storage_offset: 66048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27449,14 +27449,14 @@ test_suite_config:
                           storage_offset: 66048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27470,14 +27470,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27491,14 +27491,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27512,14 +27512,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27533,14 +27533,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27554,14 +27554,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27575,14 +27575,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27596,14 +27596,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27617,14 +27617,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27638,14 +27638,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27659,14 +27659,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27680,14 +27680,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27701,14 +27701,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27722,14 +27722,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27743,14 +27743,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27764,14 +27764,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27785,14 +27785,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27806,14 +27806,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27827,14 +27827,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27848,14 +27848,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27869,14 +27869,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28302,14 +28302,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28323,14 +28323,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28344,14 +28344,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28365,14 +28365,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28386,14 +28386,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28407,14 +28407,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28428,14 +28428,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28449,14 +28449,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28470,14 +28470,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28491,14 +28491,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28512,14 +28512,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28533,14 +28533,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28554,14 +28554,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28575,14 +28575,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28596,14 +28596,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28617,14 +28617,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28638,14 +28638,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28659,14 +28659,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28680,14 +28680,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28701,14 +28701,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28722,14 +28722,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28743,14 +28743,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28764,14 +28764,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28785,14 +28785,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28806,14 +28806,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28827,14 +28827,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28848,14 +28848,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28869,14 +28869,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28890,14 +28890,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28911,14 +28911,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28932,14 +28932,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28953,14 +28953,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28974,14 +28974,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28995,14 +28995,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29016,14 +29016,14 @@ test_suite_config:
                           storage_offset: 22016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29037,14 +29037,14 @@ test_suite_config:
                           storage_offset: 22016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29058,14 +29058,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29079,14 +29079,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29100,14 +29100,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29121,14 +29121,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29142,14 +29142,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29163,14 +29163,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29184,14 +29184,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29205,14 +29205,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29226,14 +29226,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29247,14 +29247,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29268,14 +29268,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29289,14 +29289,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29310,14 +29310,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29331,14 +29331,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29352,14 +29352,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29373,14 +29373,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29394,14 +29394,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29415,14 +29415,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29436,14 +29436,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29457,14 +29457,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29888,14 +29888,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [100352, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509
                     in torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -30363,14 +30363,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [100352, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509
                     in torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -31535,3 +31535,4 @@ test_suite_config:
                   tags:
                     - constant
                     - torch.Tensor.expand.11
+cases: []

--- a/tests/configs/model_ops_tests/granite-4.0-h-tiny_spyre.yaml
+++ b/tests/configs/model_ops_tests/granite-4.0-h-tiny_spyre.yaml
@@ -590,14 +590,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [6448, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L639
                     in torch_forward, code: projected_states = self.in_proj(input_states)'
@@ -2481,14 +2481,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 3072]
                           stride: [3072, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L830
                     in torch_forward, code: contextualized_states = self.out_proj(scan_output.to(dtype))  # [batch, seq_len, hidden_size]'
@@ -2557,14 +2557,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [64, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1034
                     in forward, code: logits = self.layer(hidden_states).float()  # [batch_size x seq_len, num_experts]'
@@ -2931,14 +2931,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -2952,14 +2952,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -2973,14 +2973,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -2994,14 +2994,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3015,14 +3015,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3036,14 +3036,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3057,14 +3057,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3078,14 +3078,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3099,14 +3099,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3120,14 +3120,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3141,14 +3141,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3162,14 +3162,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3183,14 +3183,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3204,14 +3204,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3225,14 +3225,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3246,14 +3246,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3267,14 +3267,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3288,14 +3288,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3309,14 +3309,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3330,14 +3330,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3351,14 +3351,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3372,14 +3372,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3393,14 +3393,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3414,14 +3414,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3435,14 +3435,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3456,14 +3456,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3477,14 +3477,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3498,14 +3498,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3519,14 +3519,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3540,14 +3540,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3561,14 +3561,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3582,14 +3582,14 @@ test_suite_config:
                           storage_offset: 38400
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3603,14 +3603,14 @@ test_suite_config:
                           storage_offset: 38400
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3624,14 +3624,14 @@ test_suite_config:
                           storage_offset: 41472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3645,14 +3645,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3666,14 +3666,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3687,14 +3687,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3708,14 +3708,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3729,14 +3729,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3750,14 +3750,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3771,14 +3771,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3792,14 +3792,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3813,14 +3813,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3834,14 +3834,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3855,14 +3855,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3876,14 +3876,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3897,14 +3897,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3918,14 +3918,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3939,14 +3939,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3960,14 +3960,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -3981,14 +3981,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4002,14 +4002,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4023,14 +4023,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4044,14 +4044,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4065,14 +4065,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4086,14 +4086,14 @@ test_suite_config:
                           storage_offset: 79872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4107,14 +4107,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4128,14 +4128,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4149,14 +4149,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4170,14 +4170,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4191,14 +4191,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4212,14 +4212,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4233,14 +4233,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4254,14 +4254,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4799,14 +4799,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4820,14 +4820,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4841,14 +4841,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4862,14 +4862,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4883,14 +4883,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4904,14 +4904,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4925,14 +4925,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4946,14 +4946,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4967,14 +4967,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -4988,14 +4988,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5009,14 +5009,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5030,14 +5030,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5051,14 +5051,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5072,14 +5072,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5093,14 +5093,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5114,14 +5114,14 @@ test_suite_config:
                           storage_offset: 4096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5135,14 +5135,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5156,14 +5156,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5177,14 +5177,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5198,14 +5198,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5219,14 +5219,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5240,14 +5240,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5261,14 +5261,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5282,14 +5282,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5303,14 +5303,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5324,14 +5324,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5345,14 +5345,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5366,14 +5366,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5387,14 +5387,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5408,14 +5408,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5429,14 +5429,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5450,14 +5450,14 @@ test_suite_config:
                           storage_offset: 12800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5471,14 +5471,14 @@ test_suite_config:
                           storage_offset: 12800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5492,14 +5492,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5513,14 +5513,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5534,14 +5534,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5555,14 +5555,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5576,14 +5576,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5597,14 +5597,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5618,14 +5618,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5639,14 +5639,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5660,14 +5660,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5681,14 +5681,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5702,14 +5702,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5723,14 +5723,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5744,14 +5744,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5765,14 +5765,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5786,14 +5786,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5807,14 +5807,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5828,14 +5828,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5849,14 +5849,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5870,14 +5870,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5891,14 +5891,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5912,14 +5912,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5933,14 +5933,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5954,14 +5954,14 @@ test_suite_config:
                           storage_offset: 26624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5975,14 +5975,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -5996,14 +5996,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6017,14 +6017,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6038,14 +6038,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6059,14 +6059,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6080,14 +6080,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6101,14 +6101,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6122,14 +6122,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6636,14 +6636,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [2048, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L894
                     in forward, code: hidden_states = self.input_linear(hidden_states)'
@@ -6727,14 +6727,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 1024]
                           stride: [1024, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L897
                     in forward, code: hidden_states = self.output_linear(hidden_states)'
@@ -6750,14 +6750,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6771,14 +6771,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6792,14 +6792,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6813,14 +6813,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6834,14 +6834,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6855,14 +6855,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6876,14 +6876,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6897,14 +6897,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6918,14 +6918,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6939,14 +6939,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6960,14 +6960,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -6981,14 +6981,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7002,14 +7002,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7023,14 +7023,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7044,14 +7044,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7065,14 +7065,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7086,14 +7086,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7107,14 +7107,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7128,14 +7128,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7149,14 +7149,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7170,14 +7170,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7191,14 +7191,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7212,14 +7212,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7233,14 +7233,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7254,14 +7254,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7275,14 +7275,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7296,14 +7296,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7317,14 +7317,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7338,14 +7338,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7359,14 +7359,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7380,14 +7380,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7401,14 +7401,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7422,14 +7422,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7443,14 +7443,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7464,14 +7464,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7485,14 +7485,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7506,14 +7506,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7527,14 +7527,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7548,14 +7548,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7569,14 +7569,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7590,14 +7590,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7611,14 +7611,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7632,14 +7632,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7653,14 +7653,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7674,14 +7674,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7695,14 +7695,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7716,14 +7716,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7737,14 +7737,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7758,14 +7758,14 @@ test_suite_config:
                           storage_offset: 79872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7779,14 +7779,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7800,14 +7800,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7821,14 +7821,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7842,14 +7842,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7863,14 +7863,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7884,14 +7884,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7905,14 +7905,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7926,14 +7926,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7947,14 +7947,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7968,14 +7968,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -7989,14 +7989,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8010,14 +8010,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8031,14 +8031,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8052,14 +8052,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8073,14 +8073,14 @@ test_suite_config:
                           storage_offset: 101376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8506,14 +8506,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8527,14 +8527,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8548,14 +8548,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8569,14 +8569,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8590,14 +8590,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8611,14 +8611,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8632,14 +8632,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8653,14 +8653,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8674,14 +8674,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8695,14 +8695,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8716,14 +8716,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8737,14 +8737,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8758,14 +8758,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8779,14 +8779,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8800,14 +8800,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8821,14 +8821,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8842,14 +8842,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8863,14 +8863,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8884,14 +8884,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8905,14 +8905,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8926,14 +8926,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8947,14 +8947,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8968,14 +8968,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -8989,14 +8989,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9010,14 +9010,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9031,14 +9031,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9052,14 +9052,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9073,14 +9073,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9094,14 +9094,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9115,14 +9115,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9136,14 +9136,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9157,14 +9157,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9178,14 +9178,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9199,14 +9199,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9220,14 +9220,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9241,14 +9241,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9262,14 +9262,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9283,14 +9283,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9304,14 +9304,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9325,14 +9325,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9346,14 +9346,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9367,14 +9367,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9388,14 +9388,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9409,14 +9409,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9430,14 +9430,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9451,14 +9451,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9472,14 +9472,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9493,14 +9493,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9514,14 +9514,14 @@ test_suite_config:
                           storage_offset: 26624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9535,14 +9535,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9556,14 +9556,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9577,14 +9577,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9598,14 +9598,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9619,14 +9619,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9640,14 +9640,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9661,14 +9661,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9682,14 +9682,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9703,14 +9703,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9724,14 +9724,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9745,14 +9745,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9766,14 +9766,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9787,14 +9787,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9808,14 +9808,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -9829,14 +9829,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10244,14 +10244,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10265,14 +10265,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10286,14 +10286,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10307,14 +10307,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10328,14 +10328,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10349,14 +10349,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10370,14 +10370,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10391,14 +10391,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10412,14 +10412,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10433,14 +10433,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10454,14 +10454,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10475,14 +10475,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10496,14 +10496,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10517,14 +10517,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10538,14 +10538,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10559,14 +10559,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10580,14 +10580,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10601,14 +10601,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10622,14 +10622,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10643,14 +10643,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10664,14 +10664,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10685,14 +10685,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10706,14 +10706,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10727,14 +10727,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10748,14 +10748,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10769,14 +10769,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10790,14 +10790,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10811,14 +10811,14 @@ test_suite_config:
                           storage_offset: 39936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10832,14 +10832,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10853,14 +10853,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10874,14 +10874,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10895,14 +10895,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10916,14 +10916,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10937,14 +10937,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10958,14 +10958,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -10979,14 +10979,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11000,14 +11000,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11021,14 +11021,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11042,14 +11042,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11063,14 +11063,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11084,14 +11084,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11105,14 +11105,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11126,14 +11126,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11147,14 +11147,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11168,14 +11168,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11189,14 +11189,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11210,14 +11210,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11231,14 +11231,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11252,14 +11252,14 @@ test_suite_config:
                           storage_offset: 84480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11273,14 +11273,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11294,14 +11294,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11315,14 +11315,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11336,14 +11336,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11357,14 +11357,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11378,14 +11378,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11399,14 +11399,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11420,14 +11420,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11441,14 +11441,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11462,14 +11462,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11895,14 +11895,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11916,14 +11916,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11937,14 +11937,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11958,14 +11958,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -11979,14 +11979,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12000,14 +12000,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12021,14 +12021,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12042,14 +12042,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12063,14 +12063,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12084,14 +12084,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12105,14 +12105,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12126,14 +12126,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12147,14 +12147,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12168,14 +12168,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12189,14 +12189,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12210,14 +12210,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12231,14 +12231,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12252,14 +12252,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12273,14 +12273,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12294,14 +12294,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12315,14 +12315,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12336,14 +12336,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12357,14 +12357,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12378,14 +12378,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12399,14 +12399,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12420,14 +12420,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12441,14 +12441,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12462,14 +12462,14 @@ test_suite_config:
                           storage_offset: 13312
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12483,14 +12483,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12504,14 +12504,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12525,14 +12525,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12546,14 +12546,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12567,14 +12567,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12588,14 +12588,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12609,14 +12609,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12630,14 +12630,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12651,14 +12651,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12672,14 +12672,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12693,14 +12693,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12714,14 +12714,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12735,14 +12735,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12756,14 +12756,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12777,14 +12777,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12798,14 +12798,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12819,14 +12819,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12840,14 +12840,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12861,14 +12861,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12882,14 +12882,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12903,14 +12903,14 @@ test_suite_config:
                           storage_offset: 28160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12924,14 +12924,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12945,14 +12945,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12966,14 +12966,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -12987,14 +12987,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13008,14 +13008,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13029,14 +13029,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13050,14 +13050,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13071,14 +13071,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13092,14 +13092,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13113,14 +13113,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13528,14 +13528,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13549,14 +13549,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13570,14 +13570,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13591,14 +13591,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13612,14 +13612,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13633,14 +13633,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13654,14 +13654,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13675,14 +13675,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13696,14 +13696,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13717,14 +13717,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13738,14 +13738,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13759,14 +13759,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13780,14 +13780,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13801,14 +13801,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13822,14 +13822,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13843,14 +13843,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13864,14 +13864,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13885,14 +13885,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13906,14 +13906,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13927,14 +13927,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13948,14 +13948,14 @@ test_suite_config:
                           storage_offset: 39936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13969,14 +13969,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -13990,14 +13990,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14011,14 +14011,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14032,14 +14032,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14053,14 +14053,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14074,14 +14074,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14095,14 +14095,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14116,14 +14116,14 @@ test_suite_config:
                           storage_offset: 58368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14137,14 +14137,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14158,14 +14158,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14179,14 +14179,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14200,14 +14200,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14221,14 +14221,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14242,14 +14242,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14263,14 +14263,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14284,14 +14284,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14305,14 +14305,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14326,14 +14326,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14347,14 +14347,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14368,14 +14368,14 @@ test_suite_config:
                           storage_offset: 75264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14389,14 +14389,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14410,14 +14410,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14431,14 +14431,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14452,14 +14452,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14473,14 +14473,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14494,14 +14494,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14515,14 +14515,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14536,14 +14536,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14557,14 +14557,14 @@ test_suite_config:
                           storage_offset: 84480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14578,14 +14578,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14599,14 +14599,14 @@ test_suite_config:
                           storage_offset: 89088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14620,14 +14620,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14641,14 +14641,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14662,14 +14662,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -14683,14 +14683,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15116,14 +15116,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15137,14 +15137,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15158,14 +15158,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15179,14 +15179,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15200,14 +15200,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15221,14 +15221,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15242,14 +15242,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15263,14 +15263,14 @@ test_suite_config:
                           storage_offset: 3584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15284,14 +15284,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15305,14 +15305,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15326,14 +15326,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15347,14 +15347,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15368,14 +15368,14 @@ test_suite_config:
                           storage_offset: 9728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15389,14 +15389,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15410,14 +15410,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15431,14 +15431,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15452,14 +15452,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15473,14 +15473,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15494,14 +15494,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15515,14 +15515,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15536,14 +15536,14 @@ test_suite_config:
                           storage_offset: 13312
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15557,14 +15557,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15578,14 +15578,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15599,14 +15599,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15620,14 +15620,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15641,14 +15641,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15662,14 +15662,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15683,14 +15683,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15704,14 +15704,14 @@ test_suite_config:
                           storage_offset: 19456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15725,14 +15725,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15746,14 +15746,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15767,14 +15767,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15788,14 +15788,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15809,14 +15809,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15830,14 +15830,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15851,14 +15851,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15872,14 +15872,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15893,14 +15893,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15914,14 +15914,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15935,14 +15935,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15956,14 +15956,14 @@ test_suite_config:
                           storage_offset: 25088
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15977,14 +15977,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -15998,14 +15998,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16019,14 +16019,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16040,14 +16040,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16061,14 +16061,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16082,14 +16082,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16103,14 +16103,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16124,14 +16124,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16145,14 +16145,14 @@ test_suite_config:
                           storage_offset: 28160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16166,14 +16166,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16187,14 +16187,14 @@ test_suite_config:
                           storage_offset: 29696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16208,14 +16208,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16229,14 +16229,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16250,14 +16250,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16271,14 +16271,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16686,14 +16686,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16707,14 +16707,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16728,14 +16728,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16749,14 +16749,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16770,14 +16770,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16791,14 +16791,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16812,14 +16812,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16833,14 +16833,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16854,14 +16854,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16875,14 +16875,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16896,14 +16896,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16917,14 +16917,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16938,14 +16938,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16959,14 +16959,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -16980,14 +16980,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17001,14 +17001,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17022,14 +17022,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17043,14 +17043,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17064,14 +17064,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17085,14 +17085,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17106,14 +17106,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17127,14 +17127,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17148,14 +17148,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17169,14 +17169,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17190,14 +17190,14 @@ test_suite_config:
                           storage_offset: 49152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17211,14 +17211,14 @@ test_suite_config:
                           storage_offset: 52224
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17232,14 +17232,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17253,14 +17253,14 @@ test_suite_config:
                           storage_offset: 59904
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17274,14 +17274,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17295,14 +17295,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17316,14 +17316,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17337,14 +17337,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17358,14 +17358,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17379,14 +17379,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17400,14 +17400,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17421,14 +17421,14 @@ test_suite_config:
                           storage_offset: 73728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17442,14 +17442,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17463,14 +17463,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17484,14 +17484,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17505,14 +17505,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17526,14 +17526,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17547,14 +17547,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17568,14 +17568,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17589,14 +17589,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17610,14 +17610,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17631,14 +17631,14 @@ test_suite_config:
                           storage_offset: 84480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17652,14 +17652,14 @@ test_suite_config:
                           storage_offset: 86016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17673,14 +17673,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17694,14 +17694,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17715,14 +17715,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -17736,14 +17736,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18169,14 +18169,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18190,14 +18190,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18211,14 +18211,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18232,14 +18232,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18253,14 +18253,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18274,14 +18274,14 @@ test_suite_config:
                           storage_offset: 4096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18295,14 +18295,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18316,14 +18316,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18337,14 +18337,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18358,14 +18358,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18379,14 +18379,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18400,14 +18400,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18421,14 +18421,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18442,14 +18442,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18463,14 +18463,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18484,14 +18484,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18505,14 +18505,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18526,14 +18526,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18547,14 +18547,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18568,14 +18568,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18589,14 +18589,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18610,14 +18610,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18631,14 +18631,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18652,14 +18652,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18673,14 +18673,14 @@ test_suite_config:
                           storage_offset: 16384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18694,14 +18694,14 @@ test_suite_config:
                           storage_offset: 17408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18715,14 +18715,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18736,14 +18736,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18757,14 +18757,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18778,14 +18778,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18799,14 +18799,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18820,14 +18820,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18841,14 +18841,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18862,14 +18862,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18883,14 +18883,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18904,14 +18904,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18925,14 +18925,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18946,14 +18946,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18967,14 +18967,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -18988,14 +18988,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19009,14 +19009,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19030,14 +19030,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19051,14 +19051,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19072,14 +19072,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19093,14 +19093,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19114,14 +19114,14 @@ test_suite_config:
                           storage_offset: 28160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19135,14 +19135,14 @@ test_suite_config:
                           storage_offset: 28672
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19156,14 +19156,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19177,14 +19177,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19198,14 +19198,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19219,14 +19219,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19634,14 +19634,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L159
                     in forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -19690,14 +19690,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [512, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L160
                     in forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
@@ -19891,14 +19891,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19912,14 +19912,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19933,14 +19933,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19954,14 +19954,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19975,14 +19975,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -19996,14 +19996,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20017,14 +20017,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20038,14 +20038,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20059,14 +20059,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20080,14 +20080,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20101,14 +20101,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20122,14 +20122,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20143,14 +20143,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20164,14 +20164,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20185,14 +20185,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20206,14 +20206,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20227,14 +20227,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20248,14 +20248,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20269,14 +20269,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20290,14 +20290,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20311,14 +20311,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20332,14 +20332,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20353,14 +20353,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20374,14 +20374,14 @@ test_suite_config:
                           storage_offset: 33792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20395,14 +20395,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20416,14 +20416,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20437,14 +20437,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20458,14 +20458,14 @@ test_suite_config:
                           storage_offset: 38400
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20479,14 +20479,14 @@ test_suite_config:
                           storage_offset: 41472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20500,14 +20500,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20521,14 +20521,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20542,14 +20542,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20563,14 +20563,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20584,14 +20584,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20605,14 +20605,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20626,14 +20626,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20647,14 +20647,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20668,14 +20668,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20689,14 +20689,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20710,14 +20710,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20731,14 +20731,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20752,14 +20752,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20773,14 +20773,14 @@ test_suite_config:
                           storage_offset: 55296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20794,14 +20794,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20815,14 +20815,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20836,14 +20836,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20857,14 +20857,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20878,14 +20878,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20899,14 +20899,14 @@ test_suite_config:
                           storage_offset: 76800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20920,14 +20920,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20941,14 +20941,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20962,14 +20962,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -20983,14 +20983,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21004,14 +21004,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21025,14 +21025,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21046,14 +21046,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21067,14 +21067,14 @@ test_suite_config:
                           storage_offset: 82944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21088,14 +21088,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21109,14 +21109,14 @@ test_suite_config:
                           storage_offset: 92160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21130,14 +21130,14 @@ test_suite_config:
                           storage_offset: 93696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21563,14 +21563,14 @@ test_suite_config:
                           storage_offset: 512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21584,14 +21584,14 @@ test_suite_config:
                           storage_offset: 2048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21605,14 +21605,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21626,14 +21626,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21647,14 +21647,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21668,14 +21668,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21689,14 +21689,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21710,14 +21710,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21731,14 +21731,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21752,14 +21752,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21773,14 +21773,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21794,14 +21794,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21815,14 +21815,14 @@ test_suite_config:
                           storage_offset: 6144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21836,14 +21836,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21857,14 +21857,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21878,14 +21878,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21899,14 +21899,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21920,14 +21920,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21941,14 +21941,14 @@ test_suite_config:
                           storage_offset: 9728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21962,14 +21962,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -21983,14 +21983,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22004,14 +22004,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22025,14 +22025,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22046,14 +22046,14 @@ test_suite_config:
                           storage_offset: 11264
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22067,14 +22067,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22088,14 +22088,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22109,14 +22109,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22130,14 +22130,14 @@ test_suite_config:
                           storage_offset: 12800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22151,14 +22151,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22172,14 +22172,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22193,14 +22193,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22214,14 +22214,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22235,14 +22235,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22256,14 +22256,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22277,14 +22277,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22298,14 +22298,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22319,14 +22319,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22340,14 +22340,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22361,14 +22361,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22382,14 +22382,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22403,14 +22403,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22424,14 +22424,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22445,14 +22445,14 @@ test_suite_config:
                           storage_offset: 18432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22466,14 +22466,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22487,14 +22487,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22508,14 +22508,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22529,14 +22529,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22550,14 +22550,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22571,14 +22571,14 @@ test_suite_config:
                           storage_offset: 25600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22592,14 +22592,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22613,14 +22613,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22634,14 +22634,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22655,14 +22655,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22676,14 +22676,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22697,14 +22697,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22718,14 +22718,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22739,14 +22739,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22760,14 +22760,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22781,14 +22781,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -22802,14 +22802,14 @@ test_suite_config:
                           storage_offset: 31232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23217,14 +23217,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23238,14 +23238,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23259,14 +23259,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23280,14 +23280,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23301,14 +23301,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23322,14 +23322,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23343,14 +23343,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23364,14 +23364,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23385,14 +23385,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23406,14 +23406,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23427,14 +23427,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23448,14 +23448,14 @@ test_suite_config:
                           storage_offset: 27648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23469,14 +23469,14 @@ test_suite_config:
                           storage_offset: 30720
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23490,14 +23490,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23511,14 +23511,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23532,14 +23532,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23553,14 +23553,14 @@ test_suite_config:
                           storage_offset: 35328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23574,14 +23574,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23595,14 +23595,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23616,14 +23616,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23637,14 +23637,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23658,14 +23658,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23679,14 +23679,14 @@ test_suite_config:
                           storage_offset: 50688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 55050240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23700,14 +23700,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 56623104
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23721,14 +23721,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23742,14 +23742,14 @@ test_suite_config:
                           storage_offset: 56832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23763,14 +23763,14 @@ test_suite_config:
                           storage_offset: 58368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23784,14 +23784,14 @@ test_suite_config:
                           storage_offset: 58368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23805,14 +23805,14 @@ test_suite_config:
                           storage_offset: 66048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23826,14 +23826,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23847,14 +23847,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23868,14 +23868,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23889,14 +23889,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23910,14 +23910,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23931,14 +23931,14 @@ test_suite_config:
                           storage_offset: 72192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23952,14 +23952,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23973,14 +23973,14 @@ test_suite_config:
                           storage_offset: 78336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -23994,14 +23994,14 @@ test_suite_config:
                           storage_offset: 79872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24015,14 +24015,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24036,14 +24036,14 @@ test_suite_config:
                           storage_offset: 90624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24057,14 +24057,14 @@ test_suite_config:
                           storage_offset: 96768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24078,14 +24078,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24099,14 +24099,14 @@ test_suite_config:
                           storage_offset: 98304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24120,14 +24120,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24553,14 +24553,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24574,14 +24574,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24595,14 +24595,14 @@ test_suite_config:
                           storage_offset: 1024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24616,14 +24616,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24637,14 +24637,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24658,14 +24658,14 @@ test_suite_config:
                           storage_offset: 3072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24679,14 +24679,14 @@ test_suite_config:
                           storage_offset: 5120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24700,14 +24700,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24721,14 +24721,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24742,14 +24742,14 @@ test_suite_config:
                           storage_offset: 7168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24763,14 +24763,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24784,14 +24784,14 @@ test_suite_config:
                           storage_offset: 9216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 16515072
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24805,14 +24805,14 @@ test_suite_config:
                           storage_offset: 10240
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24826,14 +24826,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24847,14 +24847,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24868,14 +24868,14 @@ test_suite_config:
                           storage_offset: 10752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24889,14 +24889,14 @@ test_suite_config:
                           storage_offset: 11776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 21233664
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24910,14 +24910,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24931,14 +24931,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24952,14 +24952,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 24379392
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24973,14 +24973,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -24994,14 +24994,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25015,14 +25015,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 27525120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25036,14 +25036,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25057,14 +25057,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25078,14 +25078,14 @@ test_suite_config:
                           storage_offset: 18944
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25099,14 +25099,14 @@ test_suite_config:
                           storage_offset: 19456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25120,14 +25120,14 @@ test_suite_config:
                           storage_offset: 19456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25141,14 +25141,14 @@ test_suite_config:
                           storage_offset: 22016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25162,14 +25162,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25183,14 +25183,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25204,14 +25204,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25225,14 +25225,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25246,14 +25246,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25267,14 +25267,14 @@ test_suite_config:
                           storage_offset: 24064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25288,14 +25288,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25309,14 +25309,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25330,14 +25330,14 @@ test_suite_config:
                           storage_offset: 26624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25351,14 +25351,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25372,14 +25372,14 @@ test_suite_config:
                           storage_offset: 30208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25393,14 +25393,14 @@ test_suite_config:
                           storage_offset: 32256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25414,14 +25414,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25435,14 +25435,14 @@ test_suite_config:
                           storage_offset: 32768
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25456,14 +25456,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25871,14 +25871,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25892,14 +25892,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25913,14 +25913,14 @@ test_suite_config:
                           storage_offset: 4608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25934,14 +25934,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25955,14 +25955,14 @@ test_suite_config:
                           storage_offset: 16896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25976,14 +25976,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -25997,14 +25997,14 @@ test_suite_config:
                           storage_offset: 19968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26018,14 +26018,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26039,14 +26039,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26060,14 +26060,14 @@ test_suite_config:
                           storage_offset: 24576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26081,14 +26081,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26102,14 +26102,14 @@ test_suite_config:
                           storage_offset: 26112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 17301504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26123,14 +26123,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26144,14 +26144,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 20447232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26165,14 +26165,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26186,14 +26186,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 23592960
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26207,14 +26207,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26228,14 +26228,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26249,14 +26249,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 28311552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26270,14 +26270,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26291,14 +26291,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26312,14 +26312,14 @@ test_suite_config:
                           storage_offset: 36864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26333,14 +26333,14 @@ test_suite_config:
                           storage_offset: 41472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26354,14 +26354,14 @@ test_suite_config:
                           storage_offset: 43008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26375,14 +26375,14 @@ test_suite_config:
                           storage_offset: 44544
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26396,14 +26396,14 @@ test_suite_config:
                           storage_offset: 46080
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26417,14 +26417,14 @@ test_suite_config:
                           storage_offset: 47616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 50331648
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26438,14 +26438,14 @@ test_suite_config:
                           storage_offset: 53760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 51904512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26459,14 +26459,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 53477376
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26480,14 +26480,14 @@ test_suite_config:
                           storage_offset: 61440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 58195968
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26501,14 +26501,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 59768832
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26522,14 +26522,14 @@ test_suite_config:
                           storage_offset: 62976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 61341696
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26543,14 +26543,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 62914560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26564,14 +26564,14 @@ test_suite_config:
                           storage_offset: 64512
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 64487424
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26585,14 +26585,14 @@ test_suite_config:
                           storage_offset: 66048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 66060288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26606,14 +26606,14 @@ test_suite_config:
                           storage_offset: 66048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 67633152
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26627,14 +26627,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 69206016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26648,14 +26648,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 70778880
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26669,14 +26669,14 @@ test_suite_config:
                           storage_offset: 67584
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 72351744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26690,14 +26690,14 @@ test_suite_config:
                           storage_offset: 69120
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 73924608
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26711,14 +26711,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 75497472
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26732,14 +26732,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 77070336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26753,14 +26753,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 78643200
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26774,14 +26774,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 80216064
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26795,14 +26795,14 @@ test_suite_config:
                           storage_offset: 70656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 81788928
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26816,14 +26816,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 83361792
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26837,14 +26837,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 84934656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26858,14 +26858,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 86507520
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26879,14 +26879,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 88080384
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26900,14 +26900,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 89653248
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26921,14 +26921,14 @@ test_suite_config:
                           storage_offset: 81408
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 91226112
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26942,14 +26942,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 92798976
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26963,14 +26963,14 @@ test_suite_config:
                           storage_offset: 87552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 94371840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -26984,14 +26984,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 95944704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27005,14 +27005,14 @@ test_suite_config:
                           storage_offset: 95232
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 97517568
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27026,14 +27026,14 @@ test_suite_config:
                           storage_offset: 99840
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 1536]
                           stride: [1536, 1]
                           storage_offset: 99090432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27459,14 +27459,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27480,14 +27480,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 786432
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27501,14 +27501,14 @@ test_suite_config:
                           storage_offset: 1536
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 1572864
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27522,14 +27522,14 @@ test_suite_config:
                           storage_offset: 2560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 2359296
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27543,14 +27543,14 @@ test_suite_config:
                           storage_offset: 5632
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3145728
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27564,14 +27564,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 3932160
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27585,14 +27585,14 @@ test_suite_config:
                           storage_offset: 6656
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 4718592
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27606,14 +27606,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 5505024
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27627,14 +27627,14 @@ test_suite_config:
                           storage_offset: 7680
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 6291456
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27648,14 +27648,14 @@ test_suite_config:
                           storage_offset: 8192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7077888
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27669,14 +27669,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 7864320
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27690,14 +27690,14 @@ test_suite_config:
                           storage_offset: 8704
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 8650752
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27711,14 +27711,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 9437184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27732,14 +27732,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 10223616
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27753,14 +27753,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11010048
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27774,14 +27774,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 11796480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27795,14 +27795,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 12582912
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27816,14 +27816,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 13369344
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27837,14 +27837,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14155776
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27858,14 +27858,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 14942208
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27879,14 +27879,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 15728640
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27900,14 +27900,14 @@ test_suite_config:
                           storage_offset: 12288
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18087936
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27921,14 +27921,14 @@ test_suite_config:
                           storage_offset: 13824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 18874368
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27942,14 +27942,14 @@ test_suite_config:
                           storage_offset: 14336
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 19660800
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27963,14 +27963,14 @@ test_suite_config:
                           storage_offset: 14848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22020096
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -27984,14 +27984,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 22806528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28005,14 +28005,14 @@ test_suite_config:
                           storage_offset: 15872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25165824
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28026,14 +28026,14 @@ test_suite_config:
                           storage_offset: 17920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 25952256
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28047,14 +28047,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 26738688
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28068,14 +28068,14 @@ test_suite_config:
                           storage_offset: 20480
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29097984
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28089,14 +28089,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 29884416
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28110,14 +28110,14 @@ test_suite_config:
                           storage_offset: 20992
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 30670848
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28131,14 +28131,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 31457280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28152,14 +28152,14 @@ test_suite_config:
                           storage_offset: 21504
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 32243712
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28173,14 +28173,14 @@ test_suite_config:
                           storage_offset: 22016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33030144
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28194,14 +28194,14 @@ test_suite_config:
                           storage_offset: 22016
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 33816576
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28215,14 +28215,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 34603008
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28236,14 +28236,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 35389440
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28257,14 +28257,14 @@ test_suite_config:
                           storage_offset: 22528
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36175872
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28278,14 +28278,14 @@ test_suite_config:
                           storage_offset: 23040
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 36962304
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28299,14 +28299,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 37748736
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28320,14 +28320,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 38535168
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28341,14 +28341,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 39321600
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28362,14 +28362,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40108032
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28383,14 +28383,14 @@ test_suite_config:
                           storage_offset: 23552
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 40894464
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28404,14 +28404,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 41680896
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28425,14 +28425,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 42467328
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28446,14 +28446,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 43253760
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28467,14 +28467,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44040192
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28488,14 +28488,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 44826624
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28509,14 +28509,14 @@ test_suite_config:
                           storage_offset: 27136
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 45613056
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28530,14 +28530,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 46399488
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28551,14 +28551,14 @@ test_suite_config:
                           storage_offset: 29184
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47185920
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28572,14 +28572,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 47972352
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28593,14 +28593,14 @@ test_suite_config:
                           storage_offset: 31744
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 48758784
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -28614,14 +28614,14 @@ test_suite_config:
                           storage_offset: 33280
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1536, 512]
                           stride: [512, 1]
                           storage_offset: 49545216
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006
                     in forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
                   tags:
@@ -29045,14 +29045,14 @@ test_suite_config:
                           storage_offset: 15360
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [100352, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509
                     in torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -29514,14 +29514,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [100352, 1536]
                           stride: [1536, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509
                     in torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
@@ -30686,3 +30686,4 @@ test_suite_config:
                   tags:
                     - constant
                     - torch.Tensor.expand.11_spyre
+cases: []

--- a/tests/configs/model_ops_tests/ministral_3_14B_Instruct_2512_spyre.yaml
+++ b/tests/configs/model_ops_tests/ministral_3_14B_Instruct_2512_spyre.yaml
@@ -1,7 +1,7 @@
 test_suite_config:
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: xfail
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db
@@ -39,7 +39,6 @@ test_suite_config:
                       - value: 2.0
                       - value: false
                       - value: false
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L329 in
@@ -54,7 +53,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (None, slice(None, None, None), None)
-
                 - name: torch.float
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L329 in
                     forward, code: inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)'
@@ -67,7 +65,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.Tensor.expand
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L329 in
@@ -84,7 +81,6 @@ test_suite_config:
                       - value: 1
                       - value: -1
                       - value: 1
-
                 - name: torch.to
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L329 in
@@ -99,7 +95,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: cuda:0
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L330 in
@@ -116,7 +111,6 @@ test_suite_config:
                           init_args:
                             high: 1000
                       - py: (slice(None, None, None), None, slice(None, None, None))
-
                 - name: torch.float
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L330 in
                     forward, code: position_ids_expanded = position_ids[:, None, :].float()'
@@ -131,7 +125,6 @@ test_suite_config:
                           init: randint
                           init_args:
                             high: 1000
-
                 - name: torch.float
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
@@ -144,7 +137,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.matmul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
@@ -156,15 +148,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 14]
                           stride: [14, 14, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
-
+                          init: xavier
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
@@ -180,7 +171,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.cat
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L335 in
@@ -202,7 +192,6 @@ test_suite_config:
                             init: rand
                     kwargs:
                       dim: -1
-
                 - name: torch.cos
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L336 in
                     forward, code: cos = emb.cos() * self.attention_scaling'
@@ -215,7 +204,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L336 in
@@ -230,7 +218,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 1.0
-
                 - name: torch.sin
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L337 in
                     forward, code: sin = emb.sin() * self.attention_scaling'
@@ -243,7 +230,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.to
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L339 in
                     forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
@@ -258,7 +244,6 @@ test_suite_config:
                           init: rand
                     kwargs:
                       dtype: torch.float16
-
                 - name: torch._C._log_api_usage_once
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L405 in
@@ -266,7 +251,6 @@ test_suite_config:
                   sample_inputs_func:
                     args:
                       - value: python.nn_module
-
                 - name: torch.pow
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L207 in
@@ -281,7 +265,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 2
-
                 - name: torch.mean
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L207 in
@@ -298,7 +281,6 @@ test_suite_config:
                       - value: -1
                     kwargs:
                       keepdim: true
-
                 - name: torch.add
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L208 in
@@ -313,7 +295,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 1.0e-05
-
                 - name: torch.rsqrt
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L208 in
                     forward, code: hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
@@ -326,7 +307,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L208 in
                     forward, code: hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
@@ -346,7 +326,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L209 in
                     forward, code: return self.weight * hidden_states.to(input_dtype)'
@@ -366,7 +345,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
@@ -379,16 +357,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.Tensor.view
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
@@ -403,7 +380,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: (1, 14, -1, 128)
-
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
@@ -419,7 +395,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
@@ -432,16 +407,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.Tensor.view
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
@@ -456,7 +430,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: (1, 14, -1, 128)
-
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
@@ -472,7 +445,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.unsqueeze
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L61 in
@@ -487,7 +459,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L63 in
                     apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)'
@@ -507,7 +478,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L37 in
@@ -522,7 +492,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (Ellipsis, slice(None, 64, None))
-
                 - name: torch.neg
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
                     rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
@@ -535,7 +504,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.cat
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
@@ -557,7 +525,6 @@ test_suite_config:
                             init: rand
                     kwargs:
                       dim: -1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L63 in
                     apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)'
@@ -577,7 +544,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.add
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L63 in
                     apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)'
@@ -597,7 +563,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L64 in
                     apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)'
@@ -617,7 +582,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L37 in
@@ -632,7 +596,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (Ellipsis, slice(None, 64, None))
-
                 - name: torch.neg
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
                     rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
@@ -645,7 +608,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.cat
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
@@ -667,7 +629,6 @@ test_suite_config:
                             init: rand
                     kwargs:
                       dim: -1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L64 in
                     apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)'
@@ -687,7 +648,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.add
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L64 in
                     apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)'
@@ -707,7 +667,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.truediv
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
@@ -724,7 +683,6 @@ test_suite_config:
                           init_args:
                             high: 1000
                       - value: 16384
-
                 - name: torch.floor
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
                     _get_llama_4_attn_scale, code: scaling = 1 + beta * torch.log(1 + torch.floor(positions_ids / max_position_embeddings))'
@@ -737,7 +695,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.add
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
@@ -752,7 +709,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.log
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
                     _get_llama_4_attn_scale, code: scaling = 1 + beta * torch.log(1 + torch.floor(positions_ids / max_position_embeddings))'
@@ -765,7 +721,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
@@ -780,7 +735,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.unsqueeze
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L107 in
@@ -795,7 +749,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: -1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L146 in
                     forward, code: query_states = query_states * _get_llama_4_attn_scale('
@@ -815,7 +768,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.zeros
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L290 in lazy_initialization, code:
@@ -826,7 +778,6 @@ test_suite_config:
                     kwargs:
                       dtype: torch.float16
                       device: cuda:0
-
                 - name: torch.index_copy_
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340 in update, code: self.keys.index_copy_(2,
@@ -857,7 +808,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24 in repeat_kv,
@@ -872,7 +822,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (slice(None, None, None), slice(None, None, None), None, slice(None, None, None), slice(None, None, None))
-
                 - name: torch.Tensor.expand
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L24 in repeat_kv,
@@ -891,7 +840,6 @@ test_suite_config:
                       - value: 4
                       - value: 2048
                       - value: 128
-
                 - name: torch.reshape
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L25 in repeat_kv,
@@ -906,7 +854,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: (1, 32, 2048, 128)
-
                 - name: torch.nn.functional.scaled_dot_product_attention
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
@@ -937,7 +884,6 @@ test_suite_config:
                       dropout_p: 0.0
                       scale: 0.08838834764831845
                       is_causal: false
-
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
@@ -953,7 +899,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.Tensor.contiguous
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
@@ -966,7 +911,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.reshape
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L173 in
@@ -981,7 +925,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: (1, 14, -1)
-
                 - name: torch.Tensor.contiguous
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L173 in
                     forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
@@ -994,7 +937,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in
@@ -1007,16 +949,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.add
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L248 in
                     forward, code: hidden_states = residual + hidden_states'
@@ -1036,7 +977,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
@@ -1049,16 +989,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [16384, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.nn.functional.silu
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103 in forward, code: return nn.functional.silu(input)'
                   sample_inputs_func:
@@ -1070,7 +1009,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -1090,7 +1028,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
@@ -1103,16 +1040,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 16384]
                           stride: [16384, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
@@ -1127,7 +1063,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
@@ -1140,18 +1075,16 @@ test_suite_config:
                           storage_offset: 66560
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [131072, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 # ── Decode pass (sequence length = 1) ────────────────────────
-
                 - name: torch.nn.functional.embedding
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L311 in forward,
@@ -1179,7 +1112,6 @@ test_suite_config:
                       - value: 2.0
                       - value: false
                       - value: false
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L330 in
@@ -1196,7 +1128,6 @@ test_suite_config:
                           init_args:
                             high: 1000
                       - py: (slice(None, None, None), None, slice(None, None, None))
-
                 - name: torch.float
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L330 in
                     forward, code: position_ids_expanded = position_ids[:, None, :].float()'
@@ -1211,7 +1142,6 @@ test_suite_config:
                           init: randint
                           init_args:
                             high: 1000
-
                 - name: torch.float
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
@@ -1224,7 +1154,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.matmul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
                     forward, code: freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
@@ -1236,15 +1165,14 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1, 1, 1]
                           stride: [1, 1, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
-
+                          init: xavier
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in
@@ -1260,7 +1188,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.cat
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L335 in
@@ -1282,7 +1209,6 @@ test_suite_config:
                             init: rand
                     kwargs:
                       dim: -1
-
                 - name: torch.cos
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L336 in
                     forward, code: cos = emb.cos() * self.attention_scaling'
@@ -1295,7 +1221,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L336 in
@@ -1310,7 +1235,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 1.0
-
                 - name: torch.sin
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L337 in
                     forward, code: sin = emb.sin() * self.attention_scaling'
@@ -1323,7 +1247,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.to
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L339 in
                     forward, code: return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)'
@@ -1338,7 +1261,6 @@ test_suite_config:
                           init: rand
                     kwargs:
                       dtype: torch.float16
-
                 - name: torch.pow
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L207 in
@@ -1353,7 +1275,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 2
-
                 - name: torch.mean
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L207 in
@@ -1370,7 +1291,6 @@ test_suite_config:
                       - value: -1
                     kwargs:
                       keepdim: true
-
                 - name: torch.add
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L208 in
@@ -1385,7 +1305,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 1.0e-05
-
                 - name: torch.rsqrt
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L208 in
                     forward, code: hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
@@ -1398,7 +1317,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L208 in
                     forward, code: hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)'
@@ -1418,7 +1336,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L209 in
                     forward, code: return self.weight * hidden_states.to(input_dtype)'
@@ -1438,7 +1355,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
@@ -1451,16 +1367,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [4096, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.Tensor.view
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
@@ -1475,7 +1390,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: (1, 1, -1, 128)
-
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in
@@ -1491,7 +1405,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
@@ -1504,16 +1417,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [1024, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.Tensor.view
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
@@ -1528,7 +1440,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: (1, 1, -1, 128)
-
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in
@@ -1544,7 +1455,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.unsqueeze
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L61 in
@@ -1559,7 +1469,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: 1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L63 in
                     apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)'
@@ -1579,7 +1488,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L37 in
@@ -1594,7 +1502,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (Ellipsis, slice(None, 64, None))
-
                 - name: torch.neg
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
                     rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
@@ -1607,7 +1514,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.cat
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
@@ -1629,7 +1535,6 @@ test_suite_config:
                             init: rand
                     kwargs:
                       dim: -1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L63 in
                     apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)'
@@ -1649,7 +1554,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.add
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L63 in
                     apply_rotary_pos_emb, code: q_embed = (q * cos) + (rotate_half(q) * sin)'
@@ -1669,7 +1573,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L64 in
                     apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)'
@@ -1689,7 +1592,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L37 in
@@ -1704,7 +1606,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (Ellipsis, slice(None, 64, None))
-
                 - name: torch.neg
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
                     rotate_half, code: return torch.cat((-x2, x1), dim=-1)'
@@ -1717,7 +1618,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.cat
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L39 in
@@ -1739,7 +1639,6 @@ test_suite_config:
                             init: rand
                     kwargs:
                       dim: -1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L64 in
                     apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)'
@@ -1759,7 +1658,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.add
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L64 in
                     apply_rotary_pos_emb, code: k_embed = (k * cos) + (rotate_half(k) * sin)'
@@ -1779,7 +1677,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.truediv
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
@@ -1796,7 +1693,6 @@ test_suite_config:
                           init_args:
                             high: 1000
                       - value: 16384
-
                 - name: torch.floor
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
                     _get_llama_4_attn_scale, code: scaling = 1 + beta * torch.log(1 + torch.floor(positions_ids / max_position_embeddings))'
@@ -1809,7 +1705,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.add
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
@@ -1824,7 +1719,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.log
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
                     _get_llama_4_attn_scale, code: scaling = 1 + beta * torch.log(1 + torch.floor(positions_ids / max_position_embeddings))'
@@ -1837,7 +1731,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L106 in
@@ -1852,7 +1745,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.unsqueeze
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L107 in
@@ -1867,7 +1759,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: -1
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L146 in
                     forward, code: query_states = query_states * _get_llama_4_attn_scale('
@@ -1887,7 +1778,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.index_copy_
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L340 in update, code: self.keys.index_copy_(2,
@@ -1918,7 +1808,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.index_copy_
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/cache_utils.py#L341 in update, code: self.values.index_copy_(2,
@@ -1949,7 +1838,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.scaled_dot_product_attention
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L92 in sdpa_attention_forward,
                     code: attn_output = torch.nn.functional.scaled_dot_product_attention('
@@ -1980,7 +1868,6 @@ test_suite_config:
                       dropout_p: 0.0
                       scale: 0.08838834764831845
                       is_causal: false
-
                 - name: torch.transpose
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
@@ -1996,7 +1883,6 @@ test_suite_config:
                           init: rand
                       - value: 1
                       - value: 2
-
                 - name: torch.Tensor.contiguous
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/sdpa_attention.py#L102 in sdpa_attention_forward,
                     code: attn_output = attn_output.transpose(1, 2).contiguous()'
@@ -2009,7 +1895,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.reshape
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L173 in
@@ -2024,7 +1909,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - value: (1, 1, -1)
-
                 - name: torch.Tensor.contiguous
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L173 in
                     forward, code: attn_output = attn_output.reshape(*input_shape, -1).contiguous()'
@@ -2037,7 +1921,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in
@@ -2050,16 +1933,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 4096]
                           stride: [4096, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.add
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L248 in
                     forward, code: hidden_states = residual + hidden_states'
@@ -2079,7 +1961,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
@@ -2092,16 +1973,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [16384, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.nn.functional.silu
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/activations.py#L103 in forward, code: return nn.functional.silu(input)'
                   sample_inputs_func:
@@ -2113,7 +1993,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.mul
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
                     forward, code: down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
@@ -2133,7 +2012,6 @@ test_suite_config:
                           dtype: torch.float16
                           device: cuda:0
                           init: rand
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in
@@ -2146,16 +2024,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [5120, 16384]
                           stride: [16384, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
                 - name: torch.getitem
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
@@ -2170,7 +2047,6 @@ test_suite_config:
                           device: cuda:0
                           init: rand
                       - py: (slice(None, None, None), slice(-1, None, None), slice(None, None, None))
-
                 - name: torch.nn.functional.linear
                   tags: [constant]
                   description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward,
@@ -2183,16 +2059,15 @@ test_suite_config:
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - tensor:
                           shape: [131072, 5120]
                           stride: [5120, 1]
                           storage_offset: 0
                           dtype: torch.float16
                           device: cuda:0
-                          init: rand
+                          init: xavier
                       - value: null
-
   global:
     supported_dtypes:
       - name: float16
@@ -2201,3 +2076,4 @@ test_suite_config:
           rtol: 0.005
     input_config:
       seed: 123
+cases: []

--- a/tests/configs/model_ops_tests/ministral_3_14B_Instruct_2512_spyre.yaml
+++ b/tests/configs/model_ops_tests/ministral_3_14B_Instruct_2512_spyre.yaml
@@ -1,7 +1,7 @@
 test_suite_config:
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/models/test_model_ops_v2.py
-      unlisted_test_mode: xfail
+      unlisted_test_mode: skip
       tests:
         - names:
             - TestSpyreModelOps::test_model_ops_db

--- a/tests/models/runner.py
+++ b/tests/models/runner.py
@@ -85,7 +85,9 @@ def make_tensor_from_conf(
     init_args = dict(tconf.get("init_args", {}))
 
     with torch.random.fork_rng(devices=[]):
-        assert init == "rand" or init == "randint", f"Unknown init: {init}"
+        assert init == "rand" or init == "randint" or init == "xavier", (
+            f"Unknown init: {init}"
+        )
         if seed is not None:
             torch.manual_seed(int(seed))
         if init == "rand":
@@ -93,8 +95,11 @@ def make_tensor_from_conf(
             high = int(init_args.get("high", 1))
             if low > high:
                 raise ValueError(
-                    "Invalid value (high for randint): must be larger than low"
+                    "Invalid value (high for rand): must be larger than low"
                 )
+            t = torch.testing.make_tensor(
+                tuple(shape), dtype=dtype, device="cpu", high=high, low=low
+            )
         elif init == "randint":
             low = int(init_args.get("low", 0))
             high = int(init_args.get("high", -1))
@@ -102,11 +107,15 @@ def make_tensor_from_conf(
                 raise ValueError(
                     "Invalid value (high for randint): must be provided (via init_args) and must be positive"
                 )
+            t = torch.testing.make_tensor(
+                tuple(shape), dtype=dtype, device="cpu", high=high, low=low
+            )
+        elif init == "xavier":
+            t = torch.nn.init.xavier_uniform_(
+                torch.empty(tuple(shape), dtype=dtype, device="cpu")
+            )
         else:
             raise ValueError(f"Unknown init: {init}")
-        t = torch.testing.make_tensor(
-            tuple(shape), dtype=dtype, device="cpu", high=high, low=low
-        )
 
     return t
 

--- a/tests/oot_test_config_models.py
+++ b/tests/oot_test_config_models.py
@@ -109,6 +109,8 @@ class InputTensorSpec(BaseModel):
             len(self.shape) != 2 or self.shape[0] != self.shape[1]
         ):
             raise ValueError(f"eye requires a square 2-D shape, got {self.shape}")
+        if self.init == "xavier" and len(self.shape) < 2:
+            raise ValueError(f"xavier requires 2-D or larger shape, got {self.shape}")
         if self.stride is not None and len(self.stride) != len(self.shape):
             raise ValueError(
                 f"stride length {len(self.stride)} must match shape length {len(self.shape)}"
@@ -142,6 +144,8 @@ class InputTensorSpec(BaseModel):
             return torch.arange(shape[0], dtype=dtype)
         elif init == "eye":
             return torch.eye(shape[0], dtype=dtype)
+        elif init == "xavier":
+            return torch.nn.init.xavier_uniform_(torch.empty(shape, dtype=dtype))
         elif init == "full":
             return torch.full(shape, ia.fill_value, dtype=dtype)
         elif init == "zeros":

--- a/tests/oot_test_constants.py
+++ b/tests/oot_test_constants.py
@@ -68,6 +68,7 @@ _VALID_INIT_STRATEGIES = {
     "ones",
     "randint",
     "arange",
+    "xavier",
     "eye",
     "full",
     "file",

--- a/tests/resource/models/Meta-Llama-3.1-8B-Instruct.yaml
+++ b/tests/resource/models/Meta-Llama-3.1-8B-Instruct.yaml
@@ -149,14 +149,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 12]
           stride: [12, 12, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
       (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -408,15 +408,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -464,15 +463,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -964,15 +962,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [14336, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1019,15 +1016,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 14336]
           stride: [14336, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1058,15 +1054,14 @@ cases:
           storage_offset: 45056
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [128256, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
@@ -1153,14 +1148,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
       (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -1405,15 +1400,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -1461,15 +1455,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -1911,15 +1904,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L291 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks:
@@ -1954,15 +1946,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [14336, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -2009,15 +2000,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 14336]
           stride: [14336, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -2048,15 +2038,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [128256, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:

--- a/tests/resource/models/Meta-Llama-3.1-8B-Instruct_spyre.yaml
+++ b/tests/resource/models/Meta-Llama-3.1-8B-Instruct_spyre.yaml
@@ -139,14 +139,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 12]
           stride: [12, 12, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
       (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.1_spyre
@@ -375,15 +375,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -425,15 +424,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -885,15 +883,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [14336, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -936,15 +933,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 14336]
           stride: [14336, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -971,15 +967,14 @@ cases:
           storage_offset: 45056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [128256, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant
@@ -1061,14 +1056,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L130 in forward, code: freqs =
       (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.5_spyre
@@ -1290,15 +1285,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L263 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -1340,15 +1334,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L264 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -1755,15 +1748,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L291 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks: constant
@@ -1795,15 +1787,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [14336, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -1846,15 +1837,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 14336]
           stride: [14336, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L183 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -1881,15 +1871,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [128256, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/llama/modeling_llama.py#L501 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant

--- a/tests/resource/models/Ministral-3-14B-Instruct-2512.yaml
+++ b/tests/resource/models/Ministral-3-14B-Instruct-2512.yaml
@@ -149,14 +149,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 14]
           stride: [14, 14, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in forward, code:
       freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -376,15 +376,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in forward, code:
       query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -432,15 +431,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in forward, code:
       key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -1022,15 +1020,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in forward, code:
       attn_output = self.o_proj(attn_output)'
     marks:
@@ -1065,15 +1062,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [16384, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1120,15 +1116,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 16384]
           stride: [16384, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1159,15 +1154,14 @@ cases:
           storage_offset: 66560
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
@@ -1254,14 +1248,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in forward, code:
       freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -1474,15 +1468,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in forward, code:
       query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -1530,15 +1523,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in forward, code:
       key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -2090,15 +2082,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in forward, code:
       attn_output = self.o_proj(attn_output)'
     marks:
@@ -2133,15 +2124,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [16384, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -2188,15 +2178,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 16384]
           stride: [16384, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -2227,15 +2216,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:

--- a/tests/resource/models/Ministral-3-14B-Instruct-2512_spyre.yaml
+++ b/tests/resource/models/Ministral-3-14B-Instruct-2512_spyre.yaml
@@ -139,14 +139,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 14]
           stride: [14, 14, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in forward, code:
       freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.1_spyre
@@ -347,15 +347,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in forward, code:
       query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -397,15 +396,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in forward, code:
       key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -939,15 +937,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in forward, code:
       attn_output = self.o_proj(attn_output)'
     marks: constant
@@ -979,15 +976,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [16384, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -1030,15 +1026,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 16384]
           stride: [16384, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -1065,15 +1060,14 @@ cases:
           storage_offset: 66560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant
@@ -1155,14 +1149,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L334 in forward, code:
       freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.5_spyre
@@ -1356,15 +1350,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L140 in forward, code:
       query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -1406,15 +1399,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L141 in forward, code:
       key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -1922,15 +1914,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L174 in forward, code:
       attn_output = self.o_proj(attn_output)'
     marks: constant
@@ -1962,15 +1953,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [16384, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -2013,15 +2003,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 16384]
           stride: [16384, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/ministral3/modeling_ministral3.py#L190 in forward, code:
       down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -2048,15 +2037,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant

--- a/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506.yaml
+++ b/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506.yaml
@@ -522,15 +522,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/pixtral/modeling_pixtral.py#L228 in forward, code: query_states
       = self.q_proj(hidden_states)'
     marks:
@@ -819,15 +818,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/pixtral/modeling_pixtral.py#L275 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -874,15 +872,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/pixtral/modeling_pixtral.py#L275 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1103,15 +1100,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L121 in torch_dynamo_resume_in_forward_at_120,
       code: hidden_states = self.linear_1(image_features)'
     marks:
@@ -1138,15 +1134,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L123 in torch_dynamo_resume_in_forward_at_120,
       code: hidden_states = self.linear_2(hidden_states)'
     marks:
@@ -1459,14 +1454,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 855]
           stride: [855, 855, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L324 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -1686,15 +1681,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L151 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -1742,15 +1736,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L152 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -2222,15 +2215,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L180 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks:
@@ -2265,15 +2257,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32768, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -2320,15 +2311,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 32768]
           stride: [32768, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -2359,15 +2349,14 @@ cases:
           storage_offset: 4372480
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in torch_dynamo_resume_in_forward_at_447,
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
@@ -2454,14 +2443,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L324 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -2674,15 +2663,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L151 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -2730,15 +2718,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L152 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -3180,15 +3167,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L180 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks:
@@ -3223,15 +3209,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32768, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -3278,15 +3263,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 32768]
           stride: [32768, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -3317,15 +3301,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:

--- a/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
+++ b/tests/resource/models/Mistral-Small-3.2-24B-Instruct-2506_spyre.yaml
@@ -487,15 +487,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/pixtral/modeling_pixtral.py#L228 in forward, code: query_states
       = self.q_proj(hidden_states)'
     marks: constant
@@ -760,15 +759,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/pixtral/modeling_pixtral.py#L275 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -811,15 +809,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/pixtral/modeling_pixtral.py#L275 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -1027,15 +1024,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L121 in torch_dynamo_resume_in_forward_at_120,
       code: hidden_states = self.linear_1(image_features)'
     marks: constant
@@ -1059,15 +1055,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L123 in torch_dynamo_resume_in_forward_at_120,
       code: hidden_states = self.linear_2(hidden_states)'
     marks: constant
@@ -1363,14 +1358,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 855]
           stride: [855, 855, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L324 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.3_spyre
@@ -1571,15 +1566,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L151 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -1621,15 +1615,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L152 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -2062,15 +2055,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L180 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks: constant
@@ -2102,15 +2094,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32768, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -2153,15 +2144,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 32768]
           stride: [32768, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -2188,15 +2178,14 @@ cases:
           storage_offset: 4372480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in torch_dynamo_resume_in_forward_at_447,
       code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant
@@ -2278,14 +2267,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L324 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.7_spyre
@@ -2479,15 +2468,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L151 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -2529,15 +2517,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L152 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -2944,15 +2931,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L180 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks: constant
@@ -2984,15 +2970,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32768, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -3035,15 +3020,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [5120, 32768]
           stride: [32768, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral/modeling_mistral.py#L47 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -3070,15 +3054,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [131072, 5120]
           stride: [5120, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/mistral3/modeling_mistral3.py#L466 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant

--- a/tests/resource/models/gpt-oss-20b.yaml
+++ b/tests/resource/models/gpt-oss-20b.yaml
@@ -149,14 +149,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 11]
           stride: [11, 11, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -333,14 +333,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096]
           stride: [1]
@@ -393,14 +393,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512]
           stride: [1]
@@ -898,14 +898,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 128]
           stride: [524288, 8192, 1, 64]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
     marks: bf16operation
@@ -1116,14 +1116,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 128, 64]
           stride: [524288, 8192, 64, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
     marks: bf16operation
@@ -1195,14 +1195,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880]
           stride: [1]
@@ -1258,14 +1258,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32]
           stride: [1]
@@ -1590,14 +1590,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [44, 2880, 5760]
           stride: [16588800, 5760, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
     marks: bf16operation
@@ -1759,14 +1759,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [44, 2880, 2880]
           stride: [8294400, 2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
     marks: bf16operation
@@ -2056,14 +2056,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 2048]
           stride: [8388608, 131072, 1, 64]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
     marks: bf16operation
@@ -2217,14 +2217,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 2048, 64]
           stride: [8388608, 131072, 64, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
     marks: bf16operation
@@ -2253,15 +2253,14 @@ cases:
           storage_offset: 28800
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [201088, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
@@ -2348,14 +2347,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -2532,14 +2531,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096]
           stride: [1]
@@ -2592,14 +2591,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512]
           stride: [1]
@@ -3018,14 +3017,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 128]
           stride: [524288, 8192, 1, 64]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
     marks: bf16operation
@@ -3201,14 +3200,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 128, 64]
           stride: [524288, 8192, 64, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
     marks: bf16operation
@@ -3280,14 +3279,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880]
           stride: [1]
@@ -3343,14 +3342,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32]
           stride: [1]
@@ -3666,14 +3665,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4, 2880, 5760]
           stride: [16588800, 5760, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
     marks: bf16operation
@@ -3835,14 +3834,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4, 2880, 2880]
           stride: [8294400, 2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
     marks: bf16operation
@@ -4053,14 +4052,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 2048]
           stride: [8388608, 131072, 1, 64]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
     marks: bf16operation
@@ -4214,14 +4213,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 2048, 64]
           stride: [8388608, 131072, 64, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
     marks: bf16operation
@@ -4250,15 +4249,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [201088, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:

--- a/tests/resource/models/gpt-oss-20b_spyre.yaml
+++ b/tests/resource/models/gpt-oss-20b_spyre.yaml
@@ -139,14 +139,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 11]
           stride: [11, 11, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.1_spyre
@@ -305,14 +305,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096]
           stride: [1]
@@ -360,14 +360,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512]
           stride: [1]
@@ -814,14 +814,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 128]
           stride: [524288, 8192, 1, 64]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
   - name: torch.mul.8_spyre
@@ -1011,14 +1011,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 128, 64]
           stride: [524288, 8192, 64, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
   - name: torch.transpose.5_spyre
@@ -1083,14 +1083,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880]
           stride: [1]
@@ -1142,14 +1142,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32]
           stride: [1]
@@ -1455,14 +1455,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [44, 2880, 5760]
           stride: [16588800, 5760, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
   - name: torch.squeeze.1_spyre
@@ -1610,14 +1610,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [44, 2880, 2880]
           stride: [8294400, 2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
   - name: torch.squeeze.2_spyre
@@ -1883,14 +1883,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 2048]
           stride: [8388608, 131072, 1, 64]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
   - name: torch.mul.12_spyre
@@ -2033,14 +2033,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 2048, 64]
           stride: [8388608, 131072, 64, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
   - name: torch.getitem.17_spyre
@@ -2066,15 +2066,14 @@ cases:
           storage_offset: 28800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [201088, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant
@@ -2156,14 +2155,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L206 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.7_spyre
@@ -2322,14 +2321,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096]
           stride: [1]
@@ -2377,14 +2376,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512]
           stride: [1]
@@ -2760,14 +2759,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 128]
           stride: [524288, 8192, 1, 64]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
   - name: torch.mul.20_spyre
@@ -2926,14 +2925,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 128, 64]
           stride: [524288, 8192, 64, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
   - name: torch.transpose.10_spyre
@@ -2998,14 +2997,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2880]
           stride: [1]
@@ -3057,14 +3056,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [32]
           stride: [1]
@@ -3361,14 +3360,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4, 2880, 5760]
           stride: [16588800, 5760, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
   - name: torch.squeeze.3_spyre
@@ -3516,14 +3515,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4, 2880, 2880]
           stride: [8294400, 2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/integrations/moe.py#L91 in _batched_linear, code: out = torch.bmm(input.unsqueeze(1),
       weight).squeeze(1)'
   - name: torch.squeeze.4_spyre
@@ -3718,14 +3717,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 64, 2048]
           stride: [8388608, 131072, 1, 64]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L257 in eager_attention_forward,
       code: attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling'
   - name: torch.mul.24_spyre
@@ -3868,14 +3867,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 64, 2048, 64]
           stride: [8388608, 131072, 64, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L271 in eager_attention_forward,
       code: attn_output = torch.matmul(attn_weights, value_states)'
   - name: torch.getitem.31_spyre
@@ -3901,15 +3900,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [201088, 2880]
           stride: [2880, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L675 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant

--- a/tests/resource/models/granite-3.3-8b-instruct-fms.yaml
+++ b/tests/resource/models/granite-3.3-8b-instruct-fms.yaml
@@ -80,15 +80,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:443 in forward, code: queries = self.query(q)'
     marks:
       - bf16operation
@@ -102,15 +101,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:444 in forward, code: keys = self.key(k)'
     marks:
       - bf16operation
@@ -605,15 +603,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:294 in forward, code: out = self.a(self.wg(x)) * self.w1(x)'
     marks:
       - bf16operation
@@ -660,15 +657,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:297 in forward, code: return self.w2(out)'
     marks:
       - bf16operation
@@ -1884,15 +1880,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cpu
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cpu
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/models/granite.py:381 in torch_dynamo_resume_in_forward_at_380, code: preds = self.head(output.to("cpu")).to("cuda")'
     marks:
       - bf16operation
@@ -2004,15 +1999,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:443 in forward, code: queries = self.query(q)'
     marks:
       - bf16operation
@@ -2026,15 +2020,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:444 in forward, code: keys = self.key(k)'
     marks:
       - bf16operation
@@ -2556,15 +2549,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:294 in forward, code: out = self.a(self.wg(x)) * self.w1(x)'
     marks:
       - bf16operation
@@ -2611,15 +2603,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:297 in forward, code: return self.w2(out)'
     marks:
       - bf16operation
@@ -3819,15 +3810,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cpu
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cpu
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/models/granite.py:381 in torch_dynamo_resume_in_forward_at_380, code: preds = self.head(output.to("cpu")).to("cuda")'
     marks:
       - bf16operation

--- a/tests/resource/models/granite-3.3-8b-instruct-fms_spyre.yaml
+++ b/tests/resource/models/granite-3.3-8b-instruct-fms_spyre.yaml
@@ -74,15 +74,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:443 in forward, code: queries = self.query(q)'
     marks: constant
   - name: torch.nn.functional.linear.2_spyre
@@ -94,15 +93,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:444 in forward, code: keys = self.key(k)'
     marks: constant
   - name: torch.Tensor.view.1_spyre
@@ -550,15 +548,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:294 in forward, code: out = self.a(self.wg(x)) * self.w1(x)'
     marks: constant
   - name: torch.nn.functional.silu.1_spyre
@@ -601,15 +598,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:297 in forward, code: return self.w2(out)'
     marks: constant
   - name: torch.nn.functional.scaled_dot_product_attention.2_spyre
@@ -1782,15 +1778,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cpu
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cpu
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/models/granite.py:381 in torch_dynamo_resume_in_forward_at_380, code: preds = self.head(output.to("cpu")).to("cuda")'
     marks:
       - constant
@@ -1892,15 +1887,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:443 in forward, code: queries = self.query(q)'
     marks: constant
   - name: torch.nn.functional.linear.7_spyre
@@ -1912,15 +1906,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/attention.py:444 in forward, code: keys = self.key(k)'
     marks: constant
   - name: torch.Tensor.view.6_spyre
@@ -2393,15 +2386,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:294 in forward, code: out = self.a(self.wg(x)) * self.w1(x)'
     marks: constant
   - name: torch.nn.functional.silu.2_spyre
@@ -2444,15 +2436,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/modules/feedforward.py:297 in forward, code: return self.w2(out)'
     marks: constant
   - name: torch.nn.functional.scaled_dot_product_attention.42_spyre
@@ -3610,15 +3601,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cpu
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cpu
-          init: rand
-      - value: null
+          init: xavier
     description: 'foundation-model-stack/fms/models/granite.py:381 in torch_dynamo_resume_in_forward_at_380, code: preds = self.head(output.to("cpu")).to("cuda")'
     marks:
       - constant

--- a/tests/resource/models/granite-3.3-8b-instruct.yaml
+++ b/tests/resource/models/granite-3.3-8b-instruct.yaml
@@ -165,14 +165,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 41]
           stride: [41, 41, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -392,15 +392,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -448,15 +447,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -948,15 +946,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1003,15 +1000,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1042,15 +1038,14 @@ cases:
           storage_offset: 163840
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:
@@ -1169,14 +1164,14 @@ cases:
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float32
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
     marks: fp32operation
@@ -1389,15 +1384,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -1445,15 +1439,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks:
@@ -1895,15 +1888,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L184 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks:
@@ -1938,15 +1930,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -1993,15 +1984,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks:
@@ -2032,15 +2022,14 @@ cases:
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.bfloat16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks:

--- a/tests/resource/models/granite-3.3-8b-instruct_spyre.yaml
+++ b/tests/resource/models/granite-3.3-8b-instruct_spyre.yaml
@@ -153,14 +153,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 41]
           stride: [41, 41, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.1_spyre
@@ -361,15 +361,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -411,15 +410,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -871,15 +869,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -922,15 +919,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -957,15 +953,14 @@ cases:
           storage_offset: 163840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant
@@ -1075,14 +1070,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1, 1, 1]
           stride: [1, 1, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L378 in forward, code: freqs
       = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)'
   - name: torch.transpose.5_spyre
@@ -1276,15 +1271,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L156 in forward, code: query_states
       = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -1326,15 +1320,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L157 in forward, code: key_states
       = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -1741,15 +1734,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L184 in forward, code: attn_output
       = self.o_proj(attn_output)'
     marks: constant
@@ -1781,15 +1773,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [12800, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -1832,15 +1823,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [4096, 12800]
           stride: [12800, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L221 in forward, code: down_proj
       = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))'
     marks: constant
@@ -1867,15 +1857,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [49159, 4096]
           stride: [4096, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granite/modeling_granite.py#L575 in forward, code: logits
       = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant

--- a/tests/resource/models/granite-4.0-h-tiny.yaml
+++ b/tests/resource/models/granite-4.0-h-tiny.yaml
@@ -436,15 +436,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [6448, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L639 in
       torch_forward, code: projected_states = self.in_proj(input_states)'
     marks: constant
@@ -2166,15 +2165,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 3072]
           stride: [3072, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L830 in
       torch_forward, code: contextualized_states = self.out_proj(scan_output.to(dtype))  # [batch, seq_len, hidden_size]'
     marks: constant
@@ -2234,15 +2232,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [64, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1034 in
       forward, code: logits = self.layer(hidden_states).float()  # [batch_size x seq_len, num_experts]'
     marks: constant
@@ -2951,14 +2948,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.5
@@ -2970,14 +2967,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.6
@@ -2989,14 +2986,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.7
@@ -3008,14 +3005,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.8
@@ -3027,14 +3024,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.9
@@ -3046,14 +3043,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.10
@@ -3065,14 +3062,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.11
@@ -3084,14 +3081,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.12
@@ -3103,14 +3100,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.13
@@ -3122,14 +3119,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.14
@@ -3141,14 +3138,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.15
@@ -3160,14 +3157,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.16
@@ -3179,14 +3176,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.17
@@ -3198,14 +3195,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.18
@@ -3217,14 +3214,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.19
@@ -3236,14 +3233,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.20
@@ -3255,14 +3252,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.21
@@ -3274,14 +3271,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.22
@@ -3293,14 +3290,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.23
@@ -3312,14 +3309,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.24
@@ -3331,14 +3328,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.25
@@ -3350,14 +3347,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.26
@@ -3369,14 +3366,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.27
@@ -3388,14 +3385,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.28
@@ -3407,14 +3404,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.29
@@ -3426,14 +3423,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.30
@@ -3445,14 +3442,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.31
@@ -3464,14 +3461,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.32
@@ -3483,14 +3480,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.33
@@ -3502,14 +3499,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.34
@@ -3521,14 +3518,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.35
@@ -3540,14 +3537,14 @@ cases:
           storage_offset: 38400
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.36
@@ -3559,14 +3556,14 @@ cases:
           storage_offset: 38400
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.37
@@ -3578,14 +3575,14 @@ cases:
           storage_offset: 41472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.38
@@ -3597,14 +3594,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.39
@@ -3616,14 +3613,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.40
@@ -3635,14 +3632,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.41
@@ -3654,14 +3651,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.42
@@ -3673,14 +3670,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.43
@@ -3692,14 +3689,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.44
@@ -3711,14 +3708,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.45
@@ -3730,14 +3727,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.46
@@ -3749,14 +3746,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.47
@@ -3768,14 +3765,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.48
@@ -3787,14 +3784,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.49
@@ -3806,14 +3803,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.50
@@ -3825,14 +3822,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.51
@@ -3844,14 +3841,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.52
@@ -3863,14 +3860,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.53
@@ -3882,14 +3879,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.54
@@ -3901,14 +3898,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.55
@@ -3920,14 +3917,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.56
@@ -3939,14 +3936,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.57
@@ -3958,14 +3955,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.58
@@ -3977,14 +3974,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.59
@@ -3996,14 +3993,14 @@ cases:
           storage_offset: 79872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.60
@@ -4015,14 +4012,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.61
@@ -4034,14 +4031,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.62
@@ -4053,14 +4050,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.63
@@ -4072,14 +4069,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.64
@@ -4091,14 +4088,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.65
@@ -4110,14 +4107,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.66
@@ -4129,14 +4126,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.67
@@ -4148,14 +4145,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.2
@@ -5047,14 +5044,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.69
@@ -5066,14 +5063,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.70
@@ -5085,14 +5082,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.71
@@ -5104,14 +5101,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.72
@@ -5123,14 +5120,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.73
@@ -5142,14 +5139,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.74
@@ -5161,14 +5158,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.75
@@ -5180,14 +5177,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.76
@@ -5199,14 +5196,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.77
@@ -5218,14 +5215,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.78
@@ -5237,14 +5234,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.79
@@ -5256,14 +5253,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.80
@@ -5275,14 +5272,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.81
@@ -5294,14 +5291,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.82
@@ -5313,14 +5310,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.83
@@ -5332,14 +5329,14 @@ cases:
           storage_offset: 4096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.84
@@ -5351,14 +5348,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.85
@@ -5370,14 +5367,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.86
@@ -5389,14 +5386,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.87
@@ -5408,14 +5405,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.88
@@ -5427,14 +5424,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.89
@@ -5446,14 +5443,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.90
@@ -5465,14 +5462,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.91
@@ -5484,14 +5481,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.92
@@ -5503,14 +5500,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.93
@@ -5522,14 +5519,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.94
@@ -5541,14 +5538,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.95
@@ -5560,14 +5557,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.96
@@ -5579,14 +5576,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.97
@@ -5598,14 +5595,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.98
@@ -5617,14 +5614,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.99
@@ -5636,14 +5633,14 @@ cases:
           storage_offset: 12800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.100
@@ -5655,14 +5652,14 @@ cases:
           storage_offset: 12800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.101
@@ -5674,14 +5671,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.102
@@ -5693,14 +5690,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.103
@@ -5712,14 +5709,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.104
@@ -5731,14 +5728,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.105
@@ -5750,14 +5747,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.106
@@ -5769,14 +5766,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.107
@@ -5788,14 +5785,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.108
@@ -5807,14 +5804,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.109
@@ -5826,14 +5823,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.110
@@ -5845,14 +5842,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.111
@@ -5864,14 +5861,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.112
@@ -5883,14 +5880,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.113
@@ -5902,14 +5899,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.114
@@ -5921,14 +5918,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.115
@@ -5940,14 +5937,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.116
@@ -5959,14 +5956,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.117
@@ -5978,14 +5975,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.118
@@ -5997,14 +5994,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.119
@@ -6016,14 +6013,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.120
@@ -6035,14 +6032,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.121
@@ -6054,14 +6051,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.122
@@ -6073,14 +6070,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.123
@@ -6092,14 +6089,14 @@ cases:
           storage_offset: 26624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.124
@@ -6111,14 +6108,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.125
@@ -6130,14 +6127,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.126
@@ -6149,14 +6146,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.127
@@ -6168,14 +6165,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.128
@@ -6187,14 +6184,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.129
@@ -6206,14 +6203,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.130
@@ -6225,14 +6222,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.131
@@ -6244,14 +6241,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.3
@@ -6744,15 +6741,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2048, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L894 in
       forward, code: hidden_states = self.input_linear(hidden_states)'
     marks: constant
@@ -6831,15 +6827,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L897 in
       forward, code: hidden_states = self.output_linear(hidden_states)'
     marks: constant
@@ -6852,14 +6847,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.135
@@ -6871,14 +6866,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.136
@@ -6890,14 +6885,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.137
@@ -6909,14 +6904,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.138
@@ -6928,14 +6923,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.139
@@ -6947,14 +6942,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.140
@@ -6966,14 +6961,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.141
@@ -6985,14 +6980,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.142
@@ -7004,14 +6999,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.143
@@ -7023,14 +7018,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.144
@@ -7042,14 +7037,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.145
@@ -7061,14 +7056,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.146
@@ -7080,14 +7075,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.147
@@ -7099,14 +7094,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.148
@@ -7118,14 +7113,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.149
@@ -7137,14 +7132,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.150
@@ -7156,14 +7151,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.151
@@ -7175,14 +7170,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.152
@@ -7194,14 +7189,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.153
@@ -7213,14 +7208,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.154
@@ -7232,14 +7227,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.155
@@ -7251,14 +7246,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.156
@@ -7270,14 +7265,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.157
@@ -7289,14 +7284,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.158
@@ -7308,14 +7303,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.159
@@ -7327,14 +7322,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.160
@@ -7346,14 +7341,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.161
@@ -7365,14 +7360,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.162
@@ -7384,14 +7379,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.163
@@ -7403,14 +7398,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.164
@@ -7422,14 +7417,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.165
@@ -7441,14 +7436,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.166
@@ -7460,14 +7455,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.167
@@ -7479,14 +7474,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.168
@@ -7498,14 +7493,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.169
@@ -7517,14 +7512,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.170
@@ -7536,14 +7531,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.171
@@ -7555,14 +7550,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.172
@@ -7574,14 +7569,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.173
@@ -7593,14 +7588,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.174
@@ -7612,14 +7607,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.175
@@ -7631,14 +7626,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.176
@@ -7650,14 +7645,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.177
@@ -7669,14 +7664,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.178
@@ -7688,14 +7683,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.179
@@ -7707,14 +7702,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.180
@@ -7726,14 +7721,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.181
@@ -7745,14 +7740,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.182
@@ -7764,14 +7759,14 @@ cases:
           storage_offset: 79872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.183
@@ -7783,14 +7778,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.184
@@ -7802,14 +7797,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.185
@@ -7821,14 +7816,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.186
@@ -7840,14 +7835,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.187
@@ -7859,14 +7854,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.188
@@ -7878,14 +7873,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.189
@@ -7897,14 +7892,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.190
@@ -7916,14 +7911,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.191
@@ -7935,14 +7930,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.192
@@ -7954,14 +7949,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.193
@@ -7973,14 +7968,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.194
@@ -7992,14 +7987,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.195
@@ -8011,14 +8006,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.196
@@ -8030,14 +8025,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.197
@@ -8049,14 +8044,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.4
@@ -8476,14 +8471,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.199
@@ -8495,14 +8490,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.200
@@ -8514,14 +8509,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.201
@@ -8533,14 +8528,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.202
@@ -8552,14 +8547,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.203
@@ -8571,14 +8566,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.204
@@ -8590,14 +8585,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.205
@@ -8609,14 +8604,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.206
@@ -8628,14 +8623,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.207
@@ -8647,14 +8642,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.208
@@ -8666,14 +8661,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.209
@@ -8685,14 +8680,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.210
@@ -8704,14 +8699,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.211
@@ -8723,14 +8718,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.212
@@ -8742,14 +8737,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.213
@@ -8761,14 +8756,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.214
@@ -8780,14 +8775,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.215
@@ -8799,14 +8794,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.216
@@ -8818,14 +8813,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.217
@@ -8837,14 +8832,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.218
@@ -8856,14 +8851,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.219
@@ -8875,14 +8870,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.220
@@ -8894,14 +8889,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.221
@@ -8913,14 +8908,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.222
@@ -8932,14 +8927,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.223
@@ -8951,14 +8946,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.224
@@ -8970,14 +8965,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.225
@@ -8989,14 +8984,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.226
@@ -9008,14 +9003,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.227
@@ -9027,14 +9022,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.228
@@ -9046,14 +9041,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.229
@@ -9065,14 +9060,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.230
@@ -9084,14 +9079,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.231
@@ -9103,14 +9098,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.232
@@ -9122,14 +9117,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.233
@@ -9141,14 +9136,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.234
@@ -9160,14 +9155,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.235
@@ -9179,14 +9174,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.236
@@ -9198,14 +9193,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.237
@@ -9217,14 +9212,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.238
@@ -9236,14 +9231,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.239
@@ -9255,14 +9250,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.240
@@ -9274,14 +9269,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.241
@@ -9293,14 +9288,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.242
@@ -9312,14 +9307,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.243
@@ -9331,14 +9326,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.244
@@ -9350,14 +9345,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.245
@@ -9369,14 +9364,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.246
@@ -9388,14 +9383,14 @@ cases:
           storage_offset: 26624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.247
@@ -9407,14 +9402,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.248
@@ -9426,14 +9421,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.249
@@ -9445,14 +9440,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.250
@@ -9464,14 +9459,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.251
@@ -9483,14 +9478,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.252
@@ -9502,14 +9497,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.253
@@ -9521,14 +9516,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.254
@@ -9540,14 +9535,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.255
@@ -9559,14 +9554,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.256
@@ -9578,14 +9573,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.257
@@ -9597,14 +9592,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.258
@@ -9616,14 +9611,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.259
@@ -9635,14 +9630,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.260
@@ -9654,14 +9649,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.261
@@ -9673,14 +9668,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.5
@@ -10084,14 +10079,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.263
@@ -10103,14 +10098,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.264
@@ -10122,14 +10117,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.265
@@ -10141,14 +10136,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.266
@@ -10160,14 +10155,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.267
@@ -10179,14 +10174,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.268
@@ -10198,14 +10193,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.269
@@ -10217,14 +10212,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.270
@@ -10236,14 +10231,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.271
@@ -10255,14 +10250,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.272
@@ -10274,14 +10269,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.273
@@ -10293,14 +10288,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.274
@@ -10312,14 +10307,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.275
@@ -10331,14 +10326,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.276
@@ -10350,14 +10345,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.277
@@ -10369,14 +10364,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.278
@@ -10388,14 +10383,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.279
@@ -10407,14 +10402,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.280
@@ -10426,14 +10421,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.281
@@ -10445,14 +10440,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.282
@@ -10464,14 +10459,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.283
@@ -10483,14 +10478,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.284
@@ -10502,14 +10497,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.285
@@ -10521,14 +10516,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.286
@@ -10540,14 +10535,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.287
@@ -10559,14 +10554,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.288
@@ -10578,14 +10573,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.289
@@ -10597,14 +10592,14 @@ cases:
           storage_offset: 39936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.290
@@ -10616,14 +10611,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.291
@@ -10635,14 +10630,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.292
@@ -10654,14 +10649,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.293
@@ -10673,14 +10668,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.294
@@ -10692,14 +10687,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.295
@@ -10711,14 +10706,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.296
@@ -10730,14 +10725,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.297
@@ -10749,14 +10744,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.298
@@ -10768,14 +10763,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.299
@@ -10787,14 +10782,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.300
@@ -10806,14 +10801,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.301
@@ -10825,14 +10820,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.302
@@ -10844,14 +10839,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.303
@@ -10863,14 +10858,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.304
@@ -10882,14 +10877,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.305
@@ -10901,14 +10896,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.306
@@ -10920,14 +10915,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.307
@@ -10939,14 +10934,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.308
@@ -10958,14 +10953,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.309
@@ -10977,14 +10972,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.310
@@ -10996,14 +10991,14 @@ cases:
           storage_offset: 84480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.311
@@ -11015,14 +11010,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.312
@@ -11034,14 +11029,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.313
@@ -11053,14 +11048,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.314
@@ -11072,14 +11067,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.315
@@ -11091,14 +11086,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.316
@@ -11110,14 +11105,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.317
@@ -11129,14 +11124,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.318
@@ -11148,14 +11143,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.319
@@ -11167,14 +11162,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.320
@@ -11186,14 +11181,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.6
@@ -11613,14 +11608,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.322
@@ -11632,14 +11627,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.323
@@ -11651,14 +11646,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.324
@@ -11670,14 +11665,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.325
@@ -11689,14 +11684,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.326
@@ -11708,14 +11703,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.327
@@ -11727,14 +11722,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.328
@@ -11746,14 +11741,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.329
@@ -11765,14 +11760,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.330
@@ -11784,14 +11779,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.331
@@ -11803,14 +11798,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.332
@@ -11822,14 +11817,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.333
@@ -11841,14 +11836,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.334
@@ -11860,14 +11855,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.335
@@ -11879,14 +11874,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.336
@@ -11898,14 +11893,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.337
@@ -11917,14 +11912,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.338
@@ -11936,14 +11931,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.339
@@ -11955,14 +11950,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.340
@@ -11974,14 +11969,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.341
@@ -11993,14 +11988,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.342
@@ -12012,14 +12007,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.343
@@ -12031,14 +12026,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.344
@@ -12050,14 +12045,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.345
@@ -12069,14 +12064,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.346
@@ -12088,14 +12083,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.347
@@ -12107,14 +12102,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.348
@@ -12126,14 +12121,14 @@ cases:
           storage_offset: 13312
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.349
@@ -12145,14 +12140,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.350
@@ -12164,14 +12159,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.351
@@ -12183,14 +12178,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.352
@@ -12202,14 +12197,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.353
@@ -12221,14 +12216,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.354
@@ -12240,14 +12235,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.355
@@ -12259,14 +12254,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.356
@@ -12278,14 +12273,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.357
@@ -12297,14 +12292,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.358
@@ -12316,14 +12311,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.359
@@ -12335,14 +12330,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.360
@@ -12354,14 +12349,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.361
@@ -12373,14 +12368,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.362
@@ -12392,14 +12387,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.363
@@ -12411,14 +12406,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.364
@@ -12430,14 +12425,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.365
@@ -12449,14 +12444,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.366
@@ -12468,14 +12463,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.367
@@ -12487,14 +12482,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.368
@@ -12506,14 +12501,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.369
@@ -12525,14 +12520,14 @@ cases:
           storage_offset: 28160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.370
@@ -12544,14 +12539,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.371
@@ -12563,14 +12558,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.372
@@ -12582,14 +12577,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.373
@@ -12601,14 +12596,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.374
@@ -12620,14 +12615,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.375
@@ -12639,14 +12634,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.376
@@ -12658,14 +12653,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.377
@@ -12677,14 +12672,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.378
@@ -12696,14 +12691,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.379
@@ -12715,14 +12710,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.7
@@ -13126,14 +13121,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.381
@@ -13145,14 +13140,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.382
@@ -13164,14 +13159,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.383
@@ -13183,14 +13178,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.384
@@ -13202,14 +13197,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.385
@@ -13221,14 +13216,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.386
@@ -13240,14 +13235,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.387
@@ -13259,14 +13254,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.388
@@ -13278,14 +13273,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.389
@@ -13297,14 +13292,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.390
@@ -13316,14 +13311,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.391
@@ -13335,14 +13330,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.392
@@ -13354,14 +13349,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.393
@@ -13373,14 +13368,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.394
@@ -13392,14 +13387,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.395
@@ -13411,14 +13406,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.396
@@ -13430,14 +13425,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.397
@@ -13449,14 +13444,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.398
@@ -13468,14 +13463,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.399
@@ -13487,14 +13482,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.400
@@ -13506,14 +13501,14 @@ cases:
           storage_offset: 39936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.401
@@ -13525,14 +13520,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.402
@@ -13544,14 +13539,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.403
@@ -13563,14 +13558,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.404
@@ -13582,14 +13577,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.405
@@ -13601,14 +13596,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.406
@@ -13620,14 +13615,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.407
@@ -13639,14 +13634,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.408
@@ -13658,14 +13653,14 @@ cases:
           storage_offset: 58368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.409
@@ -13677,14 +13672,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.410
@@ -13696,14 +13691,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.411
@@ -13715,14 +13710,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.412
@@ -13734,14 +13729,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.413
@@ -13753,14 +13748,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.414
@@ -13772,14 +13767,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.415
@@ -13791,14 +13786,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.416
@@ -13810,14 +13805,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.417
@@ -13829,14 +13824,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.418
@@ -13848,14 +13843,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.419
@@ -13867,14 +13862,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.420
@@ -13886,14 +13881,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.421
@@ -13905,14 +13900,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.422
@@ -13924,14 +13919,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.423
@@ -13943,14 +13938,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.424
@@ -13962,14 +13957,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.425
@@ -13981,14 +13976,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.426
@@ -14000,14 +13995,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.427
@@ -14019,14 +14014,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.428
@@ -14038,14 +14033,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.429
@@ -14057,14 +14052,14 @@ cases:
           storage_offset: 84480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.430
@@ -14076,14 +14071,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.431
@@ -14095,14 +14090,14 @@ cases:
           storage_offset: 89088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.432
@@ -14114,14 +14109,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.433
@@ -14133,14 +14128,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.434
@@ -14152,14 +14147,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.435
@@ -14171,14 +14166,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.8
@@ -14598,14 +14593,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.437
@@ -14617,14 +14612,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.438
@@ -14636,14 +14631,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.439
@@ -14655,14 +14650,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.440
@@ -14674,14 +14669,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.441
@@ -14693,14 +14688,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.442
@@ -14712,14 +14707,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.443
@@ -14731,14 +14726,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.444
@@ -14750,14 +14745,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.445
@@ -14769,14 +14764,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.446
@@ -14788,14 +14783,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.447
@@ -14807,14 +14802,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.448
@@ -14826,14 +14821,14 @@ cases:
           storage_offset: 9728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.449
@@ -14845,14 +14840,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.450
@@ -14864,14 +14859,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.451
@@ -14883,14 +14878,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.452
@@ -14902,14 +14897,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.453
@@ -14921,14 +14916,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.454
@@ -14940,14 +14935,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.455
@@ -14959,14 +14954,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.456
@@ -14978,14 +14973,14 @@ cases:
           storage_offset: 13312
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.457
@@ -14997,14 +14992,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.458
@@ -15016,14 +15011,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.459
@@ -15035,14 +15030,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.460
@@ -15054,14 +15049,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.461
@@ -15073,14 +15068,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.462
@@ -15092,14 +15087,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.463
@@ -15111,14 +15106,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.464
@@ -15130,14 +15125,14 @@ cases:
           storage_offset: 19456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.465
@@ -15149,14 +15144,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.466
@@ -15168,14 +15163,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.467
@@ -15187,14 +15182,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.468
@@ -15206,14 +15201,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.469
@@ -15225,14 +15220,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.470
@@ -15244,14 +15239,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.471
@@ -15263,14 +15258,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.472
@@ -15282,14 +15277,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.473
@@ -15301,14 +15296,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.474
@@ -15320,14 +15315,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.475
@@ -15339,14 +15334,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.476
@@ -15358,14 +15353,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.477
@@ -15377,14 +15372,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.478
@@ -15396,14 +15391,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.479
@@ -15415,14 +15410,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.480
@@ -15434,14 +15429,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.481
@@ -15453,14 +15448,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.482
@@ -15472,14 +15467,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.483
@@ -15491,14 +15486,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.484
@@ -15510,14 +15505,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.485
@@ -15529,14 +15524,14 @@ cases:
           storage_offset: 28160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.486
@@ -15548,14 +15543,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.487
@@ -15567,14 +15562,14 @@ cases:
           storage_offset: 29696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.488
@@ -15586,14 +15581,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.489
@@ -15605,14 +15600,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.490
@@ -15624,14 +15619,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.491
@@ -15643,14 +15638,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.9
@@ -16054,14 +16049,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.493
@@ -16073,14 +16068,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.494
@@ -16092,14 +16087,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.495
@@ -16111,14 +16106,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.496
@@ -16130,14 +16125,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.497
@@ -16149,14 +16144,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.498
@@ -16168,14 +16163,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.499
@@ -16187,14 +16182,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.500
@@ -16206,14 +16201,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.501
@@ -16225,14 +16220,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.502
@@ -16244,14 +16239,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.503
@@ -16263,14 +16258,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.504
@@ -16282,14 +16277,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.505
@@ -16301,14 +16296,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.506
@@ -16320,14 +16315,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.507
@@ -16339,14 +16334,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.508
@@ -16358,14 +16353,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.509
@@ -16377,14 +16372,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.510
@@ -16396,14 +16391,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.511
@@ -16415,14 +16410,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.512
@@ -16434,14 +16429,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.513
@@ -16453,14 +16448,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.514
@@ -16472,14 +16467,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.515
@@ -16491,14 +16486,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.516
@@ -16510,14 +16505,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.517
@@ -16529,14 +16524,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.518
@@ -16548,14 +16543,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.519
@@ -16567,14 +16562,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.520
@@ -16586,14 +16581,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.521
@@ -16605,14 +16600,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.522
@@ -16624,14 +16619,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.523
@@ -16643,14 +16638,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.524
@@ -16662,14 +16657,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.525
@@ -16681,14 +16676,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.526
@@ -16700,14 +16695,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.527
@@ -16719,14 +16714,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.528
@@ -16738,14 +16733,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.529
@@ -16757,14 +16752,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.530
@@ -16776,14 +16771,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.531
@@ -16795,14 +16790,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.532
@@ -16814,14 +16809,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.533
@@ -16833,14 +16828,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.534
@@ -16852,14 +16847,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.535
@@ -16871,14 +16866,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.536
@@ -16890,14 +16885,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.537
@@ -16909,14 +16904,14 @@ cases:
           storage_offset: 84480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.538
@@ -16928,14 +16923,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.539
@@ -16947,14 +16942,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.540
@@ -16966,14 +16961,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.541
@@ -16985,14 +16980,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.542
@@ -17004,14 +16999,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.10
@@ -17431,14 +17426,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.544
@@ -17450,14 +17445,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.545
@@ -17469,14 +17464,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.546
@@ -17488,14 +17483,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.547
@@ -17507,14 +17502,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.548
@@ -17526,14 +17521,14 @@ cases:
           storage_offset: 4096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.549
@@ -17545,14 +17540,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.550
@@ -17564,14 +17559,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.551
@@ -17583,14 +17578,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.552
@@ -17602,14 +17597,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.553
@@ -17621,14 +17616,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.554
@@ -17640,14 +17635,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.555
@@ -17659,14 +17654,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.556
@@ -17678,14 +17673,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.557
@@ -17697,14 +17692,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.558
@@ -17716,14 +17711,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.559
@@ -17735,14 +17730,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.560
@@ -17754,14 +17749,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.561
@@ -17773,14 +17768,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.562
@@ -17792,14 +17787,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.563
@@ -17811,14 +17806,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.564
@@ -17830,14 +17825,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.565
@@ -17849,14 +17844,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.566
@@ -17868,14 +17863,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.567
@@ -17887,14 +17882,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.568
@@ -17906,14 +17901,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.569
@@ -17925,14 +17920,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.570
@@ -17944,14 +17939,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.571
@@ -17963,14 +17958,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.572
@@ -17982,14 +17977,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.573
@@ -18001,14 +17996,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.574
@@ -18020,14 +18015,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.575
@@ -18039,14 +18034,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.576
@@ -18058,14 +18053,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.577
@@ -18077,14 +18072,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.578
@@ -18096,14 +18091,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.579
@@ -18115,14 +18110,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.580
@@ -18134,14 +18129,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.581
@@ -18153,14 +18148,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.582
@@ -18172,14 +18167,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.583
@@ -18191,14 +18186,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.584
@@ -18210,14 +18205,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.585
@@ -18229,14 +18224,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.586
@@ -18248,14 +18243,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.587
@@ -18267,14 +18262,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.588
@@ -18286,14 +18281,14 @@ cases:
           storage_offset: 28160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.589
@@ -18305,14 +18300,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.590
@@ -18324,14 +18319,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.591
@@ -18343,14 +18338,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.592
@@ -18362,14 +18357,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.593
@@ -18381,14 +18376,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.11
@@ -18792,15 +18787,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L159 in
       forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -18842,15 +18836,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L160 in
       forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -19021,14 +19014,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.597
@@ -19040,14 +19033,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.598
@@ -19059,14 +19052,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.599
@@ -19078,14 +19071,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.600
@@ -19097,14 +19090,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.601
@@ -19116,14 +19109,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.602
@@ -19135,14 +19128,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.603
@@ -19154,14 +19147,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.604
@@ -19173,14 +19166,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.605
@@ -19192,14 +19185,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.606
@@ -19211,14 +19204,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.607
@@ -19230,14 +19223,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.608
@@ -19249,14 +19242,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.609
@@ -19268,14 +19261,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.610
@@ -19287,14 +19280,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.611
@@ -19306,14 +19299,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.612
@@ -19325,14 +19318,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.613
@@ -19344,14 +19337,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.614
@@ -19363,14 +19356,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.615
@@ -19382,14 +19375,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.616
@@ -19401,14 +19394,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.617
@@ -19420,14 +19413,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.618
@@ -19439,14 +19432,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.619
@@ -19458,14 +19451,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.620
@@ -19477,14 +19470,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.621
@@ -19496,14 +19489,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.622
@@ -19515,14 +19508,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.623
@@ -19534,14 +19527,14 @@ cases:
           storage_offset: 38400
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.624
@@ -19553,14 +19546,14 @@ cases:
           storage_offset: 41472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.625
@@ -19572,14 +19565,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.626
@@ -19591,14 +19584,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.627
@@ -19610,14 +19603,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.628
@@ -19629,14 +19622,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.629
@@ -19648,14 +19641,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.630
@@ -19667,14 +19660,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.631
@@ -19686,14 +19679,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.632
@@ -19705,14 +19698,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.633
@@ -19724,14 +19717,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.634
@@ -19743,14 +19736,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.635
@@ -19762,14 +19755,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.636
@@ -19781,14 +19774,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.637
@@ -19800,14 +19793,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.638
@@ -19819,14 +19812,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.639
@@ -19838,14 +19831,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.640
@@ -19857,14 +19850,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.641
@@ -19876,14 +19869,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.642
@@ -19895,14 +19888,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.643
@@ -19914,14 +19907,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.644
@@ -19933,14 +19926,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.645
@@ -19952,14 +19945,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.646
@@ -19971,14 +19964,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.647
@@ -19990,14 +19983,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.648
@@ -20009,14 +20002,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.649
@@ -20028,14 +20021,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.650
@@ -20047,14 +20040,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.651
@@ -20066,14 +20059,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.652
@@ -20085,14 +20078,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.653
@@ -20104,14 +20097,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.654
@@ -20123,14 +20116,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.655
@@ -20142,14 +20135,14 @@ cases:
           storage_offset: 93696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.12
@@ -20569,14 +20562,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.657
@@ -20588,14 +20581,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.658
@@ -20607,14 +20600,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.659
@@ -20626,14 +20619,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.660
@@ -20645,14 +20638,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.661
@@ -20664,14 +20657,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.662
@@ -20683,14 +20676,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.663
@@ -20702,14 +20695,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.664
@@ -20721,14 +20714,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.665
@@ -20740,14 +20733,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.666
@@ -20759,14 +20752,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.667
@@ -20778,14 +20771,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.668
@@ -20797,14 +20790,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.669
@@ -20816,14 +20809,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.670
@@ -20835,14 +20828,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.671
@@ -20854,14 +20847,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.672
@@ -20873,14 +20866,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.673
@@ -20892,14 +20885,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.674
@@ -20911,14 +20904,14 @@ cases:
           storage_offset: 9728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.675
@@ -20930,14 +20923,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.676
@@ -20949,14 +20942,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.677
@@ -20968,14 +20961,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.678
@@ -20987,14 +20980,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.679
@@ -21006,14 +20999,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.680
@@ -21025,14 +21018,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.681
@@ -21044,14 +21037,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.682
@@ -21063,14 +21056,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.683
@@ -21082,14 +21075,14 @@ cases:
           storage_offset: 12800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.684
@@ -21101,14 +21094,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.685
@@ -21120,14 +21113,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.686
@@ -21139,14 +21132,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.687
@@ -21158,14 +21151,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.688
@@ -21177,14 +21170,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.689
@@ -21196,14 +21189,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.690
@@ -21215,14 +21208,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.691
@@ -21234,14 +21227,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.692
@@ -21253,14 +21246,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.693
@@ -21272,14 +21265,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.694
@@ -21291,14 +21284,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.695
@@ -21310,14 +21303,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.696
@@ -21329,14 +21322,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.697
@@ -21348,14 +21341,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.698
@@ -21367,14 +21360,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.699
@@ -21386,14 +21379,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.700
@@ -21405,14 +21398,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.701
@@ -21424,14 +21417,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.702
@@ -21443,14 +21436,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.703
@@ -21462,14 +21455,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.704
@@ -21481,14 +21474,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.705
@@ -21500,14 +21493,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.706
@@ -21519,14 +21512,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.707
@@ -21538,14 +21531,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.708
@@ -21557,14 +21550,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.709
@@ -21576,14 +21569,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.710
@@ -21595,14 +21588,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.711
@@ -21614,14 +21607,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.712
@@ -21633,14 +21626,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.713
@@ -21652,14 +21645,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.714
@@ -21671,14 +21664,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.715
@@ -21690,14 +21683,14 @@ cases:
           storage_offset: 31232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.13
@@ -22101,14 +22094,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.717
@@ -22120,14 +22113,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.718
@@ -22139,14 +22132,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.719
@@ -22158,14 +22151,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.720
@@ -22177,14 +22170,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.721
@@ -22196,14 +22189,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.722
@@ -22215,14 +22208,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.723
@@ -22234,14 +22227,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.724
@@ -22253,14 +22246,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.725
@@ -22272,14 +22265,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.726
@@ -22291,14 +22284,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.727
@@ -22310,14 +22303,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.728
@@ -22329,14 +22322,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.729
@@ -22348,14 +22341,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.730
@@ -22367,14 +22360,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.731
@@ -22386,14 +22379,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.732
@@ -22405,14 +22398,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.733
@@ -22424,14 +22417,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.734
@@ -22443,14 +22436,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.735
@@ -22462,14 +22455,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.736
@@ -22481,14 +22474,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.737
@@ -22500,14 +22493,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.738
@@ -22519,14 +22512,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.739
@@ -22538,14 +22531,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.740
@@ -22557,14 +22550,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.741
@@ -22576,14 +22569,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.742
@@ -22595,14 +22588,14 @@ cases:
           storage_offset: 58368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.743
@@ -22614,14 +22607,14 @@ cases:
           storage_offset: 58368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.744
@@ -22633,14 +22626,14 @@ cases:
           storage_offset: 66048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.745
@@ -22652,14 +22645,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.746
@@ -22671,14 +22664,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.747
@@ -22690,14 +22683,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.748
@@ -22709,14 +22702,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.749
@@ -22728,14 +22721,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.750
@@ -22747,14 +22740,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.751
@@ -22766,14 +22759,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.752
@@ -22785,14 +22778,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.753
@@ -22804,14 +22797,14 @@ cases:
           storage_offset: 79872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.754
@@ -22823,14 +22816,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.755
@@ -22842,14 +22835,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.756
@@ -22861,14 +22854,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.757
@@ -22880,14 +22873,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.758
@@ -22899,14 +22892,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.759
@@ -22918,14 +22911,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.14
@@ -23345,14 +23338,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.761
@@ -23364,14 +23357,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.762
@@ -23383,14 +23376,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.763
@@ -23402,14 +23395,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.764
@@ -23421,14 +23414,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.765
@@ -23440,14 +23433,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.766
@@ -23459,14 +23452,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.767
@@ -23478,14 +23471,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.768
@@ -23497,14 +23490,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.769
@@ -23516,14 +23509,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.770
@@ -23535,14 +23528,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.771
@@ -23554,14 +23547,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.772
@@ -23573,14 +23566,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.773
@@ -23592,14 +23585,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.774
@@ -23611,14 +23604,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.775
@@ -23630,14 +23623,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.776
@@ -23649,14 +23642,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.777
@@ -23668,14 +23661,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.778
@@ -23687,14 +23680,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.779
@@ -23706,14 +23699,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.780
@@ -23725,14 +23718,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.781
@@ -23744,14 +23737,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.782
@@ -23763,14 +23756,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.783
@@ -23782,14 +23775,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.784
@@ -23801,14 +23794,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.785
@@ -23820,14 +23813,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.786
@@ -23839,14 +23832,14 @@ cases:
           storage_offset: 19456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.787
@@ -23858,14 +23851,14 @@ cases:
           storage_offset: 19456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.788
@@ -23877,14 +23870,14 @@ cases:
           storage_offset: 22016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.789
@@ -23896,14 +23889,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.790
@@ -23915,14 +23908,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.791
@@ -23934,14 +23927,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.792
@@ -23953,14 +23946,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.793
@@ -23972,14 +23965,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.794
@@ -23991,14 +23984,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.795
@@ -24010,14 +24003,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.796
@@ -24029,14 +24022,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.797
@@ -24048,14 +24041,14 @@ cases:
           storage_offset: 26624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.798
@@ -24067,14 +24060,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.799
@@ -24086,14 +24079,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.800
@@ -24105,14 +24098,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.801
@@ -24124,14 +24117,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.802
@@ -24143,14 +24136,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.803
@@ -24162,14 +24155,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.15
@@ -24573,14 +24566,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.805
@@ -24592,14 +24585,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.806
@@ -24611,14 +24604,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.807
@@ -24630,14 +24623,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.808
@@ -24649,14 +24642,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.809
@@ -24668,14 +24661,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.810
@@ -24687,14 +24680,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.811
@@ -24706,14 +24699,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.812
@@ -24725,14 +24718,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.813
@@ -24744,14 +24737,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.814
@@ -24763,14 +24756,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.815
@@ -24782,14 +24775,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.816
@@ -24801,14 +24794,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.817
@@ -24820,14 +24813,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.818
@@ -24839,14 +24832,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.819
@@ -24858,14 +24851,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.820
@@ -24877,14 +24870,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.821
@@ -24896,14 +24889,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.822
@@ -24915,14 +24908,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.823
@@ -24934,14 +24927,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.824
@@ -24953,14 +24946,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.825
@@ -24972,14 +24965,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.826
@@ -24991,14 +24984,14 @@ cases:
           storage_offset: 41472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.827
@@ -25010,14 +25003,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.828
@@ -25029,14 +25022,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.829
@@ -25048,14 +25041,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.830
@@ -25067,14 +25060,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.831
@@ -25086,14 +25079,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.832
@@ -25105,14 +25098,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.833
@@ -25124,14 +25117,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.834
@@ -25143,14 +25136,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.835
@@ -25162,14 +25155,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.836
@@ -25181,14 +25174,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.837
@@ -25200,14 +25193,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.838
@@ -25219,14 +25212,14 @@ cases:
           storage_offset: 66048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.839
@@ -25238,14 +25231,14 @@ cases:
           storage_offset: 66048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.840
@@ -25257,14 +25250,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.841
@@ -25276,14 +25269,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.842
@@ -25295,14 +25288,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.843
@@ -25314,14 +25307,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.844
@@ -25333,14 +25326,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.845
@@ -25352,14 +25345,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.846
@@ -25371,14 +25364,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.847
@@ -25390,14 +25383,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.848
@@ -25409,14 +25402,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.849
@@ -25428,14 +25421,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.850
@@ -25447,14 +25440,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.851
@@ -25466,14 +25459,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.852
@@ -25485,14 +25478,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.853
@@ -25504,14 +25497,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.854
@@ -25523,14 +25516,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.855
@@ -25542,14 +25535,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.856
@@ -25561,14 +25554,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.857
@@ -25580,14 +25573,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.858
@@ -25599,14 +25592,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.859
@@ -25618,14 +25611,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.16
@@ -26045,14 +26038,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.861
@@ -26064,14 +26057,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.862
@@ -26083,14 +26076,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.863
@@ -26102,14 +26095,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.864
@@ -26121,14 +26114,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.865
@@ -26140,14 +26133,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.866
@@ -26159,14 +26152,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.867
@@ -26178,14 +26171,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.868
@@ -26197,14 +26190,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.869
@@ -26216,14 +26209,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.870
@@ -26235,14 +26228,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.871
@@ -26254,14 +26247,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.872
@@ -26273,14 +26266,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.873
@@ -26292,14 +26285,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.874
@@ -26311,14 +26304,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.875
@@ -26330,14 +26323,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.876
@@ -26349,14 +26342,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.877
@@ -26368,14 +26361,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.878
@@ -26387,14 +26380,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.879
@@ -26406,14 +26399,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.880
@@ -26425,14 +26418,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.881
@@ -26444,14 +26437,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.882
@@ -26463,14 +26456,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.883
@@ -26482,14 +26475,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.884
@@ -26501,14 +26494,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.885
@@ -26520,14 +26513,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.886
@@ -26539,14 +26532,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.887
@@ -26558,14 +26551,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.888
@@ -26577,14 +26570,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.889
@@ -26596,14 +26589,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.890
@@ -26615,14 +26608,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.891
@@ -26634,14 +26627,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.892
@@ -26653,14 +26646,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.893
@@ -26672,14 +26665,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.894
@@ -26691,14 +26684,14 @@ cases:
           storage_offset: 22016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.895
@@ -26710,14 +26703,14 @@ cases:
           storage_offset: 22016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.896
@@ -26729,14 +26722,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.897
@@ -26748,14 +26741,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.898
@@ -26767,14 +26760,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.899
@@ -26786,14 +26779,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.900
@@ -26805,14 +26798,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.901
@@ -26824,14 +26817,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.902
@@ -26843,14 +26836,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.903
@@ -26862,14 +26855,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.904
@@ -26881,14 +26874,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.905
@@ -26900,14 +26893,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.906
@@ -26919,14 +26912,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.907
@@ -26938,14 +26931,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.908
@@ -26957,14 +26950,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.909
@@ -26976,14 +26969,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.910
@@ -26995,14 +26988,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.911
@@ -27014,14 +27007,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.912
@@ -27033,14 +27026,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.913
@@ -27052,14 +27045,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.914
@@ -27071,14 +27064,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.915
@@ -27090,14 +27083,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.17
@@ -27515,15 +27508,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [100352, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509 in
       torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant
@@ -27914,15 +27906,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [100352, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509 in
       torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant

--- a/tests/resource/models/granite-4.0-h-tiny_spyre.yaml
+++ b/tests/resource/models/granite-4.0-h-tiny_spyre.yaml
@@ -436,15 +436,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [6448, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L639 in
       torch_forward, code: projected_states = self.in_proj(input_states)'
     marks: constant
@@ -2166,15 +2165,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 3072]
           stride: [3072, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L830 in
       torch_forward, code: contextualized_states = self.out_proj(scan_output.to(dtype))  # [batch, seq_len, hidden_size]'
     marks: constant
@@ -2234,15 +2232,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [64, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1034 in
       forward, code: logits = self.layer(hidden_states).float()  # [batch_size x seq_len, num_experts]'
     marks: constant
@@ -2951,14 +2948,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.5
@@ -2970,14 +2967,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.6
@@ -2989,14 +2986,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.7
@@ -3008,14 +3005,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.8
@@ -3027,14 +3024,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.9
@@ -3046,14 +3043,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.10
@@ -3065,14 +3062,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.11
@@ -3084,14 +3081,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.12
@@ -3103,14 +3100,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.13
@@ -3122,14 +3119,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.14
@@ -3141,14 +3138,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.15
@@ -3160,14 +3157,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.16
@@ -3179,14 +3176,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.17
@@ -3198,14 +3195,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.18
@@ -3217,14 +3214,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.19
@@ -3236,14 +3233,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.20
@@ -3255,14 +3252,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.21
@@ -3274,14 +3271,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.22
@@ -3293,14 +3290,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.23
@@ -3312,14 +3309,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.24
@@ -3331,14 +3328,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.25
@@ -3350,14 +3347,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.26
@@ -3369,14 +3366,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.27
@@ -3388,14 +3385,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.28
@@ -3407,14 +3404,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.29
@@ -3426,14 +3423,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.30
@@ -3445,14 +3442,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.31
@@ -3464,14 +3461,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.32
@@ -3483,14 +3480,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.33
@@ -3502,14 +3499,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.34
@@ -3521,14 +3518,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.35
@@ -3540,14 +3537,14 @@ cases:
           storage_offset: 38400
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.36
@@ -3559,14 +3556,14 @@ cases:
           storage_offset: 38400
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.37
@@ -3578,14 +3575,14 @@ cases:
           storage_offset: 41472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.38
@@ -3597,14 +3594,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.39
@@ -3616,14 +3613,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.40
@@ -3635,14 +3632,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.41
@@ -3654,14 +3651,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.42
@@ -3673,14 +3670,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.43
@@ -3692,14 +3689,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.44
@@ -3711,14 +3708,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.45
@@ -3730,14 +3727,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.46
@@ -3749,14 +3746,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.47
@@ -3768,14 +3765,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.48
@@ -3787,14 +3784,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.49
@@ -3806,14 +3803,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.50
@@ -3825,14 +3822,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.51
@@ -3844,14 +3841,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.52
@@ -3863,14 +3860,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.53
@@ -3882,14 +3879,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.54
@@ -3901,14 +3898,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.55
@@ -3920,14 +3917,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.56
@@ -3939,14 +3936,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.57
@@ -3958,14 +3955,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.58
@@ -3977,14 +3974,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.59
@@ -3996,14 +3993,14 @@ cases:
           storage_offset: 79872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.60
@@ -4015,14 +4012,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.61
@@ -4034,14 +4031,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.62
@@ -4053,14 +4050,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.63
@@ -4072,14 +4069,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.64
@@ -4091,14 +4088,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.65
@@ -4110,14 +4107,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.66
@@ -4129,14 +4126,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.67
@@ -4148,14 +4145,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.2
@@ -5047,14 +5044,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.69
@@ -5066,14 +5063,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.70
@@ -5085,14 +5082,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.71
@@ -5104,14 +5101,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.72
@@ -5123,14 +5120,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.73
@@ -5142,14 +5139,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.74
@@ -5161,14 +5158,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.75
@@ -5180,14 +5177,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.76
@@ -5199,14 +5196,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.77
@@ -5218,14 +5215,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.78
@@ -5237,14 +5234,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.79
@@ -5256,14 +5253,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.80
@@ -5275,14 +5272,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.81
@@ -5294,14 +5291,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.82
@@ -5313,14 +5310,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.83
@@ -5332,14 +5329,14 @@ cases:
           storage_offset: 4096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.84
@@ -5351,14 +5348,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.85
@@ -5370,14 +5367,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.86
@@ -5389,14 +5386,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.87
@@ -5408,14 +5405,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.88
@@ -5427,14 +5424,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.89
@@ -5446,14 +5443,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.90
@@ -5465,14 +5462,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.91
@@ -5484,14 +5481,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.92
@@ -5503,14 +5500,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.93
@@ -5522,14 +5519,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.94
@@ -5541,14 +5538,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.95
@@ -5560,14 +5557,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.96
@@ -5579,14 +5576,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.97
@@ -5598,14 +5595,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.98
@@ -5617,14 +5614,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.99
@@ -5636,14 +5633,14 @@ cases:
           storage_offset: 12800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.100
@@ -5655,14 +5652,14 @@ cases:
           storage_offset: 12800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.101
@@ -5674,14 +5671,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.102
@@ -5693,14 +5690,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.103
@@ -5712,14 +5709,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.104
@@ -5731,14 +5728,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.105
@@ -5750,14 +5747,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.106
@@ -5769,14 +5766,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.107
@@ -5788,14 +5785,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.108
@@ -5807,14 +5804,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.109
@@ -5826,14 +5823,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.110
@@ -5845,14 +5842,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.111
@@ -5864,14 +5861,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.112
@@ -5883,14 +5880,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.113
@@ -5902,14 +5899,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.114
@@ -5921,14 +5918,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.115
@@ -5940,14 +5937,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.116
@@ -5959,14 +5956,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.117
@@ -5978,14 +5975,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.118
@@ -5997,14 +5994,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.119
@@ -6016,14 +6013,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.120
@@ -6035,14 +6032,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.121
@@ -6054,14 +6051,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.122
@@ -6073,14 +6070,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.123
@@ -6092,14 +6089,14 @@ cases:
           storage_offset: 26624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.124
@@ -6111,14 +6108,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.125
@@ -6130,14 +6127,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.126
@@ -6149,14 +6146,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.127
@@ -6168,14 +6165,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.128
@@ -6187,14 +6184,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.129
@@ -6206,14 +6203,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.130
@@ -6225,14 +6222,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.131
@@ -6244,14 +6241,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.3
@@ -6744,15 +6741,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [2048, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L894 in
       forward, code: hidden_states = self.input_linear(hidden_states)'
     marks: constant
@@ -6831,15 +6827,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 1024]
           stride: [1024, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L897 in
       forward, code: hidden_states = self.output_linear(hidden_states)'
     marks: constant
@@ -6852,14 +6847,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.135
@@ -6871,14 +6866,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.136
@@ -6890,14 +6885,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.137
@@ -6909,14 +6904,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.138
@@ -6928,14 +6923,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.139
@@ -6947,14 +6942,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.140
@@ -6966,14 +6961,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.141
@@ -6985,14 +6980,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.142
@@ -7004,14 +6999,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.143
@@ -7023,14 +7018,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.144
@@ -7042,14 +7037,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.145
@@ -7061,14 +7056,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.146
@@ -7080,14 +7075,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.147
@@ -7099,14 +7094,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.148
@@ -7118,14 +7113,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.149
@@ -7137,14 +7132,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.150
@@ -7156,14 +7151,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.151
@@ -7175,14 +7170,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.152
@@ -7194,14 +7189,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.153
@@ -7213,14 +7208,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.154
@@ -7232,14 +7227,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.155
@@ -7251,14 +7246,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.156
@@ -7270,14 +7265,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.157
@@ -7289,14 +7284,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.158
@@ -7308,14 +7303,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.159
@@ -7327,14 +7322,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.160
@@ -7346,14 +7341,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.161
@@ -7365,14 +7360,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.162
@@ -7384,14 +7379,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.163
@@ -7403,14 +7398,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.164
@@ -7422,14 +7417,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.165
@@ -7441,14 +7436,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.166
@@ -7460,14 +7455,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.167
@@ -7479,14 +7474,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.168
@@ -7498,14 +7493,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.169
@@ -7517,14 +7512,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.170
@@ -7536,14 +7531,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.171
@@ -7555,14 +7550,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.172
@@ -7574,14 +7569,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.173
@@ -7593,14 +7588,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.174
@@ -7612,14 +7607,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.175
@@ -7631,14 +7626,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.176
@@ -7650,14 +7645,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.177
@@ -7669,14 +7664,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.178
@@ -7688,14 +7683,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.179
@@ -7707,14 +7702,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.180
@@ -7726,14 +7721,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.181
@@ -7745,14 +7740,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.182
@@ -7764,14 +7759,14 @@ cases:
           storage_offset: 79872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.183
@@ -7783,14 +7778,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.184
@@ -7802,14 +7797,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.185
@@ -7821,14 +7816,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.186
@@ -7840,14 +7835,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.187
@@ -7859,14 +7854,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.188
@@ -7878,14 +7873,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.189
@@ -7897,14 +7892,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.190
@@ -7916,14 +7911,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.191
@@ -7935,14 +7930,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.192
@@ -7954,14 +7949,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.193
@@ -7973,14 +7968,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.194
@@ -7992,14 +7987,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.195
@@ -8011,14 +8006,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.196
@@ -8030,14 +8025,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.197
@@ -8049,14 +8044,14 @@ cases:
           storage_offset: 101376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.4
@@ -8476,14 +8471,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.199
@@ -8495,14 +8490,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.200
@@ -8514,14 +8509,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.201
@@ -8533,14 +8528,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.202
@@ -8552,14 +8547,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.203
@@ -8571,14 +8566,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.204
@@ -8590,14 +8585,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.205
@@ -8609,14 +8604,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.206
@@ -8628,14 +8623,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.207
@@ -8647,14 +8642,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.208
@@ -8666,14 +8661,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.209
@@ -8685,14 +8680,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.210
@@ -8704,14 +8699,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.211
@@ -8723,14 +8718,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.212
@@ -8742,14 +8737,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.213
@@ -8761,14 +8756,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.214
@@ -8780,14 +8775,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.215
@@ -8799,14 +8794,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.216
@@ -8818,14 +8813,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.217
@@ -8837,14 +8832,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.218
@@ -8856,14 +8851,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.219
@@ -8875,14 +8870,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.220
@@ -8894,14 +8889,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.221
@@ -8913,14 +8908,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.222
@@ -8932,14 +8927,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.223
@@ -8951,14 +8946,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.224
@@ -8970,14 +8965,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.225
@@ -8989,14 +8984,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.226
@@ -9008,14 +9003,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.227
@@ -9027,14 +9022,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.228
@@ -9046,14 +9041,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.229
@@ -9065,14 +9060,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.230
@@ -9084,14 +9079,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.231
@@ -9103,14 +9098,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.232
@@ -9122,14 +9117,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.233
@@ -9141,14 +9136,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.234
@@ -9160,14 +9155,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.235
@@ -9179,14 +9174,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.236
@@ -9198,14 +9193,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.237
@@ -9217,14 +9212,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.238
@@ -9236,14 +9231,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.239
@@ -9255,14 +9250,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.240
@@ -9274,14 +9269,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.241
@@ -9293,14 +9288,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.242
@@ -9312,14 +9307,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.243
@@ -9331,14 +9326,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.244
@@ -9350,14 +9345,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.245
@@ -9369,14 +9364,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.246
@@ -9388,14 +9383,14 @@ cases:
           storage_offset: 26624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.247
@@ -9407,14 +9402,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.248
@@ -9426,14 +9421,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.249
@@ -9445,14 +9440,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.250
@@ -9464,14 +9459,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.251
@@ -9483,14 +9478,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.252
@@ -9502,14 +9497,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.253
@@ -9521,14 +9516,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.254
@@ -9540,14 +9535,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.255
@@ -9559,14 +9554,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.256
@@ -9578,14 +9573,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.257
@@ -9597,14 +9592,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.258
@@ -9616,14 +9611,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.259
@@ -9635,14 +9630,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.260
@@ -9654,14 +9649,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.261
@@ -9673,14 +9668,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.5
@@ -10084,14 +10079,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.263
@@ -10103,14 +10098,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.264
@@ -10122,14 +10117,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.265
@@ -10141,14 +10136,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.266
@@ -10160,14 +10155,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.267
@@ -10179,14 +10174,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.268
@@ -10198,14 +10193,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.269
@@ -10217,14 +10212,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.270
@@ -10236,14 +10231,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.271
@@ -10255,14 +10250,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.272
@@ -10274,14 +10269,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.273
@@ -10293,14 +10288,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.274
@@ -10312,14 +10307,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.275
@@ -10331,14 +10326,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.276
@@ -10350,14 +10345,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.277
@@ -10369,14 +10364,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.278
@@ -10388,14 +10383,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.279
@@ -10407,14 +10402,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.280
@@ -10426,14 +10421,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.281
@@ -10445,14 +10440,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.282
@@ -10464,14 +10459,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.283
@@ -10483,14 +10478,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.284
@@ -10502,14 +10497,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.285
@@ -10521,14 +10516,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.286
@@ -10540,14 +10535,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.287
@@ -10559,14 +10554,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.288
@@ -10578,14 +10573,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.289
@@ -10597,14 +10592,14 @@ cases:
           storage_offset: 39936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.290
@@ -10616,14 +10611,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.291
@@ -10635,14 +10630,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.292
@@ -10654,14 +10649,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.293
@@ -10673,14 +10668,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.294
@@ -10692,14 +10687,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.295
@@ -10711,14 +10706,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.296
@@ -10730,14 +10725,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.297
@@ -10749,14 +10744,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.298
@@ -10768,14 +10763,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.299
@@ -10787,14 +10782,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.300
@@ -10806,14 +10801,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.301
@@ -10825,14 +10820,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.302
@@ -10844,14 +10839,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.303
@@ -10863,14 +10858,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.304
@@ -10882,14 +10877,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.305
@@ -10901,14 +10896,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.306
@@ -10920,14 +10915,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.307
@@ -10939,14 +10934,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.308
@@ -10958,14 +10953,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.309
@@ -10977,14 +10972,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.310
@@ -10996,14 +10991,14 @@ cases:
           storage_offset: 84480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.311
@@ -11015,14 +11010,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.312
@@ -11034,14 +11029,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.313
@@ -11053,14 +11048,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.314
@@ -11072,14 +11067,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.315
@@ -11091,14 +11086,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.316
@@ -11110,14 +11105,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.317
@@ -11129,14 +11124,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.318
@@ -11148,14 +11143,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.319
@@ -11167,14 +11162,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.320
@@ -11186,14 +11181,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.6
@@ -11613,14 +11608,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.322
@@ -11632,14 +11627,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.323
@@ -11651,14 +11646,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.324
@@ -11670,14 +11665,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.325
@@ -11689,14 +11684,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.326
@@ -11708,14 +11703,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.327
@@ -11727,14 +11722,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.328
@@ -11746,14 +11741,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.329
@@ -11765,14 +11760,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.330
@@ -11784,14 +11779,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.331
@@ -11803,14 +11798,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.332
@@ -11822,14 +11817,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.333
@@ -11841,14 +11836,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.334
@@ -11860,14 +11855,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.335
@@ -11879,14 +11874,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.336
@@ -11898,14 +11893,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.337
@@ -11917,14 +11912,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.338
@@ -11936,14 +11931,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.339
@@ -11955,14 +11950,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.340
@@ -11974,14 +11969,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.341
@@ -11993,14 +11988,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.342
@@ -12012,14 +12007,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.343
@@ -12031,14 +12026,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.344
@@ -12050,14 +12045,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.345
@@ -12069,14 +12064,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.346
@@ -12088,14 +12083,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.347
@@ -12107,14 +12102,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.348
@@ -12126,14 +12121,14 @@ cases:
           storage_offset: 13312
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.349
@@ -12145,14 +12140,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.350
@@ -12164,14 +12159,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.351
@@ -12183,14 +12178,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.352
@@ -12202,14 +12197,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.353
@@ -12221,14 +12216,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.354
@@ -12240,14 +12235,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.355
@@ -12259,14 +12254,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.356
@@ -12278,14 +12273,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.357
@@ -12297,14 +12292,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.358
@@ -12316,14 +12311,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.359
@@ -12335,14 +12330,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.360
@@ -12354,14 +12349,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.361
@@ -12373,14 +12368,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.362
@@ -12392,14 +12387,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.363
@@ -12411,14 +12406,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.364
@@ -12430,14 +12425,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.365
@@ -12449,14 +12444,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.366
@@ -12468,14 +12463,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.367
@@ -12487,14 +12482,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.368
@@ -12506,14 +12501,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.369
@@ -12525,14 +12520,14 @@ cases:
           storage_offset: 28160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.370
@@ -12544,14 +12539,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.371
@@ -12563,14 +12558,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.372
@@ -12582,14 +12577,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.373
@@ -12601,14 +12596,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.374
@@ -12620,14 +12615,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.375
@@ -12639,14 +12634,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.376
@@ -12658,14 +12653,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.377
@@ -12677,14 +12672,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.378
@@ -12696,14 +12691,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.379
@@ -12715,14 +12710,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.7
@@ -13126,14 +13121,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.381
@@ -13145,14 +13140,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.382
@@ -13164,14 +13159,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.383
@@ -13183,14 +13178,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.384
@@ -13202,14 +13197,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.385
@@ -13221,14 +13216,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.386
@@ -13240,14 +13235,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.387
@@ -13259,14 +13254,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.388
@@ -13278,14 +13273,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.389
@@ -13297,14 +13292,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.390
@@ -13316,14 +13311,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.391
@@ -13335,14 +13330,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.392
@@ -13354,14 +13349,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.393
@@ -13373,14 +13368,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.394
@@ -13392,14 +13387,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.395
@@ -13411,14 +13406,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.396
@@ -13430,14 +13425,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.397
@@ -13449,14 +13444,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.398
@@ -13468,14 +13463,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.399
@@ -13487,14 +13482,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.400
@@ -13506,14 +13501,14 @@ cases:
           storage_offset: 39936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.401
@@ -13525,14 +13520,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.402
@@ -13544,14 +13539,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.403
@@ -13563,14 +13558,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.404
@@ -13582,14 +13577,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.405
@@ -13601,14 +13596,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.406
@@ -13620,14 +13615,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.407
@@ -13639,14 +13634,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.408
@@ -13658,14 +13653,14 @@ cases:
           storage_offset: 58368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.409
@@ -13677,14 +13672,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.410
@@ -13696,14 +13691,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.411
@@ -13715,14 +13710,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.412
@@ -13734,14 +13729,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.413
@@ -13753,14 +13748,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.414
@@ -13772,14 +13767,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.415
@@ -13791,14 +13786,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.416
@@ -13810,14 +13805,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.417
@@ -13829,14 +13824,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.418
@@ -13848,14 +13843,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.419
@@ -13867,14 +13862,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.420
@@ -13886,14 +13881,14 @@ cases:
           storage_offset: 75264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.421
@@ -13905,14 +13900,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.422
@@ -13924,14 +13919,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.423
@@ -13943,14 +13938,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.424
@@ -13962,14 +13957,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.425
@@ -13981,14 +13976,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.426
@@ -14000,14 +13995,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.427
@@ -14019,14 +14014,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.428
@@ -14038,14 +14033,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.429
@@ -14057,14 +14052,14 @@ cases:
           storage_offset: 84480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.430
@@ -14076,14 +14071,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.431
@@ -14095,14 +14090,14 @@ cases:
           storage_offset: 89088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.432
@@ -14114,14 +14109,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.433
@@ -14133,14 +14128,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.434
@@ -14152,14 +14147,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.435
@@ -14171,14 +14166,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.8
@@ -14598,14 +14593,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.437
@@ -14617,14 +14612,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.438
@@ -14636,14 +14631,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.439
@@ -14655,14 +14650,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.440
@@ -14674,14 +14669,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.441
@@ -14693,14 +14688,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.442
@@ -14712,14 +14707,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.443
@@ -14731,14 +14726,14 @@ cases:
           storage_offset: 3584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.444
@@ -14750,14 +14745,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.445
@@ -14769,14 +14764,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.446
@@ -14788,14 +14783,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.447
@@ -14807,14 +14802,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.448
@@ -14826,14 +14821,14 @@ cases:
           storage_offset: 9728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.449
@@ -14845,14 +14840,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.450
@@ -14864,14 +14859,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.451
@@ -14883,14 +14878,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.452
@@ -14902,14 +14897,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.453
@@ -14921,14 +14916,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.454
@@ -14940,14 +14935,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.455
@@ -14959,14 +14954,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.456
@@ -14978,14 +14973,14 @@ cases:
           storage_offset: 13312
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.457
@@ -14997,14 +14992,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.458
@@ -15016,14 +15011,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.459
@@ -15035,14 +15030,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.460
@@ -15054,14 +15049,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.461
@@ -15073,14 +15068,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.462
@@ -15092,14 +15087,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.463
@@ -15111,14 +15106,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.464
@@ -15130,14 +15125,14 @@ cases:
           storage_offset: 19456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.465
@@ -15149,14 +15144,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.466
@@ -15168,14 +15163,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.467
@@ -15187,14 +15182,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.468
@@ -15206,14 +15201,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.469
@@ -15225,14 +15220,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.470
@@ -15244,14 +15239,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.471
@@ -15263,14 +15258,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.472
@@ -15282,14 +15277,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.473
@@ -15301,14 +15296,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.474
@@ -15320,14 +15315,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.475
@@ -15339,14 +15334,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.476
@@ -15358,14 +15353,14 @@ cases:
           storage_offset: 25088
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.477
@@ -15377,14 +15372,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.478
@@ -15396,14 +15391,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.479
@@ -15415,14 +15410,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.480
@@ -15434,14 +15429,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.481
@@ -15453,14 +15448,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.482
@@ -15472,14 +15467,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.483
@@ -15491,14 +15486,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.484
@@ -15510,14 +15505,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.485
@@ -15529,14 +15524,14 @@ cases:
           storage_offset: 28160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.486
@@ -15548,14 +15543,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.487
@@ -15567,14 +15562,14 @@ cases:
           storage_offset: 29696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.488
@@ -15586,14 +15581,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.489
@@ -15605,14 +15600,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.490
@@ -15624,14 +15619,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.491
@@ -15643,14 +15638,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.9
@@ -16054,14 +16049,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.493
@@ -16073,14 +16068,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.494
@@ -16092,14 +16087,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.495
@@ -16111,14 +16106,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.496
@@ -16130,14 +16125,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.497
@@ -16149,14 +16144,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.498
@@ -16168,14 +16163,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.499
@@ -16187,14 +16182,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.500
@@ -16206,14 +16201,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.501
@@ -16225,14 +16220,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.502
@@ -16244,14 +16239,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.503
@@ -16263,14 +16258,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.504
@@ -16282,14 +16277,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.505
@@ -16301,14 +16296,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.506
@@ -16320,14 +16315,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.507
@@ -16339,14 +16334,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.508
@@ -16358,14 +16353,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.509
@@ -16377,14 +16372,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.510
@@ -16396,14 +16391,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.511
@@ -16415,14 +16410,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.512
@@ -16434,14 +16429,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.513
@@ -16453,14 +16448,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.514
@@ -16472,14 +16467,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.515
@@ -16491,14 +16486,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.516
@@ -16510,14 +16505,14 @@ cases:
           storage_offset: 49152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.517
@@ -16529,14 +16524,14 @@ cases:
           storage_offset: 52224
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.518
@@ -16548,14 +16543,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.519
@@ -16567,14 +16562,14 @@ cases:
           storage_offset: 59904
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.520
@@ -16586,14 +16581,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.521
@@ -16605,14 +16600,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.522
@@ -16624,14 +16619,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.523
@@ -16643,14 +16638,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.524
@@ -16662,14 +16657,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.525
@@ -16681,14 +16676,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.526
@@ -16700,14 +16695,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.527
@@ -16719,14 +16714,14 @@ cases:
           storage_offset: 73728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.528
@@ -16738,14 +16733,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.529
@@ -16757,14 +16752,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.530
@@ -16776,14 +16771,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.531
@@ -16795,14 +16790,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.532
@@ -16814,14 +16809,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.533
@@ -16833,14 +16828,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.534
@@ -16852,14 +16847,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.535
@@ -16871,14 +16866,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.536
@@ -16890,14 +16885,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.537
@@ -16909,14 +16904,14 @@ cases:
           storage_offset: 84480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.538
@@ -16928,14 +16923,14 @@ cases:
           storage_offset: 86016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.539
@@ -16947,14 +16942,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.540
@@ -16966,14 +16961,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.541
@@ -16985,14 +16980,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.542
@@ -17004,14 +16999,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.10
@@ -17431,14 +17426,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.544
@@ -17450,14 +17445,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.545
@@ -17469,14 +17464,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.546
@@ -17488,14 +17483,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.547
@@ -17507,14 +17502,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.548
@@ -17526,14 +17521,14 @@ cases:
           storage_offset: 4096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.549
@@ -17545,14 +17540,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.550
@@ -17564,14 +17559,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.551
@@ -17583,14 +17578,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.552
@@ -17602,14 +17597,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.553
@@ -17621,14 +17616,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.554
@@ -17640,14 +17635,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.555
@@ -17659,14 +17654,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.556
@@ -17678,14 +17673,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.557
@@ -17697,14 +17692,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.558
@@ -17716,14 +17711,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.559
@@ -17735,14 +17730,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.560
@@ -17754,14 +17749,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.561
@@ -17773,14 +17768,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.562
@@ -17792,14 +17787,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.563
@@ -17811,14 +17806,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.564
@@ -17830,14 +17825,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.565
@@ -17849,14 +17844,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.566
@@ -17868,14 +17863,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.567
@@ -17887,14 +17882,14 @@ cases:
           storage_offset: 16384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.568
@@ -17906,14 +17901,14 @@ cases:
           storage_offset: 17408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.569
@@ -17925,14 +17920,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.570
@@ -17944,14 +17939,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.571
@@ -17963,14 +17958,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.572
@@ -17982,14 +17977,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.573
@@ -18001,14 +17996,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.574
@@ -18020,14 +18015,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.575
@@ -18039,14 +18034,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.576
@@ -18058,14 +18053,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.577
@@ -18077,14 +18072,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.578
@@ -18096,14 +18091,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.579
@@ -18115,14 +18110,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.580
@@ -18134,14 +18129,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.581
@@ -18153,14 +18148,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.582
@@ -18172,14 +18167,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.583
@@ -18191,14 +18186,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.584
@@ -18210,14 +18205,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.585
@@ -18229,14 +18224,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.586
@@ -18248,14 +18243,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.587
@@ -18267,14 +18262,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.588
@@ -18286,14 +18281,14 @@ cases:
           storage_offset: 28160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.589
@@ -18305,14 +18300,14 @@ cases:
           storage_offset: 28672
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.590
@@ -18324,14 +18319,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.591
@@ -18343,14 +18338,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.592
@@ -18362,14 +18357,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.593
@@ -18381,14 +18376,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.11
@@ -18792,15 +18787,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L159 in
       forward, code: query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -18842,15 +18836,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [512, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L160 in
       forward, code: key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)'
     marks: constant
@@ -19021,14 +19014,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.597
@@ -19040,14 +19033,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.598
@@ -19059,14 +19052,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.599
@@ -19078,14 +19071,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.600
@@ -19097,14 +19090,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.601
@@ -19116,14 +19109,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.602
@@ -19135,14 +19128,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.603
@@ -19154,14 +19147,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.604
@@ -19173,14 +19166,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.605
@@ -19192,14 +19185,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.606
@@ -19211,14 +19204,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.607
@@ -19230,14 +19223,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.608
@@ -19249,14 +19242,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.609
@@ -19268,14 +19261,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.610
@@ -19287,14 +19280,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.611
@@ -19306,14 +19299,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.612
@@ -19325,14 +19318,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.613
@@ -19344,14 +19337,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.614
@@ -19363,14 +19356,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.615
@@ -19382,14 +19375,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.616
@@ -19401,14 +19394,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.617
@@ -19420,14 +19413,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.618
@@ -19439,14 +19432,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.619
@@ -19458,14 +19451,14 @@ cases:
           storage_offset: 33792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.620
@@ -19477,14 +19470,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.621
@@ -19496,14 +19489,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.622
@@ -19515,14 +19508,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.623
@@ -19534,14 +19527,14 @@ cases:
           storage_offset: 38400
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.624
@@ -19553,14 +19546,14 @@ cases:
           storage_offset: 41472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.625
@@ -19572,14 +19565,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.626
@@ -19591,14 +19584,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.627
@@ -19610,14 +19603,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.628
@@ -19629,14 +19622,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.629
@@ -19648,14 +19641,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.630
@@ -19667,14 +19660,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.631
@@ -19686,14 +19679,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.632
@@ -19705,14 +19698,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.633
@@ -19724,14 +19717,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.634
@@ -19743,14 +19736,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.635
@@ -19762,14 +19755,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.636
@@ -19781,14 +19774,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.637
@@ -19800,14 +19793,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.638
@@ -19819,14 +19812,14 @@ cases:
           storage_offset: 55296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.639
@@ -19838,14 +19831,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.640
@@ -19857,14 +19850,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.641
@@ -19876,14 +19869,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.642
@@ -19895,14 +19888,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.643
@@ -19914,14 +19907,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.644
@@ -19933,14 +19926,14 @@ cases:
           storage_offset: 76800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.645
@@ -19952,14 +19945,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.646
@@ -19971,14 +19964,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.647
@@ -19990,14 +19983,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.648
@@ -20009,14 +20002,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.649
@@ -20028,14 +20021,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.650
@@ -20047,14 +20040,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.651
@@ -20066,14 +20059,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.652
@@ -20085,14 +20078,14 @@ cases:
           storage_offset: 82944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.653
@@ -20104,14 +20097,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.654
@@ -20123,14 +20116,14 @@ cases:
           storage_offset: 92160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.655
@@ -20142,14 +20135,14 @@ cases:
           storage_offset: 93696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.12
@@ -20569,14 +20562,14 @@ cases:
           storage_offset: 512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.657
@@ -20588,14 +20581,14 @@ cases:
           storage_offset: 2048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.658
@@ -20607,14 +20600,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.659
@@ -20626,14 +20619,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.660
@@ -20645,14 +20638,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.661
@@ -20664,14 +20657,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.662
@@ -20683,14 +20676,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.663
@@ -20702,14 +20695,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.664
@@ -20721,14 +20714,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.665
@@ -20740,14 +20733,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.666
@@ -20759,14 +20752,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.667
@@ -20778,14 +20771,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.668
@@ -20797,14 +20790,14 @@ cases:
           storage_offset: 6144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.669
@@ -20816,14 +20809,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.670
@@ -20835,14 +20828,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.671
@@ -20854,14 +20847,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.672
@@ -20873,14 +20866,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.673
@@ -20892,14 +20885,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.674
@@ -20911,14 +20904,14 @@ cases:
           storage_offset: 9728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.675
@@ -20930,14 +20923,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.676
@@ -20949,14 +20942,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.677
@@ -20968,14 +20961,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.678
@@ -20987,14 +20980,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.679
@@ -21006,14 +20999,14 @@ cases:
           storage_offset: 11264
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.680
@@ -21025,14 +21018,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.681
@@ -21044,14 +21037,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.682
@@ -21063,14 +21056,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.683
@@ -21082,14 +21075,14 @@ cases:
           storage_offset: 12800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.684
@@ -21101,14 +21094,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.685
@@ -21120,14 +21113,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.686
@@ -21139,14 +21132,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.687
@@ -21158,14 +21151,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.688
@@ -21177,14 +21170,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.689
@@ -21196,14 +21189,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.690
@@ -21215,14 +21208,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.691
@@ -21234,14 +21227,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.692
@@ -21253,14 +21246,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.693
@@ -21272,14 +21265,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.694
@@ -21291,14 +21284,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.695
@@ -21310,14 +21303,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.696
@@ -21329,14 +21322,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.697
@@ -21348,14 +21341,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.698
@@ -21367,14 +21360,14 @@ cases:
           storage_offset: 18432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.699
@@ -21386,14 +21379,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.700
@@ -21405,14 +21398,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.701
@@ -21424,14 +21417,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.702
@@ -21443,14 +21436,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.703
@@ -21462,14 +21455,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.704
@@ -21481,14 +21474,14 @@ cases:
           storage_offset: 25600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.705
@@ -21500,14 +21493,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.706
@@ -21519,14 +21512,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.707
@@ -21538,14 +21531,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.708
@@ -21557,14 +21550,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.709
@@ -21576,14 +21569,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.710
@@ -21595,14 +21588,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.711
@@ -21614,14 +21607,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.712
@@ -21633,14 +21626,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.713
@@ -21652,14 +21645,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.714
@@ -21671,14 +21664,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.715
@@ -21690,14 +21683,14 @@ cases:
           storage_offset: 31232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.13
@@ -22101,14 +22094,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.717
@@ -22120,14 +22113,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.718
@@ -22139,14 +22132,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.719
@@ -22158,14 +22151,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.720
@@ -22177,14 +22170,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.721
@@ -22196,14 +22189,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.722
@@ -22215,14 +22208,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.723
@@ -22234,14 +22227,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.724
@@ -22253,14 +22246,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.725
@@ -22272,14 +22265,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.726
@@ -22291,14 +22284,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.727
@@ -22310,14 +22303,14 @@ cases:
           storage_offset: 27648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.728
@@ -22329,14 +22322,14 @@ cases:
           storage_offset: 30720
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.729
@@ -22348,14 +22341,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.730
@@ -22367,14 +22360,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.731
@@ -22386,14 +22379,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.732
@@ -22405,14 +22398,14 @@ cases:
           storage_offset: 35328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.733
@@ -22424,14 +22417,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.734
@@ -22443,14 +22436,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.735
@@ -22462,14 +22455,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.736
@@ -22481,14 +22474,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.737
@@ -22500,14 +22493,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.738
@@ -22519,14 +22512,14 @@ cases:
           storage_offset: 50688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 55050240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.739
@@ -22538,14 +22531,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 56623104
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.740
@@ -22557,14 +22550,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.741
@@ -22576,14 +22569,14 @@ cases:
           storage_offset: 56832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.742
@@ -22595,14 +22588,14 @@ cases:
           storage_offset: 58368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.743
@@ -22614,14 +22607,14 @@ cases:
           storage_offset: 58368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.744
@@ -22633,14 +22626,14 @@ cases:
           storage_offset: 66048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.745
@@ -22652,14 +22645,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.746
@@ -22671,14 +22664,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.747
@@ -22690,14 +22683,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.748
@@ -22709,14 +22702,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.749
@@ -22728,14 +22721,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.750
@@ -22747,14 +22740,14 @@ cases:
           storage_offset: 72192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.751
@@ -22766,14 +22759,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.752
@@ -22785,14 +22778,14 @@ cases:
           storage_offset: 78336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.753
@@ -22804,14 +22797,14 @@ cases:
           storage_offset: 79872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.754
@@ -22823,14 +22816,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.755
@@ -22842,14 +22835,14 @@ cases:
           storage_offset: 90624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.756
@@ -22861,14 +22854,14 @@ cases:
           storage_offset: 96768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.757
@@ -22880,14 +22873,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.758
@@ -22899,14 +22892,14 @@ cases:
           storage_offset: 98304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.759
@@ -22918,14 +22911,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.14
@@ -23345,14 +23338,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.761
@@ -23364,14 +23357,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.762
@@ -23383,14 +23376,14 @@ cases:
           storage_offset: 1024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.763
@@ -23402,14 +23395,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.764
@@ -23421,14 +23414,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.765
@@ -23440,14 +23433,14 @@ cases:
           storage_offset: 3072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.766
@@ -23459,14 +23452,14 @@ cases:
           storage_offset: 5120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.767
@@ -23478,14 +23471,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.768
@@ -23497,14 +23490,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.769
@@ -23516,14 +23509,14 @@ cases:
           storage_offset: 7168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.770
@@ -23535,14 +23528,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.771
@@ -23554,14 +23547,14 @@ cases:
           storage_offset: 9216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 16515072
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.772
@@ -23573,14 +23566,14 @@ cases:
           storage_offset: 10240
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.773
@@ -23592,14 +23585,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.774
@@ -23611,14 +23604,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.775
@@ -23630,14 +23623,14 @@ cases:
           storage_offset: 10752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.776
@@ -23649,14 +23642,14 @@ cases:
           storage_offset: 11776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 21233664
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.777
@@ -23668,14 +23661,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.778
@@ -23687,14 +23680,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.779
@@ -23706,14 +23699,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 24379392
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.780
@@ -23725,14 +23718,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.781
@@ -23744,14 +23737,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.782
@@ -23763,14 +23756,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 27525120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.783
@@ -23782,14 +23775,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.784
@@ -23801,14 +23794,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.785
@@ -23820,14 +23813,14 @@ cases:
           storage_offset: 18944
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.786
@@ -23839,14 +23832,14 @@ cases:
           storage_offset: 19456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.787
@@ -23858,14 +23851,14 @@ cases:
           storage_offset: 19456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.788
@@ -23877,14 +23870,14 @@ cases:
           storage_offset: 22016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.789
@@ -23896,14 +23889,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.790
@@ -23915,14 +23908,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.791
@@ -23934,14 +23927,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.792
@@ -23953,14 +23946,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.793
@@ -23972,14 +23965,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.794
@@ -23991,14 +23984,14 @@ cases:
           storage_offset: 24064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.795
@@ -24010,14 +24003,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.796
@@ -24029,14 +24022,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.797
@@ -24048,14 +24041,14 @@ cases:
           storage_offset: 26624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.798
@@ -24067,14 +24060,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.799
@@ -24086,14 +24079,14 @@ cases:
           storage_offset: 30208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.800
@@ -24105,14 +24098,14 @@ cases:
           storage_offset: 32256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.801
@@ -24124,14 +24117,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.802
@@ -24143,14 +24136,14 @@ cases:
           storage_offset: 32768
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.803
@@ -24162,14 +24155,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.15
@@ -24573,14 +24566,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.805
@@ -24592,14 +24585,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.806
@@ -24611,14 +24604,14 @@ cases:
           storage_offset: 4608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.807
@@ -24630,14 +24623,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.808
@@ -24649,14 +24642,14 @@ cases:
           storage_offset: 16896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.809
@@ -24668,14 +24661,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.810
@@ -24687,14 +24680,14 @@ cases:
           storage_offset: 19968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.811
@@ -24706,14 +24699,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.812
@@ -24725,14 +24718,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.813
@@ -24744,14 +24737,14 @@ cases:
           storage_offset: 24576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.814
@@ -24763,14 +24756,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.815
@@ -24782,14 +24775,14 @@ cases:
           storage_offset: 26112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 17301504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.816
@@ -24801,14 +24794,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.817
@@ -24820,14 +24813,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 20447232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.818
@@ -24839,14 +24832,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.819
@@ -24858,14 +24851,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 23592960
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.820
@@ -24877,14 +24870,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.821
@@ -24896,14 +24889,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.822
@@ -24915,14 +24908,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 28311552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.823
@@ -24934,14 +24927,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.824
@@ -24953,14 +24946,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.825
@@ -24972,14 +24965,14 @@ cases:
           storage_offset: 36864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.826
@@ -24991,14 +24984,14 @@ cases:
           storage_offset: 41472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.827
@@ -25010,14 +25003,14 @@ cases:
           storage_offset: 43008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.828
@@ -25029,14 +25022,14 @@ cases:
           storage_offset: 44544
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.829
@@ -25048,14 +25041,14 @@ cases:
           storage_offset: 46080
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.830
@@ -25067,14 +25060,14 @@ cases:
           storage_offset: 47616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 50331648
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.831
@@ -25086,14 +25079,14 @@ cases:
           storage_offset: 53760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 51904512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.832
@@ -25105,14 +25098,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 53477376
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.833
@@ -25124,14 +25117,14 @@ cases:
           storage_offset: 61440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 58195968
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.834
@@ -25143,14 +25136,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 59768832
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.835
@@ -25162,14 +25155,14 @@ cases:
           storage_offset: 62976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 61341696
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.836
@@ -25181,14 +25174,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 62914560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.837
@@ -25200,14 +25193,14 @@ cases:
           storage_offset: 64512
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 64487424
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.838
@@ -25219,14 +25212,14 @@ cases:
           storage_offset: 66048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 66060288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.839
@@ -25238,14 +25231,14 @@ cases:
           storage_offset: 66048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 67633152
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.840
@@ -25257,14 +25250,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 69206016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.841
@@ -25276,14 +25269,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 70778880
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.842
@@ -25295,14 +25288,14 @@ cases:
           storage_offset: 67584
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 72351744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.843
@@ -25314,14 +25307,14 @@ cases:
           storage_offset: 69120
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 73924608
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.844
@@ -25333,14 +25326,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 75497472
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.845
@@ -25352,14 +25345,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 77070336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.846
@@ -25371,14 +25364,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 78643200
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.847
@@ -25390,14 +25383,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 80216064
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.848
@@ -25409,14 +25402,14 @@ cases:
           storage_offset: 70656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 81788928
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.849
@@ -25428,14 +25421,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 83361792
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.850
@@ -25447,14 +25440,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 84934656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.851
@@ -25466,14 +25459,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 86507520
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.852
@@ -25485,14 +25478,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 88080384
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.853
@@ -25504,14 +25497,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 89653248
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.854
@@ -25523,14 +25516,14 @@ cases:
           storage_offset: 81408
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 91226112
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.855
@@ -25542,14 +25535,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 92798976
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.856
@@ -25561,14 +25554,14 @@ cases:
           storage_offset: 87552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 94371840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.857
@@ -25580,14 +25573,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 95944704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.858
@@ -25599,14 +25592,14 @@ cases:
           storage_offset: 95232
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 97517568
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.859
@@ -25618,14 +25611,14 @@ cases:
           storage_offset: 99840
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1024, 1536]
           stride: [1536, 1]
           storage_offset: 99090432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.16
@@ -26045,14 +26038,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.861
@@ -26064,14 +26057,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 786432
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.862
@@ -26083,14 +26076,14 @@ cases:
           storage_offset: 1536
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 1572864
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.863
@@ -26102,14 +26095,14 @@ cases:
           storage_offset: 2560
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 2359296
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.864
@@ -26121,14 +26114,14 @@ cases:
           storage_offset: 5632
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3145728
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.865
@@ -26140,14 +26133,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 3932160
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.866
@@ -26159,14 +26152,14 @@ cases:
           storage_offset: 6656
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 4718592
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.867
@@ -26178,14 +26171,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 5505024
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.868
@@ -26197,14 +26190,14 @@ cases:
           storage_offset: 7680
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 6291456
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.869
@@ -26216,14 +26209,14 @@ cases:
           storage_offset: 8192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7077888
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.870
@@ -26235,14 +26228,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 7864320
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.871
@@ -26254,14 +26247,14 @@ cases:
           storage_offset: 8704
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 8650752
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.872
@@ -26273,14 +26266,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 9437184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.873
@@ -26292,14 +26285,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 10223616
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.874
@@ -26311,14 +26304,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11010048
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.875
@@ -26330,14 +26323,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 11796480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.876
@@ -26349,14 +26342,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 12582912
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.877
@@ -26368,14 +26361,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 13369344
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.878
@@ -26387,14 +26380,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14155776
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.879
@@ -26406,14 +26399,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 14942208
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.880
@@ -26425,14 +26418,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 15728640
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.881
@@ -26444,14 +26437,14 @@ cases:
           storage_offset: 12288
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18087936
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.882
@@ -26463,14 +26456,14 @@ cases:
           storage_offset: 13824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 18874368
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.883
@@ -26482,14 +26475,14 @@ cases:
           storage_offset: 14336
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 19660800
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.884
@@ -26501,14 +26494,14 @@ cases:
           storage_offset: 14848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22020096
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.885
@@ -26520,14 +26513,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 22806528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.886
@@ -26539,14 +26532,14 @@ cases:
           storage_offset: 15872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25165824
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.887
@@ -26558,14 +26551,14 @@ cases:
           storage_offset: 17920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 25952256
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.888
@@ -26577,14 +26570,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 26738688
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.889
@@ -26596,14 +26589,14 @@ cases:
           storage_offset: 20480
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29097984
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.890
@@ -26615,14 +26608,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 29884416
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.891
@@ -26634,14 +26627,14 @@ cases:
           storage_offset: 20992
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 30670848
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.892
@@ -26653,14 +26646,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 31457280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.893
@@ -26672,14 +26665,14 @@ cases:
           storage_offset: 21504
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 32243712
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.894
@@ -26691,14 +26684,14 @@ cases:
           storage_offset: 22016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33030144
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.895
@@ -26710,14 +26703,14 @@ cases:
           storage_offset: 22016
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 33816576
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.896
@@ -26729,14 +26722,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 34603008
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.897
@@ -26748,14 +26741,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 35389440
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.898
@@ -26767,14 +26760,14 @@ cases:
           storage_offset: 22528
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36175872
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.899
@@ -26786,14 +26779,14 @@ cases:
           storage_offset: 23040
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 36962304
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.900
@@ -26805,14 +26798,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 37748736
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.901
@@ -26824,14 +26817,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 38535168
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.902
@@ -26843,14 +26836,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 39321600
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.903
@@ -26862,14 +26855,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40108032
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.904
@@ -26881,14 +26874,14 @@ cases:
           storage_offset: 23552
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 40894464
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.905
@@ -26900,14 +26893,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 41680896
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.906
@@ -26919,14 +26912,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 42467328
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.907
@@ -26938,14 +26931,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 43253760
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.908
@@ -26957,14 +26950,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44040192
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.909
@@ -26976,14 +26969,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 44826624
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.910
@@ -26995,14 +26988,14 @@ cases:
           storage_offset: 27136
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 45613056
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.911
@@ -27014,14 +27007,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 46399488
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.912
@@ -27033,14 +27026,14 @@ cases:
           storage_offset: 29184
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47185920
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.913
@@ -27052,14 +27045,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 47972352
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.914
@@ -27071,14 +27064,14 @@ cases:
           storage_offset: 31744
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 48758784
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.nn.functional.linear.915
@@ -27090,14 +27083,14 @@ cases:
           storage_offset: 33280
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [1536, 512]
           stride: [512, 1]
           storage_offset: 49545216
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1006 in
       forward, code: output_list.append(F.linear(input_list[i], self.weight[i]))'
   - name: torch.cat.17
@@ -27515,15 +27508,14 @@ cases:
           storage_offset: 15360
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [100352, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509 in
       torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant
@@ -27914,15 +27906,14 @@ cases:
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
+          init: xavier
       - tensor:
           shape: [100352, 1536]
           stride: [1536, 1]
           storage_offset: 0
           dtype: torch.float16
           device: cuda:0
-          init: rand
-      - value: null
+          init: xavier
     description: 'https://github.com/huggingface/transformers/blob/v5.2.0/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py#L1509 in
       torch_dynamo_resume_in_forward_at_1496, code: logits = self.lm_head(hidden_states[:, slice_indices, :])'
     marks: constant


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

This is a follow-up of #1909 to improve the numerical stability of matmul tests under op-level tests.

From #1909:
> Use Xavier uniform initialization instead of random normal initialization for matmul test inputs to improve numerical stability. Xavier initialization provides better-scaled initial values that are less sensitive to random seed variations, making the matmul tests more stable and reliable.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#1909
#1106

#### Special notes for your reviewer:

WIth this PR, all tests in category 3 of [this issue](https://github.com/torch-spyre/torch-spyre/issues/1106) pass.

#### Does this PR introduce a user-facing change?

#### Additional note:

cc @michihirohorie 
