### PR TITLE
fix(padding): fix crash on transposed-x matmul with unaligned K, refactor x/y identification

### DIFF
--- a/tests/inductor/test_padding.py
+++ b/tests/inductor/test_padding.py
@@ -684,6 +684,9 @@ class TestInsertPaddingIR(unittest.TestCase):
         reduction = mm.data
         assert isinstance(reduction, Reduction)
         self.assertEqual(int(reduction.reduction_ranges[0]), K)
+        # ops_before contains a restickify op for x in addition to the 4-op
+        # padding sequence for y, so _assert_constant_pad_nd_ops (which expects
+        # exactly 4 ops) cannot be used here.  Correctness is verified by assert_close.
         torch.testing.assert_close(fn(x_cpu, y_cpu), result.cpu(), atol=0.1, rtol=0.1)
 
 

--- a/tests/inductor/test_padding.py
+++ b/tests/inductor/test_padding.py
@@ -118,6 +118,17 @@ class TestInsertPaddingIR(unittest.TestCase):
         compiled(*args)
         return self.captured_operations
 
+    def compile_and_run(
+        self,
+        fn: Callable[[Unpack[Ts]], torch.Tensor],
+        args: tuple[Unpack[Ts]],
+    ) -> tuple[list[Operation], torch.Tensor]:
+        """Compile ``fn`` once, capture IR operations, and return (ops, result)."""
+        self.captured_operations = []
+        compiled = torch.compile(fn, fullgraph=True)
+        result = compiled(*args)
+        return self.captured_operations, result
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
@@ -225,13 +236,15 @@ class TestInsertPaddingIR(unittest.TestCase):
         # 67 is not a multiple of stick_size (64), so padding should occur.
         assert 67 % stick_size != 0
 
