### PR TITLE
Coarse tiling: support nested outer-output + inner-reduction

### DIFF
--- a/docs/source/compiler/coarse_tiling_loops.md
+++ b/docs/source/compiler/coarse_tiling_loops.md
@@ -636,23 +636,53 @@ correctly but waste a copy op here.
 
 When a `Reduction` op has a non-empty `loop_tiled_reduction_dims`
 (i.e. the hint named a reduction dimension), `_propagate_tiled_reduction_op`
-uses a **fill-initialize + per-tile combine** pattern:
+uses a **fill-initialize + per-tile combine** pattern.  The exact buffer
+allocation depends on whether tiling is flat (reduction dim only) or nested
+(outer output dim + inner reduction dim):
 
-1. **Allocate an HBM accumulation buffer** with the full output shape
-   (`data.ranges`, which is already the full output since only
-   `reduction_ranges` was divided by the tiling pass).
+**Flat (K-only) tiling** — a single `accum_full` HBM buffer is allocated.
+The fill and combine ops both target `accum_full` directly.
+
+1. **Allocate `accum_full`** with the full output shape (`data.ranges`,
+   which is already the full output since only `reduction_ranges` was
+   divided by the tiling pass).
 2. **Insert a fill op** (outside the loop, no `loop_info`) that writes the
-   reduction's identity value into the accumulation buffer.  The identity
-   value is produced by a `SpyreConstantFallback` scalar with a manually
-   assigned `FixedTiledLayout` (necessary because `finalize_layouts` has
-   already run by the time this pass executes).
+   reduction's identity value into `accum_full`.  The identity value is
+   produced by a `SpyreConstantFallback` scalar with a manually assigned
+   `FixedTiledLayout` (necessary because `finalize_layouts` has already run
+   by the time this pass executes).
 3. **Insert a combine op** (inside the loop, same `loop_info` as the tiled
-   reduction op) that merges each tile's partial result into the accumulation
-   buffer using the appropriate pointwise binary operator.
+   reduction op) that merges each tile's partial result into `accum_full`
+   using the appropriate pointwise binary operator.
 4. **Mark the tiled reduction op's output `per_tile_fixed`** — it is a
    per-tile scratch buffer whose base address does not advance between
    iterations.
-5. **Patch outside consumers** to read the accumulation buffer.
+5. **Patch outside consumers** to read `accum_full`.
+
+**Nested (outer output dim + inner reduction dim) tiling** — two buffers
+are allocated to enable LX scratchpad placement of the inner accumulator
+(e.g. outer-B + inner-K for bmm/mm):
+
+1. **Allocate `accum_full`** (full HBM output, shape matching the full
+   output across all outer tiles).
+2. **Allocate `accum_tile`** (per-tile scratch, same per-tile output shape).
+   `accum_tile.layout.per_tile_fixed = True` so the unroller never advances
+   its base address; `scratchpad_planning` can therefore place it in LX
+   scratchpad memory.
+3. **Insert a fill op** (inside the outer loop, carrying the outer
+   `loop_info`) that writes the identity value into `accum_tile` once per
+   outer-loop tile.
+4. **Insert a combine op** (inside the inner loop, same `loop_info` as the
+   tiled reduction op) that merges each inner-tile partial result into
+   `accum_tile`.
+5. **Insert a `coarse_tile_reduce_copy` op** (inside the outer loop, after
+   the inner loop) that copies `accum_tile → accum_full`.  It carries the
+   outer `loop_info` so the unroller advances `accum_full`'s HBM address
+   once per outer-loop tile.  The copy uses `MutationLayoutSHOULDREMOVE`
+   so no extra allocation is created.
+6. **Mark the tiled reduction op's output `per_tile_fixed`** (the inner
+   scratch for the reduction kernel itself).
+7. **Patch outside consumers** to read `accum_full`.
 
 Identity values and combine operators by `reduction_type`:
 
@@ -669,28 +699,23 @@ Identity values and combine operators by `reduction_type`:
 `RuntimeError` when a user attempts to tile them.
 
 Before running propagation, the pass calls `_validate_reduction_tiling(op)`,
-which raises `RuntimeError` for configurations deferred to Stage 2:
+which raises `RuntimeError` for configurations not yet implemented:
 
 - **Stick-dim reduction** — if the tiled reduction index corresponds to the
   within-stick dimension of the primary input (detected via
-  `device_coordinates`).
+  `device_coordinates`), except for `BATCH_MATMUL_OP` whose tile output is
+  always a full `[M, N]` matrix.
 - **Mixed output+reduction at the same nesting level** — `loop_tiled_dims[i]`
   and `loop_tiled_reduction_dims[i]` are both non-empty for some level `i`.
-- **Mixed output+reduction across different levels** — some levels tile only
-  output dims, others tile only reduction dims.
 - **Multiple reduction indices at one level** — `len(loop_tiled_reduction_dims[i]) > 1`.
 
-The cross-level mixed check runs first (before the per-level loop) so Stage 2
-errors are raised before `_reduction_tiling_is_on_stick_dim` is called, which
-requires a real `get_read_writes()` result.
+Nested tiling where outer level(s) tile output dims and the innermost level
+tiles a reduction dim (e.g. outer-B + inner-K for bmm) is fully supported
+and handled by the two-buffer pattern described above.
 
-**Stage 2 (not yet implemented):** Stick-dim reduction tiling requires
-handling the column-vector output addressing that arises when the tiling
-dimension is the innermost (stick) dimension of the input.  The
-`loop_tiled_reduction_dims` field is already shaped as a `list[list[int]]`
-to anticipate multi-level nesting; relaxing the Stage 2 guard in
-`_validate_reduction_tiling` and adding stick-dim output addressing is the
-only remaining work.
+**Not yet implemented:** Stick-dim reduction tiling (except `BATCH_MATMUL_OP`)
+requires handling column-vector output addressing when the tiling dimension is
+the innermost (stick) dimension of the input.
 
 ## Layer 2 — `CountedLoopSchedulerNode`
 

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1294,5 +1294,107 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
         self.assertIn("sympify('4')", src, "Expected loop count 4")
 
 
