### PR TITLE
fix: use traced index for load ops in multi op splitting

### DIFF
--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
@@ -38,7 +38,7 @@ test_suite_config:
             - TestOps::test_restickify_fp32_unsupported_xfail
             - TestOps::test_restickify_int64_unsupported_xfail
             # multiops split test
-            - TestOps::test_view_permute_mul.*
+            - TestOps::test_multiops_split.*
           mode: mandatory_success
           tags:
             - ops__inductor_misc_shape

--- a/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
@@ -37,6 +37,8 @@ test_suite_config:
             - TestOps::test_repeat.*
             - TestOps::test_restickify_fp32_unsupported_xfail
             - TestOps::test_restickify_int64_unsupported_xfail
+            # multiops split test
+            - TestOps::test_view_permute_mul.*
           mode: mandatory_success
           tags:
             - ops__inductor_misc_shape

--- a/tests/inductor/test_inductor_ops.py
+++ b/tests/inductor/test_inductor_ops.py
@@ -4121,6 +4121,14 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
                 "4d_dim3": (3, cached_randn((2, 4, 8, 64))),
             },
         },
+        (
+            "test_multiops_split",
+            "test_view_permute_mul",
+        ): {
+            "param_sets": {
+                "3d_to_4d_view_permute_mul": (cached_randn((2, 3, 4)),),
+            },
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -5172,6 +5180,14 @@ class TestOps(unittest.TestCase, metaclass=ParameterizedTestMeta):
 
         def fn(input):
             return torch.nn.functional.softplus(input, beta, threshold)
+
+        self.compare_with_cpu(fn, x)
+
+    def test_view_permute_mul(self, x):
+        """Create 3D tensor, view as 4D, permute, multiply by constant."""
+
+        def fn(x):
+            return x.view(*x.shape, 1).permute(0, 3, 1, 2).mul(5.0)
 
         self.compare_with_cpu(fn, x)
 

--- a/torch_spyre/_inductor/split_multi_ops.py
+++ b/torch_spyre/_inductor/split_multi_ops.py
@@ -250,7 +250,15 @@ def _normalize_op_args(op_name, input_fx_nodes, kwargs, out_dtype, device=None):
     return tuple(args), clean_kw, out_dtype
 
 
-def _build_inner_fn(op_name, value_vids, kwargs, vid_to_bufname, vid_to_constant):
+def _build_inner_fn(
+    op_name,
+    value_vids,
+    kwargs,
+    vid_to_bufname,
+    vid_to_constant,
+    vid_to_load_index=None,
+    n_dims=None,
+):
     """Build an inner_fn that loads from intermediate buffers.
 
     Special cases:
@@ -276,10 +284,16 @@ def _build_inner_fn(op_name, value_vids, kwargs, vid_to_bufname, vid_to_constant
     vid_to_stride = {}
     for v in value_vids:
         if v not in vid_to_constant:
+            if vid_to_load_index and v in vid_to_load_index:
+                continue
             buf_name = vid_to_bufname[v]
             vid_to_stride[v] = V.graph.get_buffer(buf_name).layout.stride
 
     def inner_fn(index):
+        subs = {}
+        if vid_to_load_index and n_dims:
+            subs = {sympy.Symbol(f"_i{k}"): index[k] for k in range(n_dims)}
+
         inputs = []
         for v in value_vids:
             if v in vid_to_constant:
@@ -289,6 +303,14 @@ def _build_inner_fn(op_name, value_vids, kwargs, vid_to_bufname, vid_to_constant
                     inputs.append(fill)
                 else:
                     inputs.append(V.ops.load(vid_to_bufname[v], sympy.Integer(0)))
+            elif subs and vid_to_load_index and v in vid_to_load_index:
+                # Use the original traced load index expression
+                # instead of stride since index tuple could be different
+                # from allocated buffer dimension.
+                # ref - https://github.com/torch-spyre/hf-adapters/actions/runs/27740345917/job/82065998407
+                traced_idx = vid_to_load_index[v]
+                idx = traced_idx.subs(subs)
+                inputs.append(V.ops.load(vid_to_bufname[v], idx))
             else:
                 buf_stride = vid_to_stride[v]
                 if len(index) != len(buf_stride):
@@ -368,6 +390,11 @@ def _init_vid_to_bufname(trace):
         Dictionary mapping value IDs to buffer names
     """
     return {vid: kwargs["_name"] for op, vid, _, kwargs in trace if op == "load"}
+
+
+def _init_vid_to_load_index(trace):
+    """Extract per-VID symbolic load indices from load operations in a trace."""
+    return {vid: kwargs["_index"] for op, vid, _, kwargs in trace if op == "load"}
 
 
 def _init_vid_to_constant(trace):
@@ -492,7 +519,12 @@ def _make_intermediate_bufs(
 
 
 def _update_original_buf(
-    op, final_entry, vid_to_bufname, vid_to_constant, operations
+    op,
+    final_entry,
+    vid_to_bufname,
+    vid_to_constant,
+    operations,
+    vid_to_load_index=None,
 ) -> None:
     """Update the original buffer to use intermediate buffers.
 
@@ -513,7 +545,13 @@ def _update_original_buf(
     new_data = dataclasses.replace(
         op.data,
         inner_fn=_build_inner_fn(
-            op_name, vids, kwargs, vid_to_bufname, vid_to_constant
+            op_name,
+            vids,
+            kwargs,
+            vid_to_bufname,
+            vid_to_constant,
+            vid_to_load_index=vid_to_load_index,
+            n_dims=len(op.data.ranges),
         ),
     )
 
@@ -625,6 +663,7 @@ def split_multi_ops(graph: GraphLowering):
     3. Skips if tracing fails or operation is not in operations list
     4. Requires valid FX node origins for graph manipulation
     5. Builds environment mapping from name_to_users for FX node lookup
+    6. load index is computed from traced index rather using stride
 
     Algorithm:
     1. Build FX node environment from name_to_users
@@ -690,6 +729,9 @@ def split_multi_ops(graph: GraphLowering):
             continue
 
         intermediate_ops, final_op = compute_ops[:-1], compute_ops[-1]
+
+        vid_to_load_index = _init_vid_to_load_index(trace)
+
         _make_intermediate_bufs(
             intermediate_ops,
             dtype_map,
@@ -700,7 +742,15 @@ def split_multi_ops(graph: GraphLowering):
             gl,
             orig_node,
         )
-        _update_original_buf(op, final_op, bufname_map, const_map, operations)
+
+        _update_original_buf(
+            op,
+            final_op,
+            bufname_map,
+            const_map,
+            operations,
+            vid_to_load_index=vid_to_load_index,
+        )
         logger.info(
             "split_multi_op: '%s' -> %d intermediate buffers",
             op.get_name(),

--- a/torch_spyre/_inductor/split_multi_ops.py
+++ b/torch_spyre/_inductor/split_multi_ops.py
@@ -307,7 +307,7 @@ def _build_inner_fn(
                 # Use the original traced load index expression
                 # instead of stride since index tuple could be different
                 # from allocated buffer dimension.
-                # ref - https://github.com/torch-spyre/hf-adapters/actions/runs/27740345917/job/82065998407
+                # ref - https://github.com/torch-spyre/torch-spyre/issues/2797
                 traced_idx = vid_to_load_index[v]
                 idx = traced_idx.subs(subs)
                 inputs.append(V.ops.load(vid_to_bufname[v], idx))

--- a/torch_spyre/_inductor/split_multi_ops.py
+++ b/torch_spyre/_inductor/split_multi_ops.py
@@ -284,7 +284,7 @@ def _build_inner_fn(
     vid_to_stride = {}
     for v in value_vids:
         if v not in vid_to_constant:
-            if vid_to_load_index and v in vid_to_load_index:
+            if vid_to_load_index and n_dims and v in vid_to_load_index:
                 continue
             buf_name = vid_to_bufname[v]
             vid_to_stride[v] = V.graph.get_buffer(buf_name).layout.stride


### PR DESCRIPTION
#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Computing load index from strides does not seem to work. So in this PR we use the index gathered during trace for computation. Related evidence for the issue - ref - https://github.com/torch-spyre/hf-adapters/actions/runs/27740345917/job/82065998407.

Fixes https://github.com/torch-spyre/torch-spyre/issues/2797

You can find the below trace example as well

```
op.data Pointwise(
  'spyre',
  torch.float16,
  def inner_fn(index):
      i0, i1, i2, i3 = index
      tmp0 = ops.load(buf1, i3 + 64 * i1 + 768 * i2 + 49152 * i0)
      tmp1 = ops.constant(0.3535533905932738, torch.float16)
      tmp2 = tmp0 * tmp1
      return tmp2
  ,
  ranges=[3, 12, 64, 64],
  origin_node=expand_6,
  origins=OrderedSet([mul, permute_1, view_3]),
stack_traces {} # omitted them

# some logged info
index - (d0, d1, d2, d3)
buf1's stride - [49152, 768, 1]
```

buf1's stride (3D) does not match the index dimension (4D). 


Strange part is I don't know why buf1's stide is [49152, 768, 1]
