### PR TITLE
chore(cicd): refactor and extract retry/stall-watcher logic into reusable run-test-suite composite action

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -1,0 +1,173 @@
+name: Run test suite (with retry + stall watcher)
+description: >
+  Runs a single run_test.sh config with up to MAX_ATTEMPTS retries,
+  a stall watchdog, and DTLOG_LEVEL=Info on the final attempt.
+
+inputs:
+  suite_name:
+    description: Human-readable label (used in echo/log output)
+    required: true
+  config:
+    description: Path passed to run_test.sh (e.g. tests/configs/...)
+    required: true
+  extra_test_flags:
+    description: Extra flags forwarded to run_test.sh (e.g. "-v")
+    required: false
+    default: ''
+  work_dir:
+    description: Directory to cd into before running (must have .venv)
+    required: false
+    default: /home/senuser/torch-spyre
+  max_attempts:
+    description: Total number of attempts before giving up
+    required: false
+    default: '3'
+  stall_timeout_secs:
+    description: Seconds of no stdout before the test is killed as hung
+    required: false
+    default: '300'
+  stall_check_interval:
+    description: How often (seconds) the stall watcher polls
+    required: false
+    default: '30'
+  junit_xml_path:
+    description: Full path for the --junit-xml report (leave empty to skip)
+    required: false
+    default: ''
+  report_name:
+    description: Filename of the XML report (for GITHUB_ENV export to upload step)
+    required: false
+    default: ''
+  pre_run:
+    description: Optional bash snippet run at the start of every attempt (e.g. topology reset)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Run ${{ inputs.suite_name }}
+      shell: bash
+      env:
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        STALL_TIMEOUT_SECS: ${{ inputs.stall_timeout_secs }}
+        STALL_CHECK_INTERVAL: ${{ inputs.stall_check_interval }}
+      run: |-
+        set +e
+        set +o pipefail
+
+        source "$HOME/.bashrc"
+        source /etc/profile.d/ibm-aiu-setup.sh
+        cd "${{ inputs.work_dir }}"
+        source .venv/bin/activate
+
+        CONFIG="${{ inputs.config }}"
+
+        _ARCH="$(uname -m)"
+        _SLOW_FLAG=""
+        if [[ "$_ARCH" != "x86_64" ]]; then
+          echo "Non-x86_64 platform (${_ARCH}): passing --skip-slow"
+          _SLOW_FLAG="--skip-slow"
+        fi
+
+        attempt=0
+        while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
+          attempt=$(( attempt + 1 ))
+          echo "=== Attempt ${attempt}/${MAX_ATTEMPTS}: ${{ inputs.suite_name }} ==="
+
+          LOG_FILE="$(mktemp /tmp/test_output_XXXXXX.log)"
+          STALL_FLAG="$(mktemp /tmp/stall_flag_XXXXXX.tmp)"
+
+          stall_watcher() {
+            local elapsed_stall=0
+            local prev_lines=0
+            while [[ ! -f "${STALL_FLAG}.done" ]]; do
+              sleep "$STALL_CHECK_INTERVAL"
+              current_lines=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+              if [[ "$current_lines" -eq "$prev_lines" ]]; then
+                elapsed_stall=$(( elapsed_stall + STALL_CHECK_INTERVAL ))
+                echo "[stall-watcher] No new output for ${elapsed_stall}s (lines=${current_lines})"
+                if [[ $elapsed_stall -ge $STALL_TIMEOUT_SECS ]]; then
+                  echo "[stall-watcher] STALL DETECTED — killing test child processes"
+                  kill -TERM "$TEST_PID" 2>/dev/null || true
+                  pkill -TERM -P "$TEST_PID" 2>/dev/null || true
+                  kill -TERM "$TEE_PID" 2>/dev/null || true
+                  return
+                fi
+              else
+                elapsed_stall=0
+              fi
+              prev_lines=$current_lines
+            done
+          }
+
+          # Run any per-attempt setup (e.g. topology reset for multi-Spyre)
+          if [[ -n '${{ inputs.pre_run }}' ]]; then
+            eval '${{ inputs.pre_run }}'
+          fi
+
+          echo "Running ${{ inputs.suite_name }} tests..."
+          echo "  Host Platform : ${_ARCH}"
+          echo "  Slow flag     : ${_SLOW_FLAG:-none (all tests will run)}"
+          echo "  Extra flags   : ${{ inputs.extra_test_flags }}"
+
+          # On the final attempt, enable verbose DT logging for diagnostics
+          _DTLOG_PREFIX=""
+          if [[ $attempt -eq $MAX_ATTEMPTS ]]; then
+            echo "  DTLOG_LEVEL   : Info (final attempt — verbose logging enabled)"
+            _DTLOG_PREFIX="DTLOG_LEVEL=Info"
+          fi
+
+          _JUNIT_FLAG=""
+          if [[ -n "${{ inputs.junit_xml_path }}" ]]; then
+            _JUNIT_FLAG="--junit-xml=${{ inputs.junit_xml_path }}"
+          fi
+
+          FIFO="$(mktemp -u /tmp/test_fifo_XXXXXX)"
+          mkfifo "$FIFO"
+
+          tee "$LOG_FILE" < "$FIFO" &
+          TEE_PID=$!
+
+          exec {FIFO_FD}>"$FIFO"
+
+          env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} \
+            >&"$FIFO_FD" 2>&1 &
+          TEST_PID=$!
+
+          exec {FIFO_FD}>&-
+
+          stall_watcher &
+          WATCHER_PID=$!
+
+          wait "$TEST_PID"
+          TEST_EXIT=$?
+
+          touch "${STALL_FLAG}.done"
+          kill "$WATCHER_PID" 2>/dev/null || true
+          wait "$WATCHER_PID" 2>/dev/null || true
+
+          kill "$TEE_PID" 2>/dev/null || true
+          wait "$TEE_PID" 2>/dev/null || true
+          rm -f "$FIFO"
+
+          if [[ $TEST_EXIT -eq 0 ]]; then
+            echo "=== Attempt ${attempt} PASSED ==="
+            echo "${{ inputs.suite_name }} tests done"
+            rm -f "$LOG_FILE" "$STALL_FLAG" "${STALL_FLAG}.done"
+            exit 0
+          fi
+
+          echo "=== Attempt ${attempt} FAILED (exit=${TEST_EXIT}) ==="
+          if grep -qE "ResponseTimeout|Exceeded max iterations|Fatal Python error: Aborted|LX logout" "$LOG_FILE"; then
+            echo "    --> Hardware RAS timeout detected — will retry"
+          else
+            echo "    --> Non-hardware failure — will retry (up to ${MAX_ATTEMPTS} total)"
+          fi
+
+          rm -f "$LOG_FILE" "$STALL_FLAG" "${STALL_FLAG}.done"
+          [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep 10
+        done
+
+        echo "=== All ${MAX_ATTEMPTS} attempts failed for ${{ inputs.suite_name }} ==="
+        exit 1

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -241,127 +241,11 @@ jobs:
 
       - name: Run ${{ matrix.suite.name }} tests
         id: run_tests
-        env:
-          MAX_ATTEMPTS: 3
-          STALL_TIMEOUT_SECS: 300   # 5 min with no new stdout --> kill as hung
-          STALL_CHECK_INTERVAL: 30  # check every 30s
-        run: |
-          set +e
-          set +o pipefail
-
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_TORCH_SPYRE_DIR"
-          source .venv/bin/activate
-
-          CONFIG="tests/configs/${{ matrix.suite.config }}"
-
-          _ARCH="$(uname -m)"
-          _SLOW_FLAG=""
-          if [[ "$_ARCH" != "x86_64" ]]; then
-            echo "Non-x86_64 platform (${_ARCH}): passing --skip-slow"
-            _SLOW_FLAG="--skip-slow"
-          fi
-
-          attempt=0
-          while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
-            attempt=$(( attempt + 1 ))
-            echo "=== Attempt ${attempt}/${MAX_ATTEMPTS}: ${{ matrix.suite.name }} ==="
-
-            LOG_FILE="$(mktemp /tmp/test_output_XXXXXX.log)"
-            STALL_FLAG="$(mktemp /tmp/stall_flag_XXXXXX.tmp)"
-
-            stall_watcher() {
-              local elapsed_stall=0
-              local prev_lines=0
-              while [[ ! -f "${STALL_FLAG}.done" ]]; do
-                sleep "$STALL_CHECK_INTERVAL"
-                current_lines=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
-                if [[ "$current_lines" -eq "$prev_lines" ]]; then
-                  elapsed_stall=$(( elapsed_stall + STALL_CHECK_INTERVAL ))
-                  echo "[stall-watcher] No new output for ${elapsed_stall}s (lines=${current_lines})"
-                  if [[ $elapsed_stall -ge $STALL_TIMEOUT_SECS ]]; then
-                    echo "[stall-watcher] STALL DETECTED — killing test child processes"
-                    # Kill only the direct child (run_test.sh and its children),
-                    # NOT the outer process group (which would kill the retry loop itself)
-                    kill -TERM "$TEST_PID" 2>/dev/null || true
-                    pkill -TERM -P "$TEST_PID" 2>/dev/null || true
-                    kill -TERM "$TEE_PID" 2>/dev/null || true
-                    return
-                  fi
-                else
-                  elapsed_stall=0
-                fi
-                prev_lines=$current_lines
-              done
-            }
-
-            echo "Running ${{ matrix.suite.name }} tests..."
-            echo "  Host Platform : ${_ARCH}"
-            echo "  Slow flag     : ${_SLOW_FLAG:-none (all tests will run)}"
-            echo "  Extra flags   : ${{ inputs.extra_test_flags }}"
-
-            # On the final attempt, enable verbose DT logging for diagnostics
-            _DTLOG_PREFIX=""
-            if [[ $attempt -eq $MAX_ATTEMPTS ]]; then
-              echo "  DTLOG_LEVEL   : Info (final attempt --> DTLOG_LEVEL logging enabled)"
-              _DTLOG_PREFIX="DTLOG_LEVEL=Info"
-            fi
-
-            FIFO="$(mktemp -u /tmp/test_fifo_XXXXXX)"
-            mkfifo "$FIFO"
-
-            # Start tee reading first — it blocks until a writer opens the FIFO
-            tee "$LOG_FILE" < "$FIFO" &
-            TEE_PID=$!
-
-            # Now open the write end — guaranteed to have a reader already waiting
-            exec {FIFO_FD}>"$FIFO"
-
-            env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} \
-              >&"$FIFO_FD" 2>&1 &
-            TEST_PID=$!
-
-            # Close outer shell's write end — tee will now get EOF when test exits
-            exec {FIFO_FD}>&-
-
-            stall_watcher &
-            WATCHER_PID=$!
-
-            wait "$TEST_PID"
-            TEST_EXIT=$?
-
-            # Signal watcher first, before anything that might block
-            touch "${STALL_FLAG}.done"
-            kill "$WATCHER_PID" 2>/dev/null || true
-            wait "$WATCHER_PID" 2>/dev/null || true
-
-            # Reap tee — it exits on its own once run_test.sh closes the FIFO write end,
-            # but kill it first in case it's still running (e.g. after a stall-kill)
-            kill "$TEE_PID" 2>/dev/null || true
-            wait "$TEE_PID" 2>/dev/null || true
-            rm -f "$FIFO"
-
-            if [[ $TEST_EXIT -eq 0 ]]; then
-              echo "=== Attempt ${attempt} PASSED ==="
-              echo "${{ matrix.suite.name }} tests done"
-              rm -f "$LOG_FILE" "$STALL_FLAG" "${STALL_FLAG}.done"
-              exit 0
-            fi
-
-            echo "=== Attempt ${attempt} FAILED (exit=${TEST_EXIT}) ==="
-            if grep -qE "ResponseTimeout|Exceeded max iterations|Fatal Python error: Aborted|LX logout" "$LOG_FILE"; then
-              echo "    --> Hardware RAS timeout detected — will retry"
-            else
-              echo "    --> Non-hardware failure — will retry (up to ${MAX_ATTEMPTS} total)"
-            fi
-
-            rm -f "$LOG_FILE" "$STALL_FLAG" "${STALL_FLAG}.done"
-            [[ $attempt -lt $MAX_ATTEMPTS ]] && sleep 10
-          done
-
-          echo "=== All ${MAX_ATTEMPTS} attempts failed for ${{ matrix.suite.name }} ==="
-          exit 1
+        uses: ./.github/actions/run-test-suite
+        with:
+          suite_name: ${{ matrix.suite.name }}
+          config: tests/configs/${{ matrix.suite.config }}
+          extra_test_flags: ${{ inputs.extra_test_flags }}
 
   # ---------------------------------------------------------------------------
   # Job 2: Multi-Spyre test matrix