+class TestCoarseTileNestedReductionE2E(InductorTestCase):
+    """Correctness and LoopSpec tests for nested output-dim + reduction-dim tiling.
+
+    Pattern: outer loop tiles an output dim, inner loop tiles a reduction dim.
+    The fill op runs inside the outer loop (once per outer tile), so the
+    accumulator is per-outer-tile sized.  The full output buffer spans all outer
+    tiles; address advancement across outer iterations assembles the result.
+
+    mm shapes: M=128, K=512, N=32; outer tiles M by 2 (64 rows/tile),
+    inner tiles K by 4 (128 elements/tile = 2 sticks at fp16).
+    bmm shapes: Batch=8, M=64, K=512, N=32; outer tiles Batch by 2,
+    inner tiles K by 4.
+    """
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0xCAFE)
+        # Reset the named-dims registry to prevent WeakIdKeyDict aliasing
+        # with device tensors created in earlier tests.  Dims are re-declared
+        # in each test body, so this is safe.
+        _pnd.reset()
+
+    @config.patch({"lx_planning": False})
+    def test_nested_bmm_outer_Batch_inner_K_correct(self):
+        """bmm [Batch,M,K]@[Batch,K,N] outer Batch (output) + inner K (reduction) — correct."""
+        from torch_spyre._inductor import spyre_hint
+
+        # Use Batch=4 (distinct from the K-tiling tests that use B=8) to avoid
+        # any WeakIdKeyDict aliasing when named-dim annotations are looked up.
+        Batch, M, K, N = 4, 64, 512, 32
+        a = torch.randn(Batch, M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(Batch, K, N, dtype=torch.float16) * 0.01
+        _declare_tensor_dim("Batch", Batch)
+        _declare_tensor_dim("M2", M)
+        _declare_tensor_dim("K2", K)
+        _declare_tensor_dim("N2", N)
+
+        def fn(a, b):
+            _name_tensor_dims(a, ["Batch", "M2", "K2"])
+            _name_tensor_dims(b, ["Batch", "K2", "N2"])
+            with spyre_hint(num_tiles_per_dim={"Batch": 2}):
+                with spyre_hint(num_tiles_per_dim={"K2": 4}):
+                    return torch.bmm(a, b)
+
+        compare_with_cpu(
+            fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
+        )
+
+    @config.patch({"lx_planning": False})
+    def test_nested_matmul_outer_M_inner_K_correct(self):
+        """mm [M,K]@[K,N] with outer M (output) + inner K (reduction) — correct."""
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 128, 512, 32
+        a = torch.randn(M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(K, N, dtype=torch.float16) * 0.01
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+
+        def fn(a, b):
+            _name_tensor_dims(a, ["M", "K"])
+            _name_tensor_dims(b, ["K", "N"])
+            with spyre_hint(num_tiles_per_dim={"M": 2}):
+                with spyre_hint(num_tiles_per_dim={"K": 4}):
+                    return torch.mm(a, b)
+
+        compare_with_cpu(
+            fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
+        )
+
+    @config.patch({"lx_planning": False})
+    def test_nested_matmul_outer_M_inner_K_loopspec(self):
+        """Nested mm produces two LoopSpec levels (outer count 2, inner count 4)."""
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 128, 512, 32
+        a = torch.randn(M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(K, N, dtype=torch.float16) * 0.01
+        a_dev = a.to("spyre")
+        b_dev = b.to("spyre")
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+        _name_tensor_dims(a_dev, ["M", "K"])
+        _name_tensor_dims(b_dev, ["K", "N"])
+
+        def fn(a, b):
+            with spyre_hint(num_tiles_per_dim={"M": 2}):
+                with spyre_hint(num_tiles_per_dim={"K": 4}):
+                    return torch.mm(a, b)
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, a_dev, b_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src, "Expected LoopSpec for nested mm")
+        self.assertIn("sympify('2')", src, "Expected outer loop count 2")
+        self.assertIn("sympify('4')", src, "Expected inner loop count 4")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1389,6 +1389,76 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         self.assertIn("sympify('2')", src, "Expected outer loop count 2")
         self.assertIn("sympify('4')", src, "Expected inner loop count 4")
 
+    @config.patch({"lx_planning": False, "unroll_loops": False})
+    def test_nested_matmul_copy_after_inner_loop(self):
+        """The accum→output copy op appears in generated source for nested K-tiling."""
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 128, 512, 32
+        a = torch.randn(M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(K, N, dtype=torch.float16) * 0.01
+        a_dev = a.to("spyre")
+        b_dev = b.to("spyre")
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+        _name_tensor_dims(a_dev, ["M", "K"])
+        _name_tensor_dims(b_dev, ["K", "N"])
+
+        def fn(a, b):
+            with spyre_hint(num_tiles_per_dim={"M": 2}):
+                with spyre_hint(num_tiles_per_dim={"K": 4}):
+                    return torch.mm(a, b)
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, a_dev, b_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn(
+            "coarse_tile_reduce_copy",
+            src,
+            "Expected a coarse_tile_reduce_copy op in generated source for nested M+K tiling",
+        )
+
+    @config.patch(
+        {
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+            "unroll_loops": False,
+        }
+    )
+    def test_nested_matmul_outer_M_inner_K_accum_in_lx(self):
+        """With lx_planning enabled, the tile-sized accum buffer lands in LX scratchpad."""
+        from torch_spyre._inductor import spyre_hint
+
+        M, K, N = 128, 512, 32
+        a = torch.randn(M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(K, N, dtype=torch.float16) * 0.01
+        a_dev = a.to("spyre")
+        b_dev = b.to("spyre")
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
+        _name_tensor_dims(a_dev, ["M", "K"])
+        _name_tensor_dims(b_dev, ["K", "N"])
+
+        def fn(a, b):
+            with spyre_hint(num_tiles_per_dim={"M": 2}):
+                with spyre_hint(num_tiles_per_dim={"K": 4}):
+                    return torch.mm(a, b)
+
+        cfn = torch.compile(fn)
+        with mock_patch(_LAUNCH_KERNEL), mock_patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, a_dev, b_dev)
+        self.assertTrue(len(source_codes) > 0)
+        src = source_codes[0]
+        self.assertIn(
+            "allocation={'lx'",
+            src,
+            "Expected tile-sized accum TensorArg with lx allocation for nested M+K tiling",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1304,38 +1304,32 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
 
     mm shapes: M=128, K=512, N=32; outer tiles M by 2 (64 rows/tile),
     inner tiles K by 4 (128 elements/tile = 2 sticks at fp16).
-    bmm shapes: Batch=8, M=64, K=512, N=32; outer tiles Batch by 2,
+    bmm shapes: B=4, M=64, K=512, N=32; outer tiles B by 2,
     inner tiles K by 4.
     """
 
     def setUp(self):
         super().setUp()
         torch.manual_seed(0xCAFE)
-        # Reset the named-dims registry to prevent WeakIdKeyDict aliasing
-        # with device tensors created in earlier tests.  Dims are re-declared
-        # in each test body, so this is safe.
-        _pnd.reset()
 
     @config.patch({"lx_planning": False})
     def test_nested_bmm_outer_Batch_inner_K_correct(self):
-        """bmm [Batch,M,K]@[Batch,K,N] outer Batch (output) + inner K (reduction) — correct."""
+        """bmm [B,M,K]@[B,K,N] outer B (output) + inner K (reduction) — correct."""
         from torch_spyre._inductor import spyre_hint
 
-        # Use Batch=4 (distinct from the K-tiling tests that use B=8) to avoid
-        # any WeakIdKeyDict aliasing when named-dim annotations are looked up.
-        Batch, M, K, N = 4, 64, 512, 32
-        a = torch.randn(Batch, M, K, dtype=torch.float16) * 0.01
-        b = torch.randn(Batch, K, N, dtype=torch.float16) * 0.01
-        _declare_tensor_dim("Batch", Batch)
-        _declare_tensor_dim("M2", M)
-        _declare_tensor_dim("K2", K)
-        _declare_tensor_dim("N2", N)
+        B, M, K, N = 4, 64, 512, 32
+        a = torch.randn(B, M, K, dtype=torch.float16) * 0.01
+        b = torch.randn(B, K, N, dtype=torch.float16) * 0.01
+        _declare_tensor_dim("B", B)
+        _declare_tensor_dim("M", M)
+        _declare_tensor_dim("K", K)
+        _declare_tensor_dim("N", N)
 
         def fn(a, b):
-            _name_tensor_dims(a, ["Batch", "M2", "K2"])
-            _name_tensor_dims(b, ["Batch", "K2", "N2"])
-            with spyre_hint(num_tiles_per_dim={"Batch": 2}):
-                with spyre_hint(num_tiles_per_dim={"K2": 4}):
+            _name_tensor_dims(a, ["B", "M", "K"])
+            _name_tensor_dims(b, ["B", "K", "N"])
+            with spyre_hint(num_tiles_per_dim={"B": 2}):
+                with spyre_hint(num_tiles_per_dim={"K": 4}):
                     return torch.bmm(a, b)
 
         compare_with_cpu(

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1995,6 +1995,43 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
         # output-dim-only tiling should not raise
         _validate_reduction_tiling(op)
 
+    def test_nested_fill_gets_outer_loop_info(self):
+        """Fill op gets outer-level loop_info for nested output+reduction tiling."""
+        from torch_spyre._inductor.coarse_tile import _compute_fill_loop_info
+
+        op = _make_tiled_reduction_op(
+            "red0",
+            ranges=[Integer(64)],
+            reduction_ranges=[Integer(256)],
+            reduction_type="sum",
+            loop_group_id=(0, 0),
+            loop_count=[Integer(2), Integer(4)],
+            loop_tiled_dims=[[0], []],
+        )
+        op.loop_info.loop_tiled_reduction_dims = [[], [0]]
+        fill_info = _compute_fill_loop_info(op)
+        self.assertIsNotNone(fill_info)
+        self.assertEqual(fill_info.loop_group_id, (0,))
+        self.assertEqual(fill_info.loop_count, [Integer(2)])
+        self.assertEqual(fill_info.loop_tiled_dims, [[0]])
+
+    def test_flat_fill_has_no_loop_info(self):
+        """Fill op gets no loop_info for flat (pure) reduction tiling."""
+        from torch_spyre._inductor.coarse_tile import _compute_fill_loop_info
+
+        op = _make_tiled_reduction_op(
+            "red0",
+            ranges=[Integer(128)],
+            reduction_ranges=[Integer(256)],
+            reduction_type="sum",
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[]],
+        )
+        op.loop_info.loop_tiled_reduction_dims = [[0]]
+        fill_info = _compute_fill_loop_info(op)
+        self.assertIsNone(fill_info)
+
 
 class TestComputeFillLoopInfo(unittest.TestCase):
     """_compute_fill_loop_info returns trimmed CoarseTileInfo for the fill op."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1996,6 +1996,48 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
         _validate_reduction_tiling(op)
 
 
+class TestComputeFillLoopInfo(unittest.TestCase):
+    """_compute_fill_loop_info returns trimmed CoarseTileInfo for the fill op."""
+
+    def test_flat_reduction_returns_none(self):
+        """Pure reduction tiling (no output-dim level) → None (fill before all loops)."""
+        from torch_spyre._inductor.coarse_tile import _compute_fill_loop_info
+
+        op = _make_tiled_reduction_op(
+            "red0",
+            ranges=[Integer(128)],
+            reduction_ranges=[Integer(256)],
+            reduction_type="sum",
+            loop_group_id=(0,),
+            loop_count=[Integer(4)],
+            loop_tiled_dims=[[]],
+        )
+        op.loop_info.loop_tiled_reduction_dims = [[0]]
+        result = _compute_fill_loop_info(op)
+        self.assertIsNone(result)
+
+    def test_nested_outer_output_inner_reduction(self):
+        """Outer tiles dim 0 (output), inner tiles reduction dim 0 → fill gets outer loop_info."""
+        from torch_spyre._inductor.coarse_tile import _compute_fill_loop_info
+
+        op = _make_tiled_reduction_op(
+            "red0",
+            ranges=[Integer(64)],
+            reduction_ranges=[Integer(256)],
+            reduction_type="sum",
+            loop_group_id=(0, 0),
+            loop_count=[Integer(2), Integer(4)],
+            loop_tiled_dims=[[0], []],
+        )
+        op.loop_info.loop_tiled_reduction_dims = [[], [0]]
+        result = _compute_fill_loop_info(op)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.loop_group_id, (0,))
+        self.assertEqual(result.loop_count, [Integer(2)])
+        self.assertEqual(result.loop_tiled_dims, [[0]])
+        self.assertEqual(result.loop_tiled_reduction_dims, [[]])
+
+
 class TestValidateReductionTiling(unittest.TestCase):
     """Tests for _validate_reduction_tiling: raising on unsupported cases,
     passing on supported ones."""

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1963,10 +1963,10 @@ def _make_tiled_reduction_op(
 class TestCoarseTileReductionPropagation(unittest.TestCase):
     """Tests for insert_tiling_propagation Reduction support."""
 
-    def test_reduction_tiled_reduction_dim_raises_stage2(self):
+    def test_reduction_tiled_reduction_dim_nested_ok(self):
         from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
 
-        # Mixed nesting: outer tiles output dim, inner tiles reduction dim → Stage 2 error
+        # Nested: outer tiles output dim, inner tiles reduction dim — now supported
         op = _make_tiled_reduction_op(
             "red0",
             ranges=[Integer(128)],
@@ -1977,8 +1977,7 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
             loop_tiled_dims=[[0], []],
         )
         op.loop_info.loop_tiled_reduction_dims = [[], [0]]
-        with self.assertRaises(RuntimeError, msg="mixed nested tiling should raise"):
-            _validate_reduction_tiling(op)
+        _validate_reduction_tiling(op)  # must not raise
 
     def test_reduction_output_dim_tiled_ok(self):
         from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
@@ -1998,7 +1997,8 @@ class TestCoarseTileReductionPropagation(unittest.TestCase):
 
 
 class TestValidateReductionTiling(unittest.TestCase):
-    """_validate_reduction_tiling raises for unsupported Stage-2 configurations."""
+    """Tests for _validate_reduction_tiling: raising on unsupported cases,
+    passing on supported ones."""
 
     def _make_op(self, loop_tiled_dims, loop_tiled_reduction_dims):
         from torch._inductor.ir import ComputedBuffer, Reduction
@@ -2053,14 +2053,15 @@ class TestValidateReductionTiling(unittest.TestCase):
         with self.assertRaises(RuntimeError, msg="mixed same-level should raise"):
             _validate_reduction_tiling(op)
 
-    def test_mixed_different_levels_raises(self):
-        """Output dim tiled at level 0, reduction dim at level 1 — Stage 2, raises."""
+    def test_mixed_different_levels_allowed(self):
+        """Outer output-dim tiling + inner reduction-dim tiling — now supported."""
         from torch._inductor.ir import ComputedBuffer, Reduction
         from torch_spyre._inductor.coarse_tile import _validate_reduction_tiling
 
         data = MagicMock(spec=Reduction)
         data.ranges = [Integer(128)]
         data.reduction_ranges = [Integer(256)]
+        data.reduction_type = "sum"
         op = MagicMock(spec=ComputedBuffer)
         op.data = data
         op.get_name.return_value = "test_op"
@@ -2070,8 +2071,8 @@ class TestValidateReductionTiling(unittest.TestCase):
             loop_tiled_dims=[[0], []],
             loop_tiled_reduction_dims=[[], [0]],
         )
-        with self.assertRaises(RuntimeError, msg="mixed nested levels should raise"):
-            _validate_reduction_tiling(op)
+        # Must not raise: outer output-dim + inner reduction-dim is now supported.
+        _validate_reduction_tiling(op)
 
     def test_multiple_reduction_dims_same_level_raises(self):
         """Multiple reduction dims tiled at one level — Stage 2, raises."""

--- a/tests/inductor/test_unroll_loop_specs.py
+++ b/tests/inductor/test_unroll_loop_specs.py
@@ -292,5 +292,304 @@ class TestUnrollLoopSpecs(unittest.TestCase):
         )
 
 
+class TestNestedReductionUnroll(unittest.TestCase):
+    """Tests for nested outer-output + inner-reduction tiling.
+
+    Models the bmm (B outer, K inner) scenario introduced in ct-stage2.  The
+    key invariant: when the inner K-loop is unrolled, the combine op's accum_buf
+    address must stay fixed (same slice for every K iteration).  Only the bmm's
+    K-dimension input should advance per K-tile.
+
+    Tensor geometry used throughout:
+      accum_buf  [B=2, M=64, N=32] fp16 per outer tile → HBM at ACCUM_BASE
+        device_size=[1, 2, 64], stride_map=[64, 64, 1]
+        device_coords=[c_col//64, c_b, c_col%64]   (c_b tiles batch within tile)
+      k_input    [M=64, K=128] fp16 per K-tile   → HBM at K_BASE (advances per K)
+        device_size=[2, 64, 64], stride_map=[64, 64, 1]
+        device_coords=[c_col//64, c_row, c_col%64]
+      pool_scratch per_tile_fixed=True (bmm intermediate output, stays fixed)
+    """
+
+    # --- Symbols ---
+    _C_B = Symbol("c_b")  # output batch symbol (appears in accum_buf coords)
+    _C_M = Symbol("c_m")  # M rows
+    _C_N = Symbol("c_n")  # N cols
+    _C_K = Symbol("c_k")  # K reduction symbol
+
+    # --- Base addresses ---
+    _ACCUM_BASE = 0x1000000000
+    _K_INPUT_BASE = 0x800000000
+    _POOL_BASE = 0  # pool allocation; per_tile_fixed
+
+    # Per-tile tensor geometry:
+    #   accum_buf: [B=2, N=32] per row — but using simplified 2D layout:
+    #     device_size=[1, 2, 64], stride_map=[64, 64, 1]
+    #     device_coords=[c_n//64, c_b, c_n%64]
+    #   k_input (K-dim): device_size=[2, 64, 64], stride_map=[64, 64, 1]
+    #     device_coords=[c_k//64, c_m, c_k%64]
+    #     per K-tile stride: 1 tile = 128 K-elems = 2 sticks
+    #       byte_stride = 2 * 64 * 2 = 256  (one stick = 64 fp16 = 128 bytes)
+
+    # For accum_buf: advancing 2 batches in c_b direction:
+    #   device_coords[1] = c_b; stride_map[1] = 64
+    #   byte_stride = 2 * 64 * 2 = 256
+
+    # K-input advance per K-tile (128 K-elems = 2 sticks along c_k):
+    #   device_coords[0] = c_k//64; stride_map[0] = 64
+    #   byte_stride = (128//64) * 64 * 2 = 256
+
+    def _make_accum_arg(self, base: int = _ACCUM_BASE, per_tile_fixed: bool = False):
+        return TensorArg(
+            is_input=False,
+            arg_index=-1,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=[1, 2, 64],
+            device_coordinates=[
+                self._C_N // 64,
+                self._C_B,
+                sympy.Mod(self._C_N, 64),
+            ],
+            allocation={"hbm": base},
+            stride_map=[64, 64, 1],
+            per_tile_fixed=per_tile_fixed,
+        )
+
+    def _make_k_input_arg(self, base: int = _K_INPUT_BASE):
+        return TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=[2, 64, 64],
+            device_coordinates=[
+                self._C_K // 64,
+                self._C_M,
+                sympy.Mod(self._C_K, 64),
+            ],
+            allocation={"hbm": base},
+            stride_map=[64, 64, 1],
+        )
+
+    def _make_pool_scratch(self):
+        return TensorArg(
+            is_input=False,
+            arg_index=-1,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=[1, 64, 64],
+            device_coordinates=[
+                self._C_N // 64,
+                self._C_M,
+                sympy.Mod(self._C_N, 64),
+            ],
+            allocation={"pool": self._POOL_BASE},
+            stride_map=[64, 64, 1],
+            per_tile_fixed=True,
+        )
+
+    def _make_bmm_op(self) -> OpSpec:
+        """Model bmm partial result: reads k_input, writes pool scratch."""
+        return OpSpec(
+            op="batchmatmul",
+            is_reduction=True,
+            iteration_space={
+                self._C_B: (Integer(2), 1),
+                self._C_M: (Integer(64), 1),
+                self._C_N: (Integer(32), 1),
+                self._C_K: (Integer(128), 1),
+            },
+            args=[self._make_k_input_arg(), self._make_pool_scratch()],
+            op_info={},
+            tiled_symbols=[self._C_B, self._C_K],
+        )
+
+    def _make_combine_op(self) -> OpSpec:
+        """Model combine (add): reads pool + accum_buf, writes accum_buf.
+
+        Output-only iteration space: no K symbol.
+        """
+        return OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={
+                self._C_B: (Integer(2), 1),
+                self._C_M: (Integer(64), 1),
+                self._C_N: (Integer(32), 1),
+            },
+            args=[
+                self._make_pool_scratch(),  # input: per_tile_fixed scratch
+                self._make_accum_arg(),  # input: accum_buf (read)
+                self._make_accum_arg(),  # output: accum_buf (write)
+            ],
+            op_info={},
+            tiled_symbols=[self._C_B],
+        )
+
+    # ------------------------------------------------------------------
+    # 11. Inner K-loop: combine's accum_buf does NOT advance per K-tile.
+    #
+    #     The LoopSpec for the K-loop carries tiled_symbols=[c_k].  The
+    #     combine op's iteration_space has only {c_b, c_m, c_n} — no c_k.
+    #     _arg_byte_strides_for_syms must produce stride=0 for accum_buf
+    #     across K iterations, so every K-tile combine writes to the same
+    #     address.
+    # ------------------------------------------------------------------
+
+    def test_combine_accum_fixed_across_k_iterations(self):
+        bmm = self._make_bmm_op()
+        combine = self._make_combine_op()
+        # Inner K-loop: LoopSpec explicitly carries the K symbol.
+        inner = LoopSpec(
+            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
+        )
+        result = unroll_loop_specs([inner])
+
+        self.assertEqual(len(result), 8, f"Expected 4*2=8 ops, got {len(result)}")
+        combine_copies = result[1::2]  # every other op is a combine copy
+        self.assertEqual(len(combine_copies), 4)
+
+        # accum_buf is arg index 1 and 2 of the combine; both must stay at ACCUM_BASE.
+        for i, copy_op in enumerate(combine_copies):
+            for arg_idx in (1, 2):
+                addr = copy_op.args[arg_idx].allocation["hbm"]
+                self.assertEqual(
+                    addr,
+                    self._ACCUM_BASE,
+                    f"K-iter {i}, combine arg[{arg_idx}] addr={hex(addr)}, "
+                    f"expected {hex(self._ACCUM_BASE)} (must not advance per K)",
+                )
+
+    # ------------------------------------------------------------------
+    # 12. Inner K-loop: pool scratch (per_tile_fixed) stays fixed.
+    # ------------------------------------------------------------------
+
+    def test_pool_scratch_fixed_across_k_iterations(self):
+        bmm = self._make_bmm_op()
+        combine = self._make_combine_op()
+        inner = LoopSpec(
+            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
+        )
+        result = unroll_loop_specs([inner])
+
+        for op_copy in result:
+            for arg in op_copy.args:
+                if "pool" in arg.allocation:
+                    self.assertEqual(
+                        arg.allocation["pool"],
+                        self._POOL_BASE,
+                        f"pool scratch must stay at {self._POOL_BASE}",
+                    )
+
+    # ------------------------------------------------------------------
+    # 13. Inner K-loop: bmm's K-input advances per K-tile.
+    #
+    #     k_input device_coords[0] = c_k//64; stride_map[0]=64; dtype=fp16.
+    #     Per K-tile (128 K-elems = 2 sticks):
+    #       byte_stride = (128//64) * 64 * 2 = 256
+    # ------------------------------------------------------------------
+
+    def test_bmm_k_input_advances_per_k_iteration(self):
+        K_TILE_BYTES = (128 // 64) * 64 * 2  # 256
+        bmm = self._make_bmm_op()
+        combine = self._make_combine_op()
+        inner = LoopSpec(
+            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
+        )
+        result = unroll_loop_specs([inner])
+
+        bmm_copies = result[::2]  # every other op is a bmm copy
+        self.assertEqual(len(bmm_copies), 4)
+        for i, copy_op in enumerate(bmm_copies):
+            k_arg = copy_op.args[0]  # k_input
+            expected = self._K_INPUT_BASE + i * K_TILE_BYTES
+            self.assertEqual(
+                k_arg.allocation["hbm"],
+                expected,
+                f"K-iter {i} k_input addr={hex(k_arg.allocation['hbm'])}, "
+                f"expected {hex(expected)}",
+            )
+
+    # ------------------------------------------------------------------
+    # 14. Nested outer-B + inner-K: full 2×4 layout.
+    #
+    #     Outer B-loop (tiled_symbols=[c_b], count=2):
+    #       fill op: writes accum_buf, tiled_symbols=[c_b]
+    #       Inner K-loop (tiled_symbols=[c_k], count=4):
+    #         bmm + combine
+    #
+    #     After full unrolling:
+    #     outer=2, inner=4 → 2*(1 fill + 4*(bmm+combine)) = 2+16 = 18 ops
+    #       flat result: [fill_B0, bmm_K0, add_K0, bmm_K1, add_K1, ... x4, fill_B1, ...]
+    #
+    #     Key assertions:
+    #       - fill_B0 accum addr = ACCUM_BASE
+    #       - fill_B1 accum addr = ACCUM_BASE + B_TILE_BYTES
+    #       - all add ops in B-tile 0 write to ACCUM_BASE
+    #       - all add ops in B-tile 1 write to ACCUM_BASE + B_TILE_BYTES
+    # ------------------------------------------------------------------
+
+    def test_nested_outer_b_inner_k_full_layout(self):
+        # B-tile byte advance: 2 batches in c_b, stride_map[1]=64, dtype=fp16
+        B_TILE_BYTES = 2 * 64 * 2  # 256
+
+        fill_accum = self._make_accum_arg()
+        fill_op = OpSpec(
+            op="identity",
+            is_reduction=False,
+            iteration_space={
+                self._C_B: (Integer(2), 1),
+                self._C_N: (Integer(32), 1),
+            },
+            args=[fill_accum],
+            op_info={},
+            tiled_symbols=[self._C_B],
+        )
+
+        bmm = self._make_bmm_op()
+        combine = self._make_combine_op()
+
+        inner = LoopSpec(
+            count=Integer(4), body=[bmm, combine], tiled_symbols=[self._C_K]
+        )
+        outer = LoopSpec(
+            count=Integer(2), body=[fill_op, inner], tiled_symbols=[self._C_B]
+        )
+        result = unroll_loop_specs([outer])
+
+        # Expected flat layout: 2 × (1 fill + 4 × (1 bmm + 1 combine)) = 18 ops
+        self.assertEqual(len(result), 18, f"Expected 18 ops, got {len(result)}")
+
+        # Verify fill ops (indices 0 and 9)
+        fill_b0 = result[0]
+        fill_b1 = result[9]
+        self.assertEqual(fill_b0.op, "identity")
+        self.assertEqual(fill_b1.op, "identity")
+        self.assertEqual(fill_b0.args[0].allocation["hbm"], self._ACCUM_BASE)
+        self.assertEqual(
+            fill_b1.args[0].allocation["hbm"], self._ACCUM_BASE + B_TILE_BYTES
+        )
+
+        # Verify combine ops in B-tile 0 (indices 2, 4, 6, 8 = ops 1,3,5,7 → add ops)
+        # Inner body: [bmm, combine] × 4 = ops 1..8, starting at result[1]
+        b0_adds = [result[i] for i in (2, 4, 6, 8)]
+        for i, op_copy in enumerate(b0_adds):
+            self.assertEqual(op_copy.op, "add", f"result[{2 + 2 * i}] should be add")
+            accum_write = op_copy.args[2]
+            self.assertEqual(
+                accum_write.allocation["hbm"],
+                self._ACCUM_BASE,
+                f"B-tile0 K-iter {i} combine must write to ACCUM_BASE",
+            )
+
+        # Verify combine ops in B-tile 1 (indices 11, 13, 15, 17)
+        b1_adds = [result[i] for i in (11, 13, 15, 17)]
+        for i, op_copy in enumerate(b1_adds):
+            self.assertEqual(op_copy.op, "add", f"result[{11 + 2 * i}] should be add")
+            accum_write = op_copy.args[2]
+            self.assertEqual(
+                accum_write.allocation["hbm"],
+                self._ACCUM_BASE + B_TILE_BYTES,
+                f"B-tile1 K-iter {i} combine must write to ACCUM_BASE+B_TILE_BYTES",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_unroll_loop_specs.py
+++ b/tests/inductor/test_unroll_loop_specs.py
@@ -591,5 +591,187 @@ class TestNestedReductionUnroll(unittest.TestCase):
             )
 
 
+class TestNestedReductionTileAccum(unittest.TestCase):
+    """Verify unroller behaviour for the tile-sized accum buffer pattern.
+
+    Pattern (outer B=2 tiles, inner K=4 tiles):
+      outer LoopSpec(count=2, tiled_symbols=[c_b]):
+        fill: output=accum_tile (per_tile_fixed=True)
+        inner LoopSpec(count=4, tiled_symbols=[c_k]):
+          bmm partial: K-input advances; output per_tile_fixed=True
+          combine: both args=accum_tile (per_tile_fixed=True)
+        copy: input=accum_tile (per_tile_fixed=True),
+              output=accum_full (advances per outer B-tile)
+
+    After full unrolling:
+      outer=2, inner=4 → 2*(1 fill + 4*(bmm+combine) + 1 copy) = 20 ops
+    """
+
+    _C_B = Symbol("c_b")
+    _C_M = Symbol("c_m")
+    _C_N = Symbol("c_n")
+    _C_K = Symbol("c_k")
+
+    _ACCUM_TILE_BASE = 0x0  # per_tile_fixed: always stays at 0
+    _ACCUM_FULL_BASE = 0x1000000000  # advances per outer B-tile
+
+    # accum_tile: [64, 32] fp16 per tile; simple device layout
+    _TILE_DEVICE_SIZE = [1, 64, 32]  # 1 stick-group, 64 rows, 32 cols
+    _TILE_STRIDE_MAP = [2048, 32, 1]
+
+    # accum_full: [128, 32] fp16 = 2 tiles × [64, 32]; c_b in device coords
+    # stride_map[0] = 64*32 = 2048 elements per B-tile
+    # byte stride per outer tile = 1 * 2048 * 2 = 4096
+    _FULL_DEVICE_SIZE = [1, 128, 32]
+    _FULL_STRIDE_MAP = [2048, 32, 1]
+    _OUTER_TILE_STRIDE_BYTES = 1 * 2048 * 2  # 4096
+
+    def _make_accum_tile_arg(self) -> TensorArg:
+        return TensorArg(
+            is_input=True,
+            arg_index=-1,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=list(self._TILE_DEVICE_SIZE),
+            device_coordinates=[Integer(0), self._C_M, self._C_N],
+            allocation={"hbm": self._ACCUM_TILE_BASE},
+            stride_map=list(self._TILE_STRIDE_MAP),
+            per_tile_fixed=True,
+        )
+
+    def _make_accum_full_arg(self) -> TensorArg:
+        # c_b in device_coordinates so outer-loop unroller can compute byte stride.
+        return TensorArg(
+            is_input=False,
+            arg_index=-1,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=list(self._FULL_DEVICE_SIZE),
+            device_coordinates=[self._C_B, self._C_M, self._C_N],
+            allocation={"hbm": self._ACCUM_FULL_BASE},
+            stride_map=list(self._FULL_STRIDE_MAP),
+            per_tile_fixed=False,
+        )
+
+    def _make_fill_op(self) -> OpSpec:
+        """Fill: zeros accum_tile once per outer B-tile."""
+        return OpSpec(
+            op="fill",
+            is_reduction=False,
+            iteration_space={
+                self._C_B: (Integer(1), 1),
+                self._C_M: (Integer(64), 1),
+                self._C_N: (Integer(32), 1),
+            },
+            args=[self._make_accum_tile_arg()],
+            op_info={},
+            tiled_symbols=[],
+        )
+
+    def _make_copy_op(self) -> OpSpec:
+        """Copy: accum_tile → accum_full after inner K-loop."""
+        return OpSpec(
+            op="copy",
+            is_reduction=False,
+            iteration_space={
+                self._C_B: (Integer(1), 1),
+                self._C_M: (Integer(64), 1),
+                self._C_N: (Integer(32), 1),
+            },
+            args=[
+                self._make_accum_tile_arg(),  # input: per_tile_fixed, never advances
+                self._make_accum_full_arg(),  # output: advances per outer B-tile
+            ],
+            op_info={},
+            tiled_symbols=[],
+        )
+
+    def _make_nested_loop(self) -> LoopSpec:
+        bmm_input = TensorArg(
+            is_input=True,
+            arg_index=0,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=[2, 64, 64],
+            device_coordinates=[
+                self._C_K // 64,
+                self._C_M,
+                sympy.Mod(self._C_K, 64),
+            ],
+            allocation={"hbm": 0x800000000},
+            stride_map=[64, 512, 1],
+            per_tile_fixed=False,
+        )
+        bmm_output = TensorArg(
+            is_input=False,
+            arg_index=-1,
+            device_dtype=DataFormats.SEN169_FP16,
+            device_size=list(self._TILE_DEVICE_SIZE),
+            device_coordinates=[Integer(0), self._C_M, self._C_N],
+            allocation={"hbm": 0x2000000000},
+            stride_map=list(self._TILE_STRIDE_MAP),
+            per_tile_fixed=True,
+        )
+        bmm_partial = OpSpec(
+            op="matmul",
+            is_reduction=True,
+            iteration_space={
+                self._C_M: (Integer(64), 1),
+                self._C_N: (Integer(32), 1),
+                self._C_K: (Integer(128), 1),
+            },
+            args=[bmm_input, bmm_output],
+            op_info={},
+            tiled_symbols=[self._C_K],
+        )
+        combine_op = OpSpec(
+            op="add",
+            is_reduction=False,
+            iteration_space={
+                self._C_M: (Integer(64), 1),
+                self._C_N: (Integer(32), 1),
+            },
+            args=[self._make_accum_tile_arg(), self._make_accum_tile_arg()],
+            op_info={},
+            tiled_symbols=[],
+        )
+        inner = LoopSpec(
+            count=Integer(4),
+            body=[bmm_partial, combine_op],
+            tiled_symbols=[self._C_K],
+        )
+        return LoopSpec(
+            count=Integer(2),
+            body=[self._make_fill_op(), inner, self._make_copy_op()],
+            tiled_symbols=[self._C_B],
+        )
+
+    def test_accum_tile_fixed_accum_full_advances(self):
+        """accum_tile never advances; accum_full advances by outer-tile stride each B iter."""
+        loop = self._make_nested_loop()
+        result = unroll_loop_specs([loop])
+        # 2 * (1 fill + 4*(bmm+combine) + 1 copy) = 20 ops
+        self.assertEqual(len(result), 20, f"Expected 20 ops, got {len(result)}")
+        # Positions: fill(0), bmm(1),comb(2),bmm(3),comb(4),bmm(5),comb(6),bmm(7),comb(8),
+        #            copy(9), fill(10), bmm(11)..copy(19)
+        copy_0 = result[9]
+        copy_1 = result[19]
+        # accum_tile input (index 0): per_tile_fixed, must never advance
+        self.assertEqual(copy_0.args[0].allocation["hbm"], self._ACCUM_TILE_BASE)
+        self.assertEqual(copy_1.args[0].allocation["hbm"], self._ACCUM_TILE_BASE)
+        # accum_full output (index 1): advances by one tile per outer B iteration
+        self.assertEqual(copy_0.args[1].allocation["hbm"], self._ACCUM_FULL_BASE)
+        self.assertEqual(
+            copy_1.args[1].allocation["hbm"],
+            self._ACCUM_FULL_BASE + self._OUTER_TILE_STRIDE_BYTES,
+        )
+
+    def test_fill_always_targets_tile_base(self):
+        """fill op always targets accum_tile (per_tile_fixed) regardless of outer tile."""
+        loop = self._make_nested_loop()
+        result = unroll_loop_specs([loop])
+        fill_0 = result[0]
+        fill_1 = result[10]
+        self.assertEqual(fill_0.args[0].allocation["hbm"], self._ACCUM_TILE_BASE)
+        self.assertEqual(fill_1.args[0].allocation["hbm"], self._ACCUM_TILE_BASE)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -772,6 +772,43 @@ def _insert_combine_op(
     operations.insert(tiled_idx + 1, combine_buf)
 
 
+def _compute_fill_loop_info(op: ComputedBuffer) -> "CoarseTileInfo | None":
+    """Return the loop_info to stamp on the fill op for a nested tiled reduction.
+
+    For a flat (pure reduction) tiling the fill has no loop_info — it runs
+    once before all loops.  Returns None.
+
+    For a nested tiling where outer level(s) tile output dims and the inner
+    level tiles a reduction dim, the fill must run inside the outer loop (once
+    per outer tile) so the accumulator is per-outer-tile sized.  Returns a
+    CoarseTileInfo covering only the outer output-dim levels.
+    """
+    loop_info = op.loop_info
+    tiled_rdims = getattr(loop_info, "loop_tiled_reduction_dims", [])
+
+    outer_counts: list[sympy.Expr] = []
+    outer_tiled_dims: list[list[int]] = []
+    outer_tiled_rdims: list[list[int]] = []
+    for dims, rdims, count in zip(
+        loop_info.loop_tiled_dims, tiled_rdims, loop_info.loop_count
+    ):
+        if dims:  # non-empty output-dim list → this is an output-dim level
+            outer_counts.append(count)
+            outer_tiled_dims.append(dims)
+            outer_tiled_rdims.append([])
+
+    if not outer_counts:
+        return None  # flat: fill runs before all loops
+
+    outer_gid = loop_info.loop_group_id[: len(outer_counts)]
+    return CoarseTileInfo(
+        loop_group_id=outer_gid,
+        loop_count=outer_counts,
+        loop_tiled_dims=outer_tiled_dims,
+        loop_tiled_reduction_dims=outer_tiled_rdims,
+    )
+
+
 def _propagate_tiled_reduction_op(
     op: ComputedBuffer,
     operations: list[Operation],

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -773,6 +773,45 @@ def _insert_combine_op(
     operations.insert(tiled_idx + 1, combine_buf)
 
 
+def _insert_reduction_copy_op(
+    tiled_op: ComputedBuffer,
+    accum_tile: ComputedBuffer,
+    accum_full: ComputedBuffer,
+    outer_loop_info: "CoarseTileInfo",
+    operations: list[Operation],
+) -> None:
+    """Insert a copy op that writes accum_tile → accum_full at the outer loop level.
+
+    Reads accum_tile (per_tile_fixed=True, never advances) and writes into
+    accum_full via MutationLayoutSHOULDREMOVE.  Carries outer_loop_info so
+    the unroller advances accum_full per outer output-dim tile.
+    """
+    copy_data = Pointwise(
+        device=tiled_op.get_device(),
+        dtype=tiled_op.get_dtype(),
+        inner_fn=accum_tile.make_loader(),
+        ranges=list(tiled_op.data.ranges),
+    )
+    copy_name = V.graph.qualify_name(f"coarse_tile_reduce_copy_{tiled_op.get_name()}")
+    copy_buf = ComputedBuffer(
+        name=copy_name,
+        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_full))),
+        data=copy_data,
+    )
+    copy_buf.origins = tiled_op.origins
+    copy_buf.operation_name = copy_name
+    copy_buf.loop_info = outer_loop_info  # type: ignore[attr-defined]
+    V.graph.name_to_buffer[copy_name] = copy_buf
+
+    combine_name = V.graph.qualify_name(f"coarse_tile_combine_{tiled_op.get_name()}")
+    combine_buf = V.graph.name_to_buffer.get(combine_name)
+    if combine_buf is not None and combine_buf in operations:
+        insert_idx = operations.index(combine_buf) + 1
+    else:
+        insert_idx = operations.index(tiled_op) + 1
+    operations.insert(insert_idx, copy_buf)
+
+
 def _compute_fill_loop_info(op: ComputedBuffer) -> "CoarseTileInfo | None":
     """Return the loop_info to stamp on the fill op for a nested tiled reduction.
 
@@ -859,11 +898,37 @@ def _propagate_tiled_reduction_op(
         and getattr(getattr(o, "loop_info", None), "loop_group_id", (None,))[0]
         == outer_key
     )
-    accum_buf = _allocate_full_buffer(
-        op, full_output_ranges, operations, group_start_idx
-    )
 
-    # Insert fill op immediately after the HBM allocation (outside the loop).
+    fill_loop_info = _compute_fill_loop_info(op)
+    is_nested = fill_loop_info is not None
+
+    if is_nested:
+        # Nested case: allocate separate tile-sized and full-sized buffers.
+        # accum_tile (per_tile_fixed=True) stays inside the inner K-loop;
+        # accum_full accumulates across outer B-tiles via a copy op.
+        accum_full = _allocate_full_buffer(
+            op, full_output_ranges, operations, group_start_idx
+        )
+        group_start_idx_after_full = operations.index(accum_full) + 1
+        accum_tile = _allocate_full_buffer(
+            op, per_tile_ranges, operations, group_start_idx_after_full
+        )
+        from .ir import FixedTiledLayout
+
+        if isinstance(accum_tile.layout, FixedTiledLayout):
+            accum_tile.layout.per_tile_fixed = True
+        fill_target = accum_tile
+        combine_target = accum_tile
+    else:
+        # Flat case: single full-sized buffer (unchanged behaviour).
+        accum_full = _allocate_full_buffer(
+            op, full_output_ranges, operations, group_start_idx
+        )
+        fill_target = accum_full
+        combine_target = accum_full
+
+    # Insert fill op immediately after the fill target buffer allocation
+    # (outside the loop for flat, inside the outer loop for nested).
     # Use a SpyreConstantFallback scalar as the fill source so that Spyre's
     # kernel codegen can express this as an IDENTITY_OP broadcast.  We must
     # assign a FixedTiledLayout manually here because finalize_layouts has
@@ -894,25 +959,32 @@ def _propagate_tiled_reduction_op(
     fill_name = V.graph.qualify_name(f"coarse_tile_fill_{op.get_name()}")
     fill_buf = ComputedBuffer(
         name=fill_name,
-        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(accum_buf))),
+        layout=MutationLayoutSHOULDREMOVE(TensorBox(StorageBox(fill_target))),
         data=fill_data,
     )
     fill_buf.origins = op.origins
     fill_buf.operation_name = fill_name
-    fill_loop_info = _compute_fill_loop_info(op)
     if fill_loop_info is not None:
         fill_buf.loop_info = fill_loop_info  # type: ignore[attr-defined]
     # else: no loop_info — fill runs once before all loops (flat reduction case).
     V.graph.name_to_buffer[fill_name] = fill_buf
-    accum_idx = operations.index(accum_buf)
+    fill_target_idx = operations.index(fill_target)
     # scalar_op was appended to graph.operations by register_operation(); move it
-    # to just after accum_buf, then insert fill_buf after scalar_op.
+    # to just after fill_target, then insert fill_buf after scalar_op.
     operations.remove(scalar_op)
-    operations.insert(accum_idx + 1, scalar_op)
-    operations.insert(accum_idx + 2, fill_buf)
+    operations.insert(fill_target_idx + 1, scalar_op)
+    operations.insert(fill_target_idx + 2, fill_buf)
 
     # Insert combine op after the tiled reduction op (inside the loop).
-    _insert_combine_op(op, accum_buf, operations)
+    _insert_combine_op(op, combine_target, operations)
+
+    # For nested case, insert a copy op at the outer loop level that writes
+    # accum_tile → accum_full, advancing accum_full across outer output tiles.
+    if is_nested:
+        assert fill_loop_info is not None  # guaranteed by is_nested == True
+        _insert_reduction_copy_op(
+            op, accum_tile, accum_full, fill_loop_info, operations
+        )
 
     # Mark tiled op's output as per-tile scratch (no address advance).
     if not isinstance(op.layout, FixedTiledLayout):
@@ -923,22 +995,24 @@ def _propagate_tiled_reduction_op(
         )
     op.layout.per_tile_fixed = True
 
-    # Patch consumers.
+    # Patch consumers to read accum_full (the fully-assembled output).
     buf_name = op.get_name()
     outside_consumers, is_graph_output = _find_outside_consumers(
         buf_name, loop_group_id, operations
     )
-    accum_name = accum_buf.get_name()
+    accum_name = accum_full.get_name()
     _patch_consumers(outside_consumers, buf_name, accum_name, operations)
     if is_graph_output:
-        _patch_graph_outputs(buf_name, accum_buf)
+        _patch_graph_outputs(buf_name, accum_full)
 
     logger.debug(
-        "coarse_tile: tiled reduction %s → accum %s (fill=%s, identity=%s)",
+        "coarse_tile: tiled reduction %s → accum_full %s (fill=%s, identity=%s, "
+        "nested=%s)",
         buf_name,
         accum_name,
         fill_name,
         identity,
+        is_nested,
     )
 
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -338,17 +338,17 @@ def _reduction_tiling_is_on_stick_dim(op: ComputedBuffer, red_dim_idx: int) -> b
 def _validate_reduction_tiling(op: ComputedBuffer) -> None:
     """Raise RuntimeError for Reduction tiling configurations not yet implemented.
 
-    Supported (Stage 1):
+    Supported:
       - A single level that tiles only a non-stick reduction dim.
       - A single level that tiles the K (reduction) dim of a BATCH_MATMUL_OP.
         K is the stick dim for operand x, but each tile's output is a full
         [M, N] matrix so no partial-stick sparsity occurs.
+      - Multiple nesting levels where outer level(s) tile output dims and the
+        innermost level tiles a reduction dim (e.g. outer M + inner K for mm).
 
-    Deferred to Stage 2 (raises):
+    Deferred (raises RuntimeError):
       - Reduction tiling on the stick dimension (except BATCH_MATMUL_OP above).
       - Mixed output+reduction tiling at the same nesting level.
-      - Multiple nesting levels where both output-dim and reduction-dim levels
-        appear (e.g. outer tiles output dim, inner tiles reduction dim).
       - Multiple reduction range indices tiled at one level.
     """
     data = op.data
@@ -364,16 +364,6 @@ def _validate_reduction_tiling(op: ComputedBuffer) -> None:
     n = max(len(tiled_dims), len(tiled_rdims))
     tiled_dims_padded = tiled_dims + [[]] * (n - len(tiled_dims))
     tiled_rdims_padded = tiled_rdims + [[]] * (n - len(tiled_rdims))
-
-    has_out_levels = any(d for d in tiled_dims_padded)
-    has_red_levels = any(d for d in tiled_rdims_padded)
-    if has_out_levels and has_red_levels:
-        raise RuntimeError(
-            f"coarse_tile: op {op.get_name()!r} has output-dim tiling levels "
-            f"{tiled_dims} and reduction-dim tiling levels {tiled_rdims} "
-            "across different nesting levels (mixed nested output+reduction "
-            "tiling is not yet implemented — Stage 2)."
-        )
 
     for i, (out_dims, red_dims) in enumerate(
         zip(tiled_dims_padded, tiled_rdims_padded)

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -648,13 +648,14 @@ def _allocate_full_buffer(
     else:
         device_layout = generic_layout(full_buf)
 
-    full_buf.layout = FixedTiledLayout(
+    layout = FixedTiledLayout(
         device,
         dtype,
         list(full_ranges),
         strides,
         device_layout,
     )
+    full_buf.layout = layout
 
     # Splice into operations at the correct position.
     operations.remove(full_buf)

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -816,14 +816,21 @@ def _propagate_tiled_reduction_op(
     """Handle buffer propagation for a Reduction op tiled over a reduction dim.
 
     Strategy: fill-initialize + per-tile combine.
-      1. Allocate a HBM accumulation buffer the size of the full output shape.
-      2. Insert a fill op (outside the loop) that writes the reduction's identity
-         value into the accumulation buffer.
-      3. Insert a combine op (inside the loop) that merges each tile's partial
-         result into the accumulation buffer using the reduction's combining fn.
-      4. Mark the tiled reduction op's output as per_tile_fixed (loop-internal
-         scratch, not advanced between iterations).
-      5. Patch outside consumers and graph outputs to read the accumulation buffer.
+      1. Allocate a HBM accumulation buffer sized to op.data.ranges (the
+         per-outer-tile output shape, already divided by any outer tiling).
+      2. Insert a fill op that writes the reduction's identity value into the
+         accumulation buffer.  For flat reduction tiling the fill has no
+         loop_info and runs before all loops.  For nested tiling (outer
+         output-dim loop + inner reduction loop) the fill carries the outer
+         loop's loop_info so it runs inside the outer loop — once per outer
+         tile — keeping the accumulator sized to the per-tile output shape.
+      3. Insert a combine op (inside the inner loop, same loop_info as the
+         tiled reduction op) that merges each tile's partial result into the
+         accumulation buffer using the reduction's combining fn.
+      4. Mark the tiled reduction op's output as per_tile_fixed (inner-loop
+         scratch, not advanced between inner iterations).
+      5. Patch outside consumers and graph outputs to read the accumulation
+         buffer.
     """
     loop_info = op.loop_info
     loop_group_id = loop_info.loop_group_id
@@ -884,7 +891,10 @@ def _propagate_tiled_reduction_op(
     )
     fill_buf.origins = op.origins
     fill_buf.operation_name = fill_name
-    # No loop_info: fill runs once, before the loop.
+    fill_loop_info = _compute_fill_loop_info(op)
+    if fill_loop_info is not None:
+        fill_buf.loop_info = fill_loop_info  # type: ignore[attr-defined]
+    # else: no loop_info — fill runs once before all loops (flat reduction case).
     V.graph.name_to_buffer[fill_name] = fill_buf
     accum_idx = operations.index(accum_buf)
     # scalar_op was appended to graph.operations by register_operation(); move it

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -816,8 +816,11 @@ def _propagate_tiled_reduction_op(
     """Handle buffer propagation for a Reduction op tiled over a reduction dim.
 
     Strategy: fill-initialize + per-tile combine.
