### PR TITLE
feat(cicd) add more tests from xfail to mandatory_success since they are supported in test_view_ops_config

### DIFF
--- a/tests/configs/upstream_tests/test_view_ops_config.yaml
+++ b/tests/configs/upstream_tests/test_view_ops_config.yaml
@@ -10,6 +10,11 @@ test_suite_config:
             - TestOldViewOps::test_atleast_gradient
             - TestOldViewOps::test_contiguous
             - TestOldViewOps::test_resize_as_preserves_strides
+            - TestViewOps::test_view_dtype_upsize_errors
+            - TestViewOps::test_view_tensor_split
+            - TestOldViewOps::test_broadcast_to
+            - TestOldViewOps::test_tensor_split_indices
+            - TestOldViewOps::test_tensor_split_sections
           mode: mandatory_success
 
         ############################################################
@@ -27,11 +32,6 @@ test_suite_config:
             - TestViewOps::test_view_tensor_vsplit
             - TestViewOps::test_reshape
             - TestOldViewOps::test_transpose_invalid
-            - TestViewOps::test_view_dtype_upsize_errors
-            - TestViewOps::test_view_tensor_split
-            - TestOldViewOps::test_broadcast_to
-            - TestOldViewOps::test_tensor_split_indices
-            - TestOldViewOps::test_tensor_split_sections
           mode: xfail
           # segmentation faults with @onlyNativeDeviceTypes
         - names:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### Pre-PR 
```bash
================= 30 passed, 38 xfailed, 12 xpassed in 10.04s ==================
```

#### This PR 

```bash
================= 40 passed, 38 xfailed, 2 xpassed in 6.31s ==================
```

https://github.com/torch-spyre/torch-spyre/actions/runs/27839597313/job/82395425600?pr=2774