### PR TITLE
More info for layout solvers

### DIFF
--- a/tests/inductor/test_scratchpad_patterns.py
+++ b/tests/inductor/test_scratchpad_patterns.py
@@ -45,7 +45,7 @@ BYPASS_XFAIL = os.environ.get("SCRATCHPAD_PATTERN_BYPASS_XFAIL", "0") == "1"
 
 def make_buffer_registry(names_sizes: dict[str, int]) -> dict[str, Buffer]:
     return {
-        name: Buffer(name=name, size=size, start_time=-1, end_time=-1)
+        name: Buffer(name=name, size=size, uses=[])
         for (name, size) in names_sizes.items()
     }
 
@@ -150,11 +150,13 @@ class Pattern:
         for i, op in enumerate(self.operations):
             for buffer_name in op.inputs + op.outputs:
                 buffer = self.buffers[buffer_name]
-                if buffer.start_time == -1:
-                    buffer.start_time = i
-                buffer.end_time = i + 1
+                if i not in buffer.uses:
+                    buffer.uses.append(i)
 
         self.inputs, self.outputs = self.determine_inputs_outputs()
+
+        for input_name in self.inputs:
+            self.buffers[input_name].first_use_is_read = True
 
         for i, op in enumerate(self.operations):
             output_buffer = self.buffers[op.outputs[0]]
