### PR TITLE
feat(testing): feature to enable tests parallelization within each test suite config

### DIFF
--- a/.github/actions/run-test-suite/action.yml
+++ b/.github/actions/run-test-suite/action.yml
@@ -135,7 +135,7 @@ runs:
 
           exec {FIFO_FD}>"$FIFO"
 
-          env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} \
+          env ${_DTLOG_PREFIX} bash tests/run_test.sh "$CONFIG" --parallel ${{ inputs.extra_test_flags }} ${_SLOW_FLAG} ${_JUNIT_FLAG} \
             >&"$FIFO_FD" 2>&1 &
           TEST_PID=$!
 

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -91,7 +91,7 @@ jobs:
     name: ${{ matrix.suite.name }}
     runs-on:
       - x86_64
-      - spyre_pf_x1
+      - ${{ matrix.suite.runner || 'spyre_pf_x1' }}
       - ${{ inputs.runner_label }}
       - ${{ inputs.image_label }}
     timeout-minutes: 60
@@ -167,18 +167,21 @@ jobs:
             config: torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
           - name: Inductor Ops Misc Shape A
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
+            runner: spyre_pf_x4
           - name: Inductor Ops Misc Shape B
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
           - name: Inductor Ops Misc Shape C
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_c_config.yaml
           - name: Inductor Ops Misc Compute A
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_a_config.yaml
+            runner: spyre_pf_x4
           - name: Inductor Ops Misc Compute B
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
           - name: Inductor Ops Misc Compute C
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
           - name: Inductor Ops LX Planning
             config: torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
+            runner: spyre_pf_x4
           - name: Inductor Scalar
             config: torch_spyre_tests/inductor/test_inductor_scalar_config.yaml
           - name: Inductor Logging
@@ -285,6 +288,12 @@ jobs:
           extra_test_flags: ${{ inputs.extra_test_flags }}
           junit_xml_path: ${{ env.REPORT_PATH }}
           report_name: ${{ env.REPORT_NAME }}
+          pre_run: |
+            # Clear the cached AIU setup guard and stale topo.json so
+            # ibm-aiu-setup.sh re-discovers all cards on the x4 runner.
+            unset _IBM_AIU_SETUP
+            rm -rf /tmp/etc/ibm/spyre/topo.json
+            source /etc/profile.d/ibm-aiu-setup.sh
 
       - name: Upload JUnit XML report
         if: always()

--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -179,9 +179,9 @@ jobs:
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
           - name: Inductor Ops Misc Compute C
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
+            runner: spyre_pf_x4
           - name: Inductor Ops LX Planning
             config: torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
-            runner: spyre_pf_x4
           - name: Inductor Scalar
             config: torch_spyre_tests/inductor/test_inductor_scalar_config.yaml
           - name: Inductor Logging

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -9,6 +9,18 @@
 #   bash run_test.sh config_a.yaml config_b.yaml [config_c.yaml ...] [extra pytest args...]
 #   bash run_test.sh configs/                            # all YAMLs in a directory
 #   bash run_test.sh configs/ extra.yaml -- [extra pytest args...]
+#
+# Usage (parallel -- split the tests across all available Spyre cards automatically to run parallely):
+#   bash run_test.sh config.yaml --parallel
+#   bash run_test.sh configs/ --parallel --junit-xml=report.xml
+#   bash run_test.sh config_a.yaml config_b.yaml --parallel -v
+#
+# --parallel detects the number of Spyre cards from PCIDEVICE_IBM_COM_AIU_PF
+# (comma count+1) or torch.spyre.device_count(), then distributes the resolved
+# test files round-robin across cards, running each card's slice in a
+# background subshell with SPYRE_DEVICES=<card_idx>.  Falls back to serial
+# execution when only one card is detected.  JUnit XML shards from all cards
+# are merged into the single --junit-xml destination at the end.
 
 # When more than one YAML file is supplied the configs are merged in order via
 # oot_test_utilities.py
@@ -69,17 +81,26 @@ fi
 #                  On platforms with no slow tag defined, this is a no-op.
 # --include-slow : explicit no-op (default behaviour, for clarity in scripts).
 #
+# --parallel     : run test files in parallel across all available Spyre cards.
+#                  Each card receives a round-robin slice of the resolved file
+#                  list.  Card count is detected from PCIDEVICE_IBM_COM_AIU_PF
+#                  (comma count + 1) or torch.spyre.device_count() as fallback.
+#                  Falls back to serial execution when only one card is found.
+#
 # Usage:
-#   run_test.sh config.yaml                 # default: all tests run
+#   run_test.sh config.yaml                 # default: all tests run serially
 #   run_test.sh config.yaml --include-slow  # same, explicit
 #   run_test.sh config.yaml --skip-slow     # skip slow tests on this platform
-# ---------------------------------------------------------------------------
+#   run_test.sh config.yaml --parallel      # parallelize tests across all Spyre cards
+# ------------------------------------------------------------------------------------
 _SKIP_SLOW=0
+_PARALLEL=0
 _FILTERED_ARGS=()
 for _arg in "$@"; do
     case "$_arg" in
         --skip-slow)    _SKIP_SLOW=1 ;;
         --include-slow) _SKIP_SLOW=0 ;;
+        --parallel)     _PARALLEL=1 ;;
         *)              _FILTERED_ARGS+=("$_arg") ;;
     esac
 done
@@ -1506,6 +1527,413 @@ _run_xdist_fallback() {
     fi
 }
 
+# ---------------------------------------------------------------------------
+# _detect_spyre_card_count
+#
+# Returns the number of physical Spyre cards visible to this process.
+#
+# Detection order (first non-zero result gets the priority):
+#   1. PCIDEVICE_IBM_COM_AIU_PF: contains a comma-separated list of PCI bus IDs per card.
+#      Card count = number of commas + 1.
+#   2. torch.spyre.device_count(): runtime query via the flex driver.
+#      Respects the AIU_WORLD_SIZE / SPYRE_DEVICES if already set, so we clear
+#      those for the probe to get the raw hardware count.
+#   3. Falls back to 1 (serial) if neither source yields > 0.
+#
+# ---------------------------------------------------------------------------
+_detect_spyre_card_count() {
+    # PCIDEVICE_IBM_COM_AIU_PF
+    if [[ -n "${PCIDEVICE_IBM_COM_AIU_PF:-}" ]]; then
+        local _ids="${PCIDEVICE_IBM_COM_AIU_PF//[^,]/}"   # keep only commas
+        echo $(( ${#_ids} + 1 ))
+        return
+    fi
+
+    # Alternately torch.spyre.device_count() without any env overrides
+    local _count
+    _count=$(
+        env -u AIU_WORLD_SIZE -u SPYRE_DEVICES \
+        python3 -c "
+import torch_spyre, torch
+try:
+    print(torch.spyre.device_count())
+except Exception:
+    print(0)
+" 2>/dev/null
+    ) || true
+    if [[ "$_count" =~ ^[0-9]+$ && "$_count" -gt 0 ]]; then
+        echo "$_count"
+        return
+    fi
+
+    # Fallback: single card serial
+    echo 1
+}
+
+# ---------------------------------------------------------------------------
+# _run_parallel_across_cards
+#
+# Collects every test node ID from ALL resolved files, distributes them
+# round-robin across N Spyre cards, and runs each card's slice in a
+# background subshell with SPYRE_DEVICES=<card_idx>.
+#
+# Splitting at the test-ID level (not the file level) is essential: when
+# multiple configs share a single test file (e.g. all inductor shard configs
+# point to test_inductor_ops.py), merging reduces RUN_FILES to one entry.
+# File-level round-robin would assign everything to card 0.  Test-level
+# round-robin splits individual test cases across cards regardless of how
+# many files there are.
+#
+# Collection uses `pytest --collect-only -q` run from the file's directory
+# so conftest.py and SPYRE_TEST_FILE / OOT_TEST_FILE are set up identically
+# to a real run.  Collection is done without SPYRE_DEVICES so the runtime
+# is not loaded.
+#
+# Globals read:   RUN_FILES TEST_FILES _EXTRA_NO_XML _FINAL_XML_PATH
+#                 YAML_CONFIG _XML_INJECT_PY
+# Globals written: _XML_SHARDS OVERALL_EXIT
+# ---------------------------------------------------------------------------
+_run_parallel_across_cards() {
+    local _n_cards="$1"
+
+    echo ""
+    echo "[torch_oot_device_tests_run_parallel] --parallel: collecting test IDs from ${#RUN_FILES[@]} file(s) to distribute across ${_n_cards} card(s)..."
+
+    # -----------------------------------------------------------------------
+    # Step 1: collect all test node IDs across every resolved file.
+    #
+    # Output of `pytest --collect-only -q` looks like:
+    #   TestOpsPRIVATEUSE1::test_add_spyre_float16
+    #   TestOpsPRIVATEUSE1::test_bmm_spyre_float16
+    #   ...
+    #   <N> tests collected
+    #
+    # We keep only lines that contain "::" (node IDs), discarding the
+    # summary line and any warnings.
+    #
+    # Per-file collection is done with SPYRE_TEST_FILE set (so the OOT
+    # framework can identify the config) but without SPYRE_DEVICES / hardware
+    # initialisation so collection is fast even on a login node.
+    # -----------------------------------------------------------------------
+    # _all_node_ids: parallel arrays — node_id, file_idx (into RUN_FILES)
+    local -a _all_node_ids=()
+    local -a _all_node_file_idx=()
+
+    for i in "${!RUN_FILES[@]}"; do
+        local _rf="${RUN_FILES[$i]}"
+        local _of="${TEST_FILES[$i]}"
+        local _rd _rb
+        _rd="$(dirname "$_rf")"
+        _rb="$(basename "$_rf")"
+
+        echo "[torch_oot_device_tests_run]   collecting: $(basename "$_of")"
+
+        # Build the -m probe args (same as serial path).
+        local -a _collect_args=()
+        local _has_m=0
+        for _a in "${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}"; do
+            [[ "$_a" == "-m" ]] && { _has_m=1; break; }
+        done
+        if [[ $_has_m -eq 1 ]]; then
+            local _take_next=0
+            for _a in "${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}"; do
+                if [[ $_take_next -eq 1 ]]; then
+                    _collect_args+=("$_a"); _take_next=0; continue
+                fi
+                [[ "$_a" == "-m" ]] && { _collect_args+=("$_a"); _take_next=1; }
+            done
+        fi
+
+        local _raw_ids
+        _raw_ids=$(
+            export SPYRE_TEST_FILE="$_rf"
+            export OOT_TEST_FILE="$_rf"
+            cd "$_rd" && python3 -m pytest "$_rb" \
+                "${_collect_args[@]+"${_collect_args[@]}"}" \
+                --collect-only -q --no-header 2>/dev/null \
+            | grep '\.py::' || true
+        )
+
+        if [[ -z "$_raw_ids" ]]; then
+            echo "[torch_oot_device_tests_run_serial]   WARNING: no test IDs collected from $(basename "$_of") -- it will be skipped in parallel mode." >&2
+            continue
+        fi
+
+        while IFS= read -r _id; do
+            [[ -z "$_id" ]] && continue
+            # Strip any leading directory path from the file component so IDs
+            # are always in the form  basename.py::Class::method.
+            # pytest --collect-only outputs paths relative to rootdir (set by
+            # pyproject.toml), not relative to cwd, e.g.:
+            #   tests/inductor/test_inductor_ops__oot_wrapper.py::Class::method
+            # We run pytest from run_dir so we need just:
+            #   test_inductor_ops__oot_wrapper.py::Class::method
+            local _file_part _rest
+            _file_part="${_id%%::*}"          # everything before first ::
+            _rest="${_id#*::}"                # everything after first ::
+            _file_part="${_file_part##*/}"    # strip directory — keep basename
+            _id="${_file_part}::${_rest}"
+            _all_node_ids+=("$_id")
+            _all_node_file_idx+=("$i")
+        done <<< "$_raw_ids"
+    done
+
+    local _total="${#_all_node_ids[@]}"
+    if [[ $_total -eq 0 ]]; then
+        echo "[torch_oot_device_tests_run_warning] WARNING: no test IDs collected across all files -- nothing to run." >&2
+        return
+    fi
+
+    echo "[torch_oot_device_tests_run]   total test IDs collected: ${_total}"
+    echo ""
+
+    # -----------------------------------------------------------------------
+    # Step 2: distribute node IDs round-robin across cards.
+    #
+    # Each card gets a temp file listing its assigned node IDs, one per line,
+    # prefixed by the file index so the subshell knows which RUN_FILES entry
+    # to reference (for run_dir, SPYRE_TEST_FILE, shard XML naming, etc.).
+    # Format per line:  <file_idx>:<node_id>
+    # -----------------------------------------------------------------------
+    local -a _card_id_files=()
+    local _k
+    for (( _k=0; _k<_n_cards; _k++ )); do
+        local _f="/tmp/_spyre_card_ids_${$}_${_k}.tmp"
+        : > "$_f"
+        _card_id_files+=("$_f")
+    done
+
+    for (( j=0; j<_total; j++ )); do
+        _k=$(( j % _n_cards ))
+        echo "${_all_node_file_idx[$j]}:${_all_node_ids[$j]}" >> "${_card_id_files[$_k]}"
+    done
+
+    # Print the assignment summary.
+    for (( _k=0; _k<_n_cards; _k++ )); do
+        local _cnt
+        _cnt=$(wc -l < "${_card_id_files[$_k]}" 2>/dev/null || echo 0)
+        _cnt="${_cnt// /}"   # trim whitespace
+        echo "[torch_oot_device_tests_run_parallel_info]   card ${_k} (SPYRE_DEVICES=${_k}): ${_cnt} test(s)"
+    done
+    echo ""
+
+    # -----------------------------------------------------------------------
+    # Step 3: launch one background subshell per card.
+    #
+    # Each subshell groups its assigned node IDs by file index, then runs one
+    # pytest invocation per file (passing only that card's node IDs as
+    # positional args).
+    # -----------------------------------------------------------------------
+    local -a _card_pids=()
+    local -a _card_exit_files=()
+    local -a _card_shard_list_files=()
+
+    for (( _k=0; _k<_n_cards; _k++ )); do
+        local _card_exit_tmp="/tmp/_spyre_card_exit_${$}_${_k}.tmp"
+        local _card_shard_list="/tmp/_spyre_card_shards_${$}_${_k}.tmp"
+        _card_exit_files+=("$_card_exit_tmp")
+        _card_shard_list_files+=("$_card_shard_list")
+        : > "$_card_shard_list"
+
+        local _subshell_card="$_k"
+        local _subshell_id_file="${_card_id_files[$_k]}"
+        local _subshell_exit_tmp="$_card_exit_tmp"
+        local _subshell_shard_list="$_card_shard_list"
+
+        (
+            set +euo pipefail
+            export SPYRE_DEVICES="${_subshell_card}"
+            local _card_overall=0
+
+            # Group the assigned lines by file index using an associative array.
+            # Keys are file indices; values are newline-separated node IDs.
+            declare -A _file_to_ids=()
+            declare -a _file_order=()   # preserve first-seen order
+            while IFS=: read -r _fidx _nid; do
+                [[ -z "$_fidx" ]] && continue
+                if [[ -z "${_file_to_ids[$_fidx]+set}" ]]; then
+                    _file_order+=("$_fidx")
+                    _file_to_ids[$_fidx]=""
+                fi
+                _file_to_ids[$_fidx]+="${_nid}"$'\n'
+            done < "$_subshell_id_file"
+
+            for _fidx in "${_file_order[@]}"; do
+                local run_file="${RUN_FILES[$_fidx]}"
+                local original_file="${TEST_FILES[$_fidx]}"
+                local run_dir run_basename
+                run_dir="$(dirname "$run_file")"
+                run_basename="$(basename "$run_file")"
+
+                # Convert the newline-separated ID block to an array.
+                local -a _node_ids=()
+                while IFS= read -r _nid; do
+                    [[ -n "$_nid" ]] && _node_ids+=("$_nid")
+                done <<< "${_file_to_ids[$_fidx]}"
+
+                echo "========================================================================"
+                echo "[torch_oot_device_tests_run] card ${_subshell_card} | SPYRE_DEVICES=${_subshell_card} | ${#_node_ids[@]} test(s)"
+                if [[ "$run_file" != "$original_file" ]]; then
+                    echo "[torch_oot_device_tests_run] Running (via OOT wrapper): $original_file"
+                else
+                    echo "[torch_oot_device_tests_run] Running: $run_file"
+                fi
+                echo "========================================================================"
+
+                # Shard XML path — card+file namespaced.
+                local _shard_xml=""
+                if [[ -n "$_FINAL_XML_PATH" ]]; then
+                    _shard_xml="${_FINAL_XML_PATH%.xml}__card_${_subshell_card}__shard_${_fidx}.xml"
+                    echo "$_shard_xml" >> "$_subshell_shard_list"
+                fi
+
+                # Build pytest args: base args + node IDs as positional args.
+                # Node IDs are passed as bare names (no file prefix) because
+                # pytest is invoked from run_dir with run_basename as the target.
+                local -a _file_args
+                if [[ -n "$_shard_xml" ]]; then
+                    _file_args=("${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}" "--junit-xml=${_shard_xml}")
+                else
+                    _file_args=("${_EXTRA_NO_XML[@]+"${_EXTRA_NO_XML[@]}"}")
+                fi
+
+                export SPYRE_TEST_FILE="$run_file"
+                export OOT_TEST_FILE="$run_file"
+
+                local _exit_tmp="/tmp/_spyre_pytest_exit_${$}_card${_subshell_card}_${_fidx}.tmp"
+
+                # Run pytest with this card's node IDs appended after the file.
+                # _run_pytest_isolated runs `python3 -m pytest <basename> <args...>`;
+                # we append the node IDs as deselect-safe extra positional args via
+                # the args list: pytest file.py::TestClass::test_foo ... works when
+                # each ID is a full node ID string.
+                # However _run_pytest_isolated prefixes run_basename itself, so we
+                # pass the IDs as additional pytest args (pytest accepts them as
+                # node-ID filters when they contain "::").
+                # Node IDs are already normalised to basename::Class::method by
+                # the collection step above.  Pass them directly as pytest
+                # collection targets (run from run_dir).
+                local -a _id_args=("${_node_ids[@]}")
+                # Run pytest with this card's node IDs as the collection targets
+                # instead of the bare filename so only this card's slice runs.
+                (
+                    set +euo pipefail
+                    cd "$run_dir"
+                    python3 -m pytest "${_id_args[@]}" "${_file_args[@]}"
+                    echo $? > "$_exit_tmp"
+                ) || true
+
+                local _exit=0
+                if [[ -f "$_exit_tmp" ]]; then
+                    _exit=$(< "$_exit_tmp")
+                    rm -f "$_exit_tmp"
+                else
+                    _exit=139
+                    echo "[torch_oot_device_tests_run] ERROR: pytest subshell exited abnormally for $original_file" >&2
+                fi
+
+                # XML tag injection for clean runs.
+                if [[ -n "$_shard_xml" && -f "$_shard_xml" && $_exit -lt 128 ]]; then
+                    python3 -c "$_XML_INJECT_PY" "$_shard_xml" "$YAML_CONFIG" || true
+                fi
+
+                # Exit-code handling.
+                case $_exit in
+                    0) ;;
+                    1)  [[ $_card_overall -eq 0 ]] && _card_overall=1 ;;
+                    5)  echo "[torch_oot_device_tests_run] WARNING: no tests collected for card ${_subshell_card} slice of $(basename "$original_file")" >&2 ;;
+                    127)
+                        echo "[torch_oot_device_tests_run_err] FATAL: python3/pytest not found for $original_file" >&2
+                        _card_overall=$_exit ;;
+                    130)
+                        echo "[torch_oot_device_tests_run_err] FATAL: interrupted (card ${_subshell_card}) -- aborting." >&2
+                        _card_overall=$_exit
+                        break ;;
+                    *)
+                        # Signal exit — retry the card's slice with -n1 xdist.
+                        echo "[torch_oot_device_tests_run] WARNING: pytest exited with signal (code $_exit) on card ${_subshell_card}" >&2
+                        if python3 -c "import xdist" 2>/dev/null; then
+                            local -a _xdist_args=("-n1" "${_file_args[@]+"${_file_args[@]}"}")
+                            (
+                                set +euo pipefail
+                                cd "$run_dir"
+                                python3 -m pytest "${_id_args[@]}" "${_xdist_args[@]}"
+                                echo $? > "$_exit_tmp"
+                            ) || true
+                            if [[ -f "$_exit_tmp" ]]; then
+                                local _xexit; _xexit=$(< "$_exit_tmp"); rm -f "$_exit_tmp"
+                                [[ $_xexit -ne 0 && $_xexit -ne 5 && $_card_overall -eq 0 ]] && _card_overall=$_xexit
+                                if [[ -n "$_shard_xml" && -f "$_shard_xml" ]]; then
+                                    python3 -c "$_XML_INJECT_PY" "$_shard_xml" "$YAML_CONFIG" || true
+                                fi
+                            fi
+                        else
+                            echo "[torch_oot_device_tests_run] WARNING: pytest-xdist not installed — skipping xdist fallback for card ${_subshell_card}." >&2
+                            [[ $_card_overall -eq 0 ]] && _card_overall=1
+                        fi
+                        ;;
+                esac
+            done
+
+            echo "$_card_overall" > "$_subshell_exit_tmp"
+        ) &
+
+        _card_pids+=($!)
+    done
+
+    # -----------------------------------------------------------------------
+    # Step 4: wait for all card subshells; collect exit codes and XML shards.
+    # -----------------------------------------------------------------------
+    echo "[torch_oot_device_tests_run] Waiting for all card jobs to finish..."
+    for (( _k=0; _k<_n_cards; _k++ )); do
+        wait "${_card_pids[$_k]}" || true
+
+        local _card_exit=0
+        local _exit_file="${_card_exit_files[$_k]}"
+        if [[ -f "$_exit_file" ]]; then
+            _card_exit=$(< "$_exit_file")
+            rm -f "$_exit_file"
+        else
+            _card_exit=1
+            echo "[torch_oot_device_tests_run] WARNING: card ${_k} did not write an exit code." >&2
+        fi
+        echo "[torch_oot_device_tests_run] card ${_k} finished with exit code: ${_card_exit}"
+
+        case $_card_exit in
+            0) ;;
+            1)   [[ $OVERALL_EXIT -eq 0 ]] && OVERALL_EXIT=1 ;;
+            5)   : ;;
+            *)   OVERALL_EXIT=$_card_exit ;;
+        esac
+
+        local _shard_list="${_card_shard_list_files[$_k]}"
+        if [[ -f "$_shard_list" ]]; then
+            while IFS= read -r _s; do
+                [[ -n "$_s" ]] && _XML_SHARDS+=("$_s")
+            done < "$_shard_list"
+            rm -f "$_shard_list"
+        fi
+
+        rm -f "${_card_id_files[$_k]}"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# 13. Parallel or serial execution
+# ---------------------------------------------------------------------------
+if [[ $_PARALLEL -eq 1 ]]; then
+    _N_CARDS=$(_detect_spyre_card_count)
+    echo "[torch_oot_device_tests_run_info] Detected ${_N_CARDS} Spyre card(s)."
+    if [[ $_N_CARDS -le 1 ]]; then
+        echo "[torch_oot_device_tests_run] Only 1 card detected --> falling back to serial execution."
+        _PARALLEL=0
+    fi
+fi
+
+if [[ $_PARALLEL -eq 1 ]]; then
+    _run_parallel_across_cards "$_N_CARDS"
+else
+
 for i in "${!RUN_FILES[@]}"; do
     run_file="${RUN_FILES[$i]}"
     original_file="${TEST_FILES[$i]}"