@@ -433,31 +317,16 @@ jobs:
         uses: ./.github/actions/build-torch-spyre
 
       - name: Run ${{ matrix.suite.name }} tests
-        run: |-
-          source "$HOME/.bashrc"
+        uses: ./.github/actions/run-test-suite
+        with:
+          suite_name: ${{ matrix.suite.name }}
+          config: tests/configs/${{ matrix.suite.config }}
+          extra_test_flags: ${{ inputs.extra_test_flags }}
+          pre_run: |
+            # Multi-Spyre tests require a fresh topology probe: clear the
+            # cached AIU setup guard and the stale topo.json so
+            # ibm-aiu-setup.sh re-discovers all attached cards.
 
-          # Multi-Spyre tests require a fresh topology probe: clear the
-          # cached AIU setup guard and the stale topo.json so
-          # ibm-aiu-setup.sh re-discovers all attached cards.
-          unset _IBM_AIU_SETUP
-          rm -rf /tmp/etc/ibm/spyre/topo.json
-          source /etc/profile.d/ibm-aiu-setup.sh
-
-          cd "$CLONED_TORCH_SPYRE_DIR"
-          source .venv/bin/activate
-
-          CONFIG="${{ matrix.suite.config }}"
-
-          _ARCH="$(uname -m)"
-          _SLOW_FLAG=""
-          if [[ "$_ARCH" != "x86_64" ]]; then
-            echo "Non-x86_64 platform (${_ARCH}): passing --skip-slow"
-            _SLOW_FLAG="--skip-slow"
-          fi
-
-          echo "Running ${{ matrix.suite.name }} tests..."
-          echo "  Host Platform : ${_ARCH}"
-          echo "  Slow flag     : ${_SLOW_FLAG:-none (all tests will run)}"
-          echo "  Extra flags   : ${{ inputs.extra_test_flags }}"
-          bash tests/run_test.sh "tests/configs/${CONFIG}" ${{ inputs.extra_test_flags }} ${_SLOW_FLAG}
-          echo "${{ matrix.suite.name }} tests done"
+            unset _IBM_AIU_SETUP
+            rm -rf /tmp/etc/ibm/spyre/topo.json
+            source /etc/profile.d/ibm-aiu-setup.sh

