### PR TITLE
fix(lx): keep slice-derived buffers off LX (boundary clones, partial reads, sub-extent repacks)

### DIFF
--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -545,6 +545,63 @@ class TestCloneAtGraphBoundaries(BaseTestScratchpadUsage):
             torch.equal(ref_z, result_z), "LX output clone changed result z"
         )
 
+    def test_input_read_at_multiple_offsets_is_correct(self):
+        """A graph input read by one op at two distinct offsets must not be
+        LX-pinned.
+
+        An LX-pinned buffer is addressed by a single base (SDSC start_address
+        = allocation["lx"]); per-access slice offsets are not folded into it.
+        Pinning ``x`` for ``x[:, 0:512] + x[:, 512:1024]`` made both reads
+        resolve to the LX base, so the op computed ``x0 + x0`` instead of
+        ``x0 + x1``. The allocator now skips such inputs (they stay in HBM,
+        where multi-offset reads work)."""
+        x = self.rand_device((64, 1024))
+
+        def fn(x):
+            # The fused add reads x at offset 0 and offset 512 -> two distinct
+            # offsets on the same buffer -> ineligible for LX pinning.
+            return x[:, 0:512] + x[:, 512:1024]
+
+        with ts_inductor_config.patch(lx_planning=False):
+            ref, _, _ = self._compile_and_inspect(fn, (x,))
+
+        torch.compiler.reset()
+
+        with ts_inductor_config.patch(lx_planning=True):
+            result, _, _ = self._compile_and_inspect(fn, (x,))
+
+        self.assertTrue(
+            torch.equal(ref, result),
+            "Multi-offset input read produced wrong values under LX planning",
+        )
+
+    def test_input_read_partially_is_correct(self):
+        """A graph input read only over a sub-extent (a slice) must not be
+        LX-pinned.
+
+        Strided partial reads of a multi-dim LX buffer mis-address against the
+        single LX base. Pinning ``x`` for ``add(x[:, :, 0:64].clone(),
+        x[:, :, 0:64])`` produced wrong values; the allocator now leaves such
+        inputs in HBM, where partial reads work."""
+        x = self.rand_device((3, 3, 192))
+
+        def fn(x):
+            s = x[:, :, 0:64]  # partial inner-dim slice -> sub-extent read
+            return torch.add(s.clone(), s)
+
+        with ts_inductor_config.patch(lx_planning=False):
+            ref, _, _ = self._compile_and_inspect(fn, (x,))
+
+        torch.compiler.reset()
+
+        with ts_inductor_config.patch(lx_planning=True):
+            result, _, _ = self._compile_and_inspect(fn, (x,))
+
+        self.assertTrue(
+            torch.equal(ref, result),
+            "Partial input read produced wrong values under LX planning",
+        )
+
 
 # TODO: Remove hard coded core division. This test exists to check for
 # regressions when operating on matmuls. There is likely a better

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -820,5 +820,53 @@ class CoOptAllocatorIntegrationTests(BaseTestScratchpadUsage):
         )
 
 
+class TestIntermediatePartialReadNotPinned(BaseTestScratchpadUsage):
+    """An *intermediate* buffer read partially (sliced) must not be LX-pinned.
+
+    Companion to ``TestCloneAtGraphBoundaries``, which guards graph
+    input/output clones. ``_filter_ops`` applies the same
+    ``buffer_not_read_in_full`` guard to intermediate buffers: a buffer that is
+    produced in full and then read over a sub-extent (an inner-dim slice that
+    feeds a chained op) would be LX-pinned and mis-addressed by the single-base
+    LX path. Without the intermediate guard this regresses to a large
+    numerical mismatch (~94%).
+    """
+
+    def test_sliced_intermediate_is_correct(self):
+        # Both leading dims large so the chained ops divide cleanly across
+        # cores (no core-division mismatch) -- the case that would otherwise
+        # LX-pin the sliced intermediate. allow_all_ops_in_lx_planning makes
+        # the intermediate LX-eligible; sencores=32 gives the multi-core split.
+        x = self.rand_device((128, 192, 256))
+
+        def fn(x):
+            t = torch.exp(x)  # full intermediate, produced once
+            s = t[:, :, 32:96]  # sub-stick partial read of the intermediate
+            return s.clone() + s
+
+        cpu_result = fn(x.to("cpu"))
+
+        with ts_inductor_config.patch(
+            lx_planning=True,
+            allow_all_ops_in_lx_planning=True,
+            sencores=32,
+        ):
+            result, mem_usages = self.compile_and_collect_mem_usage(fn, (x,))
+
+        # The scenario must still exercise LX-pinning, else it would pass
+        # trivially without covering the guard.
+        self.assertTrue(
+            any(u["location"] == "LX" for u in mem_usages.values()),
+            "Expected at least one LX-allocated buffer in this scenario",
+        )
+        torch.testing.assert_close(
+            result,
+            cpu_result,
+            atol=0.1,
+            rtol=0.1,
+            msg="sliced intermediate miscompiled -- is the _filter_ops guard present?",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -575,6 +575,44 @@ class TestCloneAtGraphBoundaries(BaseTestScratchpadUsage):
             "Multi-offset input read produced wrong values under LX planning",
         )
 
