### PR TITLE
enable SDSCBundles with symbolic args by default

### DIFF
--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -282,6 +282,10 @@ def _autoload():
     os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")
     os.environ.setdefault("DTLOG_LEVEL", "error")
 
+    # Enable spyre code with symbolic addresses by default
+    os.environ.setdefault("DUMP_SPYRE_CODE", "1")
+    os.environ.setdefault("BUNDLE_SYMBOLIC_ARGS", "1")
+
 
 if not profiler.is_available():
     profiler = None

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -49,7 +49,7 @@ core_id_k_fast_emission: bool = (
 # When True, addresses are emitted as runtime symbols with
 # !sdscbundle.input_arg<index> parameters, input_arg_extract ops, and
 # affine.apply indirection for tiled loops.
-bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "0") == "1"
+bundle_symbolic_args: bool = os.environ.get("BUNDLE_SYMBOLIC_ARGS", "1") == "1"
 
 # When True (default), LoopSpec nodes are fully unrolled into flat OpSpecs
 # before generate_bundle runs.  Set to False to pass LoopSpecs through intact

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -36,7 +36,7 @@ class SpyreSDSCKernelRunner:
         self.kernel_name = name
         self.code_dir = code_dir
         self.jobplan = None
-        dump_spyre_code = os.environ.get("DUMP_SPYRE_CODE", "0")
+        dump_spyre_code = os.environ.get("DUMP_SPYRE_CODE", "1")
         if dump_spyre_code.isdigit() and int(dump_spyre_code) != 0:
             self.jobplan = prepare_kernel(code_dir + "/spyreCodeDir")
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Enables symbolic args on SuperDSCBundles by default.

#### Which issue(s) this PR is related to:

Fixes #827 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
