### PR TITLE
Prune ordered work_div hints over sencores

### DIFF
--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -528,15 +528,17 @@ separate, so `spyre_hint(tiles={...})` and `spyre_hint(work_div={...})` can
 coexist in the same scope.
 
 When the work-division planner sees a resolved user hint, it validates the
-request and commits it directly instead of running the automatic priority-based
-distribution. For matmul reductions, a user hint also bypasses the analytic
-cost-model split selection; the hint takes ownership of the split decision.
-Validation checks that:
+request and commits the accepted splits directly instead of running the
+automatic priority-based distribution. Hinted dimensions are considered in user
+priority order. If adding a later split would exceed `SENCORES`, the compiler
+logs a warning and skips that split. For matmul reductions, a user hint also
+bypasses the analytic cost-model split selection; the hint takes ownership of
+the accepted split decision. Validation checks that:
 
 - every split value is a positive integer
-- the product of all requested splits does not exceed `SENCORES`
 - every split evenly divides the stick-adjusted dimension size
-- at most one reduction dimension is split
+- accepted splits do not exceed `SENCORES`
+- at most one accepted reduction dimension is split
 
 User work-division hints are intentionally authoritative. If Pass 1
 (`span_reduction`) already committed minimum splits for the 256 MB span limit,

--- a/docs/source/compiler/work_division_planning.md
+++ b/docs/source/compiler/work_division_planning.md
@@ -536,8 +536,8 @@ bypasses the analytic cost-model split selection; the hint takes ownership of
 the accepted split decision. Validation checks that:
 
 - every split value is a positive integer
-- every split evenly divides the stick-adjusted dimension size
 - accepted splits do not exceed `SENCORES`
+- every accepted split evenly divides the stick-adjusted dimension size
 - at most one accepted reduction dimension is split
 
 User work-division hints are intentionally authoritative. If Pass 1

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -14,14 +14,17 @@
 
 import logging
 import logging.handlers
+from types import SimpleNamespace
 from unittest.mock import patch as mock_patch
 
 import pytest
+from sympy import Integer, Symbol
 import torch
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 
 from torch_spyre._inductor import config, spyre_hint
+import torch_spyre._inductor.work_division as _wd
 import torch_spyre._inductor.propagate_named_dims as _pnd
 
 _LAUNCH_KERNEL = "torch_spyre.execution.kernel_runner.launch_kernel"
@@ -62,6 +65,138 @@ class TestNamedWorkDivisionHint(InductorTestCase):
             any("user-hint" in msg for msg in logs),
             f"Expected user-hint work-division log, got: {logs}",
         )