+    def test_input_feeding_reduction_is_not_cloned(self):
+        """A graph input read by a reduction must not be LX-cloned.
+
+        push_allocation_with_clone copies the first consumer's
+        op_it_space_splits onto the clone; a reduction consumer's splits are
+        keyed to its reduced-shape output and mis-map onto the full-shape
+        clone, splitting the wrong axis (wrong values / SDSC abort at
+        multi-core). The numerical failure only manifests when work is split
+        across cores; here (sencores=1) we assert the guard's decision: no
+        boundary clone is inserted for the reduction-fed input, and the result
+        is correct. Multi-core numerical coverage lives in
+        tests/inductor/test_inductor_ops.py (max_sub_broadcast, aminmax,
+        softmax)."""
+        x = self.rand_device((64, 256))
+
+        def fn(x):
+            # x feeds the max reduction (and the sub) -> reduction consumer.
+            return x - torch.unsqueeze(torch.max(x, dim=1).values, dim=1)
+
+        with ts_inductor_config.patch(lx_planning=False):
+            ref, n_ops_no_lx, _ = self._compile_and_inspect(fn, (x,))
+
+        torch.compiler.reset()
+
+        with ts_inductor_config.patch(lx_planning=True):
+            result, n_ops_with_lx, _ = self._compile_and_inspect(fn, (x,))
+
+        self.assertEqual(
+            n_ops_with_lx,
+            n_ops_no_lx,
+            "Expected no boundary clone for a reduction-fed input, but the op "
+            f"count grew ({n_ops_no_lx} -> {n_ops_with_lx})",
+        )
+        self.assertTrue(
+            torch.equal(ref, result),
+            "Reduction-fed input changed result under LX planning",
+        )
+
     def test_input_read_partially_is_correct(self):
         """A graph input read only over a sub-extent (a slice) must not be
         LX-pinned.

--- a/tests/inductor/test_scratchpad_use.py
+++ b/tests/inductor/test_scratchpad_use.py
@@ -575,17 +575,17 @@ class TestCloneAtGraphBoundaries(BaseTestScratchpadUsage):
             "Multi-offset input read produced wrong values under LX planning",
         )
 
-    def test_input_feeding_reduction_is_not_cloned(self):
-        """A graph input read by a reduction must not be LX-cloned.
+    def test_input_feeding_reduction_is_cloned_and_correct(self):
+        """A graph input read by a reduction is LX-cloned, with the clone's
+        per-core split re-keyed correctly.
 
-        push_allocation_with_clone copies the first consumer's
-        op_it_space_splits onto the clone; a reduction consumer's splits are
-        keyed to its reduced-shape output and mis-map onto the full-shape
-        clone, splitting the wrong axis (wrong values / SDSC abort at
-        multi-core). The numerical failure only manifests when work is split
-        across cores; here (sencores=1) we assert the guard's decision: no
-        boundary clone is inserted for the reduction-fed input, and the result
-        is correct. Multi-core numerical coverage lives in
+        push_allocation_with_clone re-keys the consumer's op_it_space_splits
+        through the buffer's strides before assigning them to the clone. A reduction consumer's split is keyed to its
+        reduced-shape output; copied verbatim it would split the wrong axis of
+        the full-shape clone (wrong values / SDSC abort at multi-core). The
+        numerical failure only manifests when work is split across cores; here
+        (sencores=1) we assert the clone is inserted and the result is correct.
+        Multi-core numerical coverage lives in
         tests/inductor/test_inductor_ops.py (max_sub_broadcast, aminmax,
         softmax)."""
         x = self.rand_device((64, 256))
@@ -600,13 +600,17 @@ class TestCloneAtGraphBoundaries(BaseTestScratchpadUsage):
         torch.compiler.reset()
 
         with ts_inductor_config.patch(lx_planning=True):
-            result, n_ops_with_lx, _ = self._compile_and_inspect(fn, (x,))
+            result, n_ops_with_lx, mem_usages = self._compile_and_inspect(fn, (x,))
 
-        self.assertEqual(
+        self.assertGreater(
             n_ops_with_lx,
             n_ops_no_lx,
-            "Expected no boundary clone for a reduction-fed input, but the op "
-            f"count grew ({n_ops_no_lx} -> {n_ops_with_lx})",
+            "Expected a boundary clone for the reduction-fed input, but the op "
+            f"count did not grow ({n_ops_no_lx} -> {n_ops_with_lx})",
+        )
+        self.assertTrue(
+            any(u["location"] == "LX" for u in mem_usages.values()),
+            "Expected at least one LX-allocated buffer for the reduction input",
         )
         self.assertTrue(
             torch.equal(ref, result),

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -52,7 +52,6 @@ from torch_spyre._inductor.scratchpad.passes import (
 )
 from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
-    OP_GOOD_FOR_LX_INPLACE,
     buffer_not_read_in_full,
     clone_at_graph_boundaries,
     mem_usage_by_buf,

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -54,7 +54,6 @@ from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
     OP_GOOD_FOR_LX_INPLACE,
     buffer_not_read_in_full,
-    buffer_read_by_reduction,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,
@@ -225,14 +224,12 @@ class ScratchpadAllocator(ABC):
             if _would_produce_lx_back_gap(graph, output_name, uses):
                 self.reject_reasons[output_name] = "lx back gap"
                 continue
-            if output_name in graph_output_names and (
-                buffer_not_read_in_full(graph, output_name)
-                or buffer_read_by_reduction(graph, output_name)
+            if output_name in graph_output_names and buffer_not_read_in_full(
+                graph, output_name
             ):
-                # A pinned graph output is cloned for the HBM return. Skip it if
-                # a consumer reads it partially (sliced / multi-offset -> SDSC
-                # mis-addresses the single-base LX buffer) or via a reduction
-                # (clone split mis-keys, see buffer_read_by_reduction).
+                # A pinned graph output is cloned for the HBM return; if a
+                # consumer reads it partially (sliced / multi-offset), SDSC
+                # mis-addresses the single-base LX buffer. Don't pin it.
                 continue
             buffers.append(
                 LifetimeBoundBuffer(
@@ -262,11 +259,6 @@ class ScratchpadAllocator(ABC):
                     # x[:, :, 0:64]). The clone would be pinned to LX, which
                     # SDSC addresses by a single base, so partial reads
                     # mis-address and produce wrong results.
-                    continue
-                if buffer_read_by_reduction(graph, input_name):
-                    # A reduction consumer's split mis-keys onto the full-shape
-                    # clone (see buffer_read_by_reduction), splitting the wrong
-                    # axis -> wrong values or an SDSC abort at multi-core.
                     continue
                 num_cores = ncores.get(input_name, -1)
                 if num_cores < 0:

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -52,6 +52,8 @@ from torch_spyre._inductor.scratchpad.passes import (
 )
 from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
+    OP_GOOD_FOR_LX_INPLACE,
+    buffer_not_read_in_full,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,
@@ -222,6 +224,13 @@ class ScratchpadAllocator(ABC):
             if _would_produce_lx_back_gap(graph, output_name, uses):
                 self.reject_reasons[output_name] = "lx back gap"
                 continue
+            if output_name in graph_output_names and buffer_not_read_in_full(
+                graph, output_name
+            ):
+                # A pinned graph output is cloned for the HBM return; if a
+                # consumer reads it partially (sliced / multi-offset), SDSC
+                # mis-addresses the single-base LX buffer. Don't pin it.
+                continue
             buffers.append(
                 LifetimeBoundBuffer(
                     output_name,
@@ -243,6 +252,13 @@ class ScratchpadAllocator(ABC):
                     # transfer anyway.
                     continue
                 if not GraphEditor.all_uses_are_rewritable(graph, uses):
+                    continue
+                if buffer_not_read_in_full(graph, input_name):
+                    # A consumer reads this input partially -- a sliced/
+                    # multi-offset read (e.g. x[:, 0:512] + x[:, 512:1024], or
+                    # x[:, :, 0:64]). The clone would be pinned to LX, which
+                    # SDSC addresses by a single base, so partial reads
+                    # mis-address and produce wrong results.
                     continue
                 num_cores = ncores.get(input_name, -1)
                 if num_cores < 0:

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -54,6 +54,7 @@ from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
     OP_GOOD_FOR_LX_INPLACE,
     buffer_not_read_in_full,
+    buffer_read_by_reduction,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,
@@ -224,12 +225,14 @@ class ScratchpadAllocator(ABC):
             if _would_produce_lx_back_gap(graph, output_name, uses):
                 self.reject_reasons[output_name] = "lx back gap"
                 continue
-            if output_name in graph_output_names and buffer_not_read_in_full(
-                graph, output_name
+            if output_name in graph_output_names and (
+                buffer_not_read_in_full(graph, output_name)
+                or buffer_read_by_reduction(graph, output_name)
             ):
-                # A pinned graph output is cloned for the HBM return; if a
-                # consumer reads it partially (sliced / multi-offset), SDSC
-                # mis-addresses the single-base LX buffer. Don't pin it.
+                # A pinned graph output is cloned for the HBM return. Skip it if
+                # a consumer reads it partially (sliced / multi-offset -> SDSC
+                # mis-addresses the single-base LX buffer) or via a reduction
+                # (clone split mis-keys, see buffer_read_by_reduction).
                 continue
             buffers.append(
                 LifetimeBoundBuffer(
@@ -259,6 +262,11 @@ class ScratchpadAllocator(ABC):
                     # x[:, :, 0:64]). The clone would be pinned to LX, which
                     # SDSC addresses by a single base, so partial reads
                     # mis-address and produce wrong results.
+                    continue
+                if buffer_read_by_reduction(graph, input_name):
+                    # A reduction consumer's split mis-keys onto the full-shape
+                    # clone (see buffer_read_by_reduction), splitting the wrong
+                    # axis -> wrong values or an SDSC abort at multi-core.
                     continue
                 num_cores = ncores.get(input_name, -1)
                 if num_cores < 0:

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -187,6 +187,21 @@ class ScratchpadAllocator(ABC):
                 drop_list.add(key)
                 self.reject_reasons[key] = "core div mismatch"
 
+        # filter out intermediates read partially (sliced / multi-offset): the
+        # single-base LX path mis-addresses such reads (see
+        # buffer_not_read_in_full / compute_ops._start_addr_data), e.g. an
+        # inner-dim slice x[:, :, 32:96] feeding a chained op. _build_bound_buffers
+        # applies the same guard to graph input/output clones; this covers the
+        # intermediate buffers. Overrides allow_all_ops_in_lx_planning by design.
+        # Only check ops still eligible above: ops already dropped include
+        # non-ComputedBuffer outputs (e.g. multi-output) whose layouts have no
+        # size for buffer_not_read_in_full to inspect.
+        drop_list.update(
+            op.name
+            for op in graph.operations
+            if op.name not in drop_list and buffer_not_read_in_full(graph, op.name)
+        )
+
         if not clone_at_graph_boundaries():
             # Without clone support, graph outputs cannot be LX-pinned: the caller
             # holds an HBM reference and there is no clone to redirect it to.

--- a/torch_spyre/_inductor/scratchpad/graph_editor.py
+++ b/torch_spyre/_inductor/scratchpad/graph_editor.py
@@ -15,7 +15,12 @@
 from torch.fx.graph import Graph
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ops_handler import WrapperHandler
-from torch_spyre._inductor.pass_utils import copy_op_metadata
+from torch_spyre._inductor.pass_utils import (
+    apply_splits_from_index_coeff,
+    copy_op_metadata,
+    iteration_space_from_op,
+    splits_by_index_coeff,
+)
 from torch._inductor.virtualized import V
 from torch._inductor.ir import (
     ComputedBuffer,
@@ -169,14 +174,50 @@ class GraphEditor:
         self.lowering.register_operation(new_com_buf)
         new_buf_name = new_com_buf.name
 
-        # Step 2b: Propagate per-core splits to the clone.
-        # Users share the same per_core_view (pre-checked by core_div_mismatch guard).
-        # op_it_space_splits keys are stride-based coefficients, which are layout-
-        # invariant, so the first user's output_splits transfer without re-keying.
-        # Reduction splits are dropped: the clone is Pointwise with no reduction axis.
+        # Propagate per-core splits to the clone. Users share one per_core_view
+        # (core_div_mismatch guard), so the first user is representative.
         first_user = buffer_users[0]
-        user_out_splits, _ = getattr(first_user, "op_it_space_splits", ({}, {}))
-        new_com_buf.op_it_space_splits = (user_out_splits, {})
+        fu_splits: tuple[dict, dict] = getattr(
+            first_user, "op_it_space_splits", ({}, {})
+        )
+        clone_out_splits: dict = fu_splits[0]
+        if input:
+            # An input clone is inserted *before* its consumers and they read
+            # the clone, so the clone's split must match how they read it.
+            # op_it_space_splits keys are stride coefficients in the consumer's
+            # index space -- NOT layout-invariant: a key maps to the same
+            # physical dim only when the consumer's output shape matches the
+            # clone's (== the buffer's) shape. A reduction consumer's output
+            # drops the reduced dim, so copying its keys verbatim splits the
+            # wrong axis of the full-shape clone (wrong values / SDSC abort at
+            # multi-core).
+            #
+            # Re-key: recover the consumer's {symbol: split}, then encode it
+            # against the consumer's READ index on this buffer. The clone is a
+            # Pointwise copy writing the buffer with that same (identity) index,
+            # so buffer-stride coeffs are valid clone output-split keys. Every
+            # per-core split -- output-dim or reduction/k-split -- lands on the
+            # matching buffer axis.
+            fu_rw = first_user.get_read_writes()
+            read_dep = next((d for d in fu_rw.reads if d.name == buf_name), None)
+            clone_out_splits = {}
+            if read_dep is not None and any(
+                n > 1 for d in fu_splits for n in d.values()
+            ):
+                fu_write_index = next(iter(fu_rw.writes)).index
+                fu_read_index = next((d.index for d in fu_rw.reads), fu_write_index)
+                per_sym = apply_splits_from_index_coeff(
+                    fu_splits,
+                    fu_write_index,
+                    fu_read_index,
+                    iteration_space_from_op(first_user),
+                )
+                clone_out_splits, _ = splits_by_index_coeff(
+                    per_sym, read_dep.index, read_dep.index
+                )
+        # An output clone copies the produced buffer 1:1 (same shape/layout), so
+        # the consumer's output splits transfer directly without re-keying.
+        new_com_buf.op_it_space_splits = (clone_out_splits, {})
 
         if input:
             # Step 3: Update self.graph.name_to_users (a list of TensorBox), e.g., existing users of

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -171,10 +171,13 @@ def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> 
     in HBM (correct, just unpinned).
     """
     layout = getattr(graph.get_buffer(buf_name), "layout", None)
-    if layout is None:
+    # No layout, or a layout without a concrete size (e.g. MultiOutputLayout,
+    # NoneLayout): we cannot prove a full read, so treat as unsafe to pin.
+    size = getattr(layout, "size", None)
+    if size is None:
         return True
     try:
-        full = math.prod(int(concretize_expr(s)) for s in layout.size)
+        full = math.prod(int(concretize_expr(s)) for s in size)
     except (TypeError, ValueError):
         return True
     for op in graph.operations:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -187,7 +187,7 @@ def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> 
             try:
                 if int(dep.get_numel()) < full:
                     return True
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, AttributeError):
                 return True
     return False
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -24,7 +24,7 @@ from torch._inductor.ops_handler import WrapperHandler
 import sympy
 
 from torch_spyre._inductor import config
-from torch_spyre._inductor.pass_utils import _per_core_view_on_buf
+from torch_spyre._inductor.pass_utils import _per_core_view_on_buf, concretize_expr
 
 # Op outputs eligible for LX-pinning. `amax` is the lowered form of
 # `max`; both names are listed to match whichever the IR shows.
@@ -136,6 +136,46 @@ def mem_usage_by_buf(
         }
 
     return mem_usage
+
+
+def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> bool:
+    """True if any consumer reads less than the whole ``buf_name`` (a sliced,
+    partial, or multi-offset read), or if the footprint can't be proven to
+    cover the full buffer.
+
+    An LX-pinned buffer is addressed by a single base (in SDSC codegen the
+    ``start_address`` is ``layout.allocation["lx"]``); unlike the HBM path, a
+    per-access slice offset is *not* folded into that base, and strided
+    partial reads of a multi-dim buffer mis-address. Both failure modes read
+    less than the full buffer per access:
+
+    - multi-offset: ``x[:, 0:512] + x[:, 512:1024]`` — two half reads that
+      both resolve to the LX base, yielding ``x0 + x0``;
+    - partial slice: ``x[:, :, 0:64]`` — a sub-extent read that mis-addresses
+      the 3D LX buffer.
+
+    Only buffers every consumer reads in full (e.g. ``exp(x) + x``) are safe
+    to LX-pin. We are deliberately conservative: an unprovable (symbolic)
+    footprint is treated as unsafe, costing a missed optimization but never
+    correctness.
+    """
+    layout = getattr(graph.get_buffer(buf_name), "layout", None)
+    if layout is None:
+        return True
+    try:
+        full = math.prod(int(concretize_expr(s)) for s in layout.size)
+    except (TypeError, ValueError):
+        return True
+    for op in graph.operations:
+        for dep in op.get_read_writes().reads:
+            if dep.name != buf_name:
+                continue
+            try:
+                if int(dep.get_numel()) < full:
+                    return True
+            except (TypeError, ValueError):
+                return True
+    return False
 
 
 def get_buffer_users(graph: GraphLowering | GraphView) -> dict[str, list[Operation]]:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -158,6 +158,17 @@ def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> 
     to LX-pin. We are deliberately conservative: an unprovable (symbolic)
     footprint is treated as unsafe, costing a missed optimization but never
     correctness.
+
+    Why a guard and not a codegen fix: the root cause is that the SDSC LX
+    address path (compute_ops._start_addr_data) uses only ``start_address``,
+    dropping the per-access view offset that the HBM path folds in via
+    ``core_idx_to_slice_offset``. It is a codegen gap, not a hardware limit.
+    But folding ``sum(offsets)`` into the LX base only fixes part of it: the
+    view offset interacts with per-core work-slicing (at multi-core the split
+    changes which coordinate is constant vs per-core), so a correct fix must
+    reconcile the view offset with the per-core LX work-slice geometry rather
+    than add a single constant. Until that lands, the guard keeps such buffers
+    in HBM (correct, just unpinned).
     """
     layout = getattr(graph.get_buffer(buf_name), "layout", None)
     if layout is None:

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -17,7 +17,7 @@ import math
 from typing import Any, Optional
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
-from torch._inductor.ir import Operation, IRNode, Pointwise, Reduction
+from torch._inductor.ir import Operation, IRNode, Pointwise
 from torch._inductor.virtualized import V
 from torch._inductor.ops_handler import WrapperHandler
 
@@ -175,27 +175,6 @@ def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> 
                     return True
             except (TypeError, ValueError):
                 return True
-    return False
-
-
-def buffer_read_by_reduction(graph: GraphLowering | GraphView, buf_name: str) -> bool:
-    """True if any consumer that reads ``buf_name`` wraps a ``Reduction``.
-
-    Step 2b of ``push_allocation_with_clone`` copies the first consumer's
-    ``op_it_space_splits`` onto the inserted clone. Those keys are write-index
-    stride coefficients, which only map to the same physical dimension when the
-    consumer's output shape matches the clone's (== the buffer's) shape. A
-    reduction consumer's output drops the reduced dimension, so the same
-    coefficient key lands on a *different* dim of the full-shape clone -- the
-    clone splits the wrong axis, producing wrong values or an SDSC abort at
-    multi-core. Until that split is re-keyed through the buffer's strides,
-    don't LX-pin buffers feeding a reduction.
-    """
-    for op in graph.operations:
-        if isinstance(getattr(op, "data", None), Reduction) and any(
-            dep.name == buf_name for dep in op.get_read_writes().reads
-        ):
-            return True
     return False
 
 

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -17,7 +17,7 @@ import math
 from typing import Any, Optional
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
-from torch._inductor.ir import Operation, IRNode, Pointwise
+from torch._inductor.ir import Operation, IRNode, Pointwise, Reduction
 from torch._inductor.virtualized import V
 from torch._inductor.ops_handler import WrapperHandler
 
@@ -175,6 +175,27 @@ def buffer_not_read_in_full(graph: GraphLowering | GraphView, buf_name: str) -> 
                     return True
             except (TypeError, ValueError):
                 return True
+    return False
+
+
+def buffer_read_by_reduction(graph: GraphLowering | GraphView, buf_name: str) -> bool:
+    """True if any consumer that reads ``buf_name`` wraps a ``Reduction``.
+
+    Step 2b of ``push_allocation_with_clone`` copies the first consumer's
+    ``op_it_space_splits`` onto the inserted clone. Those keys are write-index
+    stride coefficients, which only map to the same physical dimension when the
+    consumer's output shape matches the clone's (== the buffer's) shape. A
+    reduction consumer's output drops the reduced dimension, so the same
+    coefficient key lands on a *different* dim of the full-shape clone -- the
+    clone splits the wrong axis, producing wrong values or an SDSC abort at
+    multi-core. Until that split is re-keyed through the buffer's strides,
+    don't LX-pin buffers feeding a reduction.
+    """
+    for op in graph.operations:
+        if isinstance(getattr(op, "data", None), Reduction) and any(
+            dep.name == buf_name for dep in op.get_read_writes().reads
+        ):
+            return True
     return False
 
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Makes the boundary-clone path (LX_BOUNDARY_CLONES=1 / lx_boundary_clones) correct for graph input/output LX-pinning. The path was producing wrong values and SDSC aborts at multi-core for several access patterns; this PR fixes the tractable ones (reductions now pin to LX correctly) and guards the rest into HBM (correct, pending a codegen fix tracked separately).

Behind the existing default-off flag — no change to the shipped path.

##### Changes

1. Re-key input-clone splits (graph_editor.py): the real fix. push_allocation_with_clone copied a consumer's op_it_space_splits onto the inserted clone verbatim, but those keys are stride coefficients in the consumer's index space. A reduction consumer's output drops the reduced dim, so a copied key landed on the wrong axis of the full-shape clone → wrong values / SDSC abort at multi-core. Now the split is re-keyed through the consumer's read index on the buffer (which the clone writes with the same identity index), so each split lands on the correct axis. Output clones keep the verbatim copy (they copy the produced buffer 1:1; re-keying them regressed test_scalar_cpu_combined).
2. Guard partial / multi-offset reads (buffer_not_read_in_full, utils.py + allocator.py): an LX-pinned buffer is addressed by a single base; the SDSC LX path drops the per-access view offset, so sliced (x[:,:,0:64]) and multi-offset (x[:,0:512]+x[:,512:1024]) reads resolve to the base. These buffers are kept in HBM (correct). Root cause is a codegen gap, not a hardware limit — see the follow-up issue; a one-line offset fix is insufficient because the view offset interacts with per-core work-slicing.
3. Docs: record the codegen-gap finding on the guard so it reads as a deliberate decision.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
