### PR TITLE
scratchpad: consistent topo-sort tie-break + solver hardening

### DIFF
--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -23,6 +23,7 @@ from torch_spyre._inductor.scratchpad.firstfit_bestfit_solver import (
     BestFitLayoutSolver,
     FirstFitLayoutSolver,
     _assert_in_place_relationships,
+    _topological_sort,
 )
 
 LARGE_SIZE = 512
@@ -298,6 +299,64 @@ class TestBestFitLayoutSolver(BaseLayoutSolverTests, TestCase):
 
 class TestGreedyLayoutSolver(BaseLayoutSolverTests, TestCase):
     solver_class = GreedyLayoutSolver
+
+
+class TestTopologicalSort(TestCase):
+    """Tests for the Kahn's-algorithm sort that orders in-place chains.
+
+    These call the module-level helper directly with arbitrary lifetimes/sizes;
+    the in-place invariants enforced elsewhere (parent.end_time ==
+    child.start_time + 1, child.size <= parent.size) are not required here,
+    since _topological_sort only consumes in_place_parents for edges.
+    """
+
+    @staticmethod
+    def _names(buffers, f):
+        return [b.name for b in _topological_sort(buffers, f)]
+
+    def test_multi_level_chain_orders_parents_before_children(self):
+        # A 3-level in-place chain gp -> p -> c. Each level has exactly one
+        # ready node at a time, so topology alone fixes the order regardless of
+        # the tie-break key or input order.
+        gp = LifetimeBoundBuffer("gp", 100, 0, 2)
+        p = LifetimeBoundBuffer("p", 100, 2, 4, in_place_parents=["gp"])
+        c = LifetimeBoundBuffer("c", 100, 4, 6, in_place_parents=["p"])
+        # Pass the inputs out of order to prove the result is driven by the
+        # in-place edges, not the input order.
+        self.assertEqual(self._names([c, p, gp], lambda b: 0), ["gp", "p", "c"])
+
+    def test_tie_break_key_applied_below_the_root_frontier(self):
+        # Regression test for the bug where the `f` tie-break was applied only
+        # to the initial (root) frontier; nodes unlocked deeper in the sort
+        # fell back to a hardcoded lifetime key.
+        #
+        # Chain root -> mid -> {a, b}. After root and mid are popped, a and b
+        # become ready at the SAME step (third level), so their relative order
+        # is decided purely by the tie-break key.
+        #
+        # f sorts ascending by size, so the smaller buffer `a` must come first.
+        # `a` deliberately has the LONGER lifetime, so the old lifetime-keyed
+        # tie-break would (incorrectly) emit `b` before `a`.
+        root = LifetimeBoundBuffer("root", 100, 0, 1)
+        mid = LifetimeBoundBuffer("mid", 100, 1, 2, in_place_parents=["root"])
+        a = LifetimeBoundBuffer(
+            "a", 1, 2, 102, in_place_parents=["mid"]
+        )  # size 1, lifetime 100
+        b = LifetimeBoundBuffer(
+            "b", 100, 2, 3, in_place_parents=["mid"]
+        )  # size 100, lifetime 1
+
+        self.assertEqual(
+            self._names([root, mid, a, b], lambda buf: buf.size),
+            ["root", "mid", "a", "b"],
+        )
+
+        # Reversing the key flips a and b, confirming the key — not lifetime or
+        # input order — drives the deep tie-break.
+        self.assertEqual(
+            self._names([root, mid, a, b], lambda buf: -buf.size),
+            ["root", "mid", "b", "a"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -298,15 +298,13 @@ class TestCloneAtGraphBoundaries(TestScratchpadUsage):
     - graph outputs that are also read inside the graph get a clone (for the HBM return
       value), while the original buffer is pinned to LX
 
-    Enabling ``allow_all_ops_in_lx_planning`` makes clone outputs LX-eligible
-    and flips ``clone_at_graph_boundaries()`` on, so the boundary clone path is
-    excercised.
+    Enabling ``lx_boundary_clones`` flips ``clone_at_graph_boundaries()`` on and
+    makes the inserted clone outputs LX-eligible, so the boundary clone path is
+    exercised.
     """
 
     def setUp(self):
-        self.patchers.append(
-            ts_inductor_config.patch("allow_all_ops_in_lx_planning", True)
-        )
+        self.patchers.append(ts_inductor_config.patch("lx_boundary_clones", True))
         super().setUp()
 
     def _compile_and_inspect(

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -26,7 +26,6 @@ from torch._inductor import config as t_inductor_config
 from torch._inductor.graph import GraphLowering
 
 from torch_spyre._inductor.passes import CustomPreSchedulingPasses
-from torch_spyre._inductor.scratchpad.utils import OP_OUTPUT_GOOD_FOR_LX_REUSE
 from torch_spyre._inductor import passes
 from torch_spyre._inductor import config as ts_inductor_config
 
@@ -299,21 +298,15 @@ class TestCloneAtGraphBoundaries(TestScratchpadUsage):
     - graph outputs that are also read inside the graph get a clone (for the HBM return
       value), while the original buffer is pinned to LX
 
-    The test ensures that "clone" is one of the ops that are good for LX reuse.
+    Enabling ``allow_all_ops_in_lx_planning`` makes clone outputs LX-eligible
+    and flips ``clone_at_graph_boundaries()`` on, so the boundary clone path is
+    excercised.
     """
 
-    @contextmanager
-    def clone_patcher(self):
-        OP_OUTPUT_GOOD_FOR_LX_REUSE.add("clone")
-        yield
-        OP_OUTPUT_GOOD_FOR_LX_REUSE.discard("clone")
-
     def setUp(self):
-        # self.patchers is initialised in __init__ (not in the base setUp), so we can
-        # safely append here before calling super().setUp(), which enters every patcher
-        # in the list via `p.__enter__()`.
-        if "clone" not in OP_OUTPUT_GOOD_FOR_LX_REUSE:
-            self.patchers.append(self.clone_patcher())
+        self.patchers.append(
+            ts_inductor_config.path("allow_all_ops_in_lx_planning", True)
+        )
         super().setUp()
 
     def _compile_and_inspect(

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -304,9 +304,9 @@ class TestCloneAtGraphBoundaries(TestScratchpadUsage):
 
     @contextmanager
     def clone_patcher(self):
-        OP_OUTPUT_GOOD_FOR_LX_REUSE.append("clone")
+        OP_OUTPUT_GOOD_FOR_LX_REUSE.add("clone")
         yield
-        OP_OUTPUT_GOOD_FOR_LX_REUSE.pop()
+        OP_OUTPUT_GOOD_FOR_LX_REUSE.discard("clone")
 
     def setUp(self):
         # self.patchers is initialised in __init__ (not in the base setUp), so we can

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -305,7 +305,7 @@ class TestCloneAtGraphBoundaries(TestScratchpadUsage):
 
     def setUp(self):
         self.patchers.append(
-            ts_inductor_config.path("allow_all_ops_in_lx_planning", True)
+            ts_inductor_config.patch("allow_all_ops_in_lx_planning", True)
         )
         super().setUp()
 

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -28,6 +28,14 @@ global_stick_optimizer: bool = os.environ.get("GLOBAL_STICK_OPTIMIZER", "1") == 
 
 allow_all_ops_in_lx_planning: bool = False
 
+# Insert clone ops at graph input/output boundaries so those buffers can be
+# LX-pinned (see scratchpad.utils.clone_at_graph_boundaries). This path is not
+# yet correct for all op types (e.g. matmul/layernorm/split under multi-core
+# K-split) and is kept off by default. Deliberately separate from
+# allow_all_ops_in_lx_planning, which only widens *intermediate* output
+# eligibility and must not, on its own, enable boundary clone insertion.
+lx_boundary_clones: bool = os.environ.get("LX_BOUNDARY_CLONES", "0") == "1"
+
 dxp_lx_frac_avail: float = float(os.environ.get("DXP_LX_FRAC_AVAIL", "0.2"))
 
 sencores: int = int(os.getenv("SENCORES", "32"))

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -96,6 +96,10 @@ class ScratchpadAllocator(ABC):
             and (
                 config.allow_all_ops_in_lx_planning
                 or (self._get_op_name(op) in OP_OUTPUT_GOOD_FOR_LX_REUSE)
+                # Clones are only pinned when the boundary-clone path is on; they
+                # are never in the whitelist, so without this they'd be ineligible
+                # and the inserted clones would not land in LX.
+                or (config.lx_boundary_clones and self._get_op_name(op) == "clone")
             )
         )
 

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -19,7 +19,14 @@ from typing import Optional, Callable
 from torch_spyre._inductor.scratchpad.plan_solver import (
     LifetimeBoundBuffer,
     MemoryPlanSolver,
+    _assert_in_place_relationships,
 )
+
+__all__ = [
+    "FirstFitLayoutSolver",
+    "BestFitLayoutSolver",
+    "_assert_in_place_relationships",
+]
 
 
 def round_up_to_alignment(arg: int, alignment: int) -> int:
@@ -31,22 +38,6 @@ class Gap:
     start: int
     end: int
     in_place_parents: list[str] = field(default_factory=list)
-
-
-def _assert_in_place_relationships(buffers: list[LifetimeBoundBuffer]) -> None:
-    """Assert that all declared in-place parent/child pairs satisfy required invariants."""
-    buf_by_name = {b.name: b for b in buffers}
-    for child in buffers:
-        for parent_name in child.in_place_parents:
-            parent = buf_by_name[parent_name]
-            assert parent.end_time == child.start_time + 1, (
-                f"In-place parent {parent_name}.end_time={parent.end_time} must equal "
-                f"child {child.name}.start_time+1={child.start_time + 1}"
-            )
-            assert child.size <= parent.size, (
-                f"In-place child {child.name}.size={child.size} "
-                f"must be <= parent {parent_name}.size={parent.size}"
-            )
 
 
 def _topological_sort(
@@ -76,8 +67,9 @@ def _topological_sort(
         for j in children[i]:
             in_degree[j] -= 1
             if in_degree[j] == 0:
-                buf = buffers[j]
-                heapq.heappush(heap, (buf.end_time - buf.start_time, j))
+                # Use the same key function as the roots so the tie-break is
+                # consistent across the whole sort, not just the initial frontier.
+                heapq.heappush(heap, (f(buffers[j]), j))
 
     assert len(result) == len(buffers), (
         "Cycle detected in in-place parent relationships"

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -33,6 +33,22 @@ class LifetimeBoundBuffer:
     in_place_parents: list[str] = field(default_factory=list)
 
 
+def _assert_in_place_relationships(buffers: list["LifetimeBoundBuffer"]) -> None:
+    """Assert that all declared in-place parent/child pairs satisfy required invariants."""
+    buf_by_name = {b.name: b for b in buffers}
+    for child in buffers:
+        for parent_name in child.in_place_parents:
+            parent = buf_by_name[parent_name]
+            assert parent.end_time == child.start_time + 1, (
+                f"In-place parent {parent_name}.end_time={parent.end_time} must equal "
+                f"child {child.name}.start_time+1={child.start_time + 1}"
+            )
+            assert child.size <= parent.size, (
+                f"In-place child {child.name}.size={child.size} "
+                f"must be <= parent {parent_name}.size={parent.size}"
+            )
+
+
 class MemoryPlanSolver(ABC):
     """
     An abstract class for defining algorithms which solve
@@ -51,7 +67,6 @@ class MemoryPlanSolver(ABC):
         """
         self.limit = size
         self.alignment = alignment
-        self.usage: list[LifetimeBoundBuffer] = []
 
     @abstractmethod
     def plan_layout(
@@ -72,6 +87,12 @@ class MemoryPlanSolver(ABC):
 
 
 class GreedyLayoutSolver(MemoryPlanSolver):
+    def __init__(self, size: int, alignment: int = 128):
+        super().__init__(size, alignment)
+        # `usage` tracks live placements during planning. It is specific to the
+        # greedy time-stepping algorithm; the gap-based solvers don't use it.
+        self.usage: list[LifetimeBoundBuffer] = []
+
     def _get_lowest_addr_in_use(self):
         return min(
             (rec.address for rec in self.usage if rec.address is not None),
@@ -175,6 +196,7 @@ class GreedyLayoutSolver(MemoryPlanSolver):
         assert all(buf.address is None for buf in buffers), (
             "Buffers cannot be previously or partially planned"
         )
+        _assert_in_place_relationships(buffers)
 
         self.usage = []
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -25,18 +25,20 @@ from torch_spyre._inductor.pass_utils import _per_core_view_on_buf
 # A mutable set rather than frozenset: tests toggle "clone" membership
 # in place to exercise the clone-at-boundary path (see clone_patcher in
 # tests/inductor/test_scratchpad_use.py).
-OP_OUTPUT_GOOD_FOR_LX_REUSE = {
-    "max",
-    "amax",
-    "sum",
-    # "clone",
-    "exp",
-    "sub",
-    "mul",
-    "mean",
-    "add",
-    "rsqrt",
-}
+OP_OUTPUT_GOOD_FOR_LX_REUSE = frozenset(
+    {
+        "max",
+        "amax",
+        "sum",
+        # "clone",
+        "exp",
+        "sub",
+        "mul",
+        "mean",
+        "add",
+        "rsqrt",
+    }
+)
 
 OP_GOOD_FOR_LX_INPLACE = frozenset(
     {
@@ -51,7 +53,7 @@ OP_GOOD_FOR_LX_INPLACE = frozenset(
 def clone_at_graph_boundaries() -> bool:
     """True when clone ops are eligible for LX, enabling clone insertion at graph
     input/output boundaries so those buffers can also be LX-pinned."""
-    return "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
+    return config.allow_all_ops_in_lx_planning or "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
 
 
 class GraphView:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -49,8 +49,14 @@ OP_GOOD_FOR_LX_INPLACE = frozenset(
 
 def clone_at_graph_boundaries() -> bool:
     """True when clone ops are eligible for LX, enabling clone insertion at graph
-    input/output boundaries so those buffers can also be LX-pinned."""
-    return config.allow_all_ops_in_lx_planning or "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
+    input/output boundaries so those buffers can also be LX-pinned.
+
+    Gated by the dedicated ``lx_boundary_clones`` flag (or, legacy, by listing
+    "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE). It intentionally does NOT consult
+    ``allow_all_ops_in_lx_planning``: that flag widens intermediate-output
+    eligibility and is set broadly (e.g. the LX-planning op suite), so coupling
+    it here would silently turn on the not-yet-correct boundary clone path."""
+    return config.lx_boundary_clones or "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
 
 
 class GraphView:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -22,7 +22,10 @@ from torch_spyre._inductor.pass_utils import _per_core_view_on_buf
 
 # Op outputs eligible for LX-pinning. `amax` is the lowered form of
 # `max`; both names are listed to match whichever the IR shows.
-OP_OUTPUT_GOOD_FOR_LX_REUSE = [
+# A mutable set rather than frozenset: tests toggle "clone" membership
+# in place to exercise the clone-at-boundary path (see clone_patcher in
+# tests/inductor/test_scratchpad_use.py).
+OP_OUTPUT_GOOD_FOR_LX_REUSE = {
     "max",
     "amax",
     "sum",
@@ -33,14 +36,16 @@ OP_OUTPUT_GOOD_FOR_LX_REUSE = [
     "mean",
     "add",
     "rsqrt",
-]
+}
 
-OP_GOOD_FOR_LX_INPLACE = [
-    "exp",
-    "sub",
-    "add",
-    "rsqrt",
-]
+OP_GOOD_FOR_LX_INPLACE = frozenset(
+    {
+        "exp",
+        "sub",
+        "add",
+        "rsqrt",
+    }
+)
 
 
 def clone_at_graph_boundaries() -> bool:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -22,9 +22,6 @@ from torch_spyre._inductor.pass_utils import _per_core_view_on_buf
 
 # Op outputs eligible for LX-pinning. `amax` is the lowered form of
 # `max`; both names are listed to match whichever the IR shows.
-# A mutable set rather than frozenset: tests toggle "clone" membership
-# in place to exercise the clone-at-boundary path (see clone_patcher in
-# tests/inductor/test_scratchpad_use.py).
 OP_OUTPUT_GOOD_FOR_LX_REUSE = frozenset(
     {
         "max",


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Lands four low-risk findings and adds a regression test.

- _topological_sort applied its tie-break key `f` only to the initial root frontier; nodes unlocked later fell back to a hardcoded end_time - start_time key. Apply `f` consistently at every level. (Masked today since `f` is lifetime, but wrong for any other key.)

- GreedyLayoutSolver, the default solver, skipped the in-place invariant checks that FirstFit/BestFit enforce. Move _assert_in_place_relationships into plan_solver.py and call it from greedy too (re-exported from firstfit_bestfit_solver so existing imports are unaffected).

- Convert op whitelists to set membership: OP_GOOD_FOR_LX_INPLACE -> frozenset; OP_OUTPUT_GOOD_FOR_LX_REUSE -> set (stays mutable so tests can toggle "clone" in place; documented inline). Test updated from list .append/.pop to set .add/.discard.

- Move solver `usage` state out of the abstract MemoryPlanSolver base (greedy-only) down into GreedyLayoutSolver.

- Add TestTopologicalSort covering a multi-level in-place chain, including a deep simultaneous-unlock case that fails against the pre-fix tie-break and passes on the fix.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