--- a/.github/workflows/model_modules_tests.yaml
+++ b/.github/workflows/model_modules_tests.yaml
@@ -49,7 +49,6 @@ jobs:
       # The new torch-spyre image already contains a pre-cloned pytorch
       # repo at /home/senuser/pytorch which TORCH_ROOT must point at.
       TORCH_ROOT: /home/senuser/pytorch
-
     # ---------------------------------------------------------------------------
     # To add a new module test suite, append an entry here:
     #   - name: <human-readable label shown in the GHA UI>
@@ -86,30 +85,21 @@ jobs:
 
       - uses: ./.github/actions/build-torch-spyre
 
-      - name: Run ${{ matrix.suite.name }} module test suite
+      - name: Derive report paths
         run: |
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_TORCH_SPYRE_DIR"
-          source .venv/bin/activate
-
-          # Derive the XML report name from the config filename
-          # Example:
-          #   granite_3_3_8b_instruct_spyre.yaml  ->  granite_3_3_8b_instruct_spyre.xml
-          CONFIG="${{ matrix.suite.config }}"
-          REPORT_NAME="${CONFIG%.yaml}.xml"
-          REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
-
-          # Expose report path/name to subsequent steps via GITHUB_ENV
-          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
+          REPORT_NAME="${{ matrix.suite.config }}"; REPORT_NAME="${REPORT_NAME%.yaml}.xml"
           echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+          echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
 