-      1. Allocate a HBM accumulation buffer sized to op.data.ranges (the
-         per-outer-tile output shape, already divided by any outer tiling).
+      1. Allocate a HBM accumulation buffer sized to the full
+         (pre-outer-division) output shape (_compute_full_ranges), so that
+         address advancement across outer tiles writes each tile into the
+         correct slice.  For flat (reduction-only) tiling this equals
+         op.data.ranges.
       2. Insert a fill op that writes the reduction's identity value into the
          accumulation buffer.  For flat reduction tiling the fill has no
          loop_info and runs before all loops.  For nested tiling (outer
@@ -837,10 +840,14 @@ def _propagate_tiled_reduction_op(
     reduction_type = op.data.reduction_type
     identity = _reduction_identity_value(reduction_type, op.get_dtype())
 
-    # Accumulation buffer has the full output shape.  For reduction-dim-only
-    # tiling, data.ranges is already the full output shape (only
-    # reduction_ranges was divided, not ranges).
-    full_output_ranges = list(op.data.ranges)
+    # Per-outer-tile output shape (ranges after any outer tiling divided them).
+    per_tile_ranges = list(op.data.ranges)
+
+    # Accumulation buffer uses the full (pre-outer-division) output shape so
+    # that address advancement across outer output-dim tiles writes each tile's
+    # result into the correct slice.  For reduction-dim-only tiling there is no
+    # outer division, so full == per-tile.
+    full_output_ranges = _compute_full_ranges(op)
 
     # Insert HBM buffer before the first op in the loop group.
     outer_key = loop_group_id[0]
@@ -881,7 +888,7 @@ def _propagate_tiled_reduction_op(
         device=device,
         dtype=dtype,
         inner_fn=lambda index, _loader=scalar_loader: _loader([]),
-        ranges=full_output_ranges,
+        ranges=per_tile_ranges,
     )
     fill_name = V.graph.qualify_name(f"coarse_tile_fill_{op.get_name()}")
     fill_buf = ComputedBuffer(

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -54,15 +54,23 @@ def _find_leaf_sched_node(node: BaseSchedulerNode):
 def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -> list:
     """Return the OpSpec iteration-space symbols tiled at ``depth``.
 
-    Uses ``loop_tiled_dims[depth]`` from the IR node and the SchedulerNode's
-    ``iteration_space`` (which produces the same symbols as ``create_op_spec``
-    uses to build ``OpSpec.tiled_symbols``).
+    Uses ``loop_tiled_dims[depth]`` and ``loop_tiled_reduction_dims[depth]``
+    from the IR node and the SchedulerNode's ``iteration_space`` (which
+    produces the same symbols as ``create_op_spec`` uses to build
+    ``OpSpec.tiled_symbols``).
 
     ``loop_tiled_dims`` stores *host-range* dimension indices (indices into
     ``op.data.ranges``), which include unit-size batch dimensions that are
     skipped in the iteration space.  We must map host-range indices to
     iteration-space key indices by walking ``op.data.ranges`` and counting
     only the non-unit entries.
+
+    For reduction-dimension tiling (``loop_tiled_reduction_dims``), the
+    reduction symbols follow the output symbols in the iteration space key
+    list (the scheduler produces keys from reads.ranges for Reduction nodes,
+    which has output dims first then reduction dims).  The offset is the
+    number of non-unit output-dim ranges; indices in
+    ``loop_tiled_reduction_dims`` are 0-based into the reduction portion.
     """
     ir_op = sched_node.node
     if ir_op is None:
@@ -71,9 +79,11 @@ def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -
     if loop_info is None:
         return []
     raw = loop_info.loop_tiled_dims
-    if not raw:
+    raw_rdims = getattr(loop_info, "loop_tiled_reduction_dims", [])
+    if not raw and not raw_rdims:
         return []
-    dims_per_level: list[list[int]] = raw
+    dims_per_level: list[list[int]] = raw if raw else [[] for _ in raw_rdims]
+    rdims_per_level: list[list[int]] = raw_rdims if raw_rdims else [[] for _ in raw]
     if depth >= len(dims_per_level):
         return []
     it_space = iteration_space(sched_node)
@@ -95,6 +105,19 @@ def _tiled_syms_for_sched_node_at_depth(sched_node: SchedulerNode, depth: int) -
         mapped = host_to_it.get(d)
         if mapped is not None and mapped < len(keys):
             result.append(keys[mapped])
+
+    # Map reduction-dimension indices to iteration-space symbols.  For
+    # Reduction nodes the iteration space (from reads.ranges) has output-dim
+    # symbols first, then reduction-dim symbols.  The offset is the count of
+    # non-unit output-dim ranges.
+    rdims_at_depth = rdims_per_level[depth] if depth < len(rdims_per_level) else []
+    if rdims_at_depth:
+        n_output_syms = sum(1 for r in ir_op.data.ranges if int(r) != 1)
+        for rd in rdims_at_depth:
+            sym_idx = n_output_syms + rd
+            if sym_idx < len(keys):
+                result.append(keys[sym_idx])
+
     return result
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [x] documentation
- [ ] cleanup

#### What this PR does:

Enable nested coarse tiling for bmm/mm where an outer loop tiles an output
dimension and an inner loop tiles the reduction (K) dimension, with a
tile-sized accumulation buffer that is eligible for LX scratchpad placement.

**Nested loop structure enabled:**

```
outer LoopSpec(count=B, tiled_dims=[batch]):
  fill accum_tile                          ← zeros per-tile scratch
  inner LoopSpec(count=K_tiles, tiled_dims=[K]):
    bmm partial result → scratch buffer
    combine (add) partial → accum_tile
  coarse_tile_reduce_copy accum_tile → accum_full  ← new: copy out per outer tile
```

**Key changes:**

- `_validate_reduction_tiling`: remove the guard that rejected outer
  output-dim + inner reduction-dim combinations.
- `_compute_fill_loop_info`: new helper that returns an outer-only
  `CoarseTileInfo` for the fill op, so it is grouped at the outer loop level
  rather than inside the inner K-loop.
- `_stamp_group`: stamp fill ops with the loop_info from
  `_compute_fill_loop_info` in the nested case.
- `_insert_reduction_copy_op`: new helper that inserts a
  `coarse_tile_reduce_copy` op after the inner combine op, carrying the outer
  `CoarseTileInfo` so the unroller advances `accum_full` per outer tile.
- `_propagate_tiled_reduction_op`: in the nested case, allocate `accum_tile`
  (per-tile shape, `per_tile_fixed=True`, LX-eligible) and `accum_full` (full
  shape, HBM) instead of a single full-sized buffer.
- `_tiled_syms_for_sched_node_at_depth` (`scheduler.py`): handle
  `loop_tiled_reduction_dims` when computing per-level tiled symbols, so the
  unroller correctly computes byte strides for reduction-dim args in
  multi-level loops.
- `docs/source/compiler/coarse_tiling_loops.md`: document the nested path,
  two-buffer pattern, and `coarse_tile_reduce_copy` op.

#### Which issue(s) this PR is related to:

Fixes #2369
Fixes #2266 

#### Special notes for your reviewer:

The `accum_tile` / `accum_full` split is the key design decision here.
A naive implementation would allocate a single full-sized buffer (B×M×N for
bmm) so the unroller can advance its address per outer tile — but that
buffer is too large for LX scratchpad.  Instead, `accum_tile` is tile-sized
and `per_tile_fixed=True` (address never advances), making it eligible for
LX placement.  `coarse_tile_reduce_copy` assembles the per-tile results into
`accum_full` at the outer loop level.

The flat K-only tiling path (no outer output-dim loop) is unchanged: a single
`accum_full` buffer is allocated, and no copy op is inserted.

#### Does this PR introduce a user-facing change?

Yes. Users can now supply both an output-dim tile hint and a K-dim tile hint
to `torch.compile` for mm/bmm, e.g.:

```python
torch.compile(torch.mm, backend="spyre", options={"tile_M": 64, "tile_K": 128})
torch.compile(torch.bmm, backend="spyre", options={"tile_B": 4, "tile_K": 128})
```

With `LX_PLANNING=1`, the inner accumulation buffer is placed in LX scratchpad,
reducing HBM working set for the innermost loop.

#### Additional note:

New tests:

- `TestCoarseTileNestedReductionE2E` (5 tests): correctness of nested bmm and
  mm, loopspec shape, `coarse_tile_reduce_copy` in generated source, LX
  allocation of `accum_tile`.
- `TestNestedReductionUnroll` (4 tests): unroller byte-stride correctness for
  nested loops with reduction-dim tiling.
- `TestNestedReductionTileAccum` (2 tests): `accum_tile` address never
  advances; `accum_full` advances by one tile per outer iteration.
