### PR TITLE
test: Use Xavier init for test_linear weights and add down_proj cases

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -2415,23 +2415,45 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
             "param_sets": {
                 "2d_no_bias": (
                     cached_randn((67, 256)),
-                    cached_randn((128, 256)),
+                    cached_xavier((128, 256)),
                     None,
                 ),
                 "2d_bias": (
                     cached_randn((67, 256)),
-                    cached_randn((128, 256)),
+                    cached_xavier((128, 256)),
                     cached_randn((128,)),
                 ),
                 "3d_no_bias": (
                     cached_randn((3, 17, 256)),
-                    cached_randn((128, 256)),
+                    cached_xavier((128, 256)),
                     None,
                 ),
                 "3d_bias": (
                     cached_randn((3, 17, 256)),
-                    cached_randn((128, 256)),
+                    cached_xavier((128, 256)),
                     cached_randn((128,)),
+                ),
+                # down_proj-shaped cases : large reduction dim
+                # (32768) is numerically unstable with plain randn weights.
+                "down_proj_prefill_12800": (
+                    cached_randn((1, 11, 32768)),
+                    cached_xavier((12800, 32768)),
+                    cached_randn((12800,)),
+                ),
+                "down_proj_prefill_4096": (
+                    cached_randn((1, 11, 32768)),
+                    cached_xavier((4096, 32768)),
+                    cached_randn((4096,)),
+                ),
+                "down_proj_decode_12800": (
+                    cached_randn((1, 1, 32768)),
+                    cached_xavier((12800, 32768)),
+                    cached_randn((12800,)),
+                ),
+                "down_proj_decode_4096": (
+                    cached_randn((1, 1, 32768)),
+                    cached_xavier((4096, 32768)),
+                    cached_randn((4096,)),
                 ),
             }
         },


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Use Xavier uniform initialization instead of random normal initialization
for the weight tensors in the `test_linear` cases, mirroring the change
already made for `test_mm` / `test_bmm` / `test_matmul`. Plain
`randn`-initialized weights with large reduction dimensions are poorly
scaled and can produce values that exceed the fp16 comparison tolerance
against the CPU reference, even when the underlying `linear` op is correct.

This PR also adds four new `test_linear` cases covering the `down_proj`
shapes from issue #1970 (reduction dim 32768, output dims 12800/4096, for
both prefill `(1, 11, *)` and decode `(1, 1, *)` sequence lengths). With
plain `randn` weights these cases mismatch the CPU reference by several
units (max_diff up to 7.0); with Xavier-initialized weights they pass.

#### Which issue(s) this PR is related to:

#1970 

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?


#### Additional note:


