### PR TITLE
Support unaligned stick-dimension slices in mutation buffers

### DIFF
--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -2980,6 +2980,9 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "add1": lambda _, x: torch.add(x.clone(), x),
                 "add2": lambda _, x: torch.add(x, x),
                 "to_dtype": lambda _, x: x.to(dtype=torch.bool),
+                "double_read": lambda _, x: (
+                    (x + 1) + torch.amax(x, dim=-1, keepdim=True)
+                ),
             },
             "param_sets": {
                 "2d64": (1, 32, 96, cached_randn((128, 256))),
@@ -3036,6 +3039,105 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "3d128_0": (2, 32, 160, cached_randn((128, 3, 256))),
                 "3d128_1": (2, 32, 160, cached_randn((2, 192, 256))),
                 "3d128_01": (2, 32, 160, cached_randn((128, 192, 256))),
+            },
+        },
+        ("test_slice_stick_mutation", "test_slice_cpu"): {
+            "ops_dict": {
+                "input": lambda _, x, y: x.copy_(y)._base,
+                "square": lambda _, x, y: x.copy_(y.square())._base,
+                "ones": lambda _, x, _y: x.copy_(torch.ones_like(x))._base,
+                "arange": lambda _, x, _y: (
+                    x.copy_(
+                        torch.arange(
+                            x.shape[-1], dtype=x.dtype, device=x.device
+                        ).repeat(*x.shape[:-1], 1)
+                    )._base
+                ),
+                "double_read": lambda _, x, y: (
+                    z := x.copy_(y)._base,
+                    (z + 1) + torch.amax(z, dim=-1, keepdim=True),
+                )[-1],
+            },
+            "param_sets": {
+                "2d64": (1, 32, 96, cached_randn((128, 256)), cached_randn((128, 64))),
+                "2d128": (
+                    1,
+                    1,
+                    129,
+                    cached_randn((128, 256)),
+                    cached_randn((128, 128)),
+                ),
+                "3d64_0": (
+                    2,
+                    32,
+                    96,
+                    cached_randn((128, 3, 256)),
+                    cached_randn((128, 3, 64)),
+                ),
+                "3d64_1": (
+                    2,
+                    32,
+                    96,
+                    cached_randn((2, 192, 256)),
+                    cached_randn((2, 192, 64)),
+                ),
+                "3d64_01": (
+                    2,
+                    32,
+                    96,
+                    cached_randn((128, 192, 256)),
+                    cached_randn((128, 192, 64)),
+                ),
+                "3d128_0": (
+                    2,
+                    1,
+                    129,
+                    cached_randn((128, 3, 256)),
+                    cached_randn((128, 3, 128)),
+                ),
+                "3d128_1": (
+                    2,
+                    1,
+                    129,
+                    cached_randn((2, 192, 256)),
+                    cached_randn((2, 192, 128)),
+                ),
+                "3d128_01": (
+                    2,
+                    1,
+                    129,
+                    cached_randn((128, 192, 256)),
+                    cached_randn((128, 192, 128)),
+                ),
+            },
+        },
+        (
+            "test_slice_stick_mutation_layout_update",
+            "test_slice_stick_mutation_layout_update_cpu",
+        ): {
+            "param_sets": {
+                "2d64": (1, 32, 96, cached_randn((128, 256)), cached_randn((128, 64))),
+                "2d128": (
+                    1,
+                    1,
+                    129,
+                    cached_randn((128, 256)),
+                    cached_randn((128, 128)),
+                ),
+                "3d64_2": (
+                    2,
+                    32,
+                    96,
+                    cached_randn((128, 192, 256)),
+                    cached_randn((128, 192, 64)),
+                ),
+                "3d128_2": (
+                    2,
+                    1,
+                    129,
+                    cached_randn((128, 192, 256)),
+                    cached_randn((128, 192, 128)),
+                ),
             },
         },
         ("test_slice_synthetic_dims", "test_slice_synthetic_dims_cpu"): {
@@ -5726,16 +5828,69 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         self.compare_with_cpu(fn, x, clone_inputs=True, run_eager=False)
 
-    def test_slice_cpu(self, op, dim, start, end, x):
-        def fn(x):
+    @pytest.mark.filterwarnings(
+        "ignore:aten.arange.*:torch_spyre.ops.fallbacks.FallbackWarning"
+    )
+    def test_slice_cpu(self, op, dim, start, end, x, *args):
+        def fn(x, *args):
             if dim == 0:
-                return op(dim, x[start:end])
+                return op(dim, x[start:end], *args)
             elif dim == 1:
-                return op(dim, x[:, start:end])
+                return op(dim, x[:, start:end], *args)
             elif dim == 2:
-                return op(dim, x[:, :, start:end])
+                return op(dim, x[:, :, start:end], *args)
 
-        self.compare_with_cpu(fn, x, clone_inputs=True, run_eager=False)
+        self.compare_with_cpu(fn, x, *args, clone_inputs=True, run_eager=False)
+
+    def test_slice_stick_mutation_layout_update_cpu(self, dim, start, end, x, y):
+        """Test that device_tensor_layout() updates to alt STL after slice-mutation."""
+
+        def fn(x, y):
+            if dim == 1:
+                z = x[:, start:end].copy_(y)
+            elif dim == 2:
+                z = x[:, :, start:end].copy_(y)
+            return y + z
+
+        x_spyre = x.clone().to("spyre")
+        y_spyre = y.clone().to("spyre")
+        pre = x_spyre.device_tensor_layout()
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=False)
+        compiled(x_spyre, y_spyre)
+
+        post = x_spyre.device_tensor_layout()
+        self.assertNotEqual(
+            (list(pre.device_size), list(pre.stride_map)),
+            (list(post.device_size), list(post.stride_map)),
+            msg=(
+                "device_tensor_layout was not updated after slice mutation; "
+                "set_spyre_tensor_layout did not run. "
+                f"pre={pre}, post={post}"
+            ),
+        )
+
+        expected = x.clone()
+        if dim == 1:
+            expected[:, start:end].copy_(y)
+        elif dim == 2:
+            expected[:, :, start:end].copy_(y)
+        torch.testing.assert_close(x_spyre.cpu(), expected, atol=0.1, rtol=0.1)
+
+    def test_slice_stick_mutation_no_alt_dim_raises(self):
+        """Test that offset-stick slice mutation raises Unsupported when no alt dim is divisible by stick_size."""
+
+        def fn(x, y):
+            x[:, 32:96].copy_(y)
+            return x.clone()
+
+        x = torch.randn(63, 128, dtype=torch.float16, device="spyre")
+        y = torch.randn(63, 64, dtype=torch.float16, device="spyre")
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=False)
+        with pytest.raises(Exception) as exc_info:
+            compiled(x, y)
+        assert "no offset-free alternative stick dim" in str(exc_info.value)
 
     def test_slice_synthetic_dims_cpu(self, x):
         def fn(x):

