### PR TITLE
feat(cicd): enable DTLOG_LEVEL=Info on final retry attempt for tests with HW RAS error 

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -301,6 +301,12 @@ jobs:
             echo "  Slow flag     : ${_SLOW_FLAG:-none (all tests will run)}"
             echo "  Extra flags   : ${{ inputs.extra_test_flags }}"
 
+            # On the final attempt, enable verbose DT logging for diagnostics
+            _DTLOG_PREFIX=""
+            if [[ $attempt -eq $MAX_ATTEMPTS ]]; then
+              echo "  DTLOG_LEVEL   : Info (final attempt --> DTLOG_LEVEL logging enabled)"
+              _DTLOG_PREFIX="DTLOG_LEVEL=Info"
+            fi
 
             FIFO="$(mktemp -u /tmp/test_fifo_XXXXXX)"
             mkfifo "$FIFO"
@@ -312,7 +318,7 @@ jobs:
             # Now open the write end — guaranteed to have a reader already waiting
             exec {FIFO_FD}>"$FIFO"
 
-            bash tests/run_test.sh "$CONFIG" ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} \
+            env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} \
               >&"$FIFO_FD" 2>&1 &
             TEST_PID=$!
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

This PR enables verbose DT logging (`DTLOG_LEVEL=Info`) on the 3rd and final retry attempt

#### Additional note:
