### PR TITLE
fix(test:Test Launch JobPlan): replace subprocess with in-process dynamo reset for VFIO-safe JobPlan op execution

### DIFF
--- a/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
@@ -2,3 +2,10 @@ test_suite_config:
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_launch_jobplan.py
       unlisted_test_mode: mandatory_success
+      tests:
+        - names:
+            - test_abs_matches_cpu_with_symbols
+            - test_mul_matches_cpu_with_symbols
+          mode: xfail
+          tags:
+            - jobplan_symbolic_args

--- a/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
@@ -1,7 +1,9 @@
 test_suite_config:
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_launch_jobplan.py
-      unlisted_test_mode: skip
+      unlisted_test_mode: mandatory_success
+      # Marking xfail because RuntimeError: DtException: Constant cannot be a variable, 
+      # file /mnt/datadisk1/jenkins/workspace/Runtimes_x86_64_deeptools_master/util/VariableDefinition.cpp line 441
       tests:
         - names:
             - TestLaunchJobPlan::test_abs_matches_cpu_with_symbols

--- a/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
@@ -1,11 +1,17 @@
 test_suite_config:
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_launch_jobplan.py
-      unlisted_test_mode: mandatory_success
+      unlisted_test_mode: skip
       tests:
         - names:
-            - test_abs_matches_cpu_with_symbols
-            - test_mul_matches_cpu_with_symbols
+            - TestLaunchJobPlan::test_abs_matches_cpu_with_symbols
+            - TestLaunchJobPlan::test_mul_matches_cpu_with_symbols
           mode: xfail
           tags:
             - jobplan_symbolic_args
+        - names:
+            - TestLaunchJobPlan::test_abs_matches_cpu_no_symbols
+            - TestLaunchJobPlan::test_mul_matches_cpu_no_symbols
+          mode: mandatory_success
+          tags:
+            - jobplan_no_symbolic_args

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -992,7 +992,7 @@ for _p in reversed(_os.environ.get('PYTHONPATH', '').split(_os.pathsep)):
 import importlib.util as _ilu
 
 _pre_import_classes = {}
-_restricted_names = set([${quoted_restricted_list}])
+_restricted_names: set[str] = set([${quoted_restricted_list}])
 
 def _do_pre_import():
     """Capture original class objects before the star-import deletes them."""

--- a/tests/test_launch_jobplan.py
+++ b/tests/test_launch_jobplan.py
@@ -15,91 +15,80 @@
 """Tests for launching simple compiled ops through JobPlan execution."""
 
 import os
-import subprocess
-import sys
+from typing import Tuple
 
 import pytest
-
-
-def run_compiled_op_in_subprocess(op_name: str, env_vars: dict) -> bool:
-    """
-    Run a compiled op test in an isolated subprocess with specific env vars.
-
-    This ensures each test runs with a fresh torch.compile cache and config,
-    avoiding the need for torch._dynamo.reset_code_caches().
-    """
-    code = f"""
+from torch.testing._internal.common_utils import TestCase
 import torch
+import torch._dynamo
 
-# Get the op function
-op_fn = getattr(torch, "{op_name}")
+from torch_spyre._inductor import config as _spyre_config
 
-# Generate inputs based on op
-if "{op_name}" == "abs":
-    inputs = (torch.randn(64, dtype=torch.float16),)
-elif "{op_name}" == "mul":
-    inputs = (
-        torch.randn(64, dtype=torch.float16),
-        torch.randn(64, dtype=torch.float16),
-    )
-else:
-    raise ValueError(f"Unknown op: {{op_name}}")
 
-# Run on CPU
-cpu_result = op_fn(*inputs)
+def _run_compiled_op(op_name: str, symbolic_args: bool) -> None:
+    """
+    Compile an op with DUMP_SPYRE_CODE=1 and run it on Spyre, comparing to CPU.
 
-# Compile and run on Spyre
-compiled_fn = torch.compile(op_fn, backend="inductor")
-spyre_inputs = tuple(inp.to("spyre") for inp in inputs)
-spyre_result = compiled_fn(*spyre_inputs).cpu()
+    Uses a fresh dynamo compile cache each call to ensure the kernel runner is
+    re-instantiated with the current DUMP_SPYRE_CODE env var value.  Runs
+    in-process (no subprocess) so the Spyre VFIO device opened by the test
+    session is reused rather than triggering a second exclusive open from a
+    child process.
+    """
+    torch._dynamo.reset()
 
-torch.testing.assert_close(
-    spyre_result, cpu_result, atol=0.1, rtol=0.1, equal_nan=True
-)
-print("PASS")
-"""
-    env = os.environ.copy()
-    env.update(env_vars)
+    op_fn = getattr(torch, op_name)
 
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"Subprocess failed with code {result.returncode}\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    torch.manual_seed(42)
+    inputs: Tuple[torch.Tensor, ...]
+    if op_name == "abs":
+        inputs = (torch.randn(64, dtype=torch.float16),)
+    elif op_name == "mul":
+        inputs = (
+            torch.randn(64, dtype=torch.float16),
+            torch.randn(64, dtype=torch.float16),
         )