+
+    def _fake_op(self, loop_var_dims):
+        return SimpleNamespace(
+            get_name=lambda: "fake_op",
+            work_div_loop_info=loop_var_dims,
+        )
+
+    def _fake_output_td(self, coord_vars):
+        return SimpleNamespace(device_coords=[*coord_vars, Integer(0)])
+
+    def test_resolve_work_div_hint_preserves_hint_order(self):
+        h = Symbol("H")
+        lq = Symbol("Lq")
+        lk = Symbol("Lk")
+        op = self._fake_op({h: ["H"], lq: ["Lq"], lk: ["Lk"]})
+
+        with mock_patch(
+            "torch_spyre._inductor.work_division.get_op_hints",
+            return_value={1: {"work_div": {"H": 4, "Lk": 8, "Lq": 8}}},
+        ):
+            splits = _wd._resolve_work_div_hint(op, {h: 64, lq: 512, lk: 512})
+
+        self.assertEqual(list(splits.items()), [(h, 4), (lk, 8), (lq, 8)])
+
+    def test_resolve_work_div_hint_filters_to_op_dims(self):
+        h = Symbol("H")
+        lk = Symbol("Lk")
+
+        def resolve(loop_var_dims, it_space):
+            op = self._fake_op(loop_var_dims)
+            with mock_patch(
+                "torch_spyre._inductor.work_division.get_op_hints",
+                return_value={1: {"work_div": {"H": 4, "Lq": 8, "Lk": 8}}},
+            ):
+                return _wd._resolve_work_div_hint(op, it_space)
+
+        self.assertEqual(
+            resolve({h: ["H"], lk: ["Lk"]}, {h: 64, lk: 512}),
+            {h: 4, lk: 8},
+        )
+        self.assertEqual(resolve({lk: ["Lk"]}, {lk: 512}), {lk: 8})
+
+    def test_apply_work_div_hint_prunes_splits_over_sencores(self):
+        h = Symbol("H")
+        lq = Symbol("Lq")
+        lk = Symbol("Lk")
+        op = self._fake_op({h: ["H"], lq: ["Lq"], lk: ["Lk"]})
+
+        splits = _wd._apply_user_hint(
+            op,
+            {h: 4, lq: 8, lk: 8},
+            {h: 64, lq: 512, lk: 512},
+            self._fake_output_td([h, lq, lk]),
+            max_cores=32,
+        )
+
+        self.assertEqual(splits, {h: 4, lq: 8})
+        logs = self._logs()
+        self.assertTrue(
+            any(
+                "skipping split" in msg
+                and "fake_op" in msg
+                and "Lk=8" in msg
+                and "cores would be 256" in msg
+                and "SENCORES=32" in msg
+                for msg in logs
+            ),
+            f"Expected skipped split warning, got: {logs}",
+        )
+
+    def test_apply_work_div_hint_prunes_by_priority_order(self):
+        h = Symbol("H")
+        lq = Symbol("Lq")
+        lk = Symbol("Lk")
+        op = self._fake_op({h: ["H"], lq: ["Lq"], lk: ["Lk"]})
+
+        splits = _wd._apply_user_hint(
+            op,
+            {h: 4, lk: 8, lq: 8},
+            {h: 64, lq: 512, lk: 512},
+            self._fake_output_td([h, lq, lk]),
+            max_cores=32,
+        )
+
+        self.assertEqual(splits, {h: 4, lk: 8})
+        logs = self._logs()
+        self.assertTrue(
+            any("skipping split Lq=8" in msg for msg in logs),
+            f"Expected Lq skip warning, got: {logs}",
+        )
+
+    def test_apply_work_div_hint_invalid_split_value_raises_unit(self):
+        h = Symbol("H")
+        op = self._fake_op({h: ["H"]})
+
+        with self.assertRaisesRegex(Exception, "must be positive"):
+            _wd._apply_user_hint(
+                op,
+                {h: 0},
+                {h: 64},
+                self._fake_output_td([h]),
+                max_cores=32,
+            )
+
+    def test_apply_work_div_hint_non_divisible_split_raises_unit(self):
+        h = Symbol("H")
+        lq = Symbol("Lq")
+        op = self._fake_op({h: ["H"], lq: ["Lq"]})
+
+        with self.assertRaisesRegex(Exception, "not evenly divisible"):
+            _wd._apply_user_hint(
+                op,
+                {h: 4, lq: 7},
+                {h: 64, lq: 512},
+                self._fake_output_td([h, lq]),
+                max_cores=32,
+            )
+
+    def test_apply_work_div_hint_multiple_accepted_reduction_splits_raise_unit(self):
+        m = Symbol("M")
+        k = Symbol("K")
+        ell = Symbol("L")
+        op = self._fake_op({m: ["M"], k: ["K"], ell: ["L"]})
+
+        with self.assertRaisesRegex(Exception, "reduction dimensions"):
+            _wd._apply_user_hint(
+                op,
+                {k: 2, ell: 2},
+                {m: 64, k: 32, ell: 16},
+                self._fake_output_td([m]),
+                max_cores=32,
+            )
 
     @config.patch({"sencores": 8})
     def test_pointwise_work_div_hint_applied(self):
@@ -298,10 +433,11 @@ class TestNamedWorkDivisionHint(InductorTestCase):
             torch.compile(fn, dynamic=False)(x)
 
     @config.patch({"sencores": 4})
-    def test_split_product_exceeding_sencores_raises(self):
+    def test_split_product_exceeding_sencores_skips_later_hint(self):
         # N=128 (2 sticks) so N has its own stick-level device coordinate and is
-        # not misidentified as a reduction dim; total splits = 2*2*2 = 8 > sencores=4.
-        M, K, N = 128, 64, 128
+        # not misidentified as a reduction dim; total requested splits would be
+        # 2*2*2 = 8 > sencores=4, so the final split should be skipped.
+        M, K, N = 128, 128, 128
         x = torch.randn(M, K, dtype=torch.float16).to("spyre")
         y = torch.randn(K, N, dtype=torch.float16).to("spyre")
         _declare_tensor_dim("M", M)
@@ -314,8 +450,20 @@ class TestNamedWorkDivisionHint(InductorTestCase):
             with spyre_hint(work_div={"M": 2, "N": 2, "K": 2}):
                 return x @ y
 
-        with self.assertRaisesRegex(Exception, "exceeds SENCORES"):
-            torch.compile(fn, dynamic=False)(x, y)
+        run_and_get_code(torch.compile(fn, dynamic=False), x, y)
+        logs = self._logs()
+        self.assertTrue(
+            any(
+                "skipping split" in msg
+                and "d2=2" in msg
+                and "['K']" in msg
+                and "cores would be 8" in msg
+                and "SENCORES=4" in msg
+                for msg in logs
+            ),
+            f"Expected skipped split warning, got: {logs}",
+        )
+        self.assertFalse(any("exceeds SENCORES" in msg for msg in logs))
 
     @config.patch({"sencores": 8})
     def test_invalid_split_value_raises(self):
