### PR TITLE
test(coarse_tile): remove spurious lx_planning=False patches

### DIFF
--- a/tests/inductor/test_coarse_tile_e2e.py
+++ b/tests/inductor/test_coarse_tile_e2e.py
@@ -1023,7 +1023,6 @@ class TestCoarseTileReductionE2E(InductorTestCase):
         self.assertIn("LoopSpec(", src, "Expected LoopSpec for K-tiled matmul")
         self.assertIn("sympify('4')", src, "Expected loop count 4")
 
-    @config.patch({"lx_planning": False})
     def test_hint_tiled_reduction_matmul_correct(self):
         """torch.matmul tiled over K (4 tiles) produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1130,7 +1129,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
-    @config.patch({"lx_planning": False})
     def test_hint_tiled_reduction_dim0_sum_correct(self):
         """x.sum(dim=0) tiled over B produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1148,7 +1146,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=0.05, rtol=0.05)
 
-    @config.patch({"lx_planning": False})
     def test_hint_tiled_reduction_dim0_max_correct(self):
         """x.amax(dim=0) tiled over B produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1166,7 +1163,6 @@ class TestCoarseTileReductionDim0E2E(InductorTestCase):
 
         compare_with_cpu(fn, x, run_compile=True, run_eager=False, atol=1e-3, rtol=1e-3)
 
-    @config.patch({"lx_planning": False})
     def test_hint_tiled_reduction_dim0_min_correct(self):
         """x.amin(dim=0) tiled over B produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1197,7 +1193,6 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
         super().setUp()
         torch.manual_seed(0xAFFE)
 
-    @config.patch({"lx_planning": False})
     def test_mm_k_tiled_correct(self):
         """2D mm [M,K] @ [K,N] tiled over K produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1219,7 +1214,6 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
             fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    @config.patch({"lx_planning": False})
     def test_bmm_k_tiled_correct(self):
         """3D bmm [B,M,K] @ [B,K,N] tiled over K produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1242,7 +1236,6 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
             fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    @config.patch({"lx_planning": False})
     def test_bmm_3d2d_k_tiled_correct(self):
         """3D×2D matmul [B,M,K] @ [K,N] tiled over K produces correct results."""
         from torch_spyre._inductor import spyre_hint
@@ -1265,7 +1258,6 @@ class TestCoarseTileMatmulKTilingE2E(InductorTestCase):
             fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    @config.patch({"lx_planning": False})
     def test_mm_k_tiled_loopspec(self):
         """K-tiled mm produces a LoopSpec with count 4 in generated source."""
         from torch_spyre._inductor import spyre_hint
@@ -1312,7 +1304,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
         super().setUp()
         torch.manual_seed(0xCAFE)
 
-    @config.patch({"lx_planning": False})
     def test_nested_bmm_outer_Batch_inner_K_correct(self):
         """bmm [B,M,K]@[B,K,N] outer B (output) + inner K (reduction) — correct."""
         from torch_spyre._inductor import spyre_hint
@@ -1336,7 +1327,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    @config.patch({"lx_planning": False})
     def test_nested_matmul_outer_M_inner_K_correct(self):
         """mm [M,K]@[K,N] with outer M (output) + inner K (reduction) — correct."""
         from torch_spyre._inductor import spyre_hint
@@ -1359,7 +1349,6 @@ class TestCoarseTileNestedReductionE2E(InductorTestCase):
             fn, a, b, run_compile=True, run_eager=False, atol=0.05, rtol=0.05
         )
 
-    @config.patch({"lx_planning": False})
     def test_nested_matmul_outer_M_inner_K_loopspec(self):
         """Nested mm produces two LoopSpec levels (outer count 2, inner count 4)."""
         from torch_spyre._inductor import spyre_hint


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

11 correctness and loopspec tests were pinned to lx_planning=False with no documented reason.  Remove the patches so these tests run under the default lx_planning=True, verifying that LX scratchpad planning is compatible with all coarse-tiling patterns (K-tiled matmul/bmm, dim=0 reductions, and nested outer+inner tiling).

All 13 tests in the affected classes pass unchanged under lx_planning=True. The one intentional lx_planning=False patch (test_nested_matmul_copy_after_inner_loop, which is explicitly paired with its lx_planning=True counterpart) is kept.

#### Which issue(s) this PR is related to:

#206 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
