### PR TITLE
ci: revert PR-2648 testing runner labels to defaults

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,6 +15,6 @@ self-hosted-runner:
     - spyre_pf_x8
     - spyre_pf_x12
     - linux
-    - linux_for_pr_tests
+    - linux_rpm_install
     - image_torch_spyre
     - image_spyre_inference

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -18,4 +18,3 @@ self-hosted-runner:
     - linux_for_pr_tests
     - image_torch_spyre
     - image_spyre_inference
-    - image_torch_spyre_for_pr_2648

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,6 +15,5 @@ self-hosted-runner:
     - spyre_pf_x8
     - spyre_pf_x12
     - linux
-    - linux_rpm_install
     - image_torch_spyre
     - image_spyre_inference

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -5,7 +5,7 @@ name: Test matrix (reusable)
 # Called by tests.yml and tests-nightly.yml.
 #
 # All differences between the two callers are expressed as inputs:
-#   - runner_label      : linux_rpm_install (PR) vs linux (nightly)
+#   - runner_label      : linux (PR and nightly)
 #   - extra_test_flags  : "-v" (PR) vs "--cpu-compile -vvv -s" (nightly)
 #   - checkout_pytorch  : false (PR) vs true (nightly)
 #   - torch_root        : "" (PR) vs "/home/senuser/pytorch" (nightly)
@@ -16,7 +16,7 @@ on:
     inputs:
       # Runner pool to use for both test jobs
       runner_label:
-        description: Runner label appended to the fixed labels (linux_rpm_install or linux)
+        description: Runner label appended to the fixed labels (e.g. linux)
         required: true
         type: string
 

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -81,7 +81,7 @@ jobs:
       - x86_64
       - spyre_pf_x1
       - ${{ inputs.runner_label }}
-      - image_torch_spyre_for_pr_2648
+      - image_torch_spyre
     timeout-minutes: 60
     env:
       # GitHub Actions sets CI=true which causes pytest inductor tests to fail.
@@ -366,7 +366,7 @@ jobs:
       - x86_64
       - spyre_pf_x2
       - ${{ inputs.runner_label }}
-      - image_torch_spyre_for_pr_2648
+      - image_torch_spyre
     timeout-minutes: 60
     env:
       CI: ''

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -5,7 +5,7 @@ name: Test matrix (reusable)
 # Called by tests.yml and tests-nightly.yml.
 #
 # All differences between the two callers are expressed as inputs:
-#   - runner_label      : linux_for_pr_tests (PR) vs linux (nightly)
+#   - runner_label      : linux_rpm_install (PR) vs linux (nightly)
 #   - extra_test_flags  : "-v" (PR) vs "--cpu-compile -vvv -s" (nightly)
 #   - checkout_pytorch  : false (PR) vs true (nightly)
 #   - torch_root        : "" (PR) vs "/home/senuser/pytorch" (nightly)
@@ -16,7 +16,7 @@ on:
     inputs:
       # Runner pool to use for both test jobs
       runner_label:
-        description: Runner label appended to the fixed labels (linux_for_pr_tests or linux)
+        description: Runner label appended to the fixed labels (linux_rpm_install or linux)
         required: true
         type: string
 

--- a/.github/workflows/model_modules_tests.yaml
+++ b/.github/workflows/model_modules_tests.yaml
@@ -35,8 +35,8 @@ jobs:
     runs-on:
       - x86_64
       - spyre_pf_x1
-      - linux_for_pr_tests
-      - image_torch_spyre_for_pr_2648
+      - linux
+      - image_torch_spyre
     timeout-minutes: 60
     env:
       # The CI env var is very important.

--- a/.github/workflows/model_ops_tests.yaml
+++ b/.github/workflows/model_ops_tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - x86_64
       - spyre_pf_x1
       - linux
-      - image_torch_spyre_for_pr_2648
+      - image_torch_spyre
     timeout-minutes: 60
     env:
       # The CI env var is very important.

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -111,7 +111,7 @@ jobs:
     if: needs.changes.outputs.code_changed == 'true'
     uses: ./.github/workflows/_test_matrix.yaml
     with:
-      runner_label: linux_for_pr_tests
+      runner_label: linux_rpm_install
       extra_test_flags: -v
       checkout_pytorch: false
       torch_root: ''

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -111,7 +111,7 @@ jobs:
     if: needs.changes.outputs.code_changed == 'true'
     uses: ./.github/workflows/_test_matrix.yaml
     with:
-      runner_label: linux_rpm_install
+      runner_label: linux
       extra_test_flags: -v
       checkout_pytorch: false
       torch_root: ''

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -35,8 +35,8 @@ jobs:
     runs-on:
       - x86_64
       - spyre_pf_x1
-      - linux_for_pr_tests
-      - image_torch_spyre_for_pr_2648
+      - linux
+      - image_torch_spyre
     timeout-minutes: 60
     env:
       # The CI env var is very important.


### PR DESCRIPTION
## Summary

Reverts the runner-label changes introduced by the "Update labels" commit in #2727. Those swapped CI to PR-2648-specific testing runners:

- `image_torch_spyre` → `image_torch_spyre_for_pr_2648` (in `_test_matrix.yaml`, `model_modules_tests.yaml`, `model_ops_tests.yaml`, `upstream_tests.yaml`)
- `linux` → `linux_for_pr_tests` (in `model_modules_tests.yaml`, `upstream_tests.yaml`)
- Added `image_torch_spyre_for_pr_2648` to the `actionlint.yaml` allow-list

This PR reverts **only** those label changes, restoring the standard runner labels. The Flex API fixes from #2727 (C++ changes in `job_plan`, `spyre_allocator`, `spyre_stream`) are left intact.

Pre-existing labels (e.g. `linux_for_pr_tests` in the actionlint allow-list, and the `runner_label`/comment references in `_test_matrix.yaml` and `torch_spyre_tests.yaml`) are untouched, as they predate #2727.

## Test plan

- `actionlint` allow-list and workflow `runs-on` labels now reference only standard runners.