@@ -162,7 +164,8 @@ class Pattern:
                 buffer = self.buffers[buffer_name]
                 if (
                     buffer_name not in self.inputs + self.outputs
-                    and buffer.end_time == i + 1
+                    and buffer.uses
+                    and buffer.uses[-1] == i
                     and buffer.size == output_buffer.size
                 ):
                     output_buffer.in_place_parents.append(buffer_name)

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -46,10 +46,10 @@ def _two_gap_buffers():
     FirstFit picks (0,40) → addr=0; BestFit picks (100,120) → addr=100.
     """
     return [
-        LifetimeBoundBuffer("b_mid", 40, 2, 4),
-        LifetimeBoundBuffer("b_left", 30, 1, 5),
-        LifetimeBoundBuffer("b_right", 30, 3, 8),
-        LifetimeBoundBuffer("x", 10, 4, 9),
+        LifetimeBoundBuffer("b_mid", 40, [2, 3]),
+        LifetimeBoundBuffer("b_left", 30, [1, 4]),
+        LifetimeBoundBuffer("b_right", 30, [3, 7]),
+        LifetimeBoundBuffer("x", 10, [4, 8]),
     ]
 
 
@@ -76,64 +76,64 @@ class BaseLayoutSolverTests:
     def test_simple_layout(self):
         # Three non-overlapping buffers fill memory sequentially.
         buffers = [
-            LifetimeBoundBuffer("buffer0", 3, 0, 2),
-            LifetimeBoundBuffer("buffer1", 3, 0, 2),
-            LifetimeBoundBuffer("buffer2", 4, 0, 2),
+            LifetimeBoundBuffer("buffer0", 3, [0, 1]),
+            LifetimeBoundBuffer("buffer1", 3, [0, 1]),
+            LifetimeBoundBuffer("buffer2", 4, [0, 1]),
         ]
         self.verify_layout(buffers, [0, 3, 6])
 
     def test_simple_layout_below_alignment(self):
         # Buffers smaller than the alignment boundary are evicted (address=None).
         buffers = [
-            LifetimeBoundBuffer("buffer0", 3, 0, 2),
-            LifetimeBoundBuffer("buffer1", 3, 0, 2),
-            LifetimeBoundBuffer("buffer2", 4, 0, 2),
+            LifetimeBoundBuffer("buffer0", 3, [0, 1]),
+            LifetimeBoundBuffer("buffer1", 3, [0, 1]),
+            LifetimeBoundBuffer("buffer2", 4, [0, 1]),
         ]
         self.verify_layout(buffers, [0, None, None], alignment=ALIGNMENT)
 
     def test_alignment_enforced(self):
         # Each buffer is placed at the next alignment boundary.
         buffers = [
-            LifetimeBoundBuffer("buffer0", 3, 0, 2),
-            LifetimeBoundBuffer("buffer1", 3, 0, 2),
-            LifetimeBoundBuffer("buffer2", 4, 0, 2),
+            LifetimeBoundBuffer("buffer0", 3, [0, 1]),
+            LifetimeBoundBuffer("buffer1", 3, [0, 1]),
+            LifetimeBoundBuffer("buffer2", 4, [0, 1]),
         ]
         self.verify_layout(buffers, [0, 128, 256], LARGE_SIZE, ALIGNMENT)
 
     def test_simple_eviction_layout(self):
         # buffer1 is evicted because it won't fit; buffer2 reuses buffer0's space.
         buffers = [
-            LifetimeBoundBuffer("buffer0", 7, 0, 2),
-            LifetimeBoundBuffer("buffer1", 4, 0, 2),
-            LifetimeBoundBuffer("buffer2", 3, 0, 2),
+            LifetimeBoundBuffer("buffer0", 7, [0, 1]),
+            LifetimeBoundBuffer("buffer1", 4, [0, 1]),
+            LifetimeBoundBuffer("buffer2", 3, [0, 1]),
         ]
         self.verify_layout(buffers, [0, None, 7])
 
     def test_realloc(self):
         # buffer1's lifetime starts after buffer0 ends, so it reuses address 0.
         buffers = [
-            LifetimeBoundBuffer("buffer0", 10, 0, 2),
-            LifetimeBoundBuffer("buffer1", 3, 2, 3),
+            LifetimeBoundBuffer("buffer0", 10, [0, 1]),
+            LifetimeBoundBuffer("buffer1", 3, [2]),
         ]
         self.verify_layout(buffers, [0, 0])
 
     def test_realloc_between(self):
         # buffer3's lifetime begins after buffer1 ends, so it reclaims buffer1's slot.
         buffers = [
-            LifetimeBoundBuffer("buffer0", 3, 0, 4),
-            LifetimeBoundBuffer("buffer1", 3, 1, 3),
-            LifetimeBoundBuffer("buffer2", 3, 2, 4),
-            LifetimeBoundBuffer("buffer3", 3, 3, 4),
+            LifetimeBoundBuffer("buffer0", 3, [0, 3]),
+            LifetimeBoundBuffer("buffer1", 3, [1, 2]),
+            LifetimeBoundBuffer("buffer2", 3, [2, 3]),
+            LifetimeBoundBuffer("buffer3", 3, [3]),
         ]
         self.verify_layout(buffers, {(0, 3, 6, 3), (6, 0, 3, 0)})
 
     def test_realloc_between_with_alignment(self):
         # Same reuse pattern as test_realloc_between, but with alignment padding applied.
         buffers = [
-            LifetimeBoundBuffer("buffer0", 200, 0, 4),
-            LifetimeBoundBuffer("buffer1", 100, 1, 3),
-            LifetimeBoundBuffer("buffer2", 100, 2, 4),
-            LifetimeBoundBuffer("buffer3", 100, 3, 4),
+            LifetimeBoundBuffer("buffer0", 200, [0, 3]),
+            LifetimeBoundBuffer("buffer1", 100, [1, 2]),
+            LifetimeBoundBuffer("buffer2", 100, [2, 3]),
+            LifetimeBoundBuffer("buffer3", 100, [3]),
         ]
         if self.solver_class == GreedyLayoutSolver:
             self.verify_layout(buffers, [0, 256, 384, 256], LARGE_SIZE, ALIGNMENT)
@@ -144,9 +144,9 @@ class BaseLayoutSolverTests:
     def test_inplace_allocation(self):
         # Test that adding inplace options allows for more efficient peak usage
         buffers = [
-            LifetimeBoundBuffer("buffer0", LARGE_SIZE, 0, 4),
+            LifetimeBoundBuffer("buffer0", LARGE_SIZE, [0, 3]),
             LifetimeBoundBuffer(
-                "buffer1", LARGE_SIZE, 3, 4, in_place_parents=["buffer0"]
+                "buffer1", LARGE_SIZE, [3], in_place_parents=["buffer0"]
             ),
         ]
         self.verify_layout(buffers, [0, 0], LARGE_SIZE + 1, ALIGNMENT)
@@ -154,8 +154,8 @@ class BaseLayoutSolverTests:
     def test_without_inplace_allocation(self):
         # Test that buffer gets evicted without in_place
         buffers = [
-            LifetimeBoundBuffer("buffer0", LARGE_SIZE, 0, 4),
-            LifetimeBoundBuffer("buffer1", LARGE_SIZE, 3, 4),
+            LifetimeBoundBuffer("buffer0", LARGE_SIZE, [0, 3]),
+            LifetimeBoundBuffer("buffer1", LARGE_SIZE, [3]),
         ]
         self.verify_layout(buffers, {(0, None), (None, 0)}, LARGE_SIZE, ALIGNMENT)
 
@@ -163,10 +163,10 @@ class BaseLayoutSolverTests:
         # buffer0 fills the entire scratchpad; buffer1 and buffer2 are evicted.
         # buffer3 starts after buffer0 ends and should reclaim address 0.
         buffers = [
-            LifetimeBoundBuffer("buffer0", SMALL_SIZE, 0, 2),
-            LifetimeBoundBuffer("buffer1", SMALL_SIZE, 0, 2),
-            LifetimeBoundBuffer("buffer2", SMALL_SIZE, 0, 2),
-            LifetimeBoundBuffer("buffer3", SMALL_SIZE, 2, 3),
+            LifetimeBoundBuffer("buffer0", SMALL_SIZE, [0, 1]),
+            LifetimeBoundBuffer("buffer1", SMALL_SIZE, [0, 1]),
+            LifetimeBoundBuffer("buffer2", SMALL_SIZE, [0, 1]),
+            LifetimeBoundBuffer("buffer3", SMALL_SIZE, [2]),
         ]
         self.verify_layout(buffers, [0, None, None, 0])
 
@@ -175,7 +175,7 @@ class BaseLayoutSolverTests:
         # when no other allocation is live (usage is empty, so address 0 would
         # otherwise be returned without the limit guard).
         buffers = [
-            LifetimeBoundBuffer("buffer0", SMALL_SIZE + 1, 0, 2),
+            LifetimeBoundBuffer("buffer0", SMALL_SIZE + 1, [0, 1]),
         ]
         self.verify_layout(buffers, [None], size=SMALL_SIZE)
 
@@ -183,15 +183,18 @@ class BaseLayoutSolverTests:
         self.assertEqual(self.solve([]), [])
 
     def test_single_buffer_placed_at_zero(self):
-        self.verify_layout([LifetimeBoundBuffer("a", 10, 0, 5)], [0])
+        self.verify_layout([LifetimeBoundBuffer("a", 10, [0, 4])], [0])
 
     def test_single_buffer_evicted_when_too_large(self):
-        self.verify_layout([LifetimeBoundBuffer("a", 11, 0, 5)], [None], size=10)
+        self.verify_layout([LifetimeBoundBuffer("a", 11, [0, 4])], [None], size=10)
 
     def test_non_overlapping_lifetimes_reuse_address(self):
         # b1 ends at time 5 (exclusive); b2 starts at time 5 — they never coexist.
         self.verify_layout(
-            [LifetimeBoundBuffer("b1", 20, 0, 5), LifetimeBoundBuffer("b2", 20, 5, 10)],
+            [
+                LifetimeBoundBuffer("b1", 20, [0, 4]),
+                LifetimeBoundBuffer("b2", 20, [5, 9]),
+            ],
             [0, 0],
             size=LARGE_SIZE,
         )
@@ -200,9 +203,9 @@ class BaseLayoutSolverTests:
         # Equal lifetimes: stable sort preserves input order, so a(10)@0, b(20)@10, c(30)@30.
         self.verify_layout(
             [
-                LifetimeBoundBuffer("a", 10, 0, 4),
-                LifetimeBoundBuffer("b", 20, 0, 4),
-                LifetimeBoundBuffer("c", 30, 0, 4),
+                LifetimeBoundBuffer("a", 10, [0, 3]),
+                LifetimeBoundBuffer("b", 20, [0, 3]),
+                LifetimeBoundBuffer("c", 30, [0, 3]),
             ],
             [0, 10, 30],
             size=60,
@@ -212,9 +215,9 @@ class BaseLayoutSolverTests:
         # a(10)@0 and b(20)@10 consume 30 bytes; c(30) needs 30 but only 20 remain → evicted.
         self.verify_layout(
             [
-                LifetimeBoundBuffer("a", 10, 0, 4),
-                LifetimeBoundBuffer("b", 20, 0, 4),
-                LifetimeBoundBuffer("c", 30, 0, 4),
+                LifetimeBoundBuffer("a", 10, [0, 3]),
+                LifetimeBoundBuffer("b", 20, [0, 3]),
+                LifetimeBoundBuffer("c", 30, [0, 3]),
             ],
             [0, 10, None],
             size=50,
@@ -224,7 +227,10 @@ class BaseLayoutSolverTests:
         # Two same-size concurrent buffers; the second is placed at the next
         # alignment boundary after the first.
         self.verify_layout(
-            [LifetimeBoundBuffer("a", 10, 0, 4), LifetimeBoundBuffer("b", 10, 0, 4)],
+            [
+                LifetimeBoundBuffer("a", 10, [0, 3]),
+                LifetimeBoundBuffer("b", 10, [0, 3]),
+            ],
             [0, 128],
             alignment=128,
             size=LARGE_SIZE,
@@ -234,17 +240,20 @@ class BaseLayoutSolverTests:
         # a(13)@0 leaves a gap starting at 13; rounding up to alignment=10 gives
         # addr=20, but 20+12=32 > limit=30, so b is evicted.
         self.verify_layout(
-            [LifetimeBoundBuffer("a", 13, 0, 5), LifetimeBoundBuffer("b", 12, 0, 5)],
+            [
+                LifetimeBoundBuffer("a", 13, [0, 4]),
+                LifetimeBoundBuffer("b", 12, [0, 4]),
+            ],
             [0, None],
             size=30,
             alignment=10,
         )
 
     def test_child_reuses_parent_address(self):
-        # P ends at 5; C.start_time=4 == P.end_time - 1, so in-place is valid.
+        # P.end_time==5 (uses[-1]+1); C.start_time==4 (uses[0]); 5==4+1, so in-place is valid.
         # Without in-place, P's [0,20) would be subtracted and C would land at 20.
-        p = LifetimeBoundBuffer("P", 20, 0, 5)
-        c = LifetimeBoundBuffer("C", 15, 4, 9, in_place_parents=["P"])
+        p = LifetimeBoundBuffer("P", 20, [0, 4])
+        c = LifetimeBoundBuffer("C", 15, [4, 8], in_place_parents=["P"])
         result = self.solve([p, c])
         by_name = {b.name: b.address for b in result}
         self.assertEqual(by_name["P"], 0)
@@ -254,8 +263,8 @@ class BaseLayoutSolverTests:
         # P is too large to fit; C declared as in-place child of P.
         # P gets evicted (address=None), so C also cannot in-place and
         # must fall back to normal placement.
-        p = LifetimeBoundBuffer("P", 200, 0, 5)
-        c = LifetimeBoundBuffer("C", 15, 4, 9, in_place_parents=["P"])
+        p = LifetimeBoundBuffer("P", 200, [0, 4])
+        c = LifetimeBoundBuffer("C", 15, [4, 8], in_place_parents=["P"])
         result = self.solve([p, c], size=100)
         by_name = {b.name: b.address for b in result}
         self.assertIsNone(by_name["P"])
@@ -263,17 +272,17 @@ class BaseLayoutSolverTests:
         self.assertEqual(by_name["C"], 0)
 
     def test_assert_rejects_wrong_end_time(self):
-        p = LifetimeBoundBuffer("P", 20, 0, 5)
+        p = LifetimeBoundBuffer("P", 20, [0, 4])
         c = LifetimeBoundBuffer(
-            "C", 15, 3, 9, in_place_parents=["P"]
-        )  # start_time=3, need P.end_time==4
+            "C", 15, [3, 8], in_place_parents=["P"]
+        )  # uses[0]=3, need P.uses[-1]+1==4
         with self.assertRaises(AssertionError):
             _assert_in_place_relationships([p, c])
 
     def test_assert_rejects_oversized_child(self):
-        p = LifetimeBoundBuffer("P", 10, 0, 5)
+        p = LifetimeBoundBuffer("P", 10, [0, 4])
         c = LifetimeBoundBuffer(
-            "C", 15, 4, 9, in_place_parents=["P"]
+            "C", 15, [4, 8], in_place_parents=["P"]
         )  # child larger than parent
         with self.assertRaises(AssertionError):
             _assert_in_place_relationships([p, c])

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -288,7 +288,50 @@ class BaseLayoutSolverTests:
             _assert_in_place_relationships([p, c])
 
 
-class TestFirstFitLayoutSolver(BaseLayoutSolverTests, TestCase):
+class ScoreOrderingTests:
+    """Tests for the priority-score ordering in FirstFit/BestFit.
+
+    Buffers are placed in ascending order of ``(span - discount) / len(uses)``
+    (lower = placed first), where ``discount`` is 0.25 per in-place
+    relationship. These tests isolate the two terms the old
+    shortest-lifetime-first heuristic ignored: ``len(uses)`` and the in-place
+    discount. They do not apply to the Greedy solver, whose time-stepped
+    plan_layout does not score buffers.
+    """
+
+    def test_higher_use_count_placed_first(self):
+        # Two buffers with the same span (5) fully overlap and contend for the
+        # single slot that fits one of them. Score is span / len(uses), so the
+        # buffer with more uses scores lower and is placed first, winning the
+        # slot — regardless of input order. The old span-only tiebreak would
+        # tie (both span 5) and keep input order, pinning `few` instead.
+        many = LifetimeBoundBuffer("many", 10, [0, 1, 2, 3, 4])  # 5 / 5 = 1.0
+        few = LifetimeBoundBuffer("few", 10, [0, 4])  # 5 / 2 = 2.5
+        # `few` first in input order, to prove ordering is by score not input.
+        result = self.solve([few, many], size=10)
+        by_name = {b.name: b.address for b in result}
+        self.assertEqual(by_name["many"], 0)
+        self.assertIsNone(by_name["few"])
+
+    def test_inplace_discount_raises_priority(self):
+        # `plain` and `parent` have identical span (5) and use count (2), so
+        # their base scores tie at 2.5. `parent` is an in-place parent of
+        # `child`, earning a 0.25 discount → score (5 - 0.25) / 2 = 2.375 <
+        # 2.5, so it is placed first and wins the single contested slot. The
+        # old heuristic would tie and keep input order, pinning `plain`.
+        plain = LifetimeBoundBuffer("plain", 10, [0, 4])  # 5 / 2 = 2.5
+        parent = LifetimeBoundBuffer("parent", 10, [0, 4])  # (5 - 0.25) / 2
+        child = LifetimeBoundBuffer("child", 10, [4, 8], in_place_parents=["parent"])
+        # `plain` first in input order; without the discount the tie would
+        # keep input order and pin `plain`.
+        result = self.solve([plain, parent, child], size=10)
+        by_name = {b.name: b.address for b in result}
+        self.assertEqual(by_name["parent"], 0)
+        self.assertEqual(by_name["child"], 0)  # child reuses parent's slot
+        self.assertIsNone(by_name["plain"])
+
+
+class TestFirstFitLayoutSolver(ScoreOrderingTests, BaseLayoutSolverTests, TestCase):
     solver_class = FirstFitLayoutSolver
 
     def test_picks_first_gap_not_tightest(self):
@@ -297,7 +340,7 @@ class TestFirstFitLayoutSolver(BaseLayoutSolverTests, TestCase):
         self.assertEqual(x_addr, 0)
 
 
-class TestBestFitLayoutSolver(BaseLayoutSolverTests, TestCase):
+class TestBestFitLayoutSolver(ScoreOrderingTests, BaseLayoutSolverTests, TestCase):
     solver_class = BestFitLayoutSolver
 
     def test_picks_tightest_gap(self):

--- a/tests/inductor/test_scratchpad_solver.py
+++ b/tests/inductor/test_scratchpad_solver.py
@@ -330,6 +330,21 @@ class ScoreOrderingTests:
         self.assertEqual(by_name["child"], 0)  # child reuses parent's slot
         self.assertIsNone(by_name["plain"])
 
+    def test_write_first_buffer_placed_before_read_only(self):
+        # Identical span (5) and use count (2). `writer`'s first use is a write
+        # (first_use_is_read=False), so pinning it also saves the more expensive
+        # first write to HBM; its use count is inflated by 0.5, giving score
+        # 5 / 2.5 = 2.0 vs `reader`'s 5 / 2.0 = 2.5. `writer` is placed first and
+        # wins the single contested slot. Without the write bonus the scores tie
+        # and input order would pin `reader`.
+        reader = LifetimeBoundBuffer("reader", 10, [0, 4], first_use_is_read=True)
+        writer = LifetimeBoundBuffer("writer", 10, [0, 4], first_use_is_read=False)
+        # `reader` first in input order, to prove ordering is by score not input.
+        result = self.solve([reader, writer], size=10)
+        by_name = {b.name: b.address for b in result}
+        self.assertEqual(by_name["writer"], 0)
+        self.assertIsNone(by_name["reader"])
+
 
 class TestFirstFitLayoutSolver(ScoreOrderingTests, BaseLayoutSolverTests, TestCase):
     solver_class = FirstFitLayoutSolver

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 import torch
 from torch._inductor.ir import (
     TensorBox,
+    TensorBox,
     ComputedBuffer,
     Operation,
     MutationLayoutSHOULDREMOVE,
@@ -49,6 +50,7 @@ from torch_spyre._inductor.scratchpad.passes import (
 from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
     OP_GOOD_FOR_LX_INPLACE,
+    clone_at_graph_boundaries,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,
@@ -160,13 +162,12 @@ class ScratchpadAllocator(ABC):
                 continue
             if output_name in graph_output_names and not cloning_allowed:
                 continue  # we can only allocate graph outputs if we're allowed to clone
-            uses = lifetimes[output_name]
             buffers.append(
                 LifetimeBoundBuffer(
                     output_name,
                     info["size_per_core"],
-                    uses[0],
-                    uses[-1] + 1,
+                    uses,
+                    first_use_is_read=False,
                     in_place_parents=in_place.get(output_name, []),
                 )
             )
@@ -193,8 +194,8 @@ class ScratchpadAllocator(ABC):
                     LifetimeBoundBuffer(
                         input_name,
                         dev_size // num_cores,
-                        uses[0],
-                        uses[-1] + 1,
+                        uses,
+                        first_use_is_read=True,
                         in_place_parents=[],
                     )
                 )

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -20,7 +20,6 @@ from typing import Any, Optional
 import torch
 from torch._inductor.ir import (
     TensorBox,
-    TensorBox,
     ComputedBuffer,
     Operation,
     MutationLayoutSHOULDREMOVE,
@@ -50,7 +49,6 @@ from torch_spyre._inductor.scratchpad.passes import (
 from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
     OP_GOOD_FOR_LX_INPLACE,
-    clone_at_graph_boundaries,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -42,7 +42,7 @@ class Gap:
 
 def _topological_sort(
     buffers: list[LifetimeBoundBuffer],
-    f: Callable[[LifetimeBoundBuffer], int] = lambda b: 0,
+    f: Callable[[LifetimeBoundBuffer], float] = lambda b: 0,
 ) -> list[LifetimeBoundBuffer]:
     """Topological sort via Kahn's algorithm; ties broken by (f, original_index)."""
     name_to_idx = {b.name: i for i, b in enumerate(buffers)}
