### PR TITLE
docs(supported-ops): sync operations table and API reference with codebase

### DIFF
--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -103,6 +103,33 @@ that your code is portable across backends (CUDA, Spyre, etc.):
 
    :param int seed: The desired seed.
 
+.. function:: torch.spyre.get_rng_state(device="spyre") -> torch.Tensor
+
+   Returns the random number generator state for the given Spyre device
+   as a ``torch.ByteTensor``.
+
+   :param device: Device to query. Accepts ``int``, ``str``, or
+       ``torch.device``. Default: ``"spyre"``.
+   :type device: int or str or torch.device, optional
+
+.. function:: torch.spyre.set_rng_state(new_state, device="spyre")
+
+   Sets the random number generator state for the given Spyre device.
+
+   :param torch.Tensor new_state: The desired state (a ``ByteTensor``).
+   :param device: Target device. Accepts ``int``, ``str``, or
+       ``torch.device``. Default: ``"spyre"``.
+   :type device: int or str or torch.device, optional
+
+.. function:: torch.spyre.initial_seed(device="spyre") -> int
+
+   Returns the initial seed used to initialize the random number generator
+   on the given Spyre device.
+
+   :param device: Device to query. Accepts ``int``, ``str``, or
+       ``torch.device``. Default: ``"spyre"``.
+   :type device: int or str or torch.device, optional
+
 Streams
 -------
 
@@ -496,6 +523,15 @@ Environment Variables
      - Fully unroll ``LoopSpec`` nodes into flat ``OpSpec``\s before bundle
        generation (default ``1``; set ``0`` to keep the
        ``scf.for`` / ``affine.apply`` path)
+   * - ``LX_BOUNDARY_CLONES``
+     - Insert boundary clones at LX scratchpad planning edges (default
+       ``0``)
+   * - ``MAX_BUCKETS``
+     - Maximum number of work division buckets (default ``32``)
+   * - ``MIN_DEFAULT_GRANULARITY``
+     - Minimum default granularity for work division (default ``4``)
+   * - ``SPYRE_INDUCTOR_IGNORE_HINTS``
+     - Ignore ``spyre_hint(work_div={...})`` annotations (default ``0``)
 
 **Device enumeration** (``torch_spyre/csrc/spyre_device_enum.cpp``):
 

--- a/docs/source/user_guide/supported_operations.md
+++ b/docs/source/user_guide/supported_operations.md
@@ -47,8 +47,8 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.pow` | Y | Y | Spyre | |
 | `torch.nn.functional.mish` | Y | Y | Spyre | Eager via `aten.mish.out` |
 | **Pointwise Binary** | | | | |
-| `torch.add` | Y | Y | Spyre | |
-| `torch.sub` | Y | Y | Spyre | |
+| `torch.add` | Y | Y | Spyre | Supports `alpha` parameter |
+| `torch.sub` | Y | Y | Spyre | Supports `alpha` parameter |
 | `torch.mul` | Y | Y | Spyre | |
 | `torch.div` | Y | Y | Spyre | |
 | `torch.maximum` | Y | Y | Spyre | |
@@ -70,7 +70,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.max` | Y | Y | Spyre | `max.dim` via custom decomposition |
 | `torch.min` | Y | Y | Spyre | `min.dim` via custom decomposition (fp16) |
 | `torch.topk` | | Y | Spyre | Custom decomposition + custom ops (`spyre::topkvalue`, `spyre::topkindex`) |
-| `torch.linalg.vector_norm` | Y | | Spyre | Eager only; compiled support not validated |
+| `torch.linalg.vector_norm` | Y | Y | Spyre | |
 | **View Ops** [^views] | | | | |
 | `torch.reshape` / `torch.view` | | Y | Spyre | Includes `_reshape_alias` lowering |
 | `torch.transpose` | | Y | Spyre | |
@@ -83,7 +83,9 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.flatten` | | Y | Spyre | Compiled only (lowers via `reshape`) |
 | `torch.cat` | Y | Y | Spyre | |
 | `torch.stack` | Y | | Spyre | Eager only |
-| `torch.repeat` | Y | | Spyre | Eager only |
+| `torch.repeat` | Y | Y | Spyre | |
+| `torch.unbind` | Y | Y | Spyre | |
+| `torch.Tensor.unfold` | Y | Y | Spyre | View op |
 | `torch.split` | | Y | Spyre | Compiled only (lowers via `aten.slice`) |
 | `torch.expand` | | Y | Spyre | Compiled only; supported when followed by a materializing op (e.g. `clone`, `contiguous`). Used internally by `ones`, `pad`, and SDPA decompositions |
 | `torch.narrow` / `torch.select` | | Y | Spyre | Compiled only; basic slicing works (see `test_slice` / `test_split`); broader `narrow`/`select` coverage in development |
@@ -91,8 +93,15 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.ones` | Y | Y | Spyre | Custom decomposition |
 | `torch.new_ones` | Y | Y | Spyre | Custom decomposition |
 | `torch.zeros` | Y | Y | Spyre | Eager via `aten::zero_` (`ops/eager.py`) |
+| `torch.empty_like` | Y | Y | Spyre | |
 | `torch.full` | Y | Y | Spyre | Custom decomposition |
 | `torch.nn.functional.pad` / `torch.constant_pad_nd` | | Y | Spyre | Custom decomposition |
+| **In-place / Initialization** | | | | |
+| `torch.Tensor.fill_` | | Y | Spyre | Compiled only; eager kernel registered but not yet stable |
+| `torch.Tensor.normal_` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
+| `torch.Tensor.uniform_` | Y | | Spyre | Eager only |
+| `torch.Tensor.random_` | Y | | CPU fallback | Eager only; `from` overload |
+| `torch.is_nonzero` | | Y | Spyre | Compiled only |
 | **Utility** | | | | |
 | `torch.item` | Y | Y | Spyre | Copies to CPU, returns Python scalar |
 | **CPU Fallback** | | | | |
@@ -108,6 +117,7 @@ see [Adding Operations](../compiler/adding_operations.md).
 | `torch.argmax` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.argmin` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
 | `torch.cumsum` | Y | Y | CPU fallback | Runs on CPU, result transferred back |
+| `torch.index_copy` | Y | | CPU fallback | Eager only; runs on CPU |
 
 > **Column key:**
 >


### PR DESCRIPTION
## Summary

- Adds missing ops to the supported operations table: `unbind`, `unfold`, `empty_like`, `fill_`, `normal_`, `uniform_`, `random_`, `is_nonzero`, and `index_copy`
- Corrects `repeat` and `linalg.vector_norm` entries that were listed as eager-only despite having compiled-path test coverage
- Notes `alpha` parameter support on `add`/`sub` following the lowering work in #2571
- Documents `get_rng_state`, `set_rng_state`, and `initial_seed` in the API reference (already wired into `torch.spyre` but previously undocumented)
- Adds four config environment variables to the API reference: `LX_BOUNDARY_CLONES`, `MAX_BUCKETS`, `MIN_DEFAULT_GRANULARITY`, `SPYRE_INDUCTOR_IGNORE_HINTS`

## Test plan

- [ ] Sphinx build passes locally with `-W --keep-going` (confirmed)
- [ ] pymarkdown lint passes on `supported_operations.md` (confirmed)
- [ ] Cross-referenced every new table entry against `test_inductor_ops.py`, `ops/eager.py`, `ops/fallbacks.py`, and `_inductor/config.py`