### PR TITLE
Fix bug in affine_map computation when unroll_loops=False

### DIFF
--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1888,6 +1888,16 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
         self.assertEqual(mlir, expected)
 
     # --- Group 2: nested outer-B + inner-K reduction ---
+    #
+    # Strides match TestNestedReductionUnroll in test_unroll_loop_specs.py:
+    #   k_input: device_size=[2,64,64], stride_map=[64,64,1], 128 K-elems/tile
+    #     byte_stride = (128//64) * 64 * 2 = 256
+    #   accum_buf: device_size=[1,2,64], stride_map=[64,64,1], 2 batches/tile
+    #     byte_stride = 2 * 64 * 2 = 256
+    # Both happen to be 256; the combine's accum_buf stride is irrelevant (not
+    # tiled on K), so only K_STRIDE=256 appears in the affine map.
+
+    _GRP2_K_STRIDE = 256  # (128//64) * 64 * 2
 
     def _fake_nested_reduction(self, k_stride):
         c_k = self._c_k
@@ -1914,15 +1924,17 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
 
     def test_nested_reduction_bmm_emits_affine_apply(self):
         mlir = self._bundle(
-            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+            self._make_nested_reduction_specs(),
+            self._fake_nested_reduction(self._GRP2_K_STRIDE),
         )
         self.assertIn("affine.apply", mlir)
-        self.assertIn("256", mlir)
+        self.assertIn(str(self._GRP2_K_STRIDE), mlir)
 
     def test_nested_reduction_combine_no_affine_apply(self):
         """combine's accum_buf (not tiled on K) must not get an affine.apply."""
         mlir = self._bundle(
-            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+            self._make_nested_reduction_specs(),
+            self._fake_nested_reduction(self._GRP2_K_STRIDE),
         )
         # Only one affine.apply (for the bmm); the combine uses %sym_2 directly.
         self.assertEqual(mlir.count("affine.apply"), 1)
