### PR TITLE
ci: add image_label input for per-PR ephemeral runner sets (backward-compatible)

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -22,11 +22,12 @@ on:
 
       # IMAGE selector label for runs-on. Normal runs use the standing
       # image_torch_spyre set; the per-PR ephemeral flow passes that PR's set
-      # label (image_pr_<component>_<sha12>) so jobs land on the per-PR image
+      # label (image_torch_spyre_pr_<component>_<sha12>, e.g.
+      # image_torch_spyre_pr_flex_8ddcf3e155e9) so jobs land on the per-PR image
       # (the RPM is baked in -> no runtime sudo). Default keeps existing callers
       # unchanged.
       image_label:
-        description: Image scaleSetLabel to select (image_torch_spyre | image_pr_<KEY>)
+        description: Image scaleSetLabel to select (image_torch_spyre | image_torch_spyre_pr_<KEY>)
         required: false
         type: string
         default: image_torch_spyre

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -20,6 +20,17 @@ on:
         required: true
         type: string
 
+      # IMAGE selector label for runs-on. Normal runs use the standing
+      # image_torch_spyre set; the per-PR ephemeral flow passes that PR's set
+      # label (image_pr_<component>_<sha12>) so jobs land on the per-PR image
+      # (the RPM is baked in -> no runtime sudo). Default keeps existing callers
+      # unchanged.
+      image_label:
+        description: Image scaleSetLabel to select (image_torch_spyre | image_pr_<KEY>)
+        required: false
+        type: string
+        default: image_torch_spyre
+
       # Flags appended to every `bash tests/run_test.sh <config>` call
       extra_test_flags:
         description: Extra flags passed to run_test.sh (e.g. "-v" or "--cpu-compile -vvv -s")
@@ -81,7 +92,7 @@ jobs:
       - x86_64
       - spyre_pf_x1
       - ${{ inputs.runner_label }}
-      - image_torch_spyre
+      - ${{ inputs.image_label }}
     timeout-minutes: 60
     env:
       # GitHub Actions sets CI=true which causes pytest inductor tests to fail.
@@ -221,6 +232,10 @@ jobs:
         with:
           verbose: 'true'
 
+      # LEGACY runtime-RPM path. The per-PR ephemeral flow bakes the RPM into the
+      # image and sends an EMPTY rpm_names, so both RPM steps below auto-skip (no
+      # runtime `sudo dnf` — sudo is unreliable on the cluster SCC). Kept gated for
+      # the legacy path; remove once the USE_EPHEMERAL_RUNNERS=false path is retired.
       - name: Download RPMs
         if: ${{ inputs.rpm_names != '' }}
         uses: ./.github/actions/download-rpms
@@ -278,7 +293,7 @@ jobs:
       - x86_64
       - spyre_pf_x2
       - ${{ inputs.runner_label }}
-      - image_torch_spyre
+      - ${{ inputs.image_label }}
     timeout-minutes: 60
     env:
       CI: ''
@@ -316,6 +331,10 @@ jobs:
         with:
           verbose: 'true'
 
+      # LEGACY runtime-RPM path. The per-PR ephemeral flow bakes the RPM into the
+      # image and sends an EMPTY rpm_names, so both RPM steps below auto-skip (no
+      # runtime `sudo dnf` — sudo is unreliable on the cluster SCC). Kept gated for
+      # the legacy path; remove once the USE_EPHEMERAL_RUNNERS=false path is retired.
       - name: Download RPMs
         if: ${{ inputs.rpm_names != '' }}
         uses: ./.github/actions/download-rpms

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -43,7 +43,8 @@ on:
         default: true
       runner_label:
         description: |
-          Per-PR ephemeral runner-set IMAGE label to select (image_pr_<component>_<sha12>).
+          Per-PR ephemeral runner-set IMAGE label to select
+          (image_torch_spyre_pr_<component>_<sha12>, e.g. image_torch_spyre_pr_flex_8ddcf3e155e9).
           Empty = use the standing image_torch_spyre set (the RPM is then installed at
           runtime via rpm_names; the ephemeral flow leaves this set and rpm_names empty).
         required: false

--- a/.github/workflows/torch_spyre_tests.yaml
+++ b/.github/workflows/torch_spyre_tests.yaml
@@ -41,6 +41,14 @@ on:
         required: false
         type: boolean
         default: true
+      runner_label:
+        description: |
+          Per-PR ephemeral runner-set IMAGE label to select (image_pr_<component>_<sha12>).
+          Empty = use the standing image_torch_spyre set (the RPM is then installed at
+          runtime via rpm_names; the ephemeral flow leaves this set and rpm_names empty).
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.html_url) || (github.event_name == 'workflow_dispatch'
@@ -112,6 +120,8 @@ jobs:
     uses: ./.github/workflows/_test_matrix.yaml
     with:
       runner_label: linux
+      # Per-PR ephemeral image label when provided, else the standing set.
+      image_label: ${{ inputs.runner_label || 'image_torch_spyre' }}
       extra_test_flags: -v
       checkout_pytorch: false
       torch_root: ''


### PR DESCRIPTION
## What

Adds an optional `image_label` input so a workflow run can be routed onto a **specific runner-set image label** instead of the hardcoded `image_torch_spyre`. This is the github.com half of the per-PR **ephemeral CI** flow (RPM baked into a per-PR image → ephemeral ARC runner set labeled `image_pr_<component>_<sha12>` → tests run there → set torn down), which removes the runtime `sudo dnf install`.

## Changes

- **`_test_matrix.yaml`**: new optional input `image_label` (default `image_torch_spyre`). Both card-job `runs-on` blocks select `${{ inputs.image_label }}` instead of the hardcoded `image_torch_spyre`.
- **`torch_spyre_tests.yaml`**: new `workflow_dispatch` input `runner_label` (the per-PR image label), forwarded to `_test_matrix` as `image_label` (falls back to `image_torch_spyre` when empty).
- The runtime RPM steps (`Download RPMs`, `Install RPMs` / `sudo dnf`) are **left gated** on `rpm_names != ''`. The ephemeral flow sends empty `rpm_names`, so they auto-skip (RPM is baked into the image). A comment documents this. They can be removed once the legacy runtime-RPM path is retired.

## Backward compatibility

**Fully backward-compatible.** `image_label` defaults to `image_torch_spyre`, so every existing caller (`runtests_nightly`, normal PR runs, etc.) behaves exactly as before — `runs-on` resolves to the same standing label. The new behavior only activates when a dispatch explicitly passes a per-PR `runner_label`.

## Validation

YAML parses; the `${{ inputs.x || 'default' }}` form is standard GHA. Full end-to-end (a per-PR ephemeral set actually serving these jobs) is validated separately on the Jenkins side; this PR is the input plumbing.