+    else:
+        raise ValueError(f"Unknown op: {op_name}")
 
-    return "PASS" in result.stdout
+    cpu_result = op_fn(*inputs)
+
+    old_val = os.environ.get("DUMP_SPYRE_CODE")
+    try:
+        os.environ["DUMP_SPYRE_CODE"] = "1"
+        with _spyre_config.patch(bundle_symbolic_args=symbolic_args):  # type: ignore[attr-defined]
+            compiled_fn = torch.compile(op_fn, backend="inductor")
+            spyre_inputs = tuple(inp.to("spyre") for inp in inputs)
+            spyre_result = compiled_fn(*spyre_inputs).cpu()
+    finally:
+        if old_val is None:
+            os.environ.pop("DUMP_SPYRE_CODE", None)
+        else:
+            os.environ["DUMP_SPYRE_CODE"] = old_val
+
+    torch.testing.assert_close(
+        spyre_result, cpu_result, atol=0.1, rtol=0.1, equal_nan=True
+    )
 
 
-class TestLaunchJobPlan:
+class TestLaunchJobPlan(TestCase):
     """Test suite for JobPlan-backed compiled op execution."""
 
     def test_abs_matches_cpu_no_symbols(self):
         """Run compiled abs op without symbolic args and compare to CPU."""
-        assert run_compiled_op_in_subprocess("abs", {"DUMP_SPYRE_CODE": "1"})
+        _run_compiled_op("abs", symbolic_args=False)
 
     def test_abs_matches_cpu_with_symbols(self):
         """Run compiled abs op with symbolic args and compare to CPU."""
-        assert run_compiled_op_in_subprocess(
-            "abs", {"DUMP_SPYRE_CODE": "1", "BUNDLE_SYMBOLIC_ARGS": "1"}
-        )
+        _run_compiled_op("abs", symbolic_args=True)
 
     def test_mul_matches_cpu_no_symbols(self):
         """Run compiled mul op without symbolic args and compare to CPU."""
-        assert run_compiled_op_in_subprocess("mul", {"DUMP_SPYRE_CODE": "1"})
+        _run_compiled_op("mul", symbolic_args=False)
 
     def test_mul_matches_cpu_with_symbols(self):
         """Run compiled mul op with symbolic args and compare to CPU."""
-        assert run_compiled_op_in_subprocess(
-            "mul", {"DUMP_SPYRE_CODE": "1", "BUNDLE_SYMBOLIC_ARGS": "1"}
-        )
+        _run_compiled_op("mul", symbolic_args=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

This PR mainly refactors and cleans the way the test file was written. Below are the contributions:

- Replaces subprocess-based test runner with in-process execution to avoid VFIO EBUSY conflicts, where spawned subprocesses fail trying to exclusively open /dev/vfio already held by the parent process.

- Each test now calls `torch._dynamo.reset()` before compilation to get a fresh dynamo cache, replacing the cache isolation that subprocess spawning previously provided.

- `DUMP_SPYRE_CODE` is set and restored via os.environ save/restore pattern so it does not leak between tests, and bundle_symbolic_args is passed through `_spyre_config.patch()` instead of the `BUNDLE_SYMBOLIC_ARGS ` env var.

- `torch.testing.assert_close` now runs directly in-process replacing the indirect "PASS" in stdout subprocess string-parsing mechanism which will now give pytest proper AssertionError with tensor mismatch details on failure.

- `class TestLaunchJobPlan` now inherits from `TestCase` (via torch.testing._internal.common_utils.TestCase) so that framework's AST analyzer can detect it and the OOT wrapper can hook it via `instantiate_device_type_tests` and can be controlled by the test framework (config-driven)

- This allows the YAML config to correctly gate these tests through `TorchTestBase._should_run()`, which was previously bypassed entirely because the plain pytest class was invisible to the OOT framework (added `xfail` to test with symbols)

### Locally run and tested

<img width="3456" height="710" alt="image" src="https://github.com/user-attachments/assets/d0eac96d-cc03-4e1e-8b3f-79c8551c7365" />