--- a/torch_spyre/_inductor/insert_restickify.py
+++ b/torch_spyre/_inductor/insert_restickify.py
@@ -20,6 +20,7 @@ import torch
 from .constants import ELIDED_COPY_BACK_ATTR
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
+from .loop_info import copy_op_metadata
 from .pass_utils import copy_fx_custom_meta
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import (
@@ -28,6 +29,7 @@ from torch._inductor.ir import (
     InputBuffer,
     MutationLayoutSHOULDREMOVE,
     Operation,
+    ReinterpretView,
     StorageBox,
     TensorBox,
 )
@@ -194,6 +196,7 @@ def insert_restickify_on_node_inputs(
     )
     new_consumer_buffer.operation_name = op.operation_name
     new_consumer_buffer.origins = op.origins
+    copy_op_metadata(op, new_consumer_buffer)
     # Replace op in the operations list with the reconstructed buffer.
     operations[op_index] = new_consumer_buffer
     V.graph.name_to_buffer[new_consumer_buffer.get_name()] = new_consumer_buffer
@@ -326,3 +329,121 @@ def finalize_layouts(graph: GraphLowering) -> None:
             logger.debug("\n".join(lines))
         else:
             logger.debug("restickify plan: (none)")
+
+
+def insert_post_mutation_restickify(graph: GraphLowering) -> None:
+    """
+    Insert pre/post ops around a slice mutation when the original layout cannot
+    express the required stick offset.
+
+    In that case, propagate_layouts picks an alternate layout and stores
+    op._restickify_plan = (target_name, orig_stl, alt_stl). Because the
+    restickify op cannot write its output in place, the mutation writes into a
+    temporary buffer buf_tmp in alt_stl layout. This pass inserts:
+
+      1. restickify op: arg0_1 (orig_stl) -> buf_tmp        (alt_stl)
+      2. mutation op:   buf               -> buf_tmp[slice] (alt_stl)
+      3. copy-back op:  buf_tmp (alt_stl) -> arg0_1         (alt_stl)
+      4. set_spyre_tensor_layout(arg0_1, alt_stl)
+
+    Both (1) and (3) are inserted as restickify IR nodes via
+    _create_restickify_node. In (3), the input and output STLs are both alt_stl,
+    so in the later codegen pass it reduces to an identity copy. Its layout is set
+    to MutationLayoutSHOULDREMOVE(arg0_1), which makes the scheduler write the
+    result back to arg0_1's original memory address.
+
+    Both the mutation op and the copy-back use MutationLayoutSHOULDREMOVE to
+    declare their write targets and reuse Inductor's existing mutation handling.
+
+    The restickify op also records an input-layout override on
+    buf_tmp._input_layout_overrides so work division and codegen both read
+    arg0_1 using orig_stl for that op.
+
+    arg0_1 is returned unchanged so DCI still reads from the same memory address.
+    """
+    operations = graph.operations
+    tagged_ops = [op for op in operations if hasattr(op, "_restickify_plan")]
+    if not tagged_ops:
+        return
+
+    for mutation_op in tagged_ops:
+        target_name, orig_stl, alt_stl = mutation_op._restickify_plan
+        del mutation_op._restickify_plan
+        assert isinstance(mutation_op, ComputedBuffer)
+
+        graph_input = graph.graph_inputs.get(target_name)
+        assert graph_input is not None
+
+        # Create fresh layouts here, since reusing base_layout would overwrite
+        # arg0_1's address during memory_planning.
+        target_input_buf = graph_input.data.data
+        base_layout = target_input_buf.layout  # FixedTiledLayout(alt_stl)
+        buf_tmp_layout = _fixed_tiled(base_layout, alt_stl)
+        buf_copyback_layout = _fixed_tiled(base_layout, alt_stl)
+
+        # Step 1: create restickify node: arg0_1 (orig_stl) -> buf_tmp (alt_stl)
+        # This op must read arg0_1 as orig_stl, so record that override on buf_tmp.
+        orig_stl_layout = _fixed_tiled(base_layout, orig_stl)
+        _, buf_tmp = _create_restickify_node(
+            {"arg_name": target_name, "target_layout": buf_tmp_layout},
+            mutation_op,
+        )
+        buf_tmp_name = buf_tmp.get_name()
+        buf_tmp._input_layout_overrides = {target_name: orig_stl_layout}
+
+        # Step 2: retarget the mutation to buf_tmp while preserving the original slice offset.
+        # A plain MutationLayoutSHOULDREMOVE(buf_tmp) would lose the offset; wrapping buf_tmp
+        # in a ReinterpretView with the original slice layout keeps the offset and routes the
+        # bytes into buf_tmp's allocation. This keeps the mutation on the standard mutation
+        # path, where MutationLayoutSHOULDREMOVE buffers are not allocated by the wrapper.
+        mutation_name = mutation_op.get_name()
+        original_layout = mutation_op.layout
+        assert isinstance(original_layout, MutationLayoutSHOULDREMOVE)
+        slice_layout = original_layout.target.get_layout()
+        # We only reach this pass because the write stick had a non-zero offset,
+        # so the slice layout must carry it.
+        assert slice_layout.offset != 0, (
+            f"slice offset lost while retargeting mutation {mutation_name} "
+            f"(target={type(original_layout.target).__name__}, "
+            f"layout offset={slice_layout.offset!r}); the original slice offset "
+            f"is not carried by the mutation target layout"
+        )
+        slice_view_of_buf_tmp = ReinterpretView(
+            data=StorageBox(buf_tmp), layout=slice_layout
+        )
+        mutation_op.layout = MutationLayoutSHOULDREMOVE(slice_view_of_buf_tmp)
+
+        # Step 3: create the copy-back node: buf_tmp (alt_stl) -> buf_copyback (alt_stl).
+        # Since the input and output STLs are the same, this reduces to an identity copy
+        # in the later codegen pass. MutationLayoutSHOULDREMOVE(arg0_1) makes this write
+        # back to arg0_1's original storage and keeps the copy-back path live.
+        _, buf_copyback = _create_restickify_node(
+            {"arg_name": buf_tmp_name, "target_layout": buf_copyback_layout},
+            mutation_op,
+        )
+        buf_copyback.layout = MutationLayoutSHOULDREMOVE(graph_input)
+
+        # Anchor the set_spyre_tensor_layout emit on the mutation op, which
+        # cannot be elided. The chain fuses into one kernel, so the emit fires
+        # after the copy-back write-back.
+        mutation_op._emit_set_layout = (target_name, alt_stl)
+
+        # Insert buf_tmp before mutation, copy-back after mutation.
+        # _create_restickify_node -> realize() appends buf_tmp/buf_copyback at
+        # the end of operations, so they sit after mutation_op; removing them
+        # first keeps the index arithmetic below correct.
+        mutation_op_index = operations.index(mutation_op)
+        operations.remove(buf_tmp)
+        operations.insert(mutation_op_index, buf_tmp)
+        # mutation_op is now at mutation_op_index + 1; insert copy-back after it.
+        operations.remove(buf_copyback)
+        operations.insert(mutation_op_index + 2, buf_copyback)
+
+        logger.info(
+            "insert_post_mutation_restickify: %s (orig->alt) before %s; copy-back %s->%s after %s",
+            target_name,
+            mutation_name,
+            buf_tmp_name,
+            target_name,
+            mutation_name,
+        )

--- a/torch_spyre/_inductor/loop_info.py
+++ b/torch_spyre/_inductor/loop_info.py
@@ -66,6 +66,9 @@ _SPYRE_METADATA_ATTRS = (
     "dim_hints",
     "work_div_loop_info",
     "loop_info",
+    "_restickify_plan",
+    "_input_layout_overrides",
+    "_emit_set_layout",
 )
 
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -59,7 +59,11 @@ from .propagate_layouts import (
     propagate_spyre_tensor_layouts,
 )
 from .optimize_restickify import optimize_restickify_locations
-from .insert_restickify import insert_restickify, finalize_layouts
+from .insert_restickify import (
+    finalize_layouts,
+    insert_post_mutation_restickify,
+    insert_restickify,
+)
 from .memory_planning import memory_planning
 from .work_division import (
     span_reduction,
@@ -338,6 +342,7 @@ class CustomPreSchedulingPasses:
             optimize_restickify_locations,
             finalize_layouts,
             insert_restickify,
+            insert_post_mutation_restickify,
             insert_bmm_padding,
             #
             dedup_and_promote_constants,

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -172,13 +172,19 @@ def _candidate_output_stls(
     c_size: list,
     c_stride: list,
     stick_size: int,
+    skip_stick_expr: sympy.Expr,
 ) -> list[SpyreTensorLayout]:
-    """Enumerate candidate output STLs by trying each non-last dim as the stick.
+    """Enumerate candidate output STLs by trying each dim as the stick.
 
-    Skips any candidate whose resulting device stick expression has an offset.
+    Skip the dim that already produces an unsupported stick.
     """
+    out_coords = host_coordinates(output, output_dep, None)
+    skip_dim = _pick_stick_dim(skip_stick_expr, out_coords)
+
     result = []
-    for alt_stick_dim in range(len(output.size) - 1):
+    for alt_stick_dim in range(len(output.size)):
+        if alt_stick_dim == skip_dim:
+            continue
         if concretize_expr(output.size[alt_stick_dim]) % stick_size != 0:
             # TODO: Support dimensions with size not divisible by stick_size via padding (See #1756)
             continue
@@ -354,7 +360,9 @@ def _single_arg_op_layout(
     )
     if out_stl is not None:
         return [out_stl]
-    return _candidate_output_stls(output, output_dep, c_size, c_stride, stick_size)
+    return _candidate_output_stls(
+        output, output_dep, c_size, c_stride, stick_size, stick_expr
+    )
 
 
 def _clone_layout(
@@ -409,7 +417,7 @@ def _clone_layout(
     in_host_coords = host_coordinates(in_layout, in_dep, None)
     required_in_stl = None
     for candidate in _candidate_output_stls(
-        output, output_dep, c_size, c_stride, stick_size
+        output, output_dep, c_size, c_stride, stick_size, stick_expr
     ):
         target_stick = device_coordinates(candidate, output_dep, None)[-1]
         target_stl = compute_restickify_target_layout(
@@ -897,6 +905,34 @@ def _target_device_layout(target, name: str):
     return next(iter(layouts))
 
 
+def _find_alt_target_stl(
+    target_layout: FixedLayout,
+    target_stl: SpyreTensorLayout,
+    output_dep: MemoryDep,
+) -> SpyreTensorLayout | None:
+    """
+    Find an alternative SpyreTensorLayout with an offset-free stick expression
+    for a mutation target. Returns None if the current layout is already valid,
+    or raises Unsupported if no valid alternative exists.
+    """
+    stick_size = get_elem_in_stick(target_layout.dtype)
+    write_stick = device_coordinates(target_stl, output_dep, None)[-1]
+    if is_stick_expr_offset_free(write_stick, stick_size):
+        return None
+
+    c_size = [concretize_expr(s) for s in target_layout.size]
+    c_stride = [concretize_expr(s) for s in target_layout.stride]
+    candidates = _candidate_output_stls(
+        target_layout, output_dep, c_size, c_stride, stick_size, write_stick
+    )
+    if not candidates:
+        raise Unsupported(
+            f"no offset-free alternative stick dim for mutation target "
+            f"(write stick {write_stick!r}, size={target_layout.size})"
+        )
+    return candidates[0]
+
+
 def _resolve_copy_back_candidates(operations: list[Operation]) -> None:
     """Commit safe lowering-marked copy-back candidates.
 
@@ -1017,6 +1053,10 @@ def propagate_spyre_tensor_layouts(
                     raise Unsupported(f"graph input {name} does not have a FixedLayout")
                 tb.layouts = [stl]
 
+    # Alt layout each graph input has been forced to by a mutation write, so a
+    # second write can detect a conflicting alt.
+    forced_mutation_alts: dict[str, SpyreTensorLayout] = {}
+
     # Operations are in topological order (guaranteed by GraphLowering).
     # Visit them and use the input SpyreTensorLayouts and the operation being
     # performed to compute the set of possible output SpyreTensorLayouts.
@@ -1029,15 +1069,41 @@ def propagate_spyre_tensor_layouts(
                 target = op.layout.target
                 while isinstance(target, ReinterpretView):
                     target = target.data
-                target_stl = _target_device_layout(
-                    target,
-                    target.get_name() if hasattr(target, "get_name") else "",
-                )
+                target_name = target.get_name() if hasattr(target, "get_name") else ""
+                target_stl = _target_device_layout(target, target_name)
                 if target_stl is None:
                     continue
                 rw = op.get_read_writes()
                 output_dep = next(iter(rw.writes))
                 args = _get_prop_args(rw.reads)
+
+                # Find an alternative layout if the write has an unsupported stick
+                # expression (e.g. offset like v+32). Force the optimizer to use
+                # this layout for the mutation target.
+                target_layout = target.get_layout()
+                if isinstance(target_layout, FixedLayout):
+                    alt_stl = _find_alt_target_stl(
+                        target_layout, target_stl, output_dep
+                    )
+                    if alt_stl is not None:
+                        graph_input = V.graph.graph_inputs.get(target_name)
+                        assert graph_input is not None
+                        # A graph input holds only one device layout, so two
+                        # writes needing different alts cannot both be expressed.
+                        # TODO: support this by chaining relayouts between writes
+                        # through temp buffers.
+                        prior_alt = forced_mutation_alts.get(target_name)
+                        if prior_alt is not None and prior_alt != alt_stl:
+                            raise Unsupported(
+                                f"multiple mutations to graph input {target_name} "
+                                f"require conflicting alternative layouts "
+                                f"({prior_alt!r} vs {alt_stl!r}); chaining "
+                                f"relayouts between writes is not yet supported"
+                            )
+                        forced_mutation_alts[target_name] = alt_stl
+                        graph_input.layouts = [alt_stl]
+                        op._restickify_plan = (target_name, target_stl, alt_stl)
+                        target_stl = alt_stl
                 op.layouts = [target_stl]
                 op.restick_cost_fn = AllSameNode.from_args(
                     args, [target_stl], output_dep, op

--- a/torch_spyre/_inductor/scheduler.py
+++ b/torch_spyre/_inductor/scheduler.py
@@ -271,6 +271,28 @@ class SuperDSCScheduling(BaseScheduling):
                 raise RuntimeError(f"Unexpected node type: {type(node)}")
         return node_schedule
 
+    def _collect_layout_restores(self, node_schedule) -> list:
+        """Select the layout restores to emit after a kernel call.
+
+        Walks the kernel's nodes for _emit_set_layout tags set by
+        insert_post_mutation_restickify and dedups them against the ones already
+        emitted by earlier kernels, so each target restores once across the whole
+        graph. Selection is the scheduler's job (it owns the node list and the
+        cross-kernel dedup state); the kernel just emits the returned list.
+        """
+        # Dedup is graph-scoped: a target's device layout must be restored
+        # exactly once across the whole generated program, not once per kernel.
+        # The state lives on V.graph (one GraphLowering per compilation), so it
+        # starts empty for each graph without any explicit reset.
+        emitted = V.graph.__dict__.setdefault("_emitted_layout_targets", set())
+        restores = []
+        for snode in node_schedule:
+            emit = getattr(getattr(snode, "node", None), "_emit_set_layout", None)
+            if emit is not None and emit[0] not in emitted:
+                emitted.add(emit[0])
+                restores.append(emit)
+        return restores
+
     def codegen_node(
         self, node: Union[FusedSchedulerNode, SchedulerNode, CountedLoopSchedulerNode]
     ) -> None:
@@ -314,6 +336,7 @@ class SuperDSCScheduling(BaseScheduling):
 
         self.codegen_comment(node_schedule, kernel_name)
         kernel.call_kernel(kernel.kernel_name)
+        kernel.emit_layout_restores(self._collect_layout_restores(node_schedule))
 
         V.graph.removed_buffers |= kernel.removed_buffers
         V.graph.inplaced_to_remove |= kernel.inplaced_to_remove
@@ -369,6 +392,7 @@ class SuperDSCScheduling(BaseScheduling):
 
         self.codegen_comment(all_schedule_nodes, kernel_name)
         kernel.call_kernel(kernel.kernel_name)
+        kernel.emit_layout_restores(self._collect_layout_restores(all_schedule_nodes))
 
         V.graph.removed_buffers |= kernel.removed_buffers
         V.graph.inplaced_to_remove |= kernel.inplaced_to_remove

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -495,6 +495,14 @@ class SpyreKernel(Kernel[CSEVariable]):
         # can correctly isolate each loop variable's contribution.
 
         index = concretize_index(tensor.index, set(it_space.keys()))
+
+        # insert_post_mutation_restickify may override the input layout for this input tensor.
+        # Restore it here because the tensor data was uploaded as orig_stl.
+        if is_input:
+            overrides = getattr(self.current_node.node, "_input_layout_overrides", {})
+            if (layout := overrides.get(name)) is not None:
+                tensor.layout = layout
+
         device_coords = compute_coordinates(
             tensor.layout.device_layout.device_size,
             tensor.layout.device_layout.stride_map,
@@ -705,21 +713,25 @@ class SpyreKernel(Kernel[CSEVariable]):
         value: RValue,
         mode: StoreMode = None,
     ) -> None:
-        buf = V.graph.get_buffer(name)
+        # mutation_real_name maps mutation aliases to their real destination buffer. Resolve that here,
+        # and mark the buf name as removed so the wrapper does not allocate it separately.
+        real_dst_name = V.graph.scheduler.mutation_real_name.get(name, name)
+        if real_dst_name != name:
+            V.graph.removed_buffers.add(name)
+        buf = V.graph.get_buffer(real_dst_name)
         layout = buf.get_layout()
         if not isinstance(layout, FixedTiledLayout):
-            raise Unsupported(f"{name} does not have FixedTiledLayout")
+            raise Unsupported(f"{real_dst_name} does not have FixedTiledLayout")
         # Pool buffers are intermediates whose address is baked into the TensorArg
         # allocation dict; registering them as outputs would overflow SEGMENT_OFFSETS.
         # (lx buffers are already excluded from spyre_kernel_args in _tensor_arg.)
         if "pool" not in layout.allocation:
+            # Pass the alias here, not real_dst_name: args.output resolves the
+            # mutation alias internally. (load() passes the pre-resolved real
+            # name to args.input, which does not resolve.)
             _ = self.args.output(name)
         index = sympy_subs(index, V.graph.sizevars.precomputed_replacements)
-        dst = TensorAccess(name, index, layout)
-        real_dst_name = V.graph.scheduler.mutation_real_name.get(name, name)
-        if real_dst_name != name:
-            # Skip allocating an output buffer; this name is an alias to another buffer
-            V.graph.removed_buffers.add(name)
+        dst = TensorAccess(real_dst_name, index, layout)
         op_info: dict[str, Any] = {}
         if logger.isEnabledFor(logging.DEBUG):
             value_type = type(value).__name__
@@ -916,6 +928,16 @@ class SpyreKernel(Kernel[CSEVariable]):
 
         call_args_str = ", ".join(call_args)
         wrapper.writeline(f"{name}.run({call_args_str})")
+
+    def emit_layout_restores(self, restores) -> None:
+        """Emit set_spyre_tensor_layout wrapper calls after this kernel's run.
+
+        The scheduler selects and dedups the restores; this kernel just writes
+        them into the wrapper alongside its own call, using the same wrapper.
+        """
+        wrapper = V.graph.wrapper_code
+        for target_name, alt_stl in restores:
+            wrapper.writeline(f"set_spyre_tensor_layout({target_name}, {alt_stl!r})")
 
 
 def _indirect_syms_used(

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -1328,13 +1328,30 @@ def _iter_computed_buffers(operations: list[Operation]):
             logger.warning(f"unhandled operation type {type(op)}")
 
 
+def _apply_input_layout_overrides(
+    op: ComputedBuffer, args: list[SchedNodeArg]
+) -> list[SchedNodeArg]:
+    """Apply per-op input layout overrides stored in op._input_layout_overrides.
+
+    insert_post_mutation_restickify uses this to make work division treat an
+    input buffer with an override layout instead of its committed layout.
+
+    The same tag is also used by SpyreKernel.create_tensor_arg, so work
+    division and codegen agree on the input layout.
+    """
+    overrides: dict[str, FixedTiledLayout] = getattr(op, "_input_layout_overrides", {})
+    if not overrides:
+        return args
+    return [SchedNodeArg(a.dep, overrides.get(a.dep.name, a.layout)) for a in args]
+
+
 def span_reduction(graph: GraphLowering) -> None:
     """Pass 1: compute minimum per-op splits required by the 256MB span limit."""
     operations = graph.operations
     max_cores = _validate_max_cores()
     for op in _iter_computed_buffers(operations):
         rw = op.get_read_writes()
-        args = get_mem_deps_from_rw(rw)
+        args = _apply_input_layout_overrides(op, get_mem_deps_from_rw(rw))
         if isinstance(op.data, Pointwise):
             divide_pointwise_op(op, args, max_cores, span_reduction_pass)
         elif isinstance(op.data, Reduction):
@@ -1356,7 +1373,7 @@ def work_distribution(
         if op in preassigned_ops:
             continue
         rw = op.get_read_writes()
-        args = get_mem_deps_from_rw(rw)
+        args = _apply_input_layout_overrides(op, get_mem_deps_from_rw(rw))
         if isinstance(op.data, Pointwise):
             divide_pointwise_op(op, args, max_cores, work_distribution_pass)
         elif isinstance(op.data, Reduction):

--- a/torch_spyre/_inductor/wrapper.py
+++ b/torch_spyre/_inductor/wrapper.py
@@ -58,7 +58,7 @@ class SpyrePythonWrapperCodegen(PythonWrapperCodegen):
                 from sympy import sympify
                 from torch_spyre._inductor.op_spec import TensorArg, OpSpec, UnimplementedOp, LoopSpec, spyre_constant_tensor, IndirectAccess
                 from torch_spyre.execution.async_compile import SpyreAsyncCompile
-                from torch_spyre._C import DataFormats, SpyreTensorLayout, spyre_empty_with_layout
+                from torch_spyre._C import DataFormats, SpyreTensorLayout, spyre_empty_with_layout, set_spyre_tensor_layout
                 import subprocess
             """,
             strip=True,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Adds support for slice-mutation writes whose stick expression has an offset (e.g. `v + 32`) and therefore cannot be expressed in the mutation target's original layout.

When `propagate_layouts` detects such a write, it picks an alternative `SpyreTensorLayout` for the target (skipping the dim that produces the unsupported stick) and tags the mutation op with `_restickify_plan = (target_name, orig_stl, alt_stl)`.

A new pre-scheduling pass, `insert_post_mutation_restickify`, then wraps the mutation with:

1. A restickify (`orig_stl` → `alt_stl`) into a temporary buffer `buf_tmp`.
2. The slice write, retargeted at `buf_tmp` via a `ReinterpretView` that preserves the original slice offset.
3. A copy-back (`alt_stl` → `alt_stl`) routed back to the original input address through `MutationLayoutSHOULDREMOVE`. Because the in/out STLs match, codegen reduces it to an identity copy.
4. A `set_spyre_tensor_layout` call after the kernel, restoring the correct DCI metadata on the original tensor.

Supporting changes:

- `_find_alt_target_stl` centralizes the alt-layout lookup for mutation targets.
- `SpyreKernel` records scheduled nodes via `set_current_node` so `call_kernel` can emit per-op `set_spyre_tensor_layout` calls, and `create_tensor_arg` honors per-op `_input_layout_overrides` so an op can read an input under a different STL than its committed layout.
- `SpyreKernel.store` resolves `mutation_real_name` once up front, so the buffer lookup uses the real destination and the alias is added to `removed_buffers` consistently.
- `work_division` applies the same `_input_layout_overrides` so work division and codegen agree on the input layout for the restickify op.
- `wrapper.py` imports `set_spyre_tensor_layout` so generated code can call it.

This PR also includes a bug fix carried over from #2595: `_candidate_output_stls` / `_single_arg_op_layout` now take a `skip_stick_expr` so they exclude the dim that already produced an unsupported stick, instead of blindly skipping the last dim. Without this, alternative-layout enumeration could re-pick the same offending dim and loop on the same unsupported stick expression.

#### Which issue(s) this PR is related to:

Fixes:
- #1464

#### Special notes for your reviewer:

- The new copy-back op intentionally has matching input and output STLs so it collapses to an identity copy in codegen; its purpose is to route the bytes back to the original input address via `MutationLayoutSHOULDREMOVE` and to give us a hook for emitting `set_spyre_tensor_layout`.
- The existing `mutation_real_name` resolution in `SpyreKernel.store` was moved earlier in the function; behavior for non-aliased mutations is unchanged.

#### Does this PR introduce a user-facing change?

No (internal compiler pass). Models that previously failed to compile due to unaligned slice writes on the stick dimension will now compile and run.

#### Additional note:

A new test case `copy_` is added under the existing slice-mutation parametrization in `tests/inductor/test_inductor_ops.py`, exercising the new pass via `x.copy_(torch.ones_like(x))._base`.

