### PR TITLE
[DRAFT PR] Add translateExpectedInputShapes logic from spyrecode.json

### DIFF
--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -465,20 +465,23 @@ std::vector<std::vector<int64_t>> JobPlanBuilder::translateExpectedInputShapes()
   }
 
   const auto& shapes_json = spyrecode_json_["ExpectedInputShapes"];
-  TORCH_CHECK(shapes_json.is_array(), "SpyreCode ExpectedInputShapes must be a JSON array");
+  TORCH_CHECK(shapes_json.is_array(),
+              "ExpectedInputShapes must be a JSON array");
 
   std::vector<std::vector<int64_t>> shapes;
   shapes.reserve(shapes_json.size());
 
   for (size_t i = 0; i < shapes_json.size(); ++i) {
     const auto& shape_json = shapes_json[i];
-    TORCH_CHECK(shape_json.is_array(), "SpyreCode ExpectedInputShapes[", i, "] must be a JSON array");
+    TORCH_CHECK(shape_json.is_array(),
+                "ExpectedInputShapes[", i, "] must be a JSON array");
 
     std::vector<int64_t> shape;
     shape.reserve(shape_json.size());
 
     for (size_t d = 0; d < shape_json.size(); ++d) {
-      TORCH_CHECK(shape_json[d].is_number_integer(), "SpyreCode ExpectedInputShapes[", i, "][", d, "] must be an integer");
+      TORCH_CHECK(shape_json[d].is_number_integer(),
+                  "ExpectedInputShapes[", i, "][", d, "] must be an integer");
       shape.push_back(shape_json[d].get<int64_t>());
     }
     shapes.push_back(std::move(shape));
@@ -506,7 +509,6 @@ std::unique_ptr<JobPlan> JobPlanBuilder::translateJobExecPlan() {
     }
   }
 
-  // TODO(jni): expected_input_shapes to be added once provided in SpyreCode
   // Create pinned_buffers vector from pinned_buffer_map_
   // Move tensors from map to avoid unnecessary reference count increments
   std::vector<HostBuffer> pinned_buffers;