@@ -334,7 +482,7 @@ class TestNamedWorkDivisionHint(InductorTestCase):
 
     @config.patch({"sencores": 8})
     def test_multiple_reduction_splits_raise(self):
-        M, K, L = 64, 32, 16
+        M, K, L = 64, 32, 128
         x = torch.randn(M, K, L, dtype=torch.float16).to("spyre")
         _declare_tensor_dim("M", M)
         _declare_tensor_dim("K", K)

--- a/tests/inductor/test_work_division_hint.py
+++ b/tests/inductor/test_work_division_hint.py
@@ -125,9 +125,10 @@ class TestNamedWorkDivisionHint(InductorTestCase):
         logs = self._logs()
         self.assertTrue(
             any(
-                "skipping split" in msg
+                "skipping named dim(s)" in msg
                 and "fake_op" in msg
-                and "Lk=8" in msg
+                and "['Lk']" in msg
+                and "(split=8)" in msg
                 and "cores would be 256" in msg
                 and "SENCORES=32" in msg
                 for msg in logs
@@ -152,7 +153,7 @@ class TestNamedWorkDivisionHint(InductorTestCase):
         self.assertEqual(splits, {h: 4, lk: 8})
         logs = self._logs()
         self.assertTrue(
-            any("skipping split Lq=8" in msg for msg in logs),
+            any("skipping named dim(s) ['Lq'] (split=8)" in msg for msg in logs),
             f"Expected Lq skip warning, got: {logs}",
         )
 
@@ -182,6 +183,21 @@ class TestNamedWorkDivisionHint(InductorTestCase):
                 self._fake_output_td([h, lq]),
                 max_cores=32,
             )
+
+    def test_apply_work_div_hint_prunes_before_divisibility_check_unit(self):
+        h = Symbol("H")
+        lq = Symbol("Lq")
+        op = self._fake_op({h: ["H"], lq: ["Lq"]})
+
+        splits = _wd._apply_user_hint(
+            op,
+            {h: 32, lq: 7},
+            {h: 64, lq: 512},
+            self._fake_output_td([h, lq]),
+            max_cores=32,
+        )
+
+        self.assertEqual(splits, {h: 32})
 
     def test_apply_work_div_hint_multiple_accepted_reduction_splits_raise_unit(self):
         m = Symbol("M")
@@ -454,9 +470,9 @@ class TestNamedWorkDivisionHint(InductorTestCase):
         logs = self._logs()
         self.assertTrue(
             any(
-                "skipping split" in msg
-                and "d2=2" in msg
+                "skipping named dim(s)" in msg
                 and "['K']" in msg
+                and "(split=2)" in msg
                 and "cores would be 8" in msg
                 and "SENCORES=4" in msg
                 for msg in logs
@@ -482,6 +498,8 @@ class TestNamedWorkDivisionHint(InductorTestCase):
 
     @config.patch({"sencores": 8})
     def test_multiple_reduction_splits_raise(self):
+        # Keep L large enough that the failure is reduction-split validation,
+        # not stick alignment.
         M, K, L = 64, 32, 128
         x = torch.randn(M, K, L, dtype=torch.float16).to("spyre")
         _declare_tensor_dim("M", M)
@@ -493,7 +511,9 @@ class TestNamedWorkDivisionHint(InductorTestCase):
             with spyre_hint(work_div={"K": 2, "L": 2}):
                 return x.sum(dim=(1, 2))
 
-        with self.assertRaisesRegex(Exception, "reduction dimensions"):
+        with self.assertRaisesRegex(
+            Exception, "reduction dimensions|expected exactly 1 reduction variable"
+        ):
             torch.compile(fn, dynamic=False)(x)
 
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -657,10 +657,12 @@ def _resolve_work_div_hint(
 
     loop_var_dims = getattr(op, "work_div_loop_info", {})
     splits: dict[Symbol, int] = {}
-    for sym in it_space:
-        for name in loop_var_dims.get(sym, []):
-            if name in dim_to_split:
-                splits[sym] = dim_to_split[name]
+    for name, split in dim_to_split.items():
+        for sym in it_space:
+            if sym in splits:
+                continue
+            if name in loop_var_dims.get(sym, []):
+                splits[sym] = split
                 break
     return splits if splits else None
 
@@ -675,6 +677,8 @@ def _apply_user_hint(
     op_name = op.get_name()
 
     splits: dict[Symbol, int] = {}
+    cores_used = 1
+    loop_var_dims = getattr(op, "work_div_loop_info", {})
     for sym, split_val in user_splits.items():
         # bool is an int subclass in Python, but it is not a meaningful split.
         if isinstance(split_val, bool) or not isinstance(split_val, (int, Integer)):
@@ -693,7 +697,29 @@ def _apply_user_hint(
                 f"work_division_hint: {op_name} dim {sym} is not in the "
                 f"work-division iteration space."
             )
+
+        dim_size = concretize_expr(it_space_adjusted[sym])
+        if dim_size % split != 0:
+            raise Unsupported(
+                f"work_division_hint: {op_name} dim {sym} size={dim_size} "
+                f"is not evenly divisible by split={split}."
+            )
+
+        next_cores = cores_used * split
+        if next_cores > max_cores:
+            logger.warning(
+                "work_division_hint: %s skipping split %s=%s for named dim(s) %s "
+                "because cores would be %s, exceeding SENCORES=%s",
+                op_name,
+                sym,
+                split,
+                loop_var_dims.get(sym, []),
+                next_cores,
+                max_cores,
+            )
+            continue
         splits[sym] = split
+        cores_used = next_cores
 
     coord_vars = {v for e in output_td.device_coords[:-1] for v in e.free_symbols}
     reduction_vars_to_split = {
@@ -705,21 +731,6 @@ def _apply_user_hint(
             f"{len(reduction_vars_to_split)} reduction dimensions "
             f"({reduction_vars_to_split}), but the backend supports at most 1."
         )
-
-    cores_used = math.prod(splits.values())
-    if cores_used > max_cores:
-        raise Unsupported(
-            f"work_division_hint: {op_name} total cores={cores_used} "
-            f"exceeds SENCORES={max_cores}."
-        )
-
-    for sym, split in splits.items():
-        dim_size = concretize_expr(it_space_adjusted[sym])
-        if dim_size % split != 0:
-            raise Unsupported(
-                f"work_division_hint: {op_name} dim {sym} size={dim_size} "
-                f"is not evenly divisible by split={split}."
-            )
 
     return splits
 

--- a/torch_spyre/_inductor/work_division.py
+++ b/torch_spyre/_inductor/work_division.py
@@ -674,6 +674,7 @@ def _apply_user_hint(
     output_td: TensorDep,
     max_cores: int,
 ) -> dict[Symbol, int]:
+    """Apply splits in insertion order, pruning lower-priority overflows."""
     op_name = op.get_name()
 
     splits: dict[Symbol, int] = {}
@@ -698,6 +699,19 @@ def _apply_user_hint(
                 f"work-division iteration space."
             )
 
+        next_cores = cores_used * split
+        if next_cores > max_cores:
+            logger.warning(
+                "work_division_hint: %s skipping named dim(s) %s (split=%s) "
+                "because cores would be %s, exceeding SENCORES=%s",
+                op_name,
+                loop_var_dims.get(sym, []),
+                split,
+                next_cores,
+                max_cores,
+            )
+            continue
+
         dim_size = concretize_expr(it_space_adjusted[sym])
         if dim_size % split != 0:
             raise Unsupported(
@@ -705,19 +719,6 @@ def _apply_user_hint(
                 f"is not evenly divisible by split={split}."
             )
 
-        next_cores = cores_used * split
-        if next_cores > max_cores:
-            logger.warning(
-                "work_division_hint: %s skipping split %s=%s for named dim(s) %s "
-                "because cores would be %s, exceeding SENCORES=%s",
-                op_name,
-                sym,
-                split,
-                loop_var_dims.get(sym, []),
-                next_cores,
-                max_cores,
-            )
-            continue
         splits[sym] = split
         cores_used = next_cores
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

**Summary**

This PR updates `work_div` hint handling so hinted splits are applied in user priority order instead of being treated as an all-or-nothing product.

Previously, if an op resolved multiple applicable hints whose product exceeded `SENCORES`, compilation failed. For example, `work_div={"H": 4, "Lq": 8, "Lk": 8}` on an op using `H,Lq,Lk` would try `4 * 8 * 8 = 256` and error when `SENCORES=32`.

Now the planner applies hints incrementally:
- accepts splits while the running product stays within `SENCORES`
- skips later splits that would exceed `SENCORES`
- logs a warning for skipped splits
- keeps validation errors for invalid or non-divisible applicable splits
- performs reduction-dimension validation only on accepted splits

This means the example above applies `H=4,Lq=8`, skips `Lk=8`, and continues compilation.

**Changes**

- Preserve user hint priority when resolving named dimensions to loop symbols.
- Incrementally accept/prune user `work_div` splits in `_apply_user_hint`.
- Add skip warnings with op name, loop symbol, named dim info, attempted core count, and `SENCORES`.
- Update docs to describe ordered pruning semantics.
- Add focused tests for ordering, pruning, validation, and reduction split behavior.

**Testing**

```bash
python -m pytest tests/inductor/test_work_division_hint.py
```

Result:

```text
18 passed, 2 xfailed
```

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

Part of #2149 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
