### PR TITLE
Add spre_layout hook for safe_open

### DIFF
--- a/torch_spyre/_monkey_patch.py
+++ b/torch_spyre/_monkey_patch.py
@@ -202,6 +202,18 @@ def _patch_tensor_for_spyre():
 
         warnings.warn(f"Failed to install optimal weight layout patches: {e}")
 
+
+    # Register the optimal Spyre transfer hook with safetensors so that
+    # safe_open / load_file / load_model with device="spyre" uses the
+    # dim_order=[1,0] DMA layout for Linear weights automatically.
+    # This resolves issue #400.
+    try:
+        from torch_spyre.model_utils import register_safetensors_hook
+        register_safetensors_hook()
+    except Exception as e:
+        import warnings
+        warnings.warn(f"torch_spyre: failed to register safetensors hook: {e}")
+
     # ── SpyreTensorLayout Guard Extension ────────────
     # Extends TENSOR_MATCH to guard on SpyreTensorLayout
     # preventing wrong compiled graph reuse when layout

--- a/torch_spyre/model_utils.py
+++ b/torch_spyre/model_utils.py
@@ -50,7 +50,7 @@ Usage::
 """
 
 import logging
-
+from typing import List
 import torch
 import torch.nn as nn
 
@@ -256,3 +256,90 @@ def patch_module_to_for_spyre() -> None:
     _spyre_module_to._spyre_patched = True  # type: ignore[attr-defined]
     nn.Module.to = _spyre_module_to  # type: ignore[method-assign]
     logger.info("Patched nn.Module.to() for automatic Spyre weight layout optimization")
+
+
+# ---------------------------------------------------------------------------
+# Safetensors transfer hook (issue #400)
+# ---------------------------------------------------------------------------
+
+def _should_swap_dims(name: str, shape: List[int]) -> bool:
+    """Return True if dim_order=[1,0] should be used for this tensor.
+
+    Only 2-D weight tensors for Linear layers benefit from the transposed
+    Spyre storage layout.  Embeddings, normalisation weights and biases
+    use the default contiguous layout.
+    """
+    if len(shape) != 2:
+        return False
+    name_lower = name.lower()
+    if any(x in name_lower for x in ("embed", "norm", "ln_", "layernorm", "rmsnorm")):
+        return False
+    return name_lower.endswith(".weight")
+
+
+def spyre_layout_hook(
+    cpu_tensor: torch.Tensor,
+    name: str,
+    device,
+) -> torch.Tensor:
+    """Transfer hook called by safetensors for every tensor loaded to Spyre.
+
+    Satisfies the hook contract defined by
+    ``safetensors.torch._register_device_transfer_hook``:
+      hook(cpu_tensor, name, device) -> torch.Tensor
+    """
+    #print("In spyre_layout_hook::cpu_tensor.dtype = ", cpu_tensor.dtype)
+    if cpu_tensor.dtype != torch.float16 and cpu_tensor.dtype.is_floating_point:
+        cpu_tensor = cpu_tensor.to(dtype=torch.float16)
+
+    if not cpu_tensor.is_contiguous():
+        cpu_tensor = cpu_tensor.contiguous()
+
+    swap_dims = _should_swap_dims(name, list(cpu_tensor.shape))
+
+    if swap_dims:
+        layout = SpyreTensorLayout(
+            list(cpu_tensor.shape),
+            list(cpu_tensor.stride()),
+            cpu_tensor.dtype,
+            [1, 0],
+        )
+    else:
+        layout = SpyreTensorLayout(list(cpu_tensor.shape), cpu_tensor.dtype)
+
+    dst = spyre_empty_with_layout(
+        cpu_tensor.size(), cpu_tensor.stride(), cpu_tensor.dtype, layout
+    )
+    copy_tensor(cpu_tensor, dst, non_blocking=False)
+    return dst
+
+
+_safetensors_hook_registered = False
+
+
+def register_safetensors_hook() -> None:
+    """Register the Spyre layout hook with safetensors.torch.
+
+    After this call, safe_open / load_file / load_model with
+    device="spyre" all use the optimal DMA layout automatically.
+    Idempotent.
+    """
+    global _safetensors_hook_registered
+    if _safetensors_hook_registered:
+        return
+    try:
+        from safetensors.torch import _register_device_transfer_hook
+    except ImportError:
+        logger.warning(
+            "safetensors not installed; Spyre transfer hook not registered. "
+            "device='spyre' in safe_open / load_file will not work."
+        )
+        return
+
+    _register_device_transfer_hook(DEVICE_NAME, spyre_layout_hook)
+    _safetensors_hook_registered = True
+    logger.info(
+        "Registered Spyre safetensors transfer hook "
+        "(resolves issue #400; uses optimal dim_order layout for Linear weights)"
+    )
+


### PR DESCRIPTION
Registers spyre_layout_hook with safetensors.torch via the _register_device_transfer_hook API. After this, safe_open / load_file / load_model with device="spyre" automatically use the optimal DMA layout.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