@@ -520,9 +522,9 @@ std::unique_ptr<JobPlan> JobPlanBuilder::translateJobExecPlan() {
   return std::make_unique<JobPlan>(
     JobPlan{std::move(steps),                    // steps
             std::move(job_allocation_),          // job_allocation
-            translateExpectedInputShapes(),       // expected_input_shapes
+            translateExpectedInputShapes(),      // expected_input_shapes
             std::move(pinned_buffers),           // pinned_buffers
-            std::move(inits_)});                 // inits_ (new from main)
+            std::move(inits_)});
 }
 
 JobPlanBuilder::ValidationResult JobPlanBuilder::validate(

--- a/torch_spyre/csrc/prepare_kernel.cpp
+++ b/torch_spyre/csrc/prepare_kernel.cpp
@@ -459,6 +459,33 @@ std::unique_ptr<JobPlanStep> JobPlanBuilder::translateCommand(
   return nullptr;
 }
 
+std::vector<std::vector<int64_t>> JobPlanBuilder::translateExpectedInputShapes() const {
+  if (!spyrecode_json_.contains("ExpectedInputShapes")) {
+    return {};
+  }
+
+  const auto& shapes_json = spyrecode_json_["ExpectedInputShapes"];
+  TORCH_CHECK(shapes_json.is_array(), "SpyreCode ExpectedInputShapes must be a JSON array");
+
+  std::vector<std::vector<int64_t>> shapes;
+  shapes.reserve(shapes_json.size());
+
+  for (size_t i = 0; i < shapes_json.size(); ++i) {
+    const auto& shape_json = shapes_json[i];
+    TORCH_CHECK(shape_json.is_array(), "SpyreCode ExpectedInputShapes[", i, "] must be a JSON array");
+
+    std::vector<int64_t> shape;
+    shape.reserve(shape_json.size());
+
+    for (size_t d = 0; d < shape_json.size(); ++d) {
+      TORCH_CHECK(shape_json[d].is_number_integer(), "SpyreCode ExpectedInputShapes[", i, "][", d, "] must be an integer");
+      shape.push_back(shape_json[d].get<int64_t>());
+    }
+    shapes.push_back(std::move(shape));
+  }
+  return shapes;
+}
+
 std::unique_ptr<JobPlan> JobPlanBuilder::translateJobExecPlan() {
   auto job_exec_plan = spyrecode_json_["JobExecPlan"];
   TORCH_CHECK(job_exec_plan.is_array(), "JobExecPlan must be an array");
@@ -491,11 +518,11 @@ std::unique_ptr<JobPlan> JobPlanBuilder::translateJobExecPlan() {
   // Create and return the JobPlan
   // Use brace initialization to construct JobPlan with moved members
   return std::make_unique<JobPlan>(
-      JobPlan{std::move(steps),            // steps
-              std::move(job_allocation_),  // job_allocation
-              {},                          // expected_input_shapes
-              std::move(pinned_buffers),   // pinned_buffers
-              std::move(inits_)});
+    JobPlan{std::move(steps),                    // steps
+            std::move(job_allocation_),          // job_allocation
+            translateExpectedInputShapes(),       // expected_input_shapes
+            std::move(pinned_buffers),           // pinned_buffers
+            std::move(inits_)});                 // inits_ (new from main)
 }
 
 JobPlanBuilder::ValidationResult JobPlanBuilder::validate(

--- a/torch_spyre/csrc/prepare_kernel.h
+++ b/torch_spyre/csrc/prepare_kernel.h
@@ -165,6 +165,8 @@ class JobPlanBuilder {
       const nlohmann::json& cmd);
   /// Translate a DataTransfer command to a JobPlanStepH2D or JobPlanStepD2H
   std::unique_ptr<JobPlanStep> translateDataTransfer(const nlohmann::json& cmd);
+  /// Translate ExpectedInputShapes from spyrecode JSON to a vector of shapes
+  std::vector<std::vector<int64_t>> translateExpectedInputShapes() const;
 };
 
 /**

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -70,6 +71,57 @@ StreamPool& getStreamPool() {
 thread_local std::unordered_map<c10::DeviceIndex, c10::StreamId>
     current_streams;
 
+enum class ShapeCompareResult {
+  kExact,       // every dimension matches -> single-iteration path
+  kExceedsTile, // all dims >= expected, at least one strictly larger
+  kMismatch,    // rank differs or any dim is smaller than expected
+};
+
+ShapeCompareResult classifyShapes(const std::vector<at::Tensor>& tensors,
+                                  const std::vector<std::vector<int64_t>>& expected_shapes) {
+  bool any_exceeds = false;
+
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    const auto& actual = tensors[i].sizes();
+    const auto& expected = expected_shapes[i];
+
+    if (static_cast<size_t>(actual.size()) != expected.size()) {
+      return ShapeCompareResult::kMismatch;
+    }
+    for (size_t d = 0; d < expected.size(); ++d) {
+      if (actual[d] < expected[d]) return ShapeCompareResult::kMismatch;
+      if (actual[d] > expected[d]) any_exceeds = true;
+    }
+  }
+  return any_exceeds ? ShapeCompareResult::kExceedsTile
+                     : ShapeCompareResult::kExact;
+}
+
+std::string formatShapes(const std::vector<std::vector<int64_t>>& shapes) {
+  std::ostringstream oss;
+  oss << "[";
+  for (size_t i = 0; i < shapes.size(); ++i) {
+    if (i > 0) oss << ", ";
+    oss << "[";
+    for (size_t j = 0; j < shapes[i].size(); ++j) {
+      if (j > 0) oss << ", ";
+      oss << shapes[i][j];
+    }
+    oss << "]";
+  }
+  oss << "]";
+  return oss.str();
+}
+
+std::string formatShapes(const std::vector<at::Tensor>& tensors) {
+  std::vector<std::vector<int64_t>> shapes;
+  shapes.reserve(tensors.size());
+  for (const auto& tensor : tensors) {
+    shapes.push_back(tensor.sizes().vec());
+  }
+  return formatShapes(shapes);
+}
+    
 }  // anonymous namespace
 
 // Stream pool configuration
@@ -238,11 +290,51 @@ void SpyreStream::executeProgramAsync(
 }
 
 void SpyreStream::launch(const JobPlan& plan,
-                         const std::vector<at::Tensor>& args) const {
+                         const std::vector<at::Tensor>& args
+			 bool allow_tiled_launch) const {
   // Validate all tensors are on Spyre device
   for (size_t i = 0; i < args.size(); ++i) {
     TORCH_CHECK(args[i].is_privateuseone(), "SpyreStream::launch: argument ", i,
                 " must be on Spyre device, got ", args[i].device());
+  }
+
+  // Shape comparison (skip if no expected shapes - pure DMA plan)
+  if (!plan.expected_input_shapes.empty()) {
+    const size_t n_inputs = plan.expected_input_shapes.size();
+    TORCH_CHECK(args.size() >= n_inputs,
+                "SpyreStream::launch: expected >= ", n_inputs,
+                " args, received ", args.size());
+
+    const std::vector<at::Tensor> input_args(args.begin(),
+                                             args.begin() + n_inputs);
+
+    switch (classifyShapes(input_args, plan.expected_input_shapes)) {
+      case ShapeCompareResult::kExact:
+        // proceed to single-iteration launch below
+        break;
+
+      case ShapeCompareResult::kExceedsTile:
+        if (allow_tiled_launch) {
+          // TODO: tiled launch
+          TORCH_WARN_ONCE("Tiled launch requested but not yet implemented");
+          break;
+        } else {
+          TORCH_CHECK(false,
+                      "SpyreStream::launch: input shapes exceed tile size. "
+                      "Expected: ",
+                      formatShapes(plan.expected_input_shapes),
+                      ", got: ", formatShapes(input_args));
+        }
+        break;
+
+      case ShapeCompareResult::kMismatch:
+        TORCH_CHECK(false,
+                    "SpyreStream::launch: input shapes incompatible with "
+                    "compiled kernel. Expected: ",
+                    formatShapes(plan.expected_input_shapes),
+                    ", got: ", formatShapes(input_args));
+        break;
+    }
   }
 
   // Create launch context with tensor arguments

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -52,7 +52,9 @@ class SpyreStream {
   void executeProgramAsync(const KernelArtifacts& arts,
                            const std::vector<at::Tensor>& args) const;
 
-  void launch(const JobPlan& plan, const std::vector<at::Tensor>& args) const;
+  void launch(const JobPlan& plan, 
+	      const std::vector<at::Tensor>& args,
+	      bool allow_tiled_launch = true) const;
 
   // Conversions
   c10::Stream unwrap() const;


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:


Implementation of input shape comparison logic for SpyreStream.


#### Which issue(s) this PR is related to:

[P3-14] Implement shape comparison logic in SpyreStream](https://github.com/torch-spyre/torch-spyre/issues/1566)


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
2-part feature 
1. Add translation logic of expected input shapes from spyrecode.json into JobPlanBuilder.
2. Add shape comparison of expected input shapes from spyrecode with input tensors in spyrestream covering 3 criteria: 
- exact -> proceed with single iteration
- exceeds with allow_tiled_launch=true -> delegate to tiling
- exceeds with allow_tiled_launch=false -> raise exception