-        x = torch.randn(55, 67, dtype=dtype, device="spyre")
-        w = torch.randn(67, 128, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(55, 67, dtype=dtype)
+        w_cpu = torch.randn(67, 128, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return x @ w
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1, "Expected exactly one matmul op")
         mm = matmuls[0]
@@ -251,19 +264,23 @@ class TestInsertPaddingIR(unittest.TestCase):
         ops_before = self._ops_before(ops, mm)
         self._assert_constant_pad_nd_ops(ops_before)
 
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
+
     def test_mm_aligned_k_no_padding(self) -> None:
         """2D mm with K=128 (aligned) — no padding ops inserted."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 128 % stick_size == 0
 
-        x = torch.randn(55, 128, dtype=dtype, device="spyre")
-        w = torch.randn(128, 64, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(55, 128, dtype=dtype)
+        w_cpu = torch.randn(128, 64, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return x @ w
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1, "Expected exactly one matmul op")
         mm = matmuls[0]
@@ -278,19 +295,23 @@ class TestInsertPaddingIR(unittest.TestCase):
         ops_before = self._ops_before(ops, mm)
         self.assertEqual(len(ops_before), 0, "Expected no padding ops for aligned K")
 
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
+
     def test_bmm_3d_unaligned_k_pads(self) -> None:
         """3D bmm (B,M,K)×(B,K,N) with K=67 — only y is padded before bmm."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
 
-        x = torch.randn(2, 55, 67, dtype=dtype, device="spyre")
-        w = torch.randn(2, 67, 128, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(2, 55, 67, dtype=dtype)
+        w_cpu = torch.randn(2, 67, 128, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return torch.bmm(x, w)
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1, "Expected exactly one batched matmul op")
         mm = matmuls[0]
@@ -303,19 +324,23 @@ class TestInsertPaddingIR(unittest.TestCase):
         ops_before = self._ops_before(ops, mm)
         self._assert_constant_pad_nd_ops(ops_before)
 
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
+
     def test_bmm_3d_2d_unaligned_k_pads(self) -> None:
         """3D×2D bmm: (B,M,K)×(K,N) with K=67 — only y is padded."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
 
-        x = torch.randn(2, 55, 67, dtype=dtype, device="spyre")
-        w = torch.randn(67, 128, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(2, 55, 67, dtype=dtype)
+        w_cpu = torch.randn(67, 128, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return x @ w
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
@@ -327,6 +352,8 @@ class TestInsertPaddingIR(unittest.TestCase):
 
         ops_before = self._ops_before(ops, mm)
         self._assert_constant_pad_nd_ops(ops_before)
+
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
 
     def test_matmul_4d_unaligned_k_pads(self) -> None:
         """4D matmul (B,H,M,K)×(B,H,K,N) with K=67 — only y is padded."""
@@ -334,13 +361,15 @@ class TestInsertPaddingIR(unittest.TestCase):
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
 
-        x = torch.randn(2, 3, 55, 67, dtype=dtype, device="spyre")
-        w = torch.randn(2, 3, 67, 128, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(2, 3, 55, 67, dtype=dtype)
+        w_cpu = torch.randn(2, 3, 67, 128, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return x @ w
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
@@ -353,19 +382,23 @@ class TestInsertPaddingIR(unittest.TestCase):
         ops_before = self._ops_before(ops, mm)
         self._assert_constant_pad_nd_ops(ops_before)
 
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
+
     def test_einsum_mk_kn_mn_pads(self) -> None:
         """einsum('mk,kn->mn') with K=67 — y is padded; reduction_ranges stays at K."""
         dtype = torch.float16
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
 
-        x = torch.randn(55, 67, dtype=dtype, device="spyre")
-        w = torch.randn(67, 128, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(55, 67, dtype=dtype)
+        w_cpu = torch.randn(67, 128, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return torch.einsum("mk,kn->mn", x, w)
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
@@ -374,6 +407,8 @@ class TestInsertPaddingIR(unittest.TestCase):
         reduction = mm.data
         assert isinstance(reduction, Reduction)
         self.assertEqual(int(reduction.reduction_ranges[0]), 67)
+
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
 
     def test_padding_constants_deduped(self) -> None:
         """Two matmuls with the same shapes yield exactly one spyre.constant after dedup.
@@ -387,14 +422,17 @@ class TestInsertPaddingIR(unittest.TestCase):
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
 
-        x = torch.randn(2, 55, 67, dtype=dtype, device="spyre")
-        w1 = torch.randn(2, 67, 128, dtype=dtype, device="spyre")
-        w2 = torch.randn(2, 67, 128, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(2, 55, 67, dtype=dtype)
+        w1_cpu = torch.randn(2, 67, 128, dtype=dtype)
+        w2_cpu = torch.randn(2, 67, 128, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w1 = w1_cpu.to(device="spyre")
+        w2 = w2_cpu.to(device="spyre")
 
         def fn(x, w1, w2):
             return torch.bmm(x, w1) + torch.bmm(x, w2)
 
-        ops = self.compile_and_capture(fn, (x, w1, w2))
+        ops, result = self.compile_and_run(fn, (x, w1, w2))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 2, "Expected 2 matmul ops")
 
@@ -413,6 +451,10 @@ class TestInsertPaddingIR(unittest.TestCase):
             "Expected the surviving spyre.constant to be the first operation",
         )
 
+        torch.testing.assert_close(
+            fn(x_cpu, w1_cpu, w2_cpu), result.cpu(), atol=0.1, rtol=0.1
+        )
+
     def test_origin_node_set_on_rebuilt_matmul(self) -> None:
         """Rebuilt matmul ComputedBuffer retains origin_node from the original.
 
@@ -423,13 +465,15 @@ class TestInsertPaddingIR(unittest.TestCase):
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
 
-        x = torch.randn(55, 67, dtype=dtype, device="spyre")
-        w = torch.randn(67, 128, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(55, 67, dtype=dtype)
+        w_cpu = torch.randn(67, 128, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return x @ w
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
@@ -438,6 +482,8 @@ class TestInsertPaddingIR(unittest.TestCase):
             mm.origin_node,
             "origin_node should not be None after _rebuild_matmul",
         )
+
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
 
     def test_padded_buffer_sizes_y_only(self) -> None:
         """Only y is padded; x is untouched.  y_padded has host size [B, K_padded, N].
@@ -456,13 +502,15 @@ class TestInsertPaddingIR(unittest.TestCase):
         B, M, K, N = 2, 55, 67, 128
         k_padded = ((K + stick_size - 1) // stick_size) * stick_size
 
-        x = torch.randn(B, M, K, dtype=dtype, device="spyre")
-        w = torch.randn(B, K, N, dtype=dtype, device="spyre")
+        x_cpu = torch.randn(B, M, K, dtype=dtype)
+        w_cpu = torch.randn(B, K, N, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
 
         def fn(x, w):
             return torch.bmm(x, w)
 
-        ops = self.compile_and_capture(fn, (x, w))
+        ops, result = self.compile_and_run(fn, (x, w))
         matmuls = self._matmul_ops(ops)
         self.assertEqual(len(matmuls), 1)
         mm = matmuls[0]
@@ -505,6 +553,8 @@ class TestInsertPaddingIR(unittest.TestCase):
             f"got {dev_size[-4]}; full device_size={dev_size}",
         )
 
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
+
     def test_padded_buffer_preserves_stick_dimension(self) -> None:
         """y's padded buffer preserves the original within-stick stride.
 
@@ -523,38 +573,29 @@ class TestInsertPaddingIR(unittest.TestCase):
         stick_size = get_elem_in_stick(dtype)
         assert 67 % stick_size != 0
 
-        cases: list[
-            tuple[str, Callable[..., torch.Tensor], tuple[torch.Tensor, ...]]
-        ] = [
-            (
-                "mm [55,67]x[67,128]",
-                lambda x, w: x @ w,
-                (
-                    torch.randn(55, 67, dtype=dtype, device="spyre"),
-                    torch.randn(67, 128, dtype=dtype, device="spyre"),
-                ),
-            ),
-            (
-                "bmm [2,55,67]x[2,67,128]",
-                lambda x, w: torch.bmm(x, w),
-                (
-                    torch.randn(2, 55, 67, dtype=dtype, device="spyre"),
-                    torch.randn(2, 67, 128, dtype=dtype, device="spyre"),
-                ),
-            ),
+        def make_args(*shapes):
+            cpu = tuple(torch.randn(*s, dtype=dtype) for s in shapes)
+            dev = tuple(t.to(device="spyre") for t in cpu)
+            return cpu, dev
+
+        cpu0, dev0 = make_args((55, 67), (67, 128))
+        cpu1, dev1 = make_args((2, 55, 67), (2, 67, 128))
+        cpu2, dev2 = make_args((55, 67), (67, 128))
+
+        cases: list[tuple[str, Callable[..., torch.Tensor], tuple, tuple]] = [
+            ("mm [55,67]x[67,128]", lambda x, w: x @ w, dev0, cpu0),
+            ("bmm [2,55,67]x[2,67,128]", lambda x, w: torch.bmm(x, w), dev1, cpu1),
             (
                 "einsum mk,kn->mn [55,67]x[67,128]",
                 lambda x, w: torch.einsum("mk,kn->mn", x, w),
-                (
-                    torch.randn(55, 67, dtype=dtype, device="spyre"),
-                    torch.randn(67, 128, dtype=dtype, device="spyre"),
-                ),
+                dev2,
+                cpu2,
             ),
         ]
 
-        for name, fn, args in cases:
+        for name, fn, args, cpu_args in cases:
             with self.subTest(case=name):
-                ops = self.compile_and_capture(fn, args)
+                ops, result = self.compile_and_run(fn, args)
                 matmuls = self._matmul_ops(ops)
                 self.assertEqual(len(matmuls), 1, f"{name}: expected 1 matmul")
                 mm = matmuls[0]
@@ -582,6 +623,68 @@ class TestInsertPaddingIR(unittest.TestCase):
                         f"expected 1 (within-stick dim is contiguous); "
                         f"size={[int(s) for s in op.get_size()]}",
                     )
+
+                torch.testing.assert_close(
+                    fn(*cpu_args), result.cpu(), atol=0.1, rtol=0.1
+                )
+
+    def test_mm_square_unaligned_k_pads_y_only(self) -> None:
+        """Square mm (M==K==N) with unaligned K — only y is padded, not x.
+
+        Verifies that x/y identification works correctly when both inputs
+        have the same shape (M==K==N).
+        """
+        dtype = torch.float16
+        stick_size = get_elem_in_stick(dtype)
+        K = 67
+        assert K % stick_size != 0
+
+        x_cpu = torch.randn(K, K, dtype=dtype)
+        w_cpu = torch.randn(K, K, dtype=dtype)
+        x = x_cpu.to(device="spyre")
+        w = w_cpu.to(device="spyre")
+
+        def fn(x, w):
+            return x @ w
+
+        ops, result = self.compile_and_run(fn, (x, w))
+        matmuls = self._matmul_ops(ops)
+        self.assertEqual(len(matmuls), 1)
+        mm = matmuls[0]
+        reduction = mm.data
+        assert isinstance(reduction, Reduction)
+        self.assertEqual(int(reduction.reduction_ranges[0]), K)
+        ops_before = self._ops_before(ops, mm)
+        self._assert_constant_pad_nd_ops(ops_before)
+        torch.testing.assert_close(fn(x_cpu, w_cpu), result.cpu(), atol=0.1, rtol=0.1)
+
+    def test_4d_matmul_xt_restickify_pads_y(self) -> None:
+        """4D matmul where x is transposed (forcing restickify) and K is unaligned.
+
+        x is stored as [B, H, K, M] and transposed to [B, H, M, K] for the
+        matmul.  Restickify reorders x's device dims; insert_bmm_padding must
+        preserve the original inner_fn's x loader unchanged so work_division
+        sees valid device coordinates.  Regression test for that fix.
+        """
+        dtype = torch.float16
+        B, H, M, K, N = 12, 32, 256, 4, 128
+
+        x_cpu = torch.randn(B, H, K, M, dtype=dtype) * 0.01
+        y_cpu = torch.randn(B, H, K, N, dtype=dtype) * 0.01
+        x = x_cpu.to(device="spyre")
+        y = y_cpu.to(device="spyre")
+
+        def fn(x, y):
+            return torch.matmul(x.transpose(-1, -2), y)
+
+        ops, result = self.compile_and_run(fn, (x, y))
+        matmuls = self._matmul_ops(ops)
+        self.assertEqual(len(matmuls), 1, "Expected exactly one matmul op")
+        mm = matmuls[0]
+        reduction = mm.data
+        assert isinstance(reduction, Reduction)
+        self.assertEqual(int(reduction.reduction_ranges[0]), K)
+        torch.testing.assert_close(fn(x_cpu, y_cpu), result.cpu(), atol=0.1, rtol=0.1)
 
 
 if __name__ == "__main__":

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -38,9 +38,9 @@ Deduplication of identical constants across multiple pad calls happens later
 at the IR level via dedup_and_promote_constants.
 
 x and y are identified via identify_matmul_inputs() using the BatchMatmul
-preserved_dim definition: x is the input that shares a dimension with the
-output that y does not (M).  This avoids positional assumptions and handles
-square matrices (M==K==N) correctly.
+generated_dim definition: y is the input whose index contains a symbol
+present in the output but absent from x (N).  This handles M==K==N and
+M=1 (decode phase) correctly.
 """
 
 import torch
@@ -166,8 +166,9 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
     space is unchanged.  The K→K_padded widening happens at SDSC codegen time.
 
     x and y are identified via identify_matmul_inputs() using the BatchMatmul
-    preserved_dim definition: x is the input that shares a dimension with the
-    output that y does not (M).
+    generated_dim definition: y is the input whose index contains a symbol
+    present in the output but absent from x (N).  This handles M==K==N and
+    M=1 (decode phase) correctly.
 
     Deduplication of identical constants across multiple pad calls happens later
     at the IR level via dedup_and_promote_constants.

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -37,8 +37,9 @@ introduce numerical error from x.
 Deduplication of identical constants across multiple pad calls happens later
 at the IR level via dedup_and_promote_constants.
 
-x and y are identified via device_coordinates: x is the input sticked on the
-reduction coord, y is the other.  This avoids positional assumptions and handles
+x and y are identified via identify_matmul_inputs() using the BatchMatmul
+preserved_dim definition: x is the input that shares a dimension with the
+output that y does not (M).  This avoids positional assumptions and handles
 square matrices (M==K==N) correctly.
 """
 
@@ -58,12 +59,12 @@ from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
 from .pass_utils import (
     concretize_expr,
-    device_coordinates,
+    find_reduction_var,
+    identify_matmul_inputs,
     host_coordinates,
     lower_pad_sequence,
     replace_computed_buffer_body,
 )
-from .views import matching_dim
 from torch_spyre._C import get_elem_in_stick
 
 logger = get_inductor_logger("padding")
@@ -87,9 +88,7 @@ def _patch_env(graph_lowering) -> None:
     graph_lowering.env.update(env)
 
 
-def _find_arg_fx_node(
-    arg_name: str, expected_size: list[int] | None = None
-) -> torch.fx.Node:
+def _find_arg_fx_node(arg_name: str) -> torch.fx.Node:
     """Return the FX node whose lowered TensorBox has the given buffer name.
 
     Buffer names are unique, but a single buffer can be reached through
@@ -99,19 +98,13 @@ def _find_arg_fx_node(
     [M, K].  Both FX nodes lower to a TensorBox whose get_name() returns
     the same buffer name, but with different get_size() results.
 
-    ``expected_size`` selects the FX node whose TensorBox size matches the
-    dimensionality that the matmul inner_fn actually uses.  This ensures the
-    padded clone gets the right shape and _rebuild_matmul's loaders index it
-    with the correct number of dimensions.
-
-    Raises RuntimeError if no candidate matches the expected size, or if no
-    candidate exists at all.  When ``expected_size`` is None, returns the first
-    candidate (the base buffer, with no view applied).
+    Returns the first candidate (the base buffer, with no view applied).
+    Raises RuntimeError if no candidate exists.
     """
     graph_lowering = V.graph
     _patch_env(graph_lowering)
     candidates = [
-        (fx_node, tb)
+        fx_node
         for fx_node, tb in graph_lowering.env.items()
         if isinstance(fx_node, torch.fx.Node)
         and isinstance(tb, TensorBox)
@@ -119,62 +112,41 @@ def _find_arg_fx_node(
     ]
     if not candidates:
         raise RuntimeError(f"no FX node found for buffer {arg_name!r}")
-    if expected_size is not None:
-        for fx_node, tb in candidates:
-            if [int(s) for s in tb.get_size()] == expected_size:
-                return fx_node
-        raise RuntimeError(
-            f"no FX node for buffer {arg_name!r} with size {expected_size}; "
-            f"found sizes {[[int(s) for s in tb.get_size()] for _, tb in candidates]}"
-        )
-    return candidates[0][0]
+    return candidates[0]
 
 
 def _rebuild_matmul(
     op: ComputedBuffer,
-    x_ir: object,
     y_padded_buf: Buffer,
     operations: list[Operation],
 ) -> ComputedBuffer:
     """Rebuild the matmul ComputedBuffer so y's loader reads from the padded buffer.
 
-    Patches the Reduction's inner_fn to load x from its original IR node and y
-    from the padded buffer.  reduction_ranges is left unchanged (stays at K);
-    the K→K_padded extension happens at SDSC codegen time via
+    Preserves the original inner_fn's x loading unchanged; only replaces y's
+    loader with one that reads from the padded buffer.  reduction_ranges stays
+    at K; the K→K_padded extension happens at SDSC codegen time via
     _extend_matmul_k_to_padded in superdsc.py.
-
-    x_ir must support make_loader() and its get_size() must have ndim matching
-    len(output_ranges) (all output dims except N plus K) so indices
-    [batch..., M, r_K] are valid.
-    y_padded_buf must have the same ndim as the original y buffer.
     """
     reduction = op.data
     assert isinstance(reduction, Reduction)
 
-    x_loader = x_ir.make_loader()
+    orig_inner_fn = reduction.inner_fn
     y_padded_loader = y_padded_buf.make_loader()
-    # y's batch dims: y_ndim - 2 batch dims come first in y_index.
     y_ndim = len(y_padded_buf.get_size())
-    y_batch_ndim = y_ndim - 2  # number of batch dims in y (0 for non-batched y)
+    y_batch_ndim = y_ndim - 2
 
     def new_inner_fn(
         index,
         reduction_index,
-        _x_loader=x_loader,
+        _orig_inner_fn=orig_inner_fn,
         _y_loader=y_padded_loader,
         _y_batch_ndim=y_batch_ndim,
     ):
-        # x: all output dims except the last (N), plus the reduction dim.
-        # y: first y_batch_ndim batch dims, then reduction dim, then N (index[-1]).
-        # Matches the lowering pattern for all mm/bmm variants:
-        #   mm (2D×2D):   x_loader([i_M, r_K]),       y_loader([r_K, i_N])
-        #   bmm (3D×3D):  x_loader([i_B, i_M, r_K]),  y_loader([i_B, r_K, i_N])
-        #   bmm (4D×4D):  x_loader([i_B,i_H,i_M,r_K]),y_loader([i_B,i_H,r_K,i_N])
-        #   bmm (3D×2D):  x_loader([i_B, i_M, r_K]),  y_loader([r_K, i_N])
-        #   einsum→bmm:   x_loader([i_B, i_M, r_K]),  y_loader([r_K, i_N])  (y 2D)
-        x_index = list(index[:-1]) + list(reduction_index)
+        # Call the original inner_fn to get x's value, then override y.
+        x_val, _ = _orig_inner_fn(index, reduction_index)
         y_index = list(index[:_y_batch_ndim]) + list(reduction_index) + [index[-1]]
-        return (_x_loader(x_index), _y_loader(y_index))
+        y_val = _y_loader(y_index)
+        return (x_val, y_val)
 
     object.__setattr__(reduction, "inner_fn", new_inner_fn)
     # reduction_ranges stays at K; no extension here.
@@ -193,9 +165,9 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
     size by lower_pad_sequence; reduction_ranges stays at K so the IR iteration
     space is unchanged.  The K→K_padded widening happens at SDSC codegen time.
 
-    x and y are identified via device_coordinates: x is the input sticked on
-    the reduction coord, y is the other.  This avoids positional assumptions
-    and handles square matrices (M==K==N) correctly.
+    x and y are identified via identify_matmul_inputs() using the BatchMatmul
+    preserved_dim definition: x is the input that shares a dimension with the
+    output that y does not (M).
 
     Deduplication of identical constants across multiple pad calls happens later
     at the IR level via dedup_and_promote_constants.
@@ -218,8 +190,8 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         # Skip aligned-K matmuls early before any x/y identification.
         # Aligned-K matmuls need no padding regardless of input layout, and
         # skipping here avoids a spurious warning for e.g. decode-phase SDPA
-        # attention where out_coords has a constant-folded M dimension that
-        # makes reduction_coord detection fail for both inputs.
+        # attention where constant-folded dimensions cause identify_matmul_inputs
+        # to fail.
         k_val = concretize_expr(reduction.reduction_ranges[0])
         first_buf = next(
             (graph.get_buffer(d.name) for d in reads if graph.get_buffer(d.name)),
@@ -232,52 +204,32 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         if compute_padding(k_val, dtype) == 0:
             continue
 
-        # Identify x and y via device_coordinates.
-        # x is the input sticked on the reduction coord (hardware masks within-stick
-        # padding for x).  y is the other input; its K host dim is derived from the
-        # same reduction coord.  This avoids positional assumptions and handles
-        # square matrices (M==K==N) correctly.
-        # See propagate_layouts._topk_layouts for the same reduction-coord derivation.
         write_dep = next(iter(rw.writes))
-        out_coords = host_coordinates(op.get_layout(), write_dep)
-
-        x_dep = None
-        y_dep = None
-        y_host_k_dim: int | None = None
-        for dep in reads:
-            buf = graph.get_buffer(dep.name)
-            if buf is None:
-                continue
-            layout = buf.get_layout()
-            if not isinstance(layout, FixedTiledLayout):
-                continue
-            h_coords = host_coordinates(layout, dep)
-            d_coords = device_coordinates(layout.device_layout, dep)
-            stick_expr = d_coords[-1]
-            reduction_coord = next(
-                (
-                    c
-                    for c in h_coords
-                    if len(c.free_symbols) > 0 and matching_dim(out_coords, c) is None
-                ),
-                None,
-            )
-            if reduction_coord is None:
-                continue
-            stick_dim = matching_dim(h_coords, stick_expr)
-            reduction_dim_host = matching_dim(h_coords, reduction_coord)
-            if stick_dim == reduction_dim_host:
-                x_dep = dep
-            else:
-                y_dep = dep
-                y_host_k_dim = reduction_dim_host
-
+        x_dep, y_dep = identify_matmul_inputs(reads, write_dep)
         if x_dep is None or y_dep is None:
             logger.warning(
                 "insert_bmm_padding: could not identify x/y for %s, skipping",
                 op.get_name(),
             )
             continue
+
+        reduction_var = find_reduction_var(x_dep, write_dep)
+
+        # y's K host dim: the dim whose host coordinate contains reduction_var.
+        y_buf_tmp = graph.get_buffer(y_dep.name)
+        y_host_k_dim: int | None = None
+        if y_buf_tmp is not None and isinstance(
+            y_buf_tmp.get_layout(), FixedTiledLayout
+        ):
+            y_h_coords = host_coordinates(y_buf_tmp.get_layout(), y_dep)
+            y_host_k_dim = next(
+                (
+                    i
+                    for i, c in enumerate(y_h_coords)
+                    if reduction_var in c.free_symbols
+                ),
+                None,
+            )
 
         x_name = x_dep.name
         y_name = y_dep.name
@@ -286,21 +238,8 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
         if x_buf is None or y_buf is None:
             continue
 
-        # x's effective size for the inner_fn is derived from the output ranges:
-        # all output dims except N, plus K.  This correctly handles cases where
-        # the inner_fn accesses x through a view with more dims than x_buf
-        # (e.g. when mm_to_bmm_pass wraps a 2D mm into a 3D bmm).
-        output_ranges = [concretize_expr(s) for s in reduction.ranges]
-        x_size = output_ranges[:-1] + [k_val]  # [batch..., M, K]
         device = x_buf.get_device()
         pad = compute_padding(k_val, dtype)
-
-        # Find the FX node/TensorBox that presents x at x_size dimensionality.
-        # mm_to_bmm_pass may wrap a 2D x buffer with a 3D view; we need the
-        # loader to accept x_size-dimensional indices (len(output_ranges) dims).
-        x_view_fx = _find_arg_fx_node(x_name, expected_size=x_size)
-        _patch_env(graph)
-        x_view_buf = graph.env[x_view_fx]
 
         k_padded = k_val + pad
 
@@ -354,11 +293,6 @@ def insert_bmm_padding(graph: GraphLowering) -> None:
             operations.insert(op_idx + i, new_op)
 
         # --- Rebuild matmul inner_fn to load y from the padded buffer ---
-        # x keeps its original loader (via x_view_buf which presents x at the
-        # x_size dimensionality the inner_fn expects); reduction_ranges stays at K.
-        _rebuild_matmul(
-            op,
-            x_view_buf,
-            y_padded_buf,
-            operations,
-        )
+        # x is left entirely untouched: the original inner_fn's x loader is
+        # preserved as-is.  Only y's loader is replaced with the padded buffer.
+        _rebuild_matmul(op, y_padded_buf, operations)

--- a/torch_spyre/_inductor/padding.py
+++ b/torch_spyre/_inductor/padding.py
@@ -142,7 +142,7 @@ def _rebuild_matmul(
         _y_loader=y_padded_loader,
         _y_batch_ndim=y_batch_ndim,
     ):
-        # Call the original inner_fn to get x's value, then override y.
+        # x_val comes from the original inner_fn; discard its y and replace below.
         x_val, _ = _orig_inner_fn(index, reduction_index)
         y_index = list(index[:_y_batch_ndim]) + list(reduction_index) + [index[-1]]
         y_val = _y_loader(y_index)

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -426,10 +426,13 @@ def identify_matmul_inputs(
       preserved_dim: in Input1, Output,  NOT Input2
       noreuse_dim:   in Input1, Input2,  Output
 
-    Input1 (x) is uniquely identified by having a preserved_dim.
-    Input2 (y) is the other input.
+    Identifies y by its generated_dim (N): present in y and the output, absent
+    from x.  This is more robust than identifying x by its preserved_dim (M):
+    when M=1, M is constant-folded out of both x's and the output's index
+    simultaneously, making the preserved_dim test blind.  N is immune — even
+    N=1 ranges stay in the output's index expression.
 
-    Returns (None, None) if x cannot be identified.
+    Returns (None, None) if y cannot be identified.
     """
     assert len(inputs) == 2
     a, b = inputs[0], inputs[1]
@@ -437,9 +440,11 @@ def identify_matmul_inputs(
     syms_a = a.index.free_symbols
     syms_b = b.index.free_symbols
 
-    if (syms_a & out_syms) - syms_b:
-        return a, b
+    # b has generated_dim → b is y, a is x
     if (syms_b & out_syms) - syms_a:
+        return a, b
+    # a has generated_dim → a is y, b is x
+    if (syms_a & out_syms) - syms_b:
         return b, a
     return None, None
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -414,6 +414,75 @@ def host_coordinates(layout: FixedLayout, dep: MemoryDep) -> list[sympy.Expr]:
     return compute_coordinates(concrete_size, concrete_stride, dep.ranges, index)
 
 
+_T = TypeVar("_T")
+
+
+def identify_matmul_inputs(
+    inputs: list[_T],
+    write_dep: MemoryDep,
+    *,
+    get_dep: Callable[[_T], MemoryDep] = lambda x: x,  # type: ignore[assignment]
+) -> tuple[_T, _T] | tuple[None, None]:
+    """Identify Input1 (x) and Input2 (y) of a BatchMatmul op.
+
+    Uses the BatchMatmul semantic dimension definitions:
+      reduction_dim: in Input1, Input2,  NOT Output
+      generated_dim: in Input2, Output,  NOT Input1
+      preserved_dim: in Input1, Output,  NOT Input2
+      noreuse_dim:   in Input1, Input2,  Output
+
+    Input1 (x) is uniquely identified by having a preserved_dim.
+    Input2 (y) is the other input.
+
+    ``get_dep`` extracts a MemoryDep from each element — defaults to identity
+    so callers passing MemoryDep lists directly need not supply it.
+
+    Returns (None, None) if x cannot be identified.
+    """
+    assert len(inputs) == 2
+    a, b = inputs[0], inputs[1]
+    out_syms = write_dep.index.free_symbols
+    syms_a = get_dep(a).index.free_symbols
+    syms_b = get_dep(b).index.free_symbols
+
+    if (syms_a & out_syms) - syms_b:
+        return a, b
+    if (syms_b & out_syms) - syms_a:
+        return b, a
+    return None, None
+
+
+def find_reduction_var(x_dep: MemoryDep, out_dep: MemoryDep) -> sympy.Symbol:
+    """Return the single loop variable that appears in x's index but not in the output's.
+
+    Raises Unsupported if the count is not exactly 1.
+    """
+    reduction_vars = x_dep.index.free_symbols - out_dep.index.free_symbols
+    if len(reduction_vars) != 1:
+        raise Unsupported(
+            f"expected exactly 1 reduction variable, got {reduction_vars}"
+        )
+    return next(iter(reduction_vars))
+
+
+def find_matmul_generated_var(
+    y_dep: MemoryDep, x_dep: MemoryDep, out_dep: MemoryDep
+) -> sympy.Symbol:
+    """Return the single loop variable that appears in y's and the output's index but not in x's.
+
+    This is the N (generation) dimension of a matmul.
+    Raises Unsupported if the count is not exactly 1.
+    """
+    generated_vars = (
+        y_dep.index.free_symbols & out_dep.index.free_symbols
+    ) - x_dep.index.free_symbols
+    if len(generated_vars) != 1:
+        raise Unsupported(
+            f"expected exactly 1 generated variable, got {generated_vars}"
+        )
+    return next(iter(generated_vars))
+
+
 def is_stick_expr_offset_free(stick_expr: sympy.Expr, elems_per_stick: int) -> bool:
     """Check if a stick expression is free of constant offsets.
 

--- a/torch_spyre/_inductor/pass_utils.py
+++ b/torch_spyre/_inductor/pass_utils.py
@@ -414,15 +414,10 @@ def host_coordinates(layout: FixedLayout, dep: MemoryDep) -> list[sympy.Expr]:
     return compute_coordinates(concrete_size, concrete_stride, dep.ranges, index)
 
 
-_T = TypeVar("_T")
-
-
 def identify_matmul_inputs(
-    inputs: list[_T],
+    inputs: list[MemoryDep],
     write_dep: MemoryDep,
-    *,
-    get_dep: Callable[[_T], MemoryDep] = lambda x: x,  # type: ignore[assignment]
-) -> tuple[_T, _T] | tuple[None, None]:
+) -> tuple[MemoryDep, MemoryDep] | tuple[None, None]:
     """Identify Input1 (x) and Input2 (y) of a BatchMatmul op.
 
     Uses the BatchMatmul semantic dimension definitions:
@@ -434,16 +429,13 @@ def identify_matmul_inputs(
     Input1 (x) is uniquely identified by having a preserved_dim.
     Input2 (y) is the other input.
 
-    ``get_dep`` extracts a MemoryDep from each element — defaults to identity
-    so callers passing MemoryDep lists directly need not supply it.
-
     Returns (None, None) if x cannot be identified.
     """
     assert len(inputs) == 2
     a, b = inputs[0], inputs[1]
     out_syms = write_dep.index.free_symbols
-    syms_a = get_dep(a).index.free_symbols
-    syms_b = get_dep(b).index.free_symbols
+    syms_a = a.index.free_symbols
+    syms_b = b.index.free_symbols
 
     if (syms_a & out_syms) - syms_b:
         return a, b

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -59,6 +59,9 @@ from .ir import FixedTiledLayout, SpyreConstantFallback
 from .pass_utils import (
     compute_restickify_target_layout,
     concretize_expr,
+    find_matmul_generated_var,
+    find_reduction_var,
+    identify_matmul_inputs,
     host_coordinates,
     device_coordinates,
     is_stick_expr_offset_free,
@@ -408,7 +411,7 @@ def _exx2_layout(
     out_stl = SpyreTensorLayout(
         c_size, c_stride, output.dtype, out_dim_order, ElementArrangement.EXX2
     )
-    reduction_var = _find_reduction_var(x.dep, output_dep, "exx2")
+    reduction_var = find_reduction_var(x.dep, output_dep)
     req_in_stl = find_stick_compatible_input_layout(x, reduction_var, "exx2", "x")
     op.restick_cost_fn = FixedInOutNode.from_args(args, out_stl, [req_in_stl], op)
     return [out_stl]
@@ -429,38 +432,12 @@ def _layernormnorm_layout(
     c_size = [concretize_expr(s) for s in output.size]
     c_stride = [concretize_expr(s) for s in output.stride]
     out_stl = SpyreTensorLayout(c_size, c_stride, output.dtype, out_dim_order)
-    reduction_var = _find_reduction_var(x.dep, output_dep, "layernormnorm")
+    reduction_var = find_reduction_var(x.dep, output_dep)
     req_in_stl = find_stick_compatible_input_layout(
         x, reduction_var, "layernormnorm", "x"
     )
     op.restick_cost_fn = FixedInOutNode.from_args(args[:1], out_stl, [req_in_stl], op)
     return [out_stl]
-
-
-def _index_symbols(dep: MemoryDep) -> set[sympy.Symbol]:
-    return dep.index.free_symbols
-
-
-def _find_reduction_var(x_dep, out_dep, op_name: str = "reduction") -> sympy.Symbol:
-    """Reduction loop variable: appears in x's index but not in output's index."""
-    reduction_vars = _index_symbols(x_dep) - _index_symbols(out_dep)
-    if len(reduction_vars) != 1:
-        raise Unsupported(
-            f"{op_name}: expected 1 reduction variable, got {reduction_vars}"
-        )
-    return next(iter(reduction_vars))
-
-
-def _find_matmul_generated_var(y_dep, x_dep, out_dep) -> sympy.Symbol:
-    """N loop variable: appears in y's and output's index but not in x's index."""
-    generated_vars = (_index_symbols(y_dep) & _index_symbols(out_dep)) - _index_symbols(
-        x_dep
-    )
-    if len(generated_vars) != 1:
-        raise Unsupported(
-            f"matmul: expected 1 generated variable, got {generated_vars}"
-        )
-    return next(iter(generated_vars))
 
 
 def _dev_coord_for_var(dev_coords, arg_host_coords, var):
@@ -530,15 +507,16 @@ def _matmul_layouts(
     _check_supported_input_sticks(args, data.reduction_type)
     out_coords = host_coordinates(output, output_dep)
 
-    x = args[0]
-    y = args[1]
+    x, y = identify_matmul_inputs(args, output_dep, get_dep=lambda a: a.dep)
+    if x is None or y is None:
+        raise Unsupported(f"{data.reduction_type}: could not identify Input1/Input2")
 
     # Hardware stick constraints (DF16):
     #   Input1 (x): stick on reduction_var (loop var absent from output)
     #   Input2 (y): stick on generated_var (loop var present in output, absent from x)
     #   Output:     stick on generated_var
-    reduction_var = _find_reduction_var(x.dep, output_dep, data.reduction_type)
-    generated_var = _find_matmul_generated_var(y.dep, x.dep, output_dep)
+    reduction_var = find_reduction_var(x.dep, output_dep)
+    generated_var = find_matmul_generated_var(y.dep, x.dep, output_dep)
 
     x_req_stl = find_stick_compatible_input_layout(
         x, reduction_var, data.reduction_type, "x"
@@ -696,7 +674,7 @@ def _topk_layouts(
     out_coords = host_coordinates(output, output_dep)
 
     # Reduction var: in x's index but absent from output's.
-    reduction_var = _find_reduction_var(x.dep, output_dep, "topk")
+    reduction_var = find_reduction_var(x.dep, output_dep)
 
     # Coords that survive the reduction into the output.
     surviving_coords = [

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -507,9 +507,14 @@ def _matmul_layouts(
     _check_supported_input_sticks(args, data.reduction_type)
     out_coords = host_coordinates(output, output_dep)
 
-    x, y = identify_matmul_inputs(args, output_dep, get_dep=lambda a: a.dep)
-    if x is None or y is None:
+    x_dep, y_dep = identify_matmul_inputs([a.dep for a in args], output_dep)
+    if x_dep is None or y_dep is None:
         raise Unsupported(f"{data.reduction_type}: could not identify Input1/Input2")
+    # Map identified deps back to PropArgs.
+    if x_dep is args[0].dep:
+        x, y = args[0], args[1]
+    else:
+        x, y = args[1], args[0]
 
     # Hardware stick constraints (DF16):
     #   Input1 (x): stick on reduction_var (loop var absent from output)


### PR DESCRIPTION
## Summary

Compiling `matmul(x.transpose(-1,-2), y)` crashed at compile time if K was not stick-aligned. Two bugs are fixed and the x/y identification logic is refactored into shared helpers in `pass_utils.py` used by both `padding.py` and `propagate_layouts.py`.

## Problem

`insert_restickify` and `insert_bmm_padding` run in sequence. When x is transposed, `insert_restickify` rewrites x into a new buffer (`buf1`) with K as the stick dimension — changing its shape from `[B, H, M, K]` to `[B, H, K, M]` — and patches the matmul's load function to read from `buf1`.

`insert_bmm_padding` then tried to look up x's IR node by its expected shape `[B, H, M, K]` to reconstruct its load function. But `buf1` has shape `[B, H, K, M]`. No match, hard crash:

```
RuntimeError: no FX node for buffer 'buf1' with size [12, 32, 256, 4]; found sizes [[12, 32, 4, 256]]
```

A separate problem: the original x/y identification in `identify_matmul_inputs` used the preserved_dim (M) to find x. This fails when M=1: M is constant-folded out of both x's and the output's index simultaneously, making the test blind. This caused compile failures for all decode-phase (M=1) matmuls.

## Changes

### 1. Crash fix — stop reconstructing x's load function

`insert_restickify` already patched the matmul's load function to read x correctly from `buf1`. `insert_bmm_padding` just needs to leave x alone and only replace y's load with the padded buffer. The fix captures the existing load function and calls it unchanged for x.

### 2. Shared helpers for matmul input identification

The logic for identifying which dep is x and which is y — and for finding the reduction and generated variables — is now in `pass_utils.py` as three public functions:

- `identify_matmul_inputs(inputs, write_dep)` — returns `(x, y)` by identifying y via its generated_dim (N): present in y and the output, absent from x. This is more robust than identifying x by its preserved_dim (M) because N is never constant-folded out of the output's index expression, even when N=1.
- `find_reduction_var(x_dep, out_dep)` — returns K (present in x and y, absent from output)
- `find_matmul_generated_var(y_dep, x_dep, out_dep)` — returns N (present in y and output, absent from x)

These replace private implementations in `propagate_layouts.py` and are now called from both `padding.py` and `propagate_layouts.py`. The latter previously used a positional assumption (`args[0]`/`args[1]`) that worked by convention but was not guaranteed.

Note: `host_coordinates` remains in use in this pass and in `lower_pad_sequence` and `replace_computed_buffer_body`. Removing these is deferred to a follow-up PR.

## Tests

All existing `test_padding.py` tests updated to assert correctness against CPU reference (previously they only checked IR structure).

Two new tests:

**`test_mm_square_unaligned_k_pads_y_only`** — square `M==K==N` matrix that would confuse the old x/y identification.

**`test_4d_matmul_xt_restickify_pads_y`** — the exact scenario that triggered the crash: 4D matmul with transposed x and unaligned K.