@@ -1933,16 +1945,18 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
 
     def test_nested_reduction_loop_structure(self):
         mlir = self._bundle(
-            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+            self._make_nested_reduction_specs(),
+            self._fake_nested_reduction(self._GRP2_K_STRIDE),
         )
         self.assertEqual(mlir.count("scf.for"), 2)
 
     def test_nested_reduction_snapshot(self):
         mlir = self._bundle(
-            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+            self._make_nested_reduction_specs(),
+            self._fake_nested_reduction(self._GRP2_K_STRIDE),
         )
         expected = (
-            "#map_0 = affine_map<(d0)[s0] -> (s0 + 256*d0)>\n"
+            f"#map_0 = affine_map<(d0)[s0] -> (s0 + {self._GRP2_K_STRIDE}*d0)>\n"
             "module {\n"
             "\tfunc.func @sdsc_bundle() {\n"
             "\t\t%c0 = arith.constant 0 : index\n"
@@ -1967,6 +1981,15 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
         self.assertEqual(mlir, expected)
 
     # --- Group 3: tile-accum copy pattern ---
+    #
+    # Strides match TestNestedReductionTileAccum in test_unroll_loop_specs.py:
+    #   bmm K-input: same geometry as Group 2 → K_STRIDE = 256
+    #   accum_full (copy output): device_size=[1,128,32], stride_map=[2048,32,1]
+    #     device_coords=[c_b, c_m, c_n]; 1 tile advances c_b by 1
+    #     byte_stride = 1 * 2048 * 2 = 4096  (_OUTER_TILE_STRIDE_BYTES)
+
+    _GRP3_K_STRIDE = 256  # (128//64) * 64 * 2
+    _GRP3_B_STRIDE = 4096  # 1 * 2048 * 2
 
     def _fake_tile_accum(self, k_stride, b_stride):
         c_k, c_b = self._c_k, self._c_b
@@ -2000,7 +2023,8 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
     def test_tile_accum_copy_advances_per_outer_tile(self):
         """copy op (tiled on outer B) emits affine.apply with outer loop var %i_0."""
         mlir = self._bundle(
-            self._make_tile_accum_specs(), self._fake_tile_accum(256, 512)
+            self._make_tile_accum_specs(),
+            self._fake_tile_accum(self._GRP3_K_STRIDE, self._GRP3_B_STRIDE),
         )
         apply_lines = [ln for ln in mlir.splitlines() if "affine.apply" in ln]
         # bmm uses %i_1 (inner K); copy uses %i_0 (outer B)
@@ -2016,7 +2040,8 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
     def test_tile_accum_fill_no_affine_apply(self):
         """fill op (per_tile_fixed output) must not get an affine.apply."""
         mlir = self._bundle(
-            self._make_tile_accum_specs(), self._fake_tile_accum(256, 512)
+            self._make_tile_accum_specs(),
+            self._fake_tile_accum(self._GRP3_K_STRIDE, self._GRP3_B_STRIDE),
         )
         execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
         # fill is the first sdsc_execute inside the outer loop
@@ -2026,11 +2051,12 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
 
     def test_tile_accum_snapshot(self):
         mlir = self._bundle(
-            self._make_tile_accum_specs(), self._fake_tile_accum(256, 512)
+            self._make_tile_accum_specs(),
+            self._fake_tile_accum(self._GRP3_K_STRIDE, self._GRP3_B_STRIDE),
         )
         expected = (
-            "#map_0 = affine_map<(d0)[s0] -> (s0 + 256*d0)>\n"
-            "#map_1 = affine_map<(d0)[s0] -> (s0 + 512*d0)>\n"
+            f"#map_0 = affine_map<(d0)[s0] -> (s0 + {self._GRP3_K_STRIDE}*d0)>\n"
+            f"#map_1 = affine_map<(d0)[s0] -> (s0 + {self._GRP3_B_STRIDE}*d0)>\n"
             "module {\n"
             "\tfunc.func @sdsc_bundle() {\n"
             "\t\t%c0 = arith.constant 0 : index\n"

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -2087,6 +2087,69 @@ class TestGenerateBundleUnrollPath(unittest.TestCase):
         )
         self.assertEqual(mlir, expected)
 
+    # --- Group 4: two-tensor op — one tiled, one not ---
+    #
+    # Directly exercises per_tensor_lv_indices[tensor_idx] for both tensor_idx=0
+    # (tiled, non-empty index list) and tensor_idx=1 (non-tiled, empty list).
+    # Uses a single flat loop so the setup stays minimal.
+
+    def test_two_tensor_op_only_tiled_tensor_gets_affine_apply(self):
+        """Op with two tensors: first tiled (affine.apply), second not (sym direct)."""
+        s = self._s
+
+        def _make_two_tensor_json(idx, sym_id0, sym_id1):
+            return {
+                f"{idx}_mm": {
+                    "numCoresUsed_": 1,
+                    "dscs_": [
+                        {
+                            "mm": {
+                                "scheduleTree_": [
+                                    {
+                                        "component_": "hbm",
+                                        "startAddressCoreCorelet_": {
+                                            "data_": {"[0, 0, 0]": str(sym_id0)}
+                                        },
+                                    },
+                                    {
+                                        "component_": "hbm",
+                                        "startAddressCoreCorelet_": {
+                                            "data_": {"[0, 0, 0]": str(sym_id1)}
+                                        },
+                                    },
+                                ]
+                            }
+                        }
+                    ],
+                }
+            }
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+            sid0 = -(symbol_id_offset + 1)
+            sid1 = -(symbol_id_offset + 2)
+            symbols.append(0x1000)
+            symbols.append(0x2000)
+            # tensor 0 tiled, tensor 1 not tiled
+            return (
+                _make_two_tensor_json(idx, sid0, sid1),
+                [0x1000, 0x2000],
+                [{s: 256}, {}],
+                [],
+            )
+
+        op = _make_minimal_op_spec("mm")
+        loop = LoopSpec(count=Integer(4), body=[op])
+        mlir = self._bundle([loop], fake)
+
+        # Exactly one affine.apply (for tensor 0 only)
+        self.assertEqual(mlir.count("affine.apply"), 1)
+        apply_line = next(ln for ln in mlir.splitlines() if "affine.apply" in ln)
+        self.assertIn("%i_0", apply_line)
+
+        # tensor 1 (sym_2) appears directly in sdsc_execute, not via an %addr_N
+        execute_line = next(ln for ln in mlir.splitlines() if "sdsc_execute" in ln)
+        self.assertIn("%sym_2", execute_line)
+
 
 # ===========================================================================
 # 6. coarse_tile buffer propagation pass

--- a/tests/inductor/test_coarse_tiling.py
+++ b/tests/inductor/test_coarse_tiling.py
@@ -1790,6 +1790,278 @@ class TestGenerateBundleNestedTiling(unittest.TestCase):
         self.assertEqual(mlir, expected)
 
 
+class TestGenerateBundleUnrollPath(unittest.TestCase):
+    """Verify affine-map correctness for the unroll_loops=False path.
+
+    One test group per scenario covered by test_unroll_loop_specs.py:
+      Group 1 — flat row-tiling         (mirrors TestUnrollLoopSpecs)
+      Group 2 — nested outer-B/inner-K reduction  (mirrors TestNestedReductionUnroll)
+      Group 3 — tile-accum copy pattern (mirrors TestNestedReductionTileAccum)
+
+    Key invariants:
+      - ops tiled only by the inner loop var emit affine.apply with that var only
+      - ops not tiled (per_tile_fixed or fixed address) emit no affine.apply
+      - the copy op (outer-B tiled) emits affine.apply with the outer loop var
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._s = Symbol("s")
+        self._c_k = Symbol("c_k")
+        self._c_b = Symbol("c_b")
+
+    def _bundle(self, specs, fake_compile):
+        with patch(
+            "torch_spyre._inductor.codegen.bundle.compile_op_spec",
+            side_effect=fake_compile,
+        ):
+            generate_bundle(
+                "test_kernel",
+                self.tmpdir,
+                specs,
+                unroll_loops=False,
+                symbolic_args=True,
+            )
+        return _read_mlir(self.tmpdir)
+
+    # --- Group 1: flat row-tiling ---
+
+    def test_flat_loop_tiled_tensor_emits_affine_apply(self):
+        s = self._s
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(0x1000)
+            return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
+
+        op = _make_minimal_op_spec("a")
+        loop = LoopSpec(count=Integer(4), body=[op])
+        mlir = self._bundle([loop], fake)
+
+        self.assertIn("affine_map", mlir)
+        self.assertIn("affine.apply", mlir)
+        self.assertIn("256", mlir)
+
+    def test_flat_loop_non_tiled_tensor_no_affine_apply(self):
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(0x2000)
+            return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
+
+        op = _make_minimal_op_spec("b")
+        loop = LoopSpec(count=Integer(4), body=[op])
+        mlir = self._bundle([loop], fake)
+
+        self.assertNotIn("affine_map", mlir)
+        self.assertNotIn("affine.apply", mlir)
+        self.assertIn("%sym_1", mlir)
+
+    def test_flat_loop_snapshot(self):
+        s = self._s
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(0x1000)
+            return _make_tiled_json(idx, sym_id), [0x1000], [{s: 256}], []
+
+        op = _make_minimal_op_spec("a")
+        loop = LoopSpec(count=Integer(4), body=[op])
+        mlir = self._bundle([loop], fake)
+
+        expected = (
+            "#map_0 = affine_map<(d0)[s0] -> (s0 + 256*d0)>\n"
+            "module {\n"
+            "\tfunc.func @sdsc_bundle() {\n"
+            "\t\t%c0 = arith.constant 0 : index\n"
+            "\t\t%c1 = arith.constant 1 : index\n"
+            "\t\t%loop_bound_0 = arith.constant 4 : index\n"
+            "\t\t%sym_1 = arith.constant 4096 : index\n"
+            "\t\tscf.for %i_0 = %c0 to %loop_bound_0 step %c1 {\n"
+            "\t\t\t%addr_0 = affine.apply #map_0(%i_0)[%sym_1]\n"
+            '\t\t\tsdscbundle.sdsc_execute (%addr_0) {sdsc_filename="sdsc_0.json",'
+            ' "symbol_ids"=[-1]}\n'
+            "\t\t}\n"
+            "\t\treturn\n"
+            "\t}\n"
+            "}\n"
+        )
+        self.assertEqual(mlir, expected)
+
+    # --- Group 2: nested outer-B + inner-K reduction ---
+
+    def _fake_nested_reduction(self, k_stride):
+        c_k = self._c_k
+        call_count = [0]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+            i = call_count[0]
+            call_count[0] += 1
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(0x1000 * (i + 1))
+            if i == 0:  # bmm: tiled on inner K var only
+                return _make_tiled_json(idx, sym_id), [0x1000], [{c_k: k_stride}], []
+            else:  # combine: accum_buf not tiled on K
+                return _make_tiled_json(idx, sym_id), [0x2000], [{}], []
+
+        return fake
+
+    def _make_nested_reduction_specs(self):
+        bmm = _make_minimal_op_spec("batchmatmul")
+        combine = _make_minimal_op_spec("add")
+        inner = LoopSpec(count=Integer(4), body=[bmm, combine])
+        outer = LoopSpec(count=Integer(2), body=[inner])
+        return [outer]
+
+    def test_nested_reduction_bmm_emits_affine_apply(self):
+        mlir = self._bundle(
+            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+        )
+        self.assertIn("affine.apply", mlir)
+        self.assertIn("256", mlir)
+
+    def test_nested_reduction_combine_no_affine_apply(self):
+        """combine's accum_buf (not tiled on K) must not get an affine.apply."""
+        mlir = self._bundle(
+            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+        )
+        # Only one affine.apply (for the bmm); the combine uses %sym_2 directly.
+        self.assertEqual(mlir.count("affine.apply"), 1)
+        execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
+        combine_line = execute_lines[1]
+        self.assertIn("%sym_2", combine_line)
+        self.assertNotIn("addr", combine_line)
+
+    def test_nested_reduction_loop_structure(self):
+        mlir = self._bundle(
+            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+        )
+        self.assertEqual(mlir.count("scf.for"), 2)
+
+    def test_nested_reduction_snapshot(self):
+        mlir = self._bundle(
+            self._make_nested_reduction_specs(), self._fake_nested_reduction(256)
+        )
+        expected = (
+            "#map_0 = affine_map<(d0)[s0] -> (s0 + 256*d0)>\n"
+            "module {\n"
+            "\tfunc.func @sdsc_bundle() {\n"
+            "\t\t%c0 = arith.constant 0 : index\n"
+            "\t\t%c1 = arith.constant 1 : index\n"
+            "\t\t%loop_bound_0 = arith.constant 2 : index\n"
+            "\t\t%loop_bound_1 = arith.constant 4 : index\n"
+            "\t\t%sym_1 = arith.constant 4096 : index\n"
+            "\t\t%sym_2 = arith.constant 8192 : index\n"
+            "\t\tscf.for %i_0 = %c0 to %loop_bound_0 step %c1 {\n"
+            "\t\t\tscf.for %i_1 = %c0 to %loop_bound_1 step %c1 {\n"
+            "\t\t\t\t%addr_0 = affine.apply #map_0(%i_1)[%sym_1]\n"
+            '\t\t\t\tsdscbundle.sdsc_execute (%addr_0) {sdsc_filename="sdsc_0.json",'
+            ' "symbol_ids"=[-1]}\n'
+            '\t\t\t\tsdscbundle.sdsc_execute (%sym_2) {sdsc_filename="sdsc_1.json",'
+            ' "symbol_ids"=[-2]}\n'
+            "\t\t\t}\n"
+            "\t\t}\n"
+            "\t\treturn\n"
+            "\t}\n"
+            "}\n"
+        )
+        self.assertEqual(mlir, expected)
+
+    # --- Group 3: tile-accum copy pattern ---
+
+    def _fake_tile_accum(self, k_stride, b_stride):
+        c_k, c_b = self._c_k, self._c_b
+        call_count = [0]
+
+        def fake(idx, op_spec, symbols, symbol_id_offset=0, use_symbols=False):
+            i = call_count[0]
+            call_count[0] += 1
+            sym_id = -(symbol_id_offset + 1)
+            symbols.append(0x1000 * (i + 1))
+            if i == 0:  # fill: per_tile_fixed output, not tiled
+                return _make_tiled_json(idx, sym_id), [0x1000], [{}], []
+            elif i == 1:  # bmm: K-input tiled on inner K
+                return _make_tiled_json(idx, sym_id), [0x2000], [{c_k: k_stride}], []
+            elif i == 2:  # combine: per_tile_fixed accum_tile, not tiled
+                return _make_tiled_json(idx, sym_id), [0x3000], [{}], []
+            else:  # copy: accum_full advances per outer B-tile
+                return _make_tiled_json(idx, sym_id), [0x4000], [{c_b: b_stride}], []
+
+        return fake
+
+    def _make_tile_accum_specs(self):
+        fill = _make_minimal_op_spec("fill")
+        bmm = _make_minimal_op_spec("batchmatmul")
+        combine = _make_minimal_op_spec("add")
+        copy = _make_minimal_op_spec("copy")
+        inner = LoopSpec(count=Integer(4), body=[bmm, combine])
+        outer = LoopSpec(count=Integer(2), body=[fill, inner, copy])
+        return [outer]
+
+    def test_tile_accum_copy_advances_per_outer_tile(self):
+        """copy op (tiled on outer B) emits affine.apply with outer loop var %i_0."""
+        mlir = self._bundle(
+            self._make_tile_accum_specs(), self._fake_tile_accum(256, 512)
+        )
+        apply_lines = [ln for ln in mlir.splitlines() if "affine.apply" in ln]
+        # bmm uses %i_1 (inner K); copy uses %i_0 (outer B)
+        self.assertTrue(
+            any("%i_1" in ln for ln in apply_lines),
+            "Expected bmm affine.apply to use inner loop var %i_1",
+        )
+        self.assertTrue(
+            any("%i_0" in ln and "%i_1" not in ln for ln in apply_lines),
+            "Expected copy affine.apply to use only outer loop var %i_0",
+        )
+
+    def test_tile_accum_fill_no_affine_apply(self):
+        """fill op (per_tile_fixed output) must not get an affine.apply."""
+        mlir = self._bundle(
+            self._make_tile_accum_specs(), self._fake_tile_accum(256, 512)
+        )
+        execute_lines = [ln for ln in mlir.splitlines() if "sdsc_execute" in ln]
+        # fill is the first sdsc_execute inside the outer loop
+        fill_line = execute_lines[0]
+        self.assertIn("%sym_1", fill_line)
+        self.assertNotIn("addr", fill_line)
+
+    def test_tile_accum_snapshot(self):
+        mlir = self._bundle(
+            self._make_tile_accum_specs(), self._fake_tile_accum(256, 512)
+        )
+        expected = (
+            "#map_0 = affine_map<(d0)[s0] -> (s0 + 256*d0)>\n"
+            "#map_1 = affine_map<(d0)[s0] -> (s0 + 512*d0)>\n"
+            "module {\n"
+            "\tfunc.func @sdsc_bundle() {\n"
+            "\t\t%c0 = arith.constant 0 : index\n"
+            "\t\t%c1 = arith.constant 1 : index\n"
+            "\t\t%loop_bound_0 = arith.constant 2 : index\n"
+            "\t\t%loop_bound_1 = arith.constant 4 : index\n"
+            "\t\t%sym_1 = arith.constant 4096 : index\n"
+            "\t\t%sym_2 = arith.constant 8192 : index\n"
+            "\t\t%sym_3 = arith.constant 12288 : index\n"
+            "\t\t%sym_4 = arith.constant 16384 : index\n"
+            "\t\tscf.for %i_0 = %c0 to %loop_bound_0 step %c1 {\n"
+            '\t\t\tsdscbundle.sdsc_execute (%sym_1) {sdsc_filename="sdsc_0.json",'
+            ' "symbol_ids"=[-1]}\n'
+            "\t\t\tscf.for %i_1 = %c0 to %loop_bound_1 step %c1 {\n"
+            "\t\t\t\t%addr_0 = affine.apply #map_0(%i_1)[%sym_2]\n"
+            '\t\t\t\tsdscbundle.sdsc_execute (%addr_0) {sdsc_filename="sdsc_1.json",'
+            ' "symbol_ids"=[-2]}\n'
+            '\t\t\t\tsdscbundle.sdsc_execute (%sym_3) {sdsc_filename="sdsc_2.json",'
+            ' "symbol_ids"=[-3]}\n'
+            "\t\t\t}\n"
+            "\t\t\t%addr_1 = affine.apply #map_1(%i_0)[%sym_4]\n"
+            '\t\t\tsdscbundle.sdsc_execute (%addr_1) {sdsc_filename="sdsc_3.json",'
+            ' "symbol_ids"=[-4]}\n'
+            "\t\t}\n"
+            "\t\treturn\n"
+            "\t}\n"
+            "}\n"
+        )
+        self.assertEqual(mlir, expected)
+
+
 # ===========================================================================
 # 6. coarse_tile buffer propagation pass
 # ===========================================================================

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -115,11 +115,19 @@ def generate_bundle(
     _collect_loop_bounds(specs_list, loop_bounds)
 
     # Affine map deduplication: stride_key -> map index (0-based).
-    # A stride_key is a tuple of (stride,) values — one per loop variable at
-    # the nesting depth where the op lives.  For a single-level loop with one
-    # tiled sym the key is (stride_bytes,).
+    # A stride_key is a tuple of (stride,) values — one per tiled loop variable
+    # that advances this tensor.  For a single-level loop with one tiled sym the
+    # key is (stride_bytes,).
+    #
+    # affine_map_loop_var_indices: parallel to compiled, per op a list of
+    # per-tensor loop-var index lists.  Each inner list records which positions
+    # in the enclosing loop_vars list correspond to the strides in stride_key.
+    # _emit_specs uses this to pass only the relevant loop vars to affine.apply.
     affine_map_index: dict[tuple, int] = {}
-    _collect_affine_maps(specs_list, iter(compiled), [], affine_map_index)
+    affine_map_loop_var_indices: list[list[list[int]]] = []
+    _collect_affine_maps(
+        specs_list, iter(compiled), [], affine_map_index, affine_map_loop_var_indices
+    )
 
     compiled_iter = iter(compiled)
     addr_counter = [0]
@@ -270,12 +278,14 @@ def generate_bundle(
 
         # Recursive body emission.
         loop_bound_idx = [0]
+        affine_map_lv_iter = iter(affine_map_loop_var_indices)
         _emit_specs(
             specs_list,
             compiled_iter,
             loop_bounds,
             loop_bound_idx,
             affine_map_index,
+            affine_map_lv_iter,
             addr_counter,
             [],
             f,
@@ -363,8 +373,16 @@ def _collect_affine_maps(
     compiled_iter,
     loop_var_depth: list,
     affine_map_index: dict,
+    loop_var_indices_out: list,
 ) -> None:
-    """Walk the spec tree and register unique affine stride keys."""
+    """Walk the spec tree and register unique affine stride keys.
+
+    Populates ``affine_map_index`` (stride_key -> map_idx) and appends one
+    entry per OpSpec to ``loop_var_indices_out``.  Each entry is a list of
+    per-tensor index lists: ``loop_var_indices_out[op_idx][tensor_idx]`` is
+    the list of loop-var positions (into the enclosing ``loop_vars`` list at
+    emit time) that correspond to the strides in the tensor's stride_key.
+    """
     for entry in specs:
         if isinstance(entry, LoopSpec):
             _collect_affine_maps(
@@ -372,17 +390,27 @@ def _collect_affine_maps(
                 compiled_iter,
                 loop_var_depth + [len(loop_var_depth)],
                 affine_map_index,
+                loop_var_indices_out,
             )
         elif isinstance(entry, OpSpec):
             _, _, affine_strides, _ = next(compiled_iter)
+            per_tensor_lv_indices: list[list[int]] = []
             for tensor_strides in affine_strides:
                 if not tensor_strides:
+                    per_tensor_lv_indices.append([])
                     continue
                 # Build stride key from the tiled symbols present in this tensor,
                 # in the order they appear in affine_strides dict.
                 stride_key = tuple(tensor_strides.values())
                 if stride_key not in affine_map_index:
                     affine_map_index[stride_key] = len(affine_map_index)
+                # Record which loop-var positions (in the enclosing loop_vars
+                # list) correspond to each stride entry.  The strides come from
+                # the innermost loop levels inward, so we take the last
+                # len(stride_key) entries of loop_var_depth.
+                lv_idxs = list(loop_var_depth[-len(stride_key) :])
+                per_tensor_lv_indices.append(lv_idxs)
+            loop_var_indices_out.append(per_tensor_lv_indices)
 
 
 # ---------------------------------------------------------------------------
@@ -405,6 +433,7 @@ def _emit_specs(
     loop_bounds: list,
     loop_bound_idx: list,
     affine_map_index: dict,
+    affine_map_lv_iter,
     addr_counter: list,
     loop_vars: list,
     f,
@@ -451,6 +480,7 @@ def _emit_specs(
                 loop_bounds,
                 loop_bound_idx,
                 affine_map_index,
+                affine_map_lv_iter,
                 addr_counter,
                 loop_vars + [loop_var],
                 f,
@@ -464,6 +494,10 @@ def _emit_specs(
 
         elif isinstance(entry, OpSpec):
             sdsc_json, local_sym_values, affine_strides, _ = next(compiled_iter)
+            # Per-tensor loop-var index lists: which positions in the enclosing
+            # loop_vars list correspond to the strides for each tensor.
+            per_tensor_lv_indices: list[list[int]] = next(affine_map_lv_iter)
+
             # Determine the JSON filename from the sdsc_json key.
             sdsc_name = next(iter(sdsc_json))
             sdsc_idx = sdsc_name.split("_")[0]
@@ -489,7 +523,12 @@ def _emit_specs(
                     addr_name = f"%addr_{addr_counter[0]}"
                     addr_counter[0] += 1
                     base_addr_name = _resolve_sym(base_sym_id)
-                    loop_var_str = ", ".join(loop_vars)
+                    # Select only the loop vars that correspond to the strides
+                    # for this tensor (may be a subset of all enclosing loop vars
+                    # when the op is not tiled on every enclosing loop level).
+                    lv_indices = per_tensor_lv_indices[tensor_idx]
+                    apply_loop_vars = [loop_vars[i] for i in lv_indices]
+                    loop_var_str = ", ".join(apply_loop_vars)
                     f.write(
                         f"{tab}{addr_name} = affine.apply #map_{map_idx}"
                         f"({loop_var_str})[{base_addr_name}]\n"

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -277,6 +277,9 @@ def generate_bundle(
                 f.write(f"\t\t%sym_{sym_idx + 1} = arith.constant {value} : index\n")
 
         # Recursive body emission.
+        # affine_map_lv_iter spans the entire spec tree (one entry per OpSpec,
+        # in the same depth-first order as compiled_iter) and is consumed by
+        # _emit_specs across all recursive calls — not reset per loop level.
         loop_bound_idx = [0]
         affine_map_lv_iter = iter(affine_map_loop_var_indices)
         _emit_specs(
@@ -405,8 +408,10 @@ def _collect_affine_maps(
                 if stride_key not in affine_map_index:
                     affine_map_index[stride_key] = len(affine_map_index)
                 # Record which loop-var positions (in the enclosing loop_vars
-                # list) correspond to each stride entry.  The strides come from
-                # the innermost loop levels inward, so we take the last
+                # list) correspond to each stride entry.  tiled_symbols is
+                # ordered outermost-first (see spyre_kernel.py), so a K-only
+                # tiled op at nesting depth 2 has stride_key length 1 and we
+                # want the innermost loop var — hence we take the *last*
                 # len(stride_key) entries of loop_var_depth.
                 lv_idxs = list(loop_var_depth[-len(stride_key) :])
                 per_tensor_lv_indices.append(lv_idxs)


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Fixes a bug in `generate_bundle` (`unroll_loops=False` path) where
`affine.apply` was passed the wrong loop variables for ops that are
tiled on only a subset of their enclosing loop levels.

**Bug:** When a op sits inside a nested loop but is tiled by only the
inner level (e.g. a bmm tiled on the inner K-loop inside an outer
B-loop), `_emit_specs` emitted `affine.apply #map_0(%i_0, %i_1)[base]`
but the map declaration was `affine_map<(d0)[s0]>` — a 1-dim map
receiving 2 operands.  The outer loop variable `%i_0` should not appear
in the `affine.apply` for an op that doesn't advance per outer iteration.

**Fix:** `_collect_affine_maps` now records, for each op and each tiled
tensor, which positions in the enclosing `loop_vars` list correspond to
the tensor's strides.  `_emit_specs` uses this to select only the
relevant loop vars when emitting `affine.apply`.

**Tests:** Adds `TestGenerateBundleUnrollPath` (10 tests) to
`test_coarse_tiling.py`, providing parity coverage for the
`unroll_loops=False` path matching each scenario in
`test_unroll_loop_specs.py`:

- *Group 1* — flat row-tiling: tiled tensor emits `affine.apply`, non-tiled uses `%sym_N` directly (mirrors `TestUnrollLoopSpecs`)
- *Group 2* — nested outer-B + inner-K reduction: bmm emits `affine.apply %i_1`, combine has no `affine.apply` (mirrors `TestNestedReductionUnroll`)
- *Group 3* — tile-accum copy pattern: copy emits `affine.apply %i_0`, fill has no `affine.apply` (mirrors `TestNestedReductionTileAccum`)

Stride values in the new tests are derived from the same tensor geometry
as the corresponding unroll tests and verified against the ground-truth
byte offsets computed by the `unroll_loops=True` path.

#### Which issue(s) this PR is related to:

Part of #206 


#### Special notes for your reviewer:

The bug only affects the `unroll_loops=False` (affine-map / `scf.for`)
path; the `unroll_loops=True` path (which bakes concrete HBM addresses)
was unaffected.  The existing `TestGenerateBundleNestedTiling` tests
didn't catch this because they test a tensor tiled by *both* loop levels
simultaneously (`{s0: 512, s1: 64}`), where the map is 2D and all loop
vars are correctly passed.  The bug only manifests when strides span
fewer levels than the nesting depth.

`_collect_affine_maps` signature gains a new `loop_var_indices_out`
parameter (list appended in-place), and `_emit_specs` gains
`affine_map_lv_iter` (consumed in parallel with `compiled_iter`).  Both
are internal helpers with no public callers outside `generate_bundle`.

#### Does this PR introduce a user-facing change?

No direct API change.  Kernels compiled with `unroll_loops=False` (the
default in production) that involve nested tiling where an op is tiled
on only a subset of loop levels will now emit correct `affine.apply`
operands.  This affects the nested outer-output + inner-reduction pattern
(outer-B / inner-K bmm) introduced in #2672.

#### Additional note:

The module docstring in `test_coarse_tiling.py` already listed
`TestGenerateBundleUnrollPath` in section 5 as a planned class; this PR
creates it.