@@ -55,7 +55,7 @@ def _topological_sort(
             children[p].append(i)
             in_degree[i] += 1
 
-    heap: list[tuple[int, int]] = []
+    heap: list[tuple[float, int]] = []
     for i, buf in enumerate(buffers):
         if in_degree[i] == 0:
             heapq.heappush(heap, (f(buf), i))
@@ -78,14 +78,16 @@ def _topological_sort(
 
 
 class FirstFitLayoutSolver(MemoryPlanSolver):
-    """Allocates buffers shortest-lifetime-first, placing each in the first gap that fits.
+    """Allocates buffers by priority score, placing each in the first gap that fits.
 
     Buffers are sorted topologically (parents before children) with ties broken by ascending
-    lifetime, then placed one at a time. For each buffer, free address gaps during its lifetime
-    are computed; the buffer is placed at the start of the first gap large enough to hold it
-    (rounded up to alignment). In-place reuse is attempted first: if a declared parent has already
-    been placed and its address falls within a free gap, the child inherits that address.
-    Buffers that cannot fit within self.limit are evicted (address=None).
+    ``(end_time - start_time - discount) / len(uses)``, where ``discount`` is 0.25 for each
+    in-place relationship the buffer participates in (as a child, as a parent, or both, capped
+    at 0.5). Lower score = higher priority = placed first.  For each buffer, free address gaps
+    during its lifetime are computed; the buffer is placed at the start of the first gap large
+    enough to hold it (rounded up to alignment). In-place reuse is attempted first: if a declared
+    parent has already been placed and its address falls within a free gap, the child inherits
+    that address.  Buffers that cannot fit within self.limit are evicted (address=None).
     """
 
     def _all_minus(
@@ -182,9 +184,15 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
         buffers_filtered = [
             buffer for buffer in buffers if buffer.end_time >= buffer.start_time + 1
         ]
-        buffers_sorted = _topological_sort(
-            buffers_filtered, lambda b: b.end_time - b.start_time
-        )
+        parent_names = {p for b in buffers_filtered for p in b.in_place_parents}
+
+        def _sort_key(b: LifetimeBoundBuffer) -> tuple[float, int]:
+            span = b.end_time - b.start_time
+            discount = 0.25 * bool(b.in_place_parents) + 0.25 * (b.name in parent_names)
+            return (span - discount) / len(b.uses), span
+
+        buffers_filtered.sort(key=_sort_key)
+        buffers_sorted = _topological_sort(buffers_filtered)
 
         names_to_addresses: dict[str, int] = {}
         for i, buffer in enumerate(buffers_sorted):

--- a/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
+++ b/torch_spyre/_inductor/scratchpad/firstfit_bestfit_solver.py
@@ -81,13 +81,16 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
     """Allocates buffers by priority score, placing each in the first gap that fits.
 
     Buffers are sorted topologically (parents before children) with ties broken by ascending
-    ``(end_time - start_time - discount) / len(uses)``, where ``discount`` is 0.25 for each
-    in-place relationship the buffer participates in (as a child, as a parent, or both, capped
-    at 0.5). Lower score = higher priority = placed first.  For each buffer, free address gaps
-    during its lifetime are computed; the buffer is placed at the start of the first gap large
-    enough to hold it (rounded up to alignment). In-place reuse is attempted first: if a declared
-    parent has already been placed and its address falls within a free gap, the child inherits
-    that address.  Buffers that cannot fit within self.limit are evicted (address=None).
+    ``(end_time - start_time - discount) / (len(uses) + write_bonus)``. ``discount`` is 0.25 for
+    each in-place relationship the buffer participates in (as a child, as a parent, or both,
+    capped at 0.5); ``write_bonus`` is 0.5 when the buffer's first use is a write (i.e.
+    ``not first_use_is_read``) and 0 otherwise, since pinning such a buffer also saves the more
+    expensive first write to HBM. Lower score = higher priority = placed first.  For each buffer,
+    free address gaps during its lifetime are computed; the buffer is placed at the start of the
+    first gap large enough to hold it (rounded up to alignment). In-place reuse is attempted
+    first: if a declared parent has already been placed and its address falls within a free gap,
+    the child inherits that address.  Buffers that cannot fit within self.limit are evicted
+    (address=None).
     """
 
     def _all_minus(
@@ -189,7 +192,13 @@ class FirstFitLayoutSolver(MemoryPlanSolver):
         def _sort_key(b: LifetimeBoundBuffer) -> tuple[float, int]:
             span = b.end_time - b.start_time
             discount = 0.25 * bool(b.in_place_parents) + 0.25 * (b.name in parent_names)
-            return (span - discount) / len(b.uses), span
+            # A buffer whose first use is a write (not first_use_is_read) also
+            # saves a *write* to HBM on its first step when pinned in LX, on top
+            # of the reads saved on later steps. Writes are more expensive than
+            # reads, so count that first write as worth 0.5 of an extra use,
+            # inflating the denominator to give such buffers a better score.
+            uses = len(b.uses) + (0.0 if b.first_use_is_read else 0.5)
+            return (span - discount) / uses, span
 
         buffers_filtered.sort(key=_sort_key)
         buffers_sorted = _topological_sort(buffers_filtered)

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -23,14 +23,30 @@ import math
 class LifetimeBoundBuffer:
     """
     Defines the data fields required for a plan solver.
+
+    ``uses`` is the sorted list of operation indices at which the buffer is
+    accessed (as returned by ``calculate_liveness``).  ``first_use_is_read``
+    is True for graph inputs (all accesses are reads) and False for computed
+    buffers (first access is a write, all subsequent accesses are reads).
+
+    ``start_time`` and ``end_time`` are convenience properties derived from
+    ``uses``: ``uses[0]`` and ``uses[-1] + 1`` respectively.
     """
 
     name: str
     size: int
-    start_time: int
-    end_time: int
+    uses: list[int]
+    first_use_is_read: bool = False
     address: Optional[int] = None
     in_place_parents: list[str] = field(default_factory=list)
+
+    @property
+    def start_time(self) -> int:
+        return self.uses[0]
+
+    @property
+    def end_time(self) -> int:
+        return self.uses[-1] + 1
 
 
 def _assert_in_place_relationships(buffers: list["LifetimeBoundBuffer"]) -> None:

--- a/torch_spyre/_inductor/scratchpad/plan_solver.py
+++ b/torch_spyre/_inductor/scratchpad/plan_solver.py
@@ -25,7 +25,10 @@ class LifetimeBoundBuffer:
     Defines the data fields required for a plan solver.
 
     ``uses`` is the sorted list of operation indices at which the buffer is
-    accessed (as returned by ``calculate_liveness``).  ``first_use_is_read``
+    accessed (as returned by ``calculate_liveness``).  It must be non-empty:
+    the ``start_time``/``end_time`` properties index into it and the
+    FirstFit/BestFit scoring divides by ``len(uses)``, so callers must only
+    construct buffers for names that are actually used.  ``first_use_is_read``
     is True for graph inputs (all accesses are reads) and False for computed
     buffers (first access is a write, all subsequent accesses are reads).
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from dataclasses import dataclass, field
 import math
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
@@ -58,13 +57,6 @@ def clone_at_graph_boundaries() -> bool:
     eligibility and is set broadly (e.g. the LX-planning op suite), so coupling
     it here would silently turn on the not-yet-correct boundary clone path."""
     return config.lx_boundary_clones or "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
-
-
-@dataclass
-class Liveness:
-    start: int
-    end: int
-    reads: list[int] = field(default_factory=list)
 
 
 class GraphView:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from dataclasses import dataclass, field
 import math
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
@@ -64,12 +65,6 @@ class Liveness:
     start: int
     end: int
     reads: list[int] = field(default_factory=list)
-
-
-def clone_at_graph_boundaries() -> bool:
-    """True when clone ops are eligible for LX, enabling clone insertion at graph
-    input/output boundaries so those buffers can also be LX-pinned."""
-    return "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
 
 
 class GraphView:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -59,6 +59,19 @@ def clone_at_graph_boundaries() -> bool:
     return config.lx_boundary_clones or "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
 
 
+@dataclass
+class Liveness:
+    start: int
+    end: int
+    reads: list[int] = field(default_factory=list)
+
+
+def clone_at_graph_boundaries() -> bool:
+    """True when clone ops are eligible for LX, enabling clone insertion at graph
+    input/output boundaries so those buffers can also be LX-pinned."""
+    return "clone" in OP_OUTPUT_GOOD_FOR_LX_REUSE
+
+
 class GraphView:
     """
     Simple wrapper which allows filtering of returned operations


### PR DESCRIPTION
#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR adds more information into the buffer data structure used by the scratchpad layout solver. In particular, a buffer now knows the time points at which it is used. This makes it much easier for a solver to make good layout decisions: buffers that are used more often are more beneficial. This is also needed to unlock evict/reallocate logic: it needs to be able to detect stretches where a buffer is not used (much).

This PR also adds the information as to whether a buffer is being read or written in that op: a graph input is only ever read, and every other buffer is written during its first op and only ever read after that. So this information is encoded in a boolean that's added to the buffer.

The PR also modifies the first-fit and best-fit solvers to use all of this information in its heuristic. There are some parameters for this, which should probably be informed by lots of good experiments; we don't really have those experiments yet.

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Only in the sense that it might lead to a better layout solve.
#### Additional note:
