### PR TITLE
ci-cd: fix stallwatcher to not kill the parent process before the child processes (avoid creating zombies)

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -89,9 +89,13 @@ runs:
                 echo "[stall-watcher] No new output for ${elapsed_stall}s (lines=${current_lines})"
                 if [[ $elapsed_stall -ge $STALL_TIMEOUT_SECS ]]; then
                   echo "[stall-watcher] STALL DETECTED — killing test child processes"
-                  kill -TERM "$TEST_PID" 2>/dev/null || true
-                  pkill -TERM -P "$TEST_PID" 2>/dev/null || true
-                  kill -TERM "$TEE_PID" 2>/dev/null || true
+                  # Kill the parent and ALL child processes in order
+                  # 1. Freeze the parent process so it cannot spawn anything
+                  kill -STOP "$TEST_PID" || true
+                  # 2. Kill all existing child processes
+                  pkill -P "$TEST_PID" || true
+                  # 3. Kill the frozen parent process
+                  kill -KILL "$TEST_PID" || true
                   return
                 fi
               else


### PR DESCRIPTION


Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

Current stallwatcher kills parent process first, causing child processes to potentially become zombies

#### Which issue(s) this PR is related to:

Fix https://github.com/torch-spyre/torch-spyre/issues/2782

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