-          echo "Running ${{ matrix.suite.name }} module tests..."
-          bash tests/run_test.sh "tests/configs/module_tests/${CONFIG}" -v --junit-xml="${REPORT_PATH}"
-          echo "${{ matrix.suite.name }} module tests done"
-
-
-
+      - name: Run ${{ matrix.suite.name }} module test suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          suite_name: ${{ matrix.suite.name }}
+          config: tests/configs/module_tests/${{ matrix.suite.config }}
+          extra_test_flags: -v
+          work_dir: ${{ env.CLONED_TORCH_SPYRE_DIR }}
+          junit_xml_path: ${{ env.REPORT_PATH }}
+          report_name: ${{ env.REPORT_NAME }}
       # ---------------------------------------------------------------------------
       # Upload the JUnit XML as a GHA artifact so it can be downloaded and
       # ingested by the Spyre dashboard.

--- a/.github/workflows/model_ops_tests.yaml
+++ b/.github/workflows/model_ops_tests.yaml
@@ -9,8 +9,8 @@ on:
       - docs/**
       - README.md
   # Removing from CICD till the ops tests get matured
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
   # merge_group:
   #   types: [checks_requested]
 
@@ -109,28 +109,21 @@ jobs:
 
       - uses: ./.github/actions/build-torch-spyre
 
-      - name: Run ${{ matrix.suite.name }} model ops test suite
+      - name: Derive report paths
         run: |
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_TORCH_SPYRE_DIR"
-          source .venv/bin/activate
-
-          # Derive the XML report name from the config filename
-          # Example:
-          #   granite_3.3_8b_instruct_spyre.yaml  ->  granite_3.3_8b_instruct_spyre.xml
-          CONFIG="${{ matrix.suite.config }}"
-          REPORT_NAME="${CONFIG%.yaml}.xml"
-          REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
-
-          # Expose report path/name to subsequent steps via GITHUB_ENV
-          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
+          REPORT_NAME="${{ matrix.suite.config }}"; REPORT_NAME="${REPORT_NAME%.yaml}.xml"
           echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+          echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
 
-          echo "Running ${{ matrix.suite.name }} model ops tests..."
-          bash tests/run_test.sh "tests/configs/model_ops_tests/${CONFIG}" -v --junit-xml="${REPORT_PATH}"
-          echo "${{ matrix.suite.name }} model ops tests done"
-
+      - name: Run ${{ matrix.suite.name }} model ops test suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          suite_name: ${{ matrix.suite.name }}
+          config: tests/configs/model_ops_tests/${{ matrix.suite.config }}
+          extra_test_flags: -v
+          work_dir: ${{ env.CLONED_TORCH_SPYRE_DIR }}
+          junit_xml_path: ${{ env.REPORT_PATH }}
+          report_name: ${{ env.REPORT_NAME }}
 
       # ---------------------------------------------------------------------------
       # Upload the JUnit XML as a GHA artifact so it can be downloaded and

--- a/.github/workflows/model_ops_tests.yaml
+++ b/.github/workflows/model_ops_tests.yaml
@@ -9,8 +9,8 @@ on:
       - docs/**
       - README.md
   # Removing from CICD till the ops tests get matured
-  pull_request:
-    branches: [main]
+  # pull_request:
+  #   branches: [main]
   # merge_group:
   #   types: [checks_requested]
 

--- a/.github/workflows/runtests_nightly.yaml
+++ b/.github/workflows/runtests_nightly.yaml
@@ -1,8 +1,10 @@
 name: tests-nightly
 
 on:
-  schedule:
-    - cron: 0 2 * * *
+  # schedule:
+  #   - cron: 0 2 * * *
+  pull_request:
+    branches: [main]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/runtests_nightly.yaml
+++ b/.github/workflows/runtests_nightly.yaml
@@ -1,10 +1,8 @@
 name: tests-nightly
 
 on:
-  # schedule:
-  #   - cron: 0 2 * * *
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: 0 2 * * *
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -88,29 +88,20 @@ jobs:
 
       - uses: ./.github/actions/build-torch-spyre
 
-      - name: Run ${{ matrix.suite.name }} upstream test suite
+      - name: Derive report paths
         run: |
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_TORCH_SPYRE_DIR"
-          source .venv/bin/activate
-
-          # Derive the XML report name from the config filename
-          # Example:
-          #   test_view_ops_config.yaml    ->  test_view_ops_config.xml
-          #   test_profiler_config.yaml ->  test_profiler_config.xml
-          CONFIG="${{ matrix.suite.config }}"
-          REPORT_NAME="${CONFIG%.yaml}.xml"
-          REPORT_PATH="${GITHUB_WORKSPACE}/${REPORT_NAME}"
-
-          # Expose report path/name to subsequent steps via GITHUB_ENV
-          echo "REPORT_PATH=${REPORT_PATH}" >> "$GITHUB_ENV"
+          REPORT_NAME="${{ matrix.suite.config }}"; REPORT_NAME="${REPORT_NAME%.yaml}.xml"
           echo "REPORT_NAME=${REPORT_NAME}" >> "$GITHUB_ENV"
+          echo "REPORT_PATH=${GITHUB_WORKSPACE}/${REPORT_NAME}" >> "$GITHUB_ENV"
 
-          echo "Running ${{ matrix.suite.name }} upstream tests..."
-          bash tests/run_test.sh "tests/configs/upstream_tests/${CONFIG}" --capture=sys -v --junit-xml="${REPORT_PATH}"
-          echo "${{ matrix.suite.name }} upstream tests done"
-
+      - name: Run ${{ matrix.suite.name }} tests
+        uses: ./.github/actions/run-test-suite
+        with:
+          suite_name: ${{ matrix.suite.name }}
+          config: tests/configs/upstream_tests/${{ matrix.suite.config }}
+          extra_test_flags: -v
+          junit_xml_path: ${{ env.REPORT_PATH }}
+          report_name: ${{ env.REPORT_NAME }}
 
       # ---------------------------------------------------------------------------
       # Upload the JUnit XML as a GHA artifact so it can be downloaded and


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR extracts the retry loop, stall watchdog, and DTLOG_LEVEL=Info final-attempt logic from `_test_matrix.yaml` into a new reusable composite action at `.github/actions/run-test-suite/action.yml`

All workflows that previously called bash tests/run_test.sh directly (_test_matrix.yaml, upstream_tests.yml, model-module-tests.yml, model-ops-tests.yml) now delegate to this action, eliminating duplicated logic without modifying `run_test.sh` or the `Makefile`.

### All workflows were tested after the refactoring (nightly, model ops, upstream, torch-spyre, module tests) and all checks passed after the refactor (This is only for verification -- will move the nightly and model ops from pull request runs now)

<img width="1792" height="842" alt="image" src="https://github.com/user-attachments/assets/acfff9d8-2052-4e99-81d9-8cc72765d990" /> <br><br>

<img width="1722" height="620" alt="image" src="https://github.com/user-attachments/assets/348e302e-1179-45a5-9866-68fb5d895260" /> <br><br>


<img width="1738" height="198" alt="image" src="https://github.com/user-attachments/assets/a142a532-bee2-42cb-87e5-23c53873ad7b" /> <br><br>

<img width="1728" height="108" alt="image" src="https://github.com/user-attachments/assets/3781b1eb-978b-4c1c-8737-9ca98a1cbbb5" /> <br><br>

