### PR TITLE
chore(cicd): make `oot-config-checker` to use ubuntu-latest instead of spyre enabled runner

### DIFF
--- a/.github/workflows/config_integrity_checker.yaml
+++ b/.github/workflows/config_integrity_checker.yaml
@@ -27,18 +27,16 @@ permissions:
 jobs:
   check-configs:
     name: Check OOT Configs
-    runs-on:
-      - x86_64
-      - spyre_pf_x0
-      - linux
-      - image_torch_spyre
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      - name: Install dependencies
+        run: pip install regex
+
       - name: Run check-all-configs
         run: |-
-          source /home/senuser/torch-spyre/.venv/bin/activate
           make check-all-configs ${{ inputs.test_file && format('TEST_FILE={0}', inputs.test_file) || '' }}

--- a/.github/workflows/upstream_tests.yaml
+++ b/.github/workflows/upstream_tests.yaml
@@ -8,12 +8,14 @@ on:
       - tests/docs/**
       - docs/**
       - README.md
+      - .github/workflows/config_integrity_checker.yaml
   pull_request:
     branches: [main]
     paths-ignore:
       - tests/docs/**
       - docs/**
       - README.md
+      - .github/workflows/config_integrity_checker.yaml
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup