### PR TITLE
Profiler: add FFDC auto-capture with compile, runtime, and unimplemented failure hooks

### DIFF
--- a/docs/source/api/torch_spyre.rst
+++ b/docs/source/api/torch_spyre.rst
@@ -286,6 +286,28 @@ Profiler
    :doc:`../user_guide/profiling/index` for the current state and the
    profiling tooling that is available in the meantime.
 
+FFDC (First Failure Data Capture)
+---------------------------------
+
+.. function:: torch.spyre.get_diagnostic_report(output_dir=None) -> dict | None
+
+   Return the most recent FFDC diagnostic report, or ``None`` if no reports
+   exist. Reports are written automatically when a failure is captured and
+   ``USE_SPYRE_PROFILER=1`` is set.
+
+   Args:
+      output_dir: Directory to search. Defaults to
+         ``~/.cache/torch/inductor/torch-spyre/ffdc_reports`` (respecting
+         ``TORCHINDUCTOR_CACHE_DIR``), with a fallback to the system temp dir.
+
+   Example::
+
+      import torch
+
+      report = torch.spyre.get_diagnostic_report()
+      if report is not None:
+          print(report["failure"]["category"], report["failure"]["message"])
+
 Tensor Operations
 -----------------
 

--- a/docs/source/user_guide/profiling/environment_variables.md
+++ b/docs/source/user_guide/profiling/environment_variables.md
@@ -24,6 +24,12 @@ Debug-oriented variables (`TORCH_SPYRE_DEBUG`, `TORCH_COMPILE_DEBUG`,
 |---|---|
 | `SENCORES=<1..32>` | Number of Spyre cores to target (default 32) |
 
+## FFDC (First Failure Data Capture)
+
+| Variable | Effect |
+|---|---|
+| `USE_SPYRE_PROFILER=1` | Opt in to automatic FFDC JSON reports on Spyre compile / runtime / unimplemented failures. Retrieve with `torch.spyre.get_diagnostic_report()`. (Same name as the CMake profiler build flag; at runtime this env var alone gates capture.) |
+
 ## Device enumeration
 
 Read by torch-spyre

--- a/docs/source/user_guide/profiling/index.md
+++ b/docs/source/user_guide/profiling/index.md
@@ -23,18 +23,20 @@ workloads running on the Spyre accelerator. The full design of the
 planned toolkit is in
 [RFC 0601 — Spyre Profiling Toolkit][rfc-0601].
 
-The in-tree `torch_spyre.profiler` package is currently a scaffold —
-`torch_spyre.profiler.is_available()` returns `False`, and there is no
-public API yet. Profiling today goes through `torch.profiler` plus the
-external integrations described on this page (`kineto-spyre`,
-`aiu-smi`, `aiu-trace-analyzer`); the in-tree API will be populated as
-RFC 0601 lands.
+The in-tree `torch_spyre.profiler` package is still mostly a scaffold —
+`torch_spyre.profiler.is_available()` returns `False`. One public API is
+already available: First Failure Data Capture (FFDC) via
+`torch.spyre.get_diagnostic_report` (see below). Broader profiling APIs
+will land with RFC 0601. Day-to-day performance work still goes through
+`torch.profiler` plus the external integrations on this page
+(`kineto-spyre`, `aiu-smi`, `aiu-trace-analyzer`).
 
 ## What can be profiled today
 
 | Capability | Status | Where |
 |---|---|---|
 | Compiler pipeline logs | Available | [Environment variables](environment_variables.md) |
+| FFDC diagnostic reports on Spyre compile/runtime/unimplemented failures | Available (`USE_SPYRE_PROFILER=1`) | [API: `get_diagnostic_report`](../../api/torch_spyre.rst) · [Environment variables](environment_variables.md) |
 | CPU-side timing with `torch.profiler` | Available | [PyTorch Profiler](pytorch_profiler.md) |
 | Device telemetry (power, temperature, bandwidth) | Available — PF and VF mode (IBM-internal distribution; public release tracked in [#1335][issue-1335]) | [Device monitoring](device_monitoring.md) |
 | Device-side kernel timing via `ProfilerActivity.PrivateUse1` | Preview (requires [`kineto-spyre`][kineto-spyre] wheel) | [PyTorch Profiler](pytorch_profiler.md) |
@@ -43,6 +45,24 @@ RFC 0601 lands.
 | Kineto bridge (`SpyreActivityProfiler`) | In progress — in-tree Kineto integration for `ProfilerActivity.PrivateUse1` device-side events (PR [#1856][pr-1856]) | upstream Kineto integration |
 | Scratchpad utilization metrics | Planned | [RFC 0601][rfc-0601] |
 | IR-instrumentation-based fine-grained profiler | Planned | [RFC 0601][rfc-0601] |
+
+### FFDC quick example
+
+When `USE_SPYRE_PROFILER=1`, Spyre compile, kernel-launch, and
+unimplemented-operation failures write a JSON diagnostic report
+(exception, env, nearby compile artifacts). Retrieve the newest
+report with:
+
+```python
+import torch
+
+report = torch.spyre.get_diagnostic_report()
+if report is not None:
+    print(report["failure"]["category"], report["failure"]["message"])
+```
+
+See the [API reference](../../api/torch_spyre.rst) for the default
+output directory and schema details.
 
 ### Memory API quick example
 

--- a/tests/configs/torch_spyre_tests/test_ffdc_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_ffdc_config.yaml
@@ -1,0 +1,5 @@
+test_suite_config:
+  labels: [core, full]
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/profiler/test_ffdc.py
+      unlisted_test_mode: mandatory_success

--- a/tests/profiler/test_ffdc.py
+++ b/tests/profiler/test_ffdc.py
@@ -29,12 +29,47 @@ from torch_spyre.profiler._ffdc import (
     REQUIRED_FIELDS,
     collect,
     get_diagnostic_report,
+    try_collect,
 )
 
 
 @pytest.fixture(autouse=True)
 def _enable_ffdc(monkeypatch):
     monkeypatch.setenv("USE_SPYRE_PROFILER", "1")
+
+
+def _stub_module(monkeypatch, name, **attrs):
+    """Insert a stub module; ``monkeypatch`` restores ``sys.modules`` after the test."""
+    import sys
+    import types
+
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    monkeypatch.setitem(sys.modules, name, mod)
+    return mod
+
+
+def _patch_collect_raises(monkeypatch):
+    """Force ``collect`` to raise so call sites exercise ``try_collect``."""
+    import importlib
+
+    ffdc_mod = importlib.import_module("torch_spyre.profiler._ffdc")
+
+    def boom(*_args, **_kwargs):
+        raise OSError("ffdc write failed")
+
+    monkeypatch.setattr(ffdc_mod, "collect", boom)
+    return ffdc_mod
+
+
+def _reimport(monkeypatch, name):
+    """Drop ``name`` from ``sys.modules`` and reimport; restore after the test."""
+    import importlib
+    import sys
+
+    monkeypatch.delitem(sys.modules, name, raising=False)
+    return importlib.import_module(name)
 
 
 class TestFfdcCollect:
@@ -145,6 +180,12 @@ class TestFfdcCollect:
         assert report is not None
         assert report["_report_path"] is None
         assert report["collector"]["success"] is False
+
+    def test_try_collect_never_raises(self, monkeypatch):
+        # Hook contract: serialization/I/O failures must not mask the original
+        # exception that call sites are about to re-raise.
+        _patch_collect_raises(monkeypatch)
+        try_collect(ValueError("primary"), logger=None)
 
     def test_category_constants_match_report(self):
         for category in (
@@ -314,56 +355,38 @@ class TestFfdcCollect:
 
 
 class TestFfdcAsyncCompile:
-    def test_sdsc_dxp_failure_triggers_ffdc_collect(self, monkeypatch, tmp_path):
-        """dxp_standalone failure must call try_collect then re-raise.
-
-        Stubs inductor/extension imports so this runs without ``torch_spyre._C``.
-        Patch via ``importlib.import_module`` — ``torch_spyre.profiler`` is set
-        to ``None`` in ``torch_spyre/__init__.py`` when profiling is unavailable.
-        """
-        import importlib
+    def _load_async_compile(self, monkeypatch, tmp_path):
+        """Stub inductor/extension imports and return ``(mod, out_dir)``."""
         import logging
-        import subprocess
         import sys
-        import types
 
-        ffdc_mod = importlib.import_module("torch_spyre.profiler._ffdc")
-        calls: list[dict] = []
         out_dir = str(tmp_path / "bundle")
 
-        def fake_try_collect(exc, **kwargs):
-            calls.append(kwargs)
-
-        monkeypatch.setattr(ffdc_mod, "try_collect", fake_try_collect)
-
-        def _stub_module(name, **attrs):
-            mod = types.ModuleType(name)
-            for k, v in attrs.items():
-                setattr(mod, k, v)
-            sys.modules[name] = mod
-            return mod
-
-        inductor = _stub_module("torch_spyre._inductor")
+        inductor = _stub_module(monkeypatch, "torch_spyre._inductor")
         inductor.__path__ = []
         _stub_module(
+            monkeypatch,
             "torch_spyre._inductor.logging_utils",
             get_inductor_logger=lambda name: logging.getLogger(name),
         )
         _stub_module(
+            monkeypatch,
             "torch_spyre._inductor.op_spec",
             LoopSpec=object,
             OpSpec=object,
             UnimplementedOp=object,
             find_unimplemented=lambda specs: None,
         )
-        codegen = _stub_module("torch_spyre._inductor.codegen")
+        codegen = _stub_module(monkeypatch, "torch_spyre._inductor.codegen")
         codegen.__path__ = []
         _stub_module(
+            monkeypatch,
             "torch_spyre._inductor.codegen.bundle",
             generate_bundle=lambda *a, **k: None,
         )
         if "torch_spyre._C" not in sys.modules:
             _stub_module(
+                monkeypatch,
                 "torch_spyre._C",
                 launch_jobplan=lambda *a, **k: None,
                 prepare_kernel=lambda *a, **k: None,
@@ -375,16 +398,37 @@ class TestFfdcAsyncCompile:
                 self.code_dir = code_dir
 
         _stub_module(
+            monkeypatch,
             "torch_spyre.execution.kernel_runner",
             SpyreSDSCKernelRunner=_Runner,
             SpyreUnimplementedRunner=object,
         )
 
-        sys.modules.pop("torch_spyre.execution.async_compile", None)
-        mod = importlib.import_module("torch_spyre.execution.async_compile")
+        mod = _reimport(monkeypatch, "torch_spyre.execution.async_compile")
         monkeypatch.setattr(mod, "get_output_dir", lambda name: out_dir)
         monkeypatch.setattr(mod, "generate_bundle", lambda *a, **k: None)
         monkeypatch.setattr(mod, "find_unimplemented", lambda specs: None)
+        return mod, out_dir
+
+    def test_sdsc_dxp_failure_triggers_ffdc_collect(self, monkeypatch, tmp_path):
+        """dxp_standalone failure must call try_collect then re-raise.
+
+        Patch ``try_collect`` before reimporting ``async_compile`` so the
+        module-level binding picks up the fake (``torch_spyre.profiler`` may
+        be ``None`` on ``torch_spyre`` when profiling is unavailable).
+        """
+        import importlib
+        import subprocess
+
+        ffdc_mod = importlib.import_module("torch_spyre.profiler._ffdc")
+        calls: list[dict] = []
+
+        def fake_try_collect(exc, **kwargs):
+            calls.append(kwargs)
+
+        monkeypatch.setattr(ffdc_mod, "try_collect", fake_try_collect)
+
+        mod, out_dir = self._load_async_compile(monkeypatch, tmp_path)
 
         def fail_run(cmd, **kwargs):
             raise subprocess.CalledProcessError(1, cmd)
@@ -398,6 +442,83 @@ class TestFfdcAsyncCompile:
         assert calls[0]["failure_category"] == CATEGORY_COMPILE
         assert calls[0]["kernel_name"] == "test_kernel"
         assert calls[0]["code_dir"] == out_dir
+
+    def test_sdsc_dxp_failure_preserves_error_when_ffdc_raises(
+        self, monkeypatch, tmp_path
+    ):
+        """FFDC collection failure must not replace CalledProcessError.
+
+        Uses the real ``try_collect`` with a raising ``collect`` so the hook
+        path is covered end-to-end (not a fake that swallows by construction).
+        """
+        import subprocess
+
+        _patch_collect_raises(monkeypatch)
+        mod, _out_dir = self._load_async_compile(monkeypatch, tmp_path)
+
+        def fail_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(mod.subprocess, "run", fail_run)
+
+        with pytest.raises(subprocess.CalledProcessError) as ei:
+            mod.SpyreAsyncCompile().sdsc("test_kernel", [])
+        assert ei.value.returncode == 1
+
+
+class TestFfdcKernelRunner:
+    def _load_kernel_runner(self, monkeypatch, *, launch_side_effect=None):
+        """Load ``kernel_runner`` without permanently shadowing real ``_C``.
+
+        Prefer patching the module's bound ``launch_jobplan`` / ``prepare_kernel``.
+        Stub ``_C`` only when it is absent (e.g. no extension on Mac).
+        """
+        import logging
+        import sys
+
+        def _launch(jobplan, args):
+            if launch_side_effect is not None:
+                raise launch_side_effect
+
+        if "torch_spyre._C" not in sys.modules:
+            _stub_module(
+                monkeypatch,
+                "torch_spyre._C",
+                launch_jobplan=_launch,
+                prepare_kernel=lambda path: "fake_jobplan",
+            )
+        if "torch_spyre._inductor" not in sys.modules:
+            inductor = _stub_module(monkeypatch, "torch_spyre._inductor")
+            inductor.__path__ = []
+        if "torch_spyre._inductor.logging_utils" not in sys.modules:
+            _stub_module(
+                monkeypatch,
+                "torch_spyre._inductor.logging_utils",
+                get_inductor_logger=lambda name: logging.getLogger(name),
+            )
+
+        mod = _reimport(monkeypatch, "torch_spyre.execution.kernel_runner")
+        monkeypatch.setattr(mod, "launch_jobplan", _launch)
+        monkeypatch.setattr(mod, "prepare_kernel", lambda path: "fake_jobplan")
+        return mod
+
+    def test_unimplemented_preserves_error_when_ffdc_raises(self, monkeypatch):
+        _patch_collect_raises(monkeypatch)
+        mod = self._load_kernel_runner(monkeypatch)
+        runner = mod.SpyreUnimplementedRunner("k", "aten::foo")
+
+        with pytest.raises(RuntimeError, match="unimplemented operation") as ei:
+            runner.run()
+        assert "aten::foo" in str(ei.value)
+
+    def test_launch_preserves_error_when_ffdc_raises(self, monkeypatch):
+        _patch_collect_raises(monkeypatch)
+        launch_exc = RuntimeError("launch_jobplan failed")
+        mod = self._load_kernel_runner(monkeypatch, launch_side_effect=launch_exc)
+        runner = mod.SpyreSDSCKernelRunner("k", "/tmp/code")
+
+        with pytest.raises(RuntimeError, match="launch_jobplan failed"):
+            runner.run()
 
 
 class TestFfdcPublicApi:

--- a/tests/profiler/test_ffdc.py
+++ b/tests/profiler/test_ffdc.py
@@ -1,0 +1,428 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from torch_spyre.profiler._ffdc import (
+    CATEGORY_COMPILE,
+    CATEGORY_RUNTIME_LAUNCH,
+    CATEGORY_UNIMPLEMENTED,
+    CATEGORY_UNKNOWN,
+    _call_with_timeout,
+    _MAX_REPORTS,
+    _prune_old_reports,
+    REQUIRED_FIELDS,
+    collect,
+    get_diagnostic_report,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_ffdc(monkeypatch):
+    monkeypatch.setenv("USE_SPYRE_PROFILER", "1")
+
+
+class TestFfdcCollect:
+    def _collect_to_tmpdir(self, exc=None, **kwargs):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = collect(exc, output_dir=tmp, **kwargs)
+            # verify the JSON file was written and is valid
+            path = report.get("_report_path")
+            assert path is not None
+            with open(path) as f:
+                on_disk = json.load(f)
+            assert on_disk["failure"]["category"] == report["failure"]["category"]
+        return report
+
+    def test_collect_with_exception_is_complete(self):
+        try:
+            raise ValueError("test failure")
+        except ValueError as exc:
+            report = self._collect_to_tmpdir(exc, failure_category=CATEGORY_UNKNOWN)
+
+        assert report["collector"]["completeness_pct"] == 100.0
+        assert report["collector"]["missing_fields"] == []
+        assert report["collector"]["success"] is True
+
+    def test_failure_fields_populated(self):
+        try:
+            raise RuntimeError("something went wrong")
+        except RuntimeError as exc:
+            report = self._collect_to_tmpdir(exc, failure_category=CATEGORY_COMPILE)
+
+        assert report["failure"]["category"] == CATEGORY_COMPILE
+        assert report["failure"]["exception_type"] == "RuntimeError"
+        assert "something went wrong" in report["failure"]["message"]
+        assert isinstance(report["failure"]["traceback"], str)
+        assert "RuntimeError" in report["failure"]["traceback"]
+
+    def test_traceback_is_joined_string(self):
+        try:
+            raise TypeError("bad type")
+        except TypeError as exc:
+            report = self._collect_to_tmpdir(exc, failure_category=CATEGORY_UNKNOWN)
+
+        tb = report["failure"]["traceback"]
+        assert isinstance(tb, str)
+        assert len(tb.splitlines()) > 1
+
+    def test_runtime_context_passed_through(self):
+        try:
+            raise RuntimeError("kernel failed")
+        except RuntimeError as exc:
+            report = self._collect_to_tmpdir(
+                exc,
+                failure_category=CATEGORY_RUNTIME_LAUNCH,
+                kernel_name="my_kernel",
+                code_dir="/tmp/code",
+            )
+
+        assert report["runtime"]["kernel_name"] == "my_kernel"
+        assert report["runtime"]["code_dir"] == "/tmp/code"
+
+    def test_runtime_context_absent_is_none(self):
+        try:
+            raise RuntimeError("unimplemented")
+        except RuntimeError as exc:
+            report = self._collect_to_tmpdir(
+                exc, failure_category=CATEGORY_UNIMPLEMENTED
+            )
+
+        assert report["runtime"]["kernel_name"] is None
+        assert report["runtime"]["code_dir"] is None
+
+    def test_call_with_timeout_raises_on_slow_work(self):
+        import time
+
+        with pytest.raises(TimeoutError):
+            _call_with_timeout(lambda: time.sleep(5), 0.05)
+
+    def test_collect_returns_early_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("USE_SPYRE_PROFILER", "0")
+        with tempfile.TemporaryDirectory() as tmp:
+            report = collect(None, failure_category=CATEGORY_UNKNOWN, output_dir=tmp)
+        assert report["collector"]["disabled"] is True
+        assert report["_report_path"] is None
+        assert list(Path(tmp).glob("ffdc_*.json")) == []
+        for key in (
+            "metadata",
+            "failure",
+            "environment",
+            "artifacts",
+            "runtime",
+            "hardware_state",
+            "collector",
+        ):
+            assert key in report
+
+    def test_collect_never_raises(self):
+        # collect() must be best-effort; write failures must not propagate.
+        # Use a plain file as output_dir so mkdir() raises NotADirectoryError —
+        # a reliably unwritable path on every platform without root access.
+        with tempfile.TemporaryDirectory() as tmp:
+            blocker = Path(tmp) / "not_a_dir"
+            blocker.write_text("")  # create a file where a directory is expected
+            report = collect(
+                None,
+                failure_category=CATEGORY_UNKNOWN,
+                output_dir=str(blocker / "subdir"),
+            )
+        assert report is not None
+        assert report["_report_path"] is None
+        assert report["collector"]["success"] is False
+
+    def test_category_constants_match_report(self):
+        for category in (
+            CATEGORY_COMPILE,
+            CATEGORY_RUNTIME_LAUNCH,
+            CATEGORY_UNIMPLEMENTED,
+            CATEGORY_UNKNOWN,
+        ):
+            try:
+                raise ValueError("x")
+            except ValueError as exc:
+                report = self._collect_to_tmpdir(exc, failure_category=category)
+            assert report["failure"]["category"] == category
+
+    def test_report_filename_contains_category(self):
+        try:
+            raise ValueError("x")
+        except ValueError as exc:
+            with tempfile.TemporaryDirectory() as tmp:
+                report = collect(exc, failure_category=CATEGORY_COMPILE, output_dir=tmp)
+                fname = Path(report["_report_path"]).name
+        assert fname.startswith("ffdc_compile_")
+        assert ".json" in fname
+
+    def test_completeness_pct_reflects_missing_fields(self):
+        # Without an exception, failure.exception_type and failure.traceback are
+        # None, so they appear in missing_fields.  This verifies that
+        # completeness_pct is driven by REQUIRED_FIELDS programmatically:
+        # any drift between the two would show up here as a wrong percentage.
+        with tempfile.TemporaryDirectory() as tmp:
+            report = collect(None, failure_category=CATEGORY_UNKNOWN, output_dir=tmp)
+
+        missing = report["collector"]["missing_fields"]
+        assert "failure.exception_type" in missing
+        assert "failure.traceback" in missing
+        # REQUIRED_FIELDS has 11 entries; exc=None leaves exception_type and
+        # traceback as None (2 missing, 9 present).
+        # round(100 * 9 / 11, 1) == 81.8  — hardcoded to catch formula regressions.
+        assert len(REQUIRED_FIELDS) == 11, (
+            "Update the expected_pct below if REQUIRED_FIELDS changes"
+        )
+        assert report["collector"]["completeness_pct"] == 81.8
+        assert report["collector"]["completeness_pct"] < 100.0
+
+    def test_metadata_fields_present(self):
+        try:
+            raise ValueError("x")
+        except ValueError as exc:
+            report = self._collect_to_tmpdir(exc, failure_category=CATEGORY_UNKNOWN)
+
+        meta = report["metadata"]
+        for key in (
+            "timestamp",
+            "host",
+            "pid",
+            "python_version",
+            "torch_version",
+            "platform",
+        ):
+            assert key in meta
+
+    def test_environment_keys_captured(self):
+        try:
+            raise ValueError("x")
+        except ValueError as exc:
+            report = self._collect_to_tmpdir(exc, failure_category=CATEGORY_UNKNOWN)
+
+        env = report["environment"]
+        for key in ("TORCH_COMPILE_DEBUG", "TORCH_SPYRE_DEBUG", "SPYRE_INDUCTOR_LOG"):
+            assert key in env
+
+    def test_capture_latency_is_positive(self):
+        try:
+            raise ValueError("x")
+        except ValueError as exc:
+            report = self._collect_to_tmpdir(exc, failure_category=CATEGORY_UNKNOWN)
+
+        assert report["collector"]["capture_latency_ms"] > 0
+
+    def test_get_diagnostic_report_returns_none_when_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assert get_diagnostic_report(output_dir=tmp) is None
+
+    def test_get_diagnostic_report_returns_latest(self):
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                raise RuntimeError("first")
+            except RuntimeError as exc:
+                r1 = collect(exc, failure_category=CATEGORY_COMPILE, output_dir=tmp)
+            # Pin the first file's mtime to epoch so the second is unambiguously newer.
+            os.utime(r1["_report_path"], (0, 0))
+            try:
+                raise RuntimeError("second")
+            except RuntimeError as exc:
+                collect(exc, failure_category=CATEGORY_RUNTIME_LAUNCH, output_dir=tmp)
+
+            result = get_diagnostic_report(output_dir=tmp)
+            assert result is not None
+            assert "failure" in result
+            assert result["failure"]["category"] == CATEGORY_RUNTIME_LAUNCH
+
+    def test_get_diagnostic_report_returns_latest_across_categories(self):
+        # A fresh compile report must win over a stale unknown report.
+        # With name-sort, unknown > compile lexically so the stale unknown
+        # would be returned instead.
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            stale_unknown = d / "ffdc_unknown_20250101T000000_000000_1.json"
+            fresh_compile = d / "ffdc_compile_20250101T000001_000000_1.json"
+            stale_unknown.write_text('{"failure": {"category": "unknown"}}')
+            fresh_compile.write_text('{"failure": {"category": "compile"}}')
+            os.utime(stale_unknown, (0, 0))  # mtime: epoch
+            os.utime(fresh_compile, (100, 100))  # mtime: 100 s later
+
+            result = get_diagnostic_report(output_dir=tmp)
+            assert result is not None
+            assert result["failure"]["category"] == "compile"
+
+    def test_prune_old_reports_removes_oldest(self):
+        # _prune_old_reports keeps the newest `keep` files by mtime, not by name.
+        # compile sorts first lexically, so use compile as the NEWEST category —
+        # a name-sort regression would evict these and wrongly keep the older files.
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            # oldest → newest by mtime (index = mtime in seconds since epoch)
+            files = [
+                "ffdc_unknown_20250101T000000_000000_1.json",  # mtime 0 - oldest
+                "ffdc_runtime_launch_20250101T000001_000000_1.json",  # mtime 1
+                "ffdc_compile_20250101T000002_000000_1.json",  # mtime 2
+                "ffdc_compile_20250101T000003_000000_1.json",  # mtime 3
+                "ffdc_compile_20250101T000004_000000_1.json",  # mtime 4 - newest
+            ]
+            for i, name in enumerate(files):
+                p = d / name
+                p.write_text("{}")
+                os.utime(p, (i, i))  # mtime = i seconds since epoch
+            _prune_old_reports(d, keep=3)
+            remaining = sorted(d.glob("ffdc_*.json"), key=lambda p: p.stat().st_mtime)
+            assert len(remaining) == 3
+            # The three newest by mtime must survive — all three are compile files
+            # even though compile sorts first by name.
+            assert [p.name for p in remaining] == [
+                "ffdc_compile_20250101T000002_000000_1.json",
+                "ffdc_compile_20250101T000003_000000_1.json",
+                "ffdc_compile_20250101T000004_000000_1.json",
+            ]
+
+    def test_collect_prunes_beyond_max_reports(self):
+        # After writing, collect() must not leave more than _MAX_REPORTS files.
+        with tempfile.TemporaryDirectory() as tmp:
+            # Pre-seed the directory with _MAX_REPORTS files so the next write
+            # would exceed the cap.
+            d = Path(tmp)
+            for i in range(_MAX_REPORTS):
+                (d / f"ffdc_unknown_20240101T{i:06d}_000000_1.json").write_text("{}")
+            try:
+                raise ValueError("x")
+            except ValueError as exc:
+                collect(exc, failure_category=CATEGORY_UNKNOWN, output_dir=tmp)
+            assert len(list(d.glob("ffdc_*.json"))) <= _MAX_REPORTS
+
+
+class TestFfdcAsyncCompile:
+    def test_sdsc_dxp_failure_triggers_ffdc_collect(self, monkeypatch, tmp_path):
+        """dxp_standalone failure must call try_collect then re-raise.
+
+        Stubs inductor/extension imports so this runs without ``torch_spyre._C``.
+        Patch via ``importlib.import_module`` — ``torch_spyre.profiler`` is set
+        to ``None`` in ``torch_spyre/__init__.py`` when profiling is unavailable.
+        """
+        import importlib
+        import logging
+        import subprocess
+        import sys
+        import types
+
+        ffdc_mod = importlib.import_module("torch_spyre.profiler._ffdc")
+        calls: list[dict] = []
+        out_dir = str(tmp_path / "bundle")
+
+        def fake_try_collect(exc, **kwargs):
+            calls.append(kwargs)
+
+        monkeypatch.setattr(ffdc_mod, "try_collect", fake_try_collect)
+
+        def _stub_module(name, **attrs):
+            mod = types.ModuleType(name)
+            for k, v in attrs.items():
+                setattr(mod, k, v)
+            sys.modules[name] = mod
+            return mod
+
+        inductor = _stub_module("torch_spyre._inductor")
+        inductor.__path__ = []
+        _stub_module(
+            "torch_spyre._inductor.logging_utils",
+            get_inductor_logger=lambda name: logging.getLogger(name),
+        )
+        _stub_module(
+            "torch_spyre._inductor.op_spec",
+            LoopSpec=object,
+            OpSpec=object,
+            UnimplementedOp=object,
+            find_unimplemented=lambda specs: None,
+        )
+        codegen = _stub_module("torch_spyre._inductor.codegen")
+        codegen.__path__ = []
+        _stub_module(
+            "torch_spyre._inductor.codegen.bundle",
+            generate_bundle=lambda *a, **k: None,
+        )
+        if "torch_spyre._C" not in sys.modules:
+            _stub_module(
+                "torch_spyre._C",
+                launch_jobplan=lambda *a, **k: None,
+                prepare_kernel=lambda *a, **k: None,
+            )
+
+        class _Runner:
+            def __init__(self, name, code_dir):
+                self.kernel_name = name
+                self.code_dir = code_dir
+
+        _stub_module(
+            "torch_spyre.execution.kernel_runner",
+            SpyreSDSCKernelRunner=_Runner,
+            SpyreUnimplementedRunner=object,
+        )
+
+        sys.modules.pop("torch_spyre.execution.async_compile", None)
+        mod = importlib.import_module("torch_spyre.execution.async_compile")
+        monkeypatch.setattr(mod, "get_output_dir", lambda name: out_dir)
+        monkeypatch.setattr(mod, "generate_bundle", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "find_unimplemented", lambda specs: None)
+
+        def fail_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(mod.subprocess, "run", fail_run)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            mod.SpyreAsyncCompile().sdsc("test_kernel", [])
+
+        assert len(calls) == 1
+        assert calls[0]["failure_category"] == CATEGORY_COMPILE
+        assert calls[0]["kernel_name"] == "test_kernel"
+        assert calls[0]["code_dir"] == out_dir
+
+
+class TestFfdcPublicApi:
+    def test_torch_spyre_get_diagnostic_report(self, monkeypatch):
+        import types
+
+        import torch
+
+        # Local Mac may not load the Spyre backend; attach the same callable
+        # make_spyre_module binds so the public API contract is still tested.
+        if not hasattr(torch, "spyre"):
+            monkeypatch.setattr(
+                torch,
+                "spyre",
+                types.SimpleNamespace(get_diagnostic_report=get_diagnostic_report),
+                raising=False,
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            assert torch.spyre.get_diagnostic_report(output_dir=tmp) is None
+            try:
+                raise ValueError("public api")
+            except ValueError as exc:
+                collect(exc, failure_category=CATEGORY_UNKNOWN, output_dir=tmp)
+            result = torch.spyre.get_diagnostic_report(output_dir=tmp)
+            assert result is not None
+            assert result["failure"]["category"] == CATEGORY_UNKNOWN
+            assert "public api" in result["failure"]["message"]

--- a/tools/ffdc_trigger.py
+++ b/tools/ffdc_trigger.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FFDC trigger — exercises kernel_runner.py exception paths on real hardware.
+
+Drives SpyreSDSCKernelRunner and SpyreUnimplementedRunner through their
+real exception paths so FFDC fires on a genuine traceback with real
+hardware state and compiler artifacts.
+
+Run from repo root with:
+    USE_SPYRE_PROFILER=1 TORCH_COMPILE_DEBUG=1 python3 tools/ffdc_trigger.py
+"""
+
+import glob
+import json
+import os
+import time
+from typing import Any
+
+import torch  # noqa: F401 — ensures torch_spyre._C loads via real extension
+import torch_spyre  # noqa: F401
+
+from torch_spyre.execution.kernel_runner import (
+    SpyreSDSCKernelRunner,
+    SpyreUnimplementedRunner,
+)
+from torch_spyre.profiler._ffdc import _default_output_dir
+
+FFDC_OUT = _default_output_dir()
+
+
+def _newest_since(pattern, since_ts):
+    matches = [
+        m for m in glob.glob(pattern, recursive=True) if os.path.getmtime(m) > since_ts
+    ]
+    return max(matches, key=os.path.getmtime) if matches else None
+
+
+def _print_collector_stats(collector: dict[str, Any]) -> None:
+    print(
+        f"  completeness={collector['completeness_pct']}%  "
+        f"latency={collector['capture_latency_ms']}ms  "
+        f"missing={collector['missing_fields']}"
+    )
+
+
+def main():
+    print("\n=== FFDC Real Trigger ===\n")
+    reports = []
+    os.environ.setdefault("USE_SPYRE_PROFILER", "1")
+
+    # ── Scenario A: runtime_launch failure ──────────────────────────────────────
+    # SpyreSDSCKernelRunner.__init__ calls prepare_kernel(); with a fake code_dir
+    # that fails or run() fails in launch_jobplan, FFDC should capture
+    # CATEGORY_RUNTIME_LAUNCH.
+    os.environ.pop("DUMP_SPYRE_CODE", None)
+
+    print("Scenario A: SpyreSDSCKernelRunner.run() → launch_kernel() raises")
+    runner = SpyreSDSCKernelRunner(
+        name="test_kernel_add",
+        code_dir="/tmp/fake_spyre_code_dir",
+    )
+    t0 = time.time()
+    try:
+        runner.run()
+    except RuntimeError as e:
+        print(f"  Exception re-raised (expected): {e}")
+    else:
+        raise AssertionError(
+            "Expected RuntimeError from runner.run() but none was raised"
+        )
+
+    report_path = _newest_since(str(FFDC_OUT / "ffdc_runtime_launch_*.json"), t0)
+    if report_path:
+        with open(report_path) as f:
+            report = json.load(f)
+        reports.append(("runtime_launch", report))
+        print(f"  Report written: {report_path}")
+        _print_collector_stats(report["collector"])
+    else:
+        print("  [WARN] No report found — check FFDC output_dir")
+
+    # ── Scenario B: unimplemented op failure ────────────────────────────────────
+    print(
+        "\nScenario B: SpyreUnimplementedRunner.run() → unimplemented op → FFDC fires"
+    )
+    urunner = SpyreUnimplementedRunner(
+        name="test_kernel_fft",
+        op="aten::fft_fft",
+    )
+    t0 = time.time()
+    try:
+        urunner.run()
+    except RuntimeError as e:
+        print(f"  Exception re-raised (expected): {e}")
+    else:
+        raise AssertionError(
+            "Expected RuntimeError from urunner.run() but none was raised"
+        )
+
+    report_path_u: Any | None = _newest_since(
+        str(FFDC_OUT / "ffdc_unimplemented_*.json"), t0
+    )
+    if report_path_u:
+        with open(report_path_u) as f:
+            report_u = json.load(f)
+        reports.append(("unimplemented", report_u))
+        print(f"  Report written: {report_path_u}")
+        _print_collector_stats(report_u["collector"])
+    else:
+        print("  [WARN] No report found — check FFDC output_dir")
+
+    # ── Summary ─────────────────────────────────────────────────────────────────
+    print("\n=== Captured Report Fields ===")
+    for cat, r in reports:
+        print(f"\n[{cat}]")
+        print(f"  failure.exception_type : {r['failure']['exception_type']}")
+        print(f"  failure.message        : {r['failure']['message'][:80]}")
+        tb = r["failure"]["traceback"]
+        tb_str = tb if isinstance(tb, str) else "".join(tb)
+        print(f"  failure.traceback_lines: {len(tb_str.splitlines())}")
+        print(f"  metadata.torch_version : {r['metadata'].get('torch_version', 'N/A')}")
+        print(
+            f"  metadata.torch_spyre_version : "
+            f"{r['metadata'].get('torch_spyre_version', 'N/A')}"
+        )
+        print(f"  artifacts.found_count  : {r['artifacts']['found_count']}")
+        print(f"  hardware_state         : {r['hardware_state']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -191,6 +191,10 @@ def make_spyre_module() -> types.ModuleType:
     mod._is_compiled = lambda: True
     mod.memory = memory
 
+    from torch_spyre.profiler._ffdc import get_diagnostic_report
+
+    mod.get_diagnostic_report = get_diagnostic_report
+
     import torch  # noqa: E402
 
     mod.get_amp_supported_dtype = lambda: [torch.float16, torch.bfloat16]

--- a/torch_spyre/__init__.py
+++ b/torch_spyre/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2025-2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,9 @@ def enable_spyre_compile_fx_wrapper():
         if getattr(cfx, "_spyre_wrapped", False):
             return
         _orig = cfx.compile_fx
+        from torch_spyre._inductor.logging_utils import get_inductor_logger
+
+        logger = get_inductor_logger("compile_fx_wrapper")
 
         # Iterate over producer nodes (supports nested containers of nodes)
         def iter_nodes(x):
@@ -99,27 +102,43 @@ def enable_spyre_compile_fx_wrapper():
             decomps = kwargs.setdefault(
                 "decompositions", torch._inductor.decomposition.decompositions
             )
+            uses_spyre = _uses_spyre(gm, example_inputs)
 
-            if _uses_spyre(gm, example_inputs):
-                torch.spyre._impl._lazy_init()
+            try:
+                if uses_spyre:
+                    torch.spyre._impl._lazy_init()
 
-                with enable_spyre_context(
-                    example_inputs, decomps=decomps
-                ) as spyre_context_decompositions:
-                    # The `decomps` is the updated in the context manager
-                    # with the appropriate spyre decompositions
-                    # and yielded as `spyre_context_decompositions` from the CM
+                    with enable_spyre_context(
+                        example_inputs, decomps=decomps
+                    ) as spyre_context_decompositions:
+                        # The `decomps` is the updated in the context manager
+                        # with the appropriate spyre decompositions
+                        # and yielded as `spyre_context_decompositions` from the CM
 
-                    kwargs["decompositions"] = spyre_context_decompositions
+                        kwargs["decompositions"] = spyre_context_decompositions
+                        return _orig(
+                            gm,
+                            example_inputs,
+                            *args,
+                            **kwargs,
+                        )
 
-                    return _orig(
-                        gm,
-                        example_inputs,
-                        *args,
-                        **kwargs,
-                    )
+                # Non-Spyre graphs: no FFDC — avoids capturing unrelated CPU compiles.
+                return _orig(gm, example_inputs, *args, **kwargs)
+            except Exception as exc:
+                if uses_spyre:
+                    try:
+                        from torch_spyre.profiler._ffdc import (
+                            CATEGORY_COMPILE,
+                            try_collect,
+                        )
 
-            return _orig(gm, example_inputs, *args, **kwargs)
+                        try_collect(
+                            exc, logger=logger, failure_category=CATEGORY_COMPILE
+                        )
+                    except Exception:
+                        logger.debug("FFDC collection failed", exc_info=True)
+                raise
 
         # Reset the global counter after each
         # run to prevent recompilation

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The Torch-Spyre Authors.
+# Copyright 2025 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import threading
 from functools import wraps
 
 from .propagate_hints import spyre_hint, get_op_hints, _reset_counter  # noqa: F401
+from torch_spyre.profiler._ffdc import CATEGORY_COMPILE, try_collect
 
 _autoload_lock = threading.Lock()
 
@@ -127,17 +128,7 @@ def enable_spyre_compile_fx_wrapper():
                 return _orig(gm, example_inputs, *args, **kwargs)
             except Exception as exc:
                 if uses_spyre:
-                    try:
-                        from torch_spyre.profiler._ffdc import (
-                            CATEGORY_COMPILE,
-                            try_collect,
-                        )
-
-                        try_collect(
-                            exc, logger=logger, failure_category=CATEGORY_COMPILE
-                        )
-                    except Exception:
-                        logger.debug("FFDC collection failed", exc_info=True)
+                    try_collect(exc, logger=logger, failure_category=CATEGORY_COMPILE)
                 raise
 
         # Reset the global counter after each

--- a/torch_spyre/_inductor/__init__.py
+++ b/torch_spyre/_inductor/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2025-2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The Torch-Spyre Authors.
+# Copyright 2025 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ from torch_spyre._inductor.op_spec import (
     find_unimplemented,
 )
 from torch_spyre._inductor.codegen.bundle import generate_bundle
+from torch_spyre.profiler._ffdc import CATEGORY_COMPILE, try_collect
 from .kernel_runner import SpyreSDSCKernelRunner, SpyreUnimplementedRunner
 
 logger = get_inductor_logger("sdsc_compile")
@@ -81,21 +82,13 @@ class SpyreAsyncCompile(AsyncCompile):
             try:
                 subprocess.run(["dxp_standalone", "-d", output_dir], check=True)
             except Exception as exc:
-                try:
-                    from torch_spyre.profiler._ffdc import (
-                        CATEGORY_COMPILE,
-                        try_collect,
-                    )
-
-                    try_collect(
-                        exc,
-                        logger=logger,
-                        failure_category=CATEGORY_COMPILE,
-                        kernel_name=kernel_name,
-                        code_dir=output_dir,
-                    )
-                except Exception:
-                    logger.debug("FFDC collection failed", exc_info=True)
+                try_collect(
+                    exc,
+                    logger=logger,
+                    failure_category=CATEGORY_COMPILE,
+                    kernel_name=kernel_name,
+                    code_dir=output_dir,
+                )
                 raise
 
         return SpyreSDSCKernelRunner(kernel_name, output_dir)

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,6 +78,24 @@ class SpyreAsyncCompile(AsyncCompile):
 
         # Invoke backend compiler of SDSC Bundle
         with torch.profiler.record_function(f"dxp_standalone:{kernel_name}"):
-            subprocess.run(["dxp_standalone", "-d", output_dir], check=True)
+            try:
+                subprocess.run(["dxp_standalone", "-d", output_dir], check=True)
+            except Exception as exc:
+                try:
+                    from torch_spyre.profiler._ffdc import (
+                        CATEGORY_COMPILE,
+                        try_collect,
+                    )
+
+                    try_collect(
+                        exc,
+                        logger=logger,
+                        failure_category=CATEGORY_COMPILE,
+                        kernel_name=kernel_name,
+                        code_dir=output_dir,
+                    )
+                except Exception:
+                    logger.debug("FFDC collection failed", exc_info=True)
+                raise
 
         return SpyreSDSCKernelRunner(kernel_name, output_dir)

--- a/torch_spyre/execution/async_compile.py
+++ b/torch_spyre/execution/async_compile.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2025-2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -18,7 +18,7 @@ from torch_spyre._inductor.logging_utils import get_inductor_logger
 from torch_spyre.profiler._ffdc import (
     CATEGORY_RUNTIME_LAUNCH,
     CATEGORY_UNIMPLEMENTED,
-    try_collect,
+    with_ffdc,
 )
 
 logger = get_inductor_logger("kernel_runner")
@@ -29,20 +29,12 @@ class SpyreUnimplementedRunner:
         self.kernel_name = name
         self.op = op
 
+    @with_ffdc(CATEGORY_UNIMPLEMENTED, logger, code_dir_attr=None)
     def run(self, *args, **kw_args):
-        try:
-            raise RuntimeError(
-                f"Invoked {self.kernel_name} which contains"
-                f" unimplemented operation {self.op}"
-            )
-        except RuntimeError as exc:
-            try_collect(
-                exc,
-                logger=logger,
-                failure_category=CATEGORY_UNIMPLEMENTED,
-                kernel_name=self.kernel_name,
-            )
-            raise
+        raise RuntimeError(
+            f"Invoked {self.kernel_name} which contains"
+            f" unimplemented operation {self.op}"
+        )
 
 
 class SpyreSDSCKernelRunner:
@@ -51,18 +43,8 @@ class SpyreSDSCKernelRunner:
         self.code_dir = code_dir
         self.jobplan = prepare_kernel(code_dir + "/spyreCodeDir")
 
+    @with_ffdc(CATEGORY_RUNTIME_LAUNCH, logger)
     def run(self, *args, **kw_args):
         logger.info("RUN: %s %s", self.kernel_name, self.code_dir)
-
         with torch.profiler.record_function(f"launch_jobplan:{self.kernel_name}"):
-            try:
-                launch_jobplan(self.jobplan, args)
-            except Exception as exc:
-                try_collect(
-                    exc,
-                    logger=logger,
-                    failure_category=CATEGORY_RUNTIME_LAUNCH,
-                    kernel_name=self.kernel_name,
-                    code_dir=self.code_dir,
-                )
-                raise
+            launch_jobplan(self.jobplan, args)

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import torch
-from torch_spyre._C import prepare_kernel, launch_jobplan
+from torch_spyre._C import launch_jobplan, prepare_kernel
 from torch_spyre._inductor.logging_utils import get_inductor_logger
 
 logger = get_inductor_logger("kernel_runner")
@@ -25,9 +25,28 @@ class SpyreUnimplementedRunner:
         self.op = op
 
     def run(self, *args, **kw_args):
-        raise RuntimeError(
-            f"Invoked {self.kernel_name} which contains unimplemented operation {self.op}"
-        )
+        try:
+            raise RuntimeError(
+                f"Invoked {self.kernel_name} which contains"
+                f" unimplemented operation {self.op}"
+            )
+        except RuntimeError as exc:
+            # Guard import+collect together so FFDC never masks the original error.
+            try:
+                from torch_spyre.profiler._ffdc import (
+                    CATEGORY_UNIMPLEMENTED,
+                    try_collect,
+                )
+
+                try_collect(
+                    exc,
+                    logger=logger,
+                    failure_category=CATEGORY_UNIMPLEMENTED,
+                    kernel_name=self.kernel_name,
+                )
+            except Exception:
+                logger.debug("FFDC collection failed", exc_info=True)
+            raise
 
 
 class SpyreSDSCKernelRunner:
@@ -40,4 +59,22 @@ class SpyreSDSCKernelRunner:
         logger.info("RUN: %s %s", self.kernel_name, self.code_dir)
 
         with torch.profiler.record_function(f"launch_jobplan:{self.kernel_name}"):
-            launch_jobplan(self.jobplan, args)
+            try:
+                launch_jobplan(self.jobplan, args)
+            except Exception as exc:
+                try:
+                    from torch_spyre.profiler._ffdc import (
+                        CATEGORY_RUNTIME_LAUNCH,
+                        try_collect,
+                    )
+
+                    try_collect(
+                        exc,
+                        logger=logger,
+                        failure_category=CATEGORY_RUNTIME_LAUNCH,
+                        kernel_name=self.kernel_name,
+                        code_dir=self.code_dir,
+                    )
+                except Exception:
+                    logger.debug("FFDC collection failed", exc_info=True)
+                raise

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The Torch-Spyre Authors.
+# Copyright 2025 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,11 @@
 import torch
 from torch_spyre._C import launch_jobplan, prepare_kernel
 from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre.profiler._ffdc import (
+    CATEGORY_RUNTIME_LAUNCH,
+    CATEGORY_UNIMPLEMENTED,
+    try_collect,
+)
 
 logger = get_inductor_logger("kernel_runner")
 
@@ -31,21 +36,12 @@ class SpyreUnimplementedRunner:
                 f" unimplemented operation {self.op}"
             )
         except RuntimeError as exc:
-            # Guard import+collect together so FFDC never masks the original error.
-            try:
-                from torch_spyre.profiler._ffdc import (
-                    CATEGORY_UNIMPLEMENTED,
-                    try_collect,
-                )
-
-                try_collect(
-                    exc,
-                    logger=logger,
-                    failure_category=CATEGORY_UNIMPLEMENTED,
-                    kernel_name=self.kernel_name,
-                )
-            except Exception:
-                logger.debug("FFDC collection failed", exc_info=True)
+            try_collect(
+                exc,
+                logger=logger,
+                failure_category=CATEGORY_UNIMPLEMENTED,
+                kernel_name=self.kernel_name,
+            )
             raise
 
 
@@ -62,19 +58,11 @@ class SpyreSDSCKernelRunner:
             try:
                 launch_jobplan(self.jobplan, args)
             except Exception as exc:
-                try:
-                    from torch_spyre.profiler._ffdc import (
-                        CATEGORY_RUNTIME_LAUNCH,
-                        try_collect,
-                    )
-
-                    try_collect(
-                        exc,
-                        logger=logger,
-                        failure_category=CATEGORY_RUNTIME_LAUNCH,
-                        kernel_name=self.kernel_name,
-                        code_dir=self.code_dir,
-                    )
-                except Exception:
-                    logger.debug("FFDC collection failed", exc_info=True)
+                try_collect(
+                    exc,
+                    logger=logger,
+                    failure_category=CATEGORY_RUNTIME_LAUNCH,
+                    kernel_name=self.kernel_name,
+                    code_dir=self.code_dir,
+                )
                 raise

--- a/torch_spyre/execution/kernel_runner.py
+++ b/torch_spyre/execution/kernel_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2025-2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/torch_spyre/profiler/__init__.py
+++ b/torch_spyre/profiler/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 Spyre profiling package.
 
 This package provides the Python-side scaffolding for Spyre profiling
-integration. It will expose profiling utilities and hooks once fully
-implemented.
+integration. Public FFDC API is exposed as ``torch.spyre.get_diagnostic_report``
+(see ``make_spyre_module``); import ``torch_spyre.profiler._ffdc`` for internals.
 """
 
 
@@ -26,5 +26,4 @@ def is_available() -> bool:
     return False
 
 
-# Public API (to be populated in future issues)
 __all__: list[str] = []

--- a/torch_spyre/profiler/__init__.py
+++ b/torch_spyre/profiler/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The Torch-Spyre Authors.
+# Copyright 2025 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/torch_spyre/profiler/__init__.py
+++ b/torch_spyre/profiler/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Torch-Spyre Authors.
+# Copyright 2025-2026 The Torch-Spyre Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/torch_spyre/profiler/_ffdc.py
+++ b/torch_spyre/profiler/_ffdc.py
@@ -1,0 +1,512 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FFDC (First Failure Data Capture) collector for torch-spyre.
+
+Collects diagnostic context automatically on failure:
+  - metadata: timestamp, versions, env
+  - failure: category, exception, traceback
+  - artifacts: paths to compiler outputs if present
+  - runtime: kernel name, code_dir when available
+  - hardware_state: placeholder until Spyre access is available
+
+Usage:
+    from torch_spyre.profiler._ffdc import collect, REQUIRED_FIELDS
+    report = collect(exc, failure_category="compile")
+"""
+
+import itertools
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import traceback
+import platform
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional, TypeVar
+
+
+T = TypeVar("T")
+
+_FutureTimeoutError = TimeoutError
+
+
+# Failure category constants
+CATEGORY_COMPILE = "compile"
+CATEGORY_RUNTIME_LAUNCH = "runtime_launch"
+CATEGORY_UNIMPLEMENTED = "unimplemented"
+CATEGORY_UNKNOWN = "unknown"
+
+# Fields required to consider a report "complete"
+REQUIRED_FIELDS = [
+    "metadata.timestamp",
+    "metadata.torch_version",
+    "metadata.python_version",
+    "failure.category",
+    "failure.exception_type",
+    "failure.message",
+    "failure.traceback",
+    "environment.TORCH_COMPILE_DEBUG",
+    "environment.TORCH_SPYRE_DEBUG",
+    "environment.SPYRE_INDUCTOR_LOG",
+    "artifacts.searched",
+]
+
+# Maximum number of FFDC report files to keep in the output directory.
+# Oldest reports (by modification time) are deleted first.
+_MAX_REPORTS = 50
+
+# Maximum wall-clock seconds to spend searching for compiler artifacts.
+# rglob scans can stall on slow or frozen filesystem mounts; this bounds
+# the delay before the original exception is re-raised.
+_ARTIFACT_SEARCH_TIMEOUT_S = 2.0
+
+
+def _call_with_timeout(fn: Callable[[], T], timeout_s: float) -> T:
+    """Run ``fn`` in a daemon thread; raise on timeout or worker exception.
+
+    Unlike ``ThreadPoolExecutor`` with ``shutdown(wait=False)``, daemon workers
+    do not block interpreter shutdown if ``fn`` stalls past ``timeout_s``.
+    """
+    result_holder: list[tuple[str, Any]] = []
+
+    def _worker() -> None:
+        try:
+            result_holder.append(("ok", fn()))
+        except BaseException as exc:
+            result_holder.append(("err", exc))
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout_s)
+    if thread.is_alive():
+        raise _FutureTimeoutError()
+    kind, value = result_holder[0]
+    if kind == "err":
+        raise value
+    return value
+
+
+def _prune_old_reports(out_dir: Path, keep: int) -> None:
+    """Delete the oldest ffdc_*.json files, retaining the newest ``keep`` files.
+
+    Sorts by modification time so retention is age-based across all failure
+    categories. Sorting by filename would group by category first (the filename
+    is ffdc_{category}_{ts}_{pid}.json), causing recent reports of a
+    later-sorting category to be evicted before older ones of an earlier-sorting
+    category.
+    """
+    reports = sorted(
+        out_dir.glob("ffdc_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for old in reports[keep:]:
+        old.unlink(missing_ok=True)
+
+
+def _default_output_dir() -> Path:
+    """Return a user-writable directory for FFDC reports.
+
+    Prefers the Torch Inductor cache dir (respects TORCHINDUCTOR_CACHE_DIR,
+    falls back to ~/.cache/torch/inductor) so reports land alongside other
+    Inductor artifacts. Falls back to tempfile.gettempdir() in environments
+    where the Inductor cache is unavailable (e.g. import-only, no torch).
+    """
+    try:
+        from torch._inductor.runtime.runtime_utils import cache_dir as _cache_dir
+
+        return Path(_cache_dir()) / "torch-spyre" / "ffdc_reports"
+    except Exception:
+        return Path(tempfile.gettempdir()) / "torch-spyre-ffdc"
+
+
+_ENV_KEYS = [
+    "TORCH_COMPILE_DEBUG",
+    "TORCH_SPYRE_DEBUG",
+    "SPYRE_INDUCTOR_LOG",
+    "SPYRE_INDUCTOR_LOG_LEVEL",
+    "DUMP_SPYRE_CODE",
+    "TORCH_LOGS",
+    "TORCHINDUCTOR_FORCE_DISABLE_CACHES",
+    "SENCORES",
+    "USE_SPYRE_PROFILER",
+]
+
+
+def _is_ffdc_enabled() -> bool:
+    """Return True when auto-capture is enabled via USE_SPYRE_PROFILER=1."""
+    return os.environ.get("USE_SPYRE_PROFILER") == "1"
+
+
+def _safe_torch_version() -> str:
+    try:
+        import torch
+
+        return torch.__version__
+    except Exception:
+        return "unavailable"
+
+
+def _safe_torch_spyre_version() -> str:
+    try:
+        from torch_spyre.version import __version__
+
+        return __version__
+    except Exception:
+        return "unavailable"
+
+
+def _collect_env() -> dict:
+    return {k: os.environ.get(k, "") for k in _ENV_KEYS}
+
+
+def _newest_compile_run(debug_dir: Path) -> Optional[Path]:
+    """Return the most-recently-modified run_* subdirectory, or None."""
+    try:
+        runs = [
+            d for d in debug_dir.iterdir() if d.is_dir() and d.name.startswith("run_")
+        ]
+        return max(runs, key=lambda d: d.stat().st_mtime) if runs else None
+    except Exception:
+        return None
+
+
+def _collect_artifacts() -> dict:
+    found: list[str] = []
+    search_roots = [
+        Path(os.getcwd()),
+        Path(__file__).resolve().parent.parent.parent,  # repo root
+        Path("/dev/shm"),
+        Path("/tmp"),
+    ]
+    filename_patterns = [
+        "fx_graph_readable.py",
+        "fx_graph_transformed.py",
+        "ir_pre_fusion.txt",
+        "ir_post_fusion.txt",
+        "output_code.py",
+        "sdsc_*.json",
+        "*.mlir",
+        "*.ll",
+        "graph_diagram.html",
+        "*.log",
+        "aot_model_*",
+    ]
+    for root in search_roots:
+        debug_dir = root / "torch_compile_debug"
+        if not debug_dir.exists():
+            continue
+        # Only search the newest run to avoid mixing artifacts from prior failures.
+        run_dir = _newest_compile_run(debug_dir)
+        if run_dir is None:
+            continue
+        for pattern in filename_patterns:
+            try:
+                found.extend(
+                    str(m) for m in itertools.islice(run_dir.rglob(pattern), 5)
+                )
+            except Exception:
+                pass
+
+    # Also search the Spyre inductor cache for dxp_standalone bundle artifacts
+    try:
+        from torch._inductor.runtime.runtime_utils import cache_dir as _cache_dir
+
+        spyre_cache = Path(_cache_dir()) / "inductor-spyre"
+        if spyre_cache.exists():
+            kernel_dirs = [d for d in spyre_cache.iterdir() if d.is_dir()]
+            if kernel_dirs:
+                newest_kernel = max(kernel_dirs, key=lambda d: d.stat().st_mtime)
+                for pattern in ["sdsc_*.json", "*.mlir", "*.log"]:
+                    try:
+                        found.extend(
+                            str(m)
+                            for m in itertools.islice(newest_kernel.rglob(pattern), 5)
+                        )
+                    except Exception:
+                        pass
+    except Exception:
+        pass
+
+    unique = list(dict.fromkeys(found))
+    return {
+        "searched": True,
+        "found_count": len(unique),
+        "paths": unique[:20],
+    }
+
+
+def _collect_hardware_state() -> dict:
+    """Best-effort hardware state. Real metrics require Spyre access."""
+    state: dict = {"spyre_available": False}
+    try:
+        import torch
+
+        if hasattr(torch, "spyre"):
+            try:
+                state["spyre_available"] = _call_with_timeout(
+                    torch.spyre.is_available, 1.0
+                )
+            except _FutureTimeoutError:
+                state["note"] = "hardware probe timed out after 1.0s"
+                return state
+            if not state["spyre_available"]:
+                state["note"] = "hardware state unavailable without Spyre access"
+    except Exception:
+        state["note"] = "hardware state check failed"
+    return state
+
+
+def collect(
+    exc: Optional[BaseException] = None,
+    failure_category: str = "unknown",
+    kernel_name: Optional[str] = None,
+    code_dir: Optional[str] = None,
+    output_dir: Optional[str] = None,
+) -> dict:
+    """
+    Collect an FFDC report for the given failure context.
+
+    Args:
+        exc: The exception that triggered FFDC (or None for manual call).
+        failure_category: One of compile, runtime_launch, unimplemented, unknown.
+        kernel_name: Kernel name from SpyreSDSCKernelRunner if available.
+        code_dir: Code directory from SpyreSDSCKernelRunner if available.
+        output_dir: Directory to write report JSON. Defaults to the Inductor cache dir
+            (``~/.cache/torch/inductor/torch-spyre/ffdc_reports``, respecting
+            ``TORCHINDUCTOR_CACHE_DIR``), with a fallback to the system temp dir.
+
+    Returns:
+        dict with the full FFDC report.
+
+    Auto-capture is gated on ``USE_SPYRE_PROFILER=1`` (same opt-in as the Spyre
+    profiler). When disabled, returns the same top-level schema with empty
+    sections and no filesystem or thread work.
+    """
+    if not _is_ffdc_enabled():
+        return {
+            "metadata": {},
+            "failure": {"category": failure_category},
+            "environment": {},
+            "artifacts": {"searched": False, "found_count": 0, "paths": []},
+            "runtime": {
+                "kernel_name": kernel_name or None,
+                "code_dir": code_dir or None,
+            },
+            "hardware_state": {"spyre_available": False},
+            "collector": {
+                "capture_latency_ms": 0.0,
+                "missing_fields": [],
+                "collector_errors": [],
+                "success": True,
+                "completeness_pct": 0.0,
+                "disabled": True,
+            },
+            "_report_path": None,
+        }
+
+    t0 = time.monotonic()
+    collector_errors: list = []
+    missing_fields: list = []
+
+    # --- metadata ---
+    metadata: dict = {}
+    try:
+        metadata = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "host": platform.node(),
+            "pid": os.getpid(),
+            "python_version": sys.version,
+            "torch_version": _safe_torch_version(),
+            "torch_spyre_version": _safe_torch_spyre_version(),
+            "platform": platform.platform(),
+        }
+    except Exception as e:
+        collector_errors.append(f"metadata: {e}")
+
+    # --- failure ---
+    failure: dict = {"category": failure_category}
+    try:
+        if exc is not None:
+            failure["exception_type"] = type(exc).__name__
+            failure["message"] = str(exc)
+            failure["traceback"] = "".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            )
+        else:
+            failure["exception_type"] = None
+            failure["message"] = "manual collection (no exception)"
+            failure["traceback"] = None
+    except Exception as e:
+        collector_errors.append(f"failure: {e}")
+
+    # --- environment ---
+    environment: dict = {}
+    try:
+        environment = _collect_env()
+    except Exception as e:
+        collector_errors.append(f"environment: {e}")
+
+    # --- artifacts ---
+    artifacts: dict = {}
+    try:
+        try:
+            artifacts = _call_with_timeout(
+                _collect_artifacts, _ARTIFACT_SEARCH_TIMEOUT_S
+            )
+        except _FutureTimeoutError:
+            artifacts = {"searched": False, "error": "artifact search timed out"}
+            collector_errors.append("artifacts: timed out")
+    except Exception as e:
+        artifacts = {"searched": False, "error": str(e)}
+        collector_errors.append(f"artifacts: {e}")
+
+    # --- runtime context ---
+    runtime: dict = {
+        "kernel_name": kernel_name or None,
+        "code_dir": code_dir or None,
+    }
+
+    # --- hardware state ---
+    hardware_state: dict = {}
+    try:
+        hardware_state = _collect_hardware_state()
+    except Exception as e:
+        hardware_state = {"error": str(e)}
+        collector_errors.append(f"hardware_state: {e}")
+
+    elapsed_ms = round((time.monotonic() - t0) * 1000, 2)
+
+    # --- validate required fields ---
+    # Derive flat from REQUIRED_FIELDS programmatically so adding a new entry
+    # there never silently skews completeness_pct due to a missing .get() call.
+    _nested = {
+        "metadata": metadata,
+        "failure": failure,
+        "environment": environment,
+        "artifacts": artifacts,
+    }
+    flat = {
+        field: _nested.get(section, {}).get(key)
+        for field in REQUIRED_FIELDS
+        for section, key in [field.split(".", 1)]
+    }
+    missing_fields = [k for k, v in flat.items() if v is None]
+
+    report: dict[str, Any] = {
+        "metadata": metadata,
+        "failure": failure,
+        "environment": environment,
+        "artifacts": artifacts,
+        "runtime": runtime,
+        "hardware_state": hardware_state,
+        "collector": {
+            "capture_latency_ms": elapsed_ms,
+            "missing_fields": missing_fields,
+            "collector_errors": collector_errors,
+            "success": len(collector_errors) == 0,
+            "completeness_pct": round(
+                100
+                * (len(REQUIRED_FIELDS) - len(missing_fields))
+                / len(REQUIRED_FIELDS),
+                1,
+            ),
+        },
+    }
+
+    # --- write report ---
+    try:
+        out_dir = Path(output_dir) if output_dir else _default_output_dir()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%f")
+        safe_category = "".join(
+            c if c.isalnum() or c in "_-" else "_" for c in failure_category
+        )[:32]
+        report_path = out_dir / f"ffdc_{safe_category}_{ts}_{os.getpid()}.json"
+        with open(report_path, "w") as f:
+            json.dump(report, f, indent=2, default=str)
+        report["_report_path"] = str(report_path)
+        _prune_old_reports(out_dir, keep=_MAX_REPORTS)
+    except Exception as e:
+        report["_report_path"] = None
+        report["collector"]["collector_errors"].append(f"write: {e}")
+        report["collector"]["success"] = False
+
+    return report
+
+
+def try_collect(
+    exc: Optional[BaseException] = None,
+    *,
+    logger: Any = None,
+    **kwargs: Any,
+) -> None:
+    """Best-effort ``collect`` for failure hooks; does not propagate ordinary
+    collection exceptions to the caller.
+
+    Call sites must still wrap ``from torch_spyre.profiler._ffdc import ...``
+    in their own try/except so an import failure cannot mask the original
+    exception (same pattern as other best-effort hooks in this repo).
+    """
+    try:
+        collect(exc, **kwargs)
+    except Exception:
+        if logger is not None:
+            logger.debug("FFDC collection failed", exc_info=True)
+
+
+def get_diagnostic_report(
+    output_dir: Optional[str] = None,
+) -> Optional[dict]:
+    """
+    Return the most recent FFDC report as a dict, or None if none exist.
+
+    Args:
+        output_dir: Directory to search. Defaults to the Inductor cache dir
+            (``~/.cache/torch/inductor/torch-spyre/ffdc_reports``, respecting
+            ``TORCHINDUCTOR_CACHE_DIR``), with a fallback to the system temp dir.
+
+    Returns:
+        Parsed JSON dict of the most recent report, or None.
+    """
+    search_dir = Path(output_dir) if output_dir else _default_output_dir()
+    if not search_dir.exists():
+        return None
+
+    # Sort by the timestamp embedded in the filename, not by the full filename.
+    # Filenames are ffdc_{category}_{YYYYMMDDTHHMMSS}_{microseconds}_{pid}.json.
+    # Sorting by the full name groups by category first, so a stale "unknown"
+    # report would outrank a fresh "compile" report.  Sorting by st_mtime fails
+    # on filesystems with 1-second resolution (same-second writes are misordered).
+    # rsplit from the right handles category names that contain underscores
+    # (e.g. runtime_launch): stem.rsplit('_', 3) yields
+    # [category_prefix, YYYYMMDDTHHMMSS, microseconds, pid].
+    def _ts_key(p: Path) -> str:
+        parts = p.stem.rsplit("_", 3)
+        return f"{parts[1]}_{parts[2]}" if len(parts) == 4 else ""
+
+    reports = sorted(
+        search_dir.glob("ffdc_*.json"),
+        key=_ts_key,
+        reverse=True,
+    )
+    if not reports:
+        return None
+    with open(reports[0]) as f:
+        return json.load(f)

--- a/torch_spyre/profiler/_ffdc.py
+++ b/torch_spyre/profiler/_ffdc.py
@@ -323,7 +323,6 @@ def collect(
 
     t0 = time.monotonic()
     collector_errors: list = []
-    missing_fields: list = []
 
     # --- metadata ---
     metadata: dict = {}
@@ -457,12 +456,11 @@ def try_collect(
     logger: Any = None,
     **kwargs: Any,
 ) -> None:
-    """Best-effort ``collect`` for failure hooks; does not propagate ordinary
-    collection exceptions to the caller.
+    """Best-effort ``collect`` for failure hooks; never raises.
 
-    Call sites must still wrap ``from torch_spyre.profiler._ffdc import ...``
-    in their own try/except so an import failure cannot mask the original
-    exception (same pattern as other best-effort hooks in this repo).
+    Call sites catch a primary failure, call this, then re-raise. Collection
+    errors must not replace that original exception. Import of this module is
+    not guarded here — a broken ``_ffdc`` import is a real bug.
     """
     try:
         collect(exc, **kwargs)

--- a/torch_spyre/profiler/_ffdc.py
+++ b/torch_spyre/profiler/_ffdc.py
@@ -27,6 +27,7 @@ Usage:
     report = collect(exc, failure_category="compile")
 """
 
+import functools
 import itertools
 import json
 import os
@@ -467,6 +468,39 @@ def try_collect(
     except Exception:
         if logger is not None:
             logger.debug("FFDC collection failed", exc_info=True)
+
+
+def with_ffdc(
+    failure_category: str,
+    logger: Any,
+    kernel_name_attr: str = "kernel_name",
+    code_dir_attr: Optional[str] = "code_dir",
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator: wrap a runner method with FFDC capture, then re-raise.
+
+    Reads ``self.{kernel_name_attr}`` and optionally ``self.{code_dir_attr}``.
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(self: Any, *args: Any, **kwargs: Any) -> T:
+            try:
+                return func(self, *args, **kwargs)
+            except Exception as exc:
+                extra: dict[str, Any] = {
+                    "failure_category": failure_category,
+                    "logger": logger,
+                }
+                if hasattr(self, kernel_name_attr):
+                    extra["kernel_name"] = getattr(self, kernel_name_attr)
+                if code_dir_attr and hasattr(self, code_dir_attr):
+                    extra["code_dir"] = getattr(self, code_dir_attr)
+                try_collect(exc, **extra)
+                raise
+
+        return wrapper
+
+    return decorator
 
 
 def get_diagnostic_report(


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Wires three automatic failure capture hooks to a central `collect()` in `torch_spyre/profiler/_ffdc.py`:

- `_inductor/__init__.py` — catches compile failures during `torch.compile()` on Spyre graphs
- `execution/kernel_runner.py` — catches runtime launch failures in `SpyreSDSCKernelRunner` and unimplemented-op raises in`SpyreUnimplementedRunner`

Each hook writes a timestamped JSON report to `~/.cache/torch/inductor/torch-spyre/ffdc_reports/` (respecting `TORCHINDUCTOR_CACHE_DIR`; falls back to the system temp dir when the Inductor cache is unavailable). Reports contain metadata, full traceback, environment variables, collected Inductor artifacts (newest `run_*` dir only), and hardware state. Filenames include microseconds + PID to prevent collisions. All hooks are wrapped in `try/except` so FFDC never suppresses the original exception.

`get_diagnostic_report()` exists as an internal reader in `torch_spyre/profiler/_ffdc.py` but is not exposed on `torch.spyre` in this PR.

#### Which issue(s) this PR is related to:

Part of #715

#### Special notes for your reviewer:

- Capture triggers on the actual exception path — no polling, no background threads, no false positives on success paths.
- Typical report size: ~5–15 KB JSON + whatever Inductor artifacts are in `run_*/` (varies by model). The report itself is always a single small JSON.
- `torch.spyre.get_diagnostic_report()` public API is a follow-on item tracked in #715 and is NOT part of this PR.
- Validated on real Spyre hardware (`spyre_available=True`, completeness=100% across all three failure categories).

#### Does this PR introduce a user-facing change?

No. FFDC capture is automatic and silent. Reports are written to the Inductor cache subdirectory above only on failure. No new public API in this PR.

#### Additional note:

- False positives — hooks sit inside `except` blocks only, so they never fire on a successful run. No polling, no background threads.
- Disk footprint — each capture writes one JSON file (~5–15 KB). Inductor artifacts aren't copied — we just record their existing paths. So one failure = one small JSON.