@@ -1692,6 +2120,8 @@ for i in "${!RUN_FILES[@]}"; do
             ;;
     esac
 done
+
+fi  # end of serial-vs-parallel branch
 
 # ---------------------------------------------------------------------------
 # Merge all XML shards into the final output path requested by the caller.

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1743,6 +1743,12 @@ _run_parallel_across_cards() {
         (
             set +euo pipefail
             export SPYRE_DEVICES="${_subshell_card}"
+            # Isolate the Inductor / FxGraph cache per card so that concurrent
+            # shutil.rmtree() calls from FxGraphCache.clear() in different card
+            # subshells do not race on the same /tmp/torchinductor_*/fxgraph/
+            # directory (OSError ENOTEMPTY).
+            _base_cache="${TORCHINDUCTOR_CACHE_DIR:-/tmp/torchinductor_${USER:-$(id -un)}}"
+            export TORCHINDUCTOR_CACHE_DIR="${_base_cache}__card_${_subshell_card}"
             local _card_overall=0
 
             # Group the assigned lines by file index using an associative array.

--- a/torch_spyre/_inductor/dtype_ops.py
+++ b/torch_spyre/_inductor/dtype_ops.py
@@ -70,8 +70,8 @@ class DtypeOpTable:
         return cls._TYPECAST_OPS_TABLE
 
     @classmethod
-    def get_dtype_pairs(cls) -> set[tuple[torch.dtype, torch.dtype]]:
-        return cls._TYPECAST_OP_DTYPES
+    def get_dtype_pairs(cls) -> list[tuple[torch.dtype, torch.dtype]]:
+        return list(cls._TYPECAST_OPS_TABLE.keys())
 
     @classmethod
     def is_dtype_op(cls, op: str) -> bool:

--- a/torch_spyre/_inductor/dtype_ops.py
+++ b/torch_spyre/_inductor/dtype_ops.py
@@ -70,8 +70,8 @@ class DtypeOpTable:
         return cls._TYPECAST_OPS_TABLE
 
     @classmethod
-    def get_dtype_pairs(cls) -> list[tuple[torch.dtype, torch.dtype]]:
-        return list(cls._TYPECAST_OPS_TABLE.keys())
+    def get_dtype_pairs(cls) -> set[tuple[torch.dtype, torch.dtype]]:
+        return cls._TYPECAST_OP_DTYPES
 
     @classmethod
     def is_dtype_op(cls, op: str) -> bool:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

## What this PR does:

### Changes to the framework

- Add `--parallel` flag to `tests/run_test.sh` that automatically detects the number of available Spyre AIU cards and distributes tests across them (round-robin)

- Card count is detected from `PCIDEVICE_IBM_COM_AIU_PF` with fallback to `torch.spyre.device_count()`; falls back to   serial execution when only one card is found.

- Distribution is at the **test-ID level** (not file level): `pytest --collect-only` is used to enumerate all test node IDs, which are then assigned round-robin across cards. So this will also correctly handle the case where multiple YAML shard configs all point at the same test file (e.g. `test_inductor_ops.py`)

- Each card runs in a background subshell with `SPYRE_DEVICES=<card_idx>` exported and signal exits trigger the existing xdist `-n1` fallback; JUnit XML shards from all cards are merged into the single `--junit-xml` destination

- Serial path is a fallback path when no parallelism can be exploited ( 1 spyre card)

- Fix `OSError: [Errno 39] Directory not empty in FxGraphCache.clear()`: when multiple card subshells run concurrently they all default to the same `/tmp/torchinductor_<user>/fxgraph/` directory. FxGraphCache.clear() calls shutil.rmtree() on that path at the start of every test, so two subshells racing on the same directory produce a non-deterministic ENOTEMPTY failure. Fixed by setting TORCHINDUCTOR_CACHE_DIR to a card-scoped path at the top of each card subshell, fully isolating the Inductor cache per card.

- Adds `runner: spyre_pf_x4` in the matrix for lx op planning, inductor_ops_misc_shape_a, inductor_ops_misc_compute_a. Rest all run with 1 spyre card.

## Verification of correctness with `test_inductor_ops_matmul_config` suite:

Result with serial run is that of around 9:30 for inductor matmul tests.

#### With 2 Spyre cards -- spun up a pod with the latest dev image with 2 spyre cards 

Command ran:
```bash
bash run_test.sh configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml -v --parallel
```

Output
```bash
[torch_oot_device_tests_run] Detected 2 Spyre card(s).

[torch_oot_device_tests_run] --parallel: collecting test IDs from 1 file(s) to distribute across 2 card(s)...
[torch_oot_device_tests_run]   collecting: test_inductor_ops.py
[torch_oot_device_tests_run]   total test IDs collected: 56

[torch_oot_device_tests_run]   card 0 (SPYRE_DEVICES=0): 28 test(s)
[torch_oot_device_tests_run]   card 1 (SPYRE_DEVICES=1): 28 test(s)
.....
...
....
======= 27 passed, 1 xfailed in 295.65s (0:04:55) ======
======= 28 passed in 334.14s (0:05:34) =====

[torch_oot_device_tests_run] card 0 finished with exit code: 0
[torch_oot_device_tests_run] card 1 finished with exit code: 0

[torch_oot_device_tests_run] Done. Overall exit code: 0
```
Result: The two cards ran in parallel, so the total wall-clock time is max(4:55, 5:34) = 5 mins 34 seconds


#### With 4 Spyre cards -- spun up a pod with the latest dev image with 4 spyre cards 
Command ran:
```bash
bash run_test.sh configs/torch_spyre_tests/inductor/test_inductor_ops_matmul_config.yaml -v --parallel
```


Output:
```
[torch_oot_device_tests_run_info] Detected 4 Spyre card(s).

[torch_oot_device_tests_run_parallel] --parallel: collecting test IDs from 1 file(s) to distribute across 4 card(s)...
[torch_oot_device_tests_run]   collecting: test_inductor_ops.py
[torch_oot_device_tests_run]   total test IDs collected: 56

[torch_oot_device_tests_run_parallel_info]   card 0 (SPYRE_DEVICES=0): 14 test(s)
[torch_oot_device_tests_run_parallel_info]   card 1 (SPYRE_DEVICES=1): 14 test(s)
[torch_oot_device_tests_run_parallel_info]   card 2 (SPYRE_DEVICES=2): 14 test(s)
[torch_oot_device_tests_run_parallel_info]   card 3 (SPYRE_DEVICES=3): 14 test(s)

[torch_oot_device_tests_run] Waiting for all card jobs to finish...
========================================================================
[torch_oot_device_tests_run] card 0 | SPYRE_DEVICES=0 | 14 test(s)
[torch_oot_device_tests_run] Running (via OOT wrapper): /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/test_inductor_ops.py
========================================================================
========================================================================
[torch_oot_device_tests_run] card 2 | SPYRE_DEVICES=2 | 14 test(s)
[torch_oot_device_tests_run] Running (via OOT wrapper): /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/test_inductor_ops.py
========================================================================
========================================================================
[torch_oot_device_tests_run] card 3 | SPYRE_DEVICES=3 | 14 test(s)
[torch_oot_device_tests_run] Running (via OOT wrapper): /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/test_inductor_ops.py
========================================================================
========================================================================
[torch_oot_device_tests_run] card 1 | SPYRE_DEVICES=1 | 14 test(s)
[torch_oot_device_tests_run] Running (via OOT wrapper): /dev/shm/dt-inductor/torch-spyre-anu-forked/tests/inductor/test_inductor_ops.py
....
....
...
=============== 14 passed in 180.07s (0:03:00) ======================
=============== 13 passed, 1 xfailed in 190.83s (0:03:10) ===============
=============== 14 passed in 195.22s (0:03:15) =================
=============== 14 passed in 208.06s (0:03:28) =================
```

Result: The 4 cards ran in parallel, so the total wall-clock time is max(03:00,03:10,03:15,03:28) = 3 mins 28 secs

3:28 < 5:34 < ~9:30 


## Previous vs Current PR comparision:

https://github.com/torch-spyre/torch-spyre/actions/runs/27909571780/job/82584279706:

**Inductor Ops Misc Shape A : 12 min 12 seconds**
Inductor Ops Misc Compute A : 5 min 55 seconds 
**Inductor Ops LX Planning: 18 mins 8 secs**

This PR triggered https://github.com/torch-spyre/torch-spyre/actions/runs/27934531361/job/82653180928?pr=2786

**Inductor Ops Misc Shape A : 5 min 30 secs**
Inductor Ops Misc Compute A: 3 min 54 secs
**Inductor Ops LX Planning: 7 mins 15 secs**

