### PR TITLE
on-chip LX relayout collective

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -173,6 +173,8 @@ jobs:
           - name: Inductor Ops LX Planning
             config: torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
             runner: spyre_pf_x4
+          - name: Inductor LX Relayout
+            config: torch_spyre_tests/inductor/test_lx_relayout_config.yaml
           - name: Inductor Scalar
             config: torch_spyre_tests/inductor/test_inductor_scalar_config.yaml
           - name: Inductor Logging

--- a/tests/configs/torch_spyre_tests/inductor/test_lx_relayout_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_lx_relayout_config.yaml
@@ -1,0 +1,4 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_lx_relayout.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_lx_relayout.py
+++ b/tests/inductor/test_lx_relayout.py
@@ -1,0 +1,425 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+
+import sympy
+
+from torch_spyre._C import DataFormats
+from torch_spyre._inductor import config as spyre_config
+from torch_spyre._inductor.codegen.lx_relayout import (
+    _expand_dataop_movement_ranges,
+    patch_lx_relayout_mixed_schedules,
+    build_lx_relayout_sdsc,
+)
+from torch_spyre._inductor.lx_relayout import (
+    LXRelayoutCell,
+    LXRelayoutPlan,
+    LXRelayoutSubview,
+    _lx_relayout_v1_support_reason,
+    _planned_payload,
+    build_lx_relayout_cells,
+    validate_lx_relayout_cell_coverage,
+)
+from torch_spyre._inductor.op_spec import OpSpec
+from torch_spyre._inductor.op_spec import TensorArg
+from torch_spyre._inductor.pass_utils import PerCoreView
+
+
+def test_lx_relayout_cells_cover_matmul_to_pointwise_reshard():
+    core_id = sympy.Symbol("core_id")
+    producer_view = PerCoreView(
+        work_slice_dims=((0, 4), (1, 8)),
+        core_to_slot=((0, sympy.Mod(core_id, 4)), (1, sympy.floor(core_id / 4))),
+    )
+    consumer_view = PerCoreView(
+        work_slice_dims=((0, 32),),
+        core_to_slot=((0, sympy.Mod(core_id, 32)),),
+    )
+
+    cells, reason = build_lx_relayout_cells(
+        producer_view=producer_view,
+        consumer_view=consumer_view,
+        device_sizes=[512, 12800],
+        element_bytes=2,
+        producer_core_count=32,
+        consumer_core_count=32,
+    )
+
+    assert reason is None
+    assert validate_lx_relayout_cell_coverage(cells, device_sizes=[512, 12800]) is None
+    assert len(cells) == 256
+    assert sum(cell.bytes for cell in cells) == 512 * 12800 * 2
+    assert cells[1].source_core == 4
+    assert cells[1].dest_core == 0
+    assert cells[8].source_core == 0
+    assert cells[8].dest_core == 1
+
+
+def test_lx_relayout_v1_rejects_unaligned_and_overlapping_cells(monkeypatch):
+    monkeypatch.setattr(spyre_config, "lx_relayout_producer_lx_base", 0)
+    monkeypatch.setattr(spyre_config, "lx_relayout_consumer_lx_base", 0x100000)
+    aligned = LXRelayoutCell(
+        cell_index=0,
+        source_core=0,
+        dest_core=0,
+        dim_starts={"d0_": 0},
+        dim_sizes={"d0_": 64},
+        bytes=128,
+        source_offset_bytes=0,
+        dest_offset_bytes=0,
+    )
+
+    assert _lx_relayout_v1_support_reason([aligned]) is None
+    assert (
+        _lx_relayout_v1_support_reason(
+            [dataclasses.replace(aligned, dest_offset_bytes=16)]
+        )
+        == "lx-relayout-v1-requires-stick-aligned-destination-address"
+    )
+    assert (
+        _lx_relayout_v1_support_reason(
+            [
+                dataclasses.replace(aligned, bytes=256),
+                dataclasses.replace(
+                    aligned,
+                    cell_index=1,
+                    source_offset_bytes=128,
+                    dest_offset_bytes=128,
+                ),
+            ]
+        )
+        == "lx-relayout-v1-requires-contiguous-destination-cells"
+    )
+
+
+def test_stcdp_range_carrier_wraps_relayout_as_stcdp_lx(monkeypatch):
+    monkeypatch.setattr(spyre_config, "lx_relayout_producer_lx_base", 0x1000)
+    monkeypatch.setattr(spyre_config, "lx_relayout_consumer_lx_base", 0x9000)
+    monkeypatch.setattr(spyre_config, "lx_relayout_chunk_cells", 32)
+
+    core_id = sympy.Symbol("core_id")
+    producer_view = PerCoreView(
+        work_slice_dims=((0, 2),),
+        core_to_slot=((0, sympy.Mod(core_id, 2)),),
+    )
+    consumer_view = PerCoreView(work_slice_dims=(), core_to_slot=())
+    cells, reason = build_lx_relayout_cells(
+        producer_view=producer_view,
+        consumer_view=consumer_view,
+        device_sizes=[2, 64],
+        device_stride_map=[64, 1],
+        element_bytes=2,
+        producer_core_count=2,
+        consumer_core_count=1,
+        lx_relayout_v1=True,
+    )
+    assert reason is None
+
+    plan = _lx_relayout_plan_payload(cells, device_sizes=[2, 64], element_bytes=2)
+    producer_payload = {
+        "1_batchmatmul": _minimal_sdsc_payload(
+            "batchmatmul",
+            output_lds_idx=2,
+            input_lds_indices=[0, 1],
+            core_ids=[0, 1],
+        )
+    }
+    consumer_payload = {
+        "2_neg": _minimal_sdsc_payload(
+            "neg",
+            output_lds_idx=1,
+            input_lds_indices=[0],
+            core_ids=[0],
+        )
+    }
+    output_arg = TensorArg(
+        is_input=False,
+        arg_index=0,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[2, 64],
+        device_coordinates=[],
+        allocation=None,
+        name="buf0",
+    )
+
+    patched_producer, mixed_consumer = build_lx_relayout_sdsc(
+        1,
+        2,
+        producer_payload,
+        consumer_payload,
+        output_arg,
+        dataclasses.replace(output_arg, is_input=True, arg_index=0),
+        2,
+        0,
+        plan,
+    )
+
+    producer_dsc = next(iter(patched_producer["1_batchmatmul"]["dscs_"][0].values()))
+    assert producer_dsc["labeledDs_"][2]["memOrg_"] == {"lx": {"isPresent": 1}}
+
+    mixed_root = mixed_consumer["2_LXRelayoutSTCDPOpLx"]
+    dataops = [next(iter(row.values())) for row in mixed_root["datadscs_"]]
+    movements = [move for dataop in dataops for move in _dataop_movements(dataop)]
+    consumer_dsc = next(iter(mixed_root["dscs_"][0].values()))
+
+    assert all(dataop["op"]["name"] == "STCDPOpLx" for dataop in dataops)
+    assert all("rangedLxRemap" in dataop["op"] for dataop in dataops)
+    assert all(
+        dataop["op"]["rangedLxRemap"]["schemaVersion"] == 0 for dataop in dataops
+    )
+    assert all(
+        dataop["op"]["rangedLxRemap"]["producerLxBase"] == 0x1000 for dataop in dataops
+    )
+    assert all(
+        dataop["op"]["rangedLxRemap"]["consumerLxBase"] == 0x9000 for dataop in dataops
+    )
+    assert all("movementRanges" in dataop["op"]["rangedLxRemap"] for dataop in dataops)
+    assert all("movements" not in dataop["op"]["rangedLxRemap"] for dataop in dataops)
+    assert {move["source"]["core"] for move in movements} == {0, 1}
+    assert "STCDPOpLx" in mixed_root["opFuncsUsed_"]
+    assert consumer_dsc["labeledDs_"][0]["memOrg_"] == {"lx": {"isPresent": 1}}
+
+
+def test_stcdp_range_carrier_patches_nonadjacent_split_subview_consumer(
+    monkeypatch,
+):
+    monkeypatch.setattr(spyre_config, "lx_planner_relayout_realize", True)
+    monkeypatch.setattr(spyre_config, "lx_relayout_producer_lx_base", 0x1000)
+    monkeypatch.setattr(spyre_config, "lx_relayout_consumer_lx_base", 0x9000)
+
+    cells = [
+        LXRelayoutCell(
+            cell_index=0,
+            source_core=0,
+            dest_core=1,
+            dim_starts={"d0_": 0},
+            dim_sizes={"d0_": 64},
+            bytes=128,
+            source_offset_bytes=0,
+            dest_offset_bytes=0,
+        )
+    ]
+    first_half_plan = _lx_relayout_plan_payload(
+        cells,
+        device_sizes=[128],
+        element_bytes=2,
+        movement_subview=LXRelayoutSubview(starts=[0], sizes=[64]),
+    )
+    second_half_plan = _lx_relayout_plan_payload(
+        [
+            dataclasses.replace(
+                cells[0],
+                dim_starts={"d0_": 64},
+                source_offset_bytes=128,
+                dest_offset_bytes=0,
+            )
+        ],
+        device_sizes=[128],
+        element_bytes=2,
+        movement_subview=LXRelayoutSubview(starts=[64], sizes=[64]),
+    )
+
+    specs = [
+        OpSpec(
+            op="batchmatmul",
+            is_reduction=False,
+            iteration_space={},
+            args=[
+                _tensor_arg("x", True, 0),
+                _tensor_arg("w", True, 1),
+                _tensor_arg("buf0", False, 2),
+            ],
+            op_info={},
+        ),
+        OpSpec(
+            op="neg",
+            is_reduction=False,
+            iteration_space={},
+            args=[_tensor_arg("buf0", True, 0), _tensor_arg("buf1", False, 1)],
+            op_info={"lx_relayout": {"buf0": first_half_plan}},
+        ),
+        OpSpec(
+            op="exp",
+            is_reduction=False,
+            iteration_space={},
+            args=[_tensor_arg("buf0", True, 0), _tensor_arg("buf2", False, 1)],
+            op_info={"lx_relayout": {"buf0": first_half_plan}},
+        ),
+        OpSpec(
+            op="mul",
+            is_reduction=False,
+            iteration_space={},
+            args=[_tensor_arg("buf0", True, 0), _tensor_arg("buf3", False, 1)],
+            op_info={"lx_relayout": {"buf0": second_half_plan}},
+        ),
+    ]
+    compiled = [
+        (
+            {
+                "0_batchmatmul": _minimal_sdsc_payload(
+                    "batchmatmul",
+                    output_lds_idx=2,
+                    input_lds_indices=[0, 1],
+                    core_ids=[0, 1],
+                )
+            },
+            [],
+            [],
+            [],
+        ),
+        (
+            {
+                "1_neg": _minimal_sdsc_payload(
+                    "neg",
+                    output_lds_idx=1,
+                    input_lds_indices=[0],
+                    core_ids=[0, 1],
+                )
+            },
+            [],
+            [],
+            [],
+        ),
+        (
+            {
+                "2_exp": _minimal_sdsc_payload(
+                    "exp",
+                    output_lds_idx=1,
+                    input_lds_indices=[0],
+                    core_ids=[0, 1],
+                )
+            },
+            [],
+            [],
+            [],
+        ),
+        (
+            {
+                "3_mul": _minimal_sdsc_payload(
+                    "mul",
+                    output_lds_idx=1,
+                    input_lds_indices=[0],
+                    core_ids=[0, 1],
+                )
+            },
+            [],
+            [],
+            [],
+        ),
+    ]
+
+    patch_lx_relayout_mixed_schedules(compiled, specs)
+
+    assert "1_LXRelayoutSTCDPOpLx" in compiled[1][0]
+    assert len(compiled[1][0]["1_LXRelayoutSTCDPOpLx"]["datadscs_"]) == 1
+    assert "2_exp" in compiled[2][0]
+    exp_dsc = next(iter(compiled[2][0]["2_exp"]["dscs_"][0].values()))
+    assert exp_dsc["labeledDs_"][0]["memOrg_"] == {"lx": {"isPresent": 1}}
+    assert "3_LXRelayoutSTCDPOpLx" in compiled[3][0]
+    assert len(compiled[3][0]["3_LXRelayoutSTCDPOpLx"]["datadscs_"]) == 1
+
+
+def _lx_relayout_plan_payload(
+    cells: list[LXRelayoutCell],
+    *,
+    device_sizes: list[int],
+    element_bytes: int,
+    movement_subview: LXRelayoutSubview | None = None,
+) -> dict:
+    plan = LXRelayoutPlan(
+        source_name="buf0",
+        producer_name="buf0",
+        consumer_name="buf1",
+        device_sizes=device_sizes,
+        device_stride_map=list(range(len(device_sizes))),
+        element_bytes=element_bytes,
+        producer_core_count=2,
+        consumer_core_count=1,
+        producer_region_bytes=sum(cell.bytes for cell in cells),
+        consumer_region_bytes=sum(cell.bytes for cell in cells),
+        cells=cells,
+        movement_subview=movement_subview,
+    )
+    return _planned_payload(plan)
+
+
+def _dataop_movements(dataop: dict) -> list[dict]:
+    if (dataop.get("op") or {}).get("name") == "STCDPOpLx":
+        dataop = (dataop.get("op") or {}).get("rangedLxRemap") or {}
+    return _expand_dataop_movement_ranges(dataop.get("movementRanges") or [])
+
+
+def _minimal_sdsc_payload(
+    name: str,
+    *,
+    output_lds_idx: int,
+    input_lds_indices: list[int],
+    core_ids: list[int],
+) -> dict:
+    max_lds_idx = max([output_lds_idx, *input_lds_indices])
+    return {
+        "numCoresUsed_": len(core_ids),
+        "opFuncsUsed_": [name],
+        "dscs_": [
+            {
+                name: {
+                    "numCoresUsed_": len(core_ids),
+                    "coreIdsUsed_": core_ids,
+                    "scheduleTree_": [
+                        {
+                            "name_": f"allocate_lds{idx}_hbm",
+                            "ldsIdx_": idx,
+                            "component_": "hbm",
+                        }
+                        for idx in range(max_lds_idx + 1)
+                    ],
+                    "labeledDs_": [
+                        {
+                            "ldsIdx_": idx,
+                            "dsType_": (
+                                "OUTPUT"
+                                if idx == output_lds_idx
+                                else "INPUT"
+                                if idx in input_lds_indices
+                                else "LOCAL"
+                            ),
+                            "memOrg_": {"hbm": {"isPresent": 1}},
+                        }
+                        for idx in range(max_lds_idx + 1)
+                    ],
+                    "computeOp_": [
+                        {
+                            "inputLabeledDs": [
+                                f"tensor-idx{idx}" for idx in input_lds_indices
+                            ],
+                            "outputLabeledDs": [f"tensor-idx{output_lds_idx}"],
+                        }
+                    ],
+                }
+            }
+        ],
+    }
+
+
+def _tensor_arg(name: str, is_input: bool, arg_index: int) -> TensorArg:
+    return TensorArg(
+        is_input=is_input,
+        arg_index=arg_index,
+        device_dtype=DataFormats.SEN169_FP16,
+        device_size=[128],
+        device_coordinates=[],
+        allocation=None,
+        name=name,
+    )

--- a/torch_spyre/_inductor/codegen/bundle.py
+++ b/torch_spyre/_inductor/codegen/bundle.py
@@ -21,6 +21,7 @@ import sympy
 
 from torch_spyre._inductor import config as _spyre_config
 from torch_spyre._inductor.codegen.compute_ops import SymbolKind
+from torch_spyre._inductor.codegen.lx_relayout import patch_lx_relayout_mixed_schedules
 from torch_spyre._inductor.codegen.superdsc import compile_op_spec
 from torch_spyre._inductor.codegen.unroll import unroll_loop_specs
 from torch_spyre._inductor.op_spec import LoopSpec, OpSpec
@@ -40,7 +41,7 @@ logger = get_inductor_logger("sdsc_compile")
 #                       {tiled_sym: stride_bytes} for tiled HBM tensors,
 #                       empty dict for non-tiled / lx tensors
 #   symbol_kinds:       list[SymbolKind] parallel to base_symbol_values
-_CompiledEntry = tuple[Any, list[int], list[dict], list[SymbolKind]]
+_CompiledEntry = tuple[Any | None, list[int], list[dict], list[SymbolKind]]
 
 
 # ---------------------------------------------------------------------------
@@ -88,8 +89,8 @@ def generate_bundle(
     # -----------------------------------------------------------------------
     # Pass 1: compile all OpSpecs depth-first.
     # ``symbols`` is indexed by abs(symbol_id)-1: one entry per symbol ID in
-    # registration order, values may repeat across SDSCs.  Writes one
-    # ``sdsc_N.json`` file per OpSpec.
+    # registration order, values may repeat across SDSCs.  JSON files are
+    # written after optional bundle-level rewrites below.
     # -----------------------------------------------------------------------
     symbols: list[int] = []
     compiled: list[_CompiledEntry] = []
@@ -105,6 +106,21 @@ def generate_bundle(
         output_dir,
         use_symbols=use_symbols,
     )
+
+    if _spyre_config.lx_planner_relayout_realize and not use_symbols:
+        patch_lx_relayout_mixed_schedules(compiled, specs_list)
+    elif _spyre_config.lx_planner_relayout_realize and use_symbols:
+        logger.info("LX relayout realization skipped for symbolic bundle args")
+
+    for sdsc_json, _local_sym_values, _affine_strides, _local_symbol_kinds in compiled:
+        if sdsc_json is None:
+            continue
+        sdsc_name = next(iter(sdsc_json))
+        sdsc_idx = sdsc_name.split("_", 1)[0]
+        file_name = f"sdsc_{sdsc_idx}.json"
+        with open(os.path.join(output_dir, file_name), "w") as f:
+            logger.info(f"Generating {f.name}")
+            json.dump(sdsc_json, f, indent=2)
 
     # -----------------------------------------------------------------------
     # Pass 2: emit bundle.mlir.
@@ -346,10 +362,6 @@ def _compile_specs(
             compiled.append(
                 (sdsc_json, local_sym_values, affine_strides, local_symbol_kinds)
             )
-            file_name = f"sdsc_{idx}.json"
-            with open(os.path.join(output_dir, file_name), "w") as f:
-                logger.info(f"Generating {f.name}")
-                json.dump(sdsc_json, f, indent=2)
         # UnimplementedOp and other types are silently skipped.
 
 
@@ -502,6 +514,8 @@ def _emit_specs(
             # Per-tensor loop-var index lists: which positions in the enclosing
             # loop_vars list correspond to the strides for each tensor.
             per_tensor_lv_indices: list[list[int]] = next(affine_map_lv_iter)
+            if sdsc_json is None:
+                continue
 
             # Determine the JSON filename from the sdsc_json key.
             sdsc_name = next(iter(sdsc_json))

--- a/torch_spyre/_inductor/codegen/lx_relayout.py
+++ b/torch_spyre/_inductor/codegen/lx_relayout.py
@@ -1,0 +1,818 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""STCDPOpLx SDSC carrier helpers for experimental LX relayout."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+from torch_spyre._inductor import config
+from torch_spyre._inductor.lx_relayout import (
+    LX_RELAYOUT_OP_INFO_KEY,
+    _dataop_movement_ranges,
+    _expand_dataop_movement_ranges,
+)
+from torch_spyre._inductor.op_spec import LoopSpec, OpSpec, TensorArg
+
+_LX_SIZE_BYTES = 2 * 1024 * 1024
+
+
+def patch_lx_relayout_mixed_schedules(
+    compiled: list[tuple[Any, list[int], list[dict], list[Any]]],
+    specs: list[Any],
+) -> None:
+    """Attach a data-op carrier to adjacent producer/consumer SDSCs.
+
+    This v1 realization is intentionally narrow: unrolled non-symbolic OpSpec
+    lists only.  The planner still records all candidates; unsupported bundle
+    shapes fail closed and keep the original SDSCs.
+    """
+
+    if not config.lx_planner_relayout_realize:
+        return
+    if any(isinstance(spec, LoopSpec) for spec in specs):
+        return
+    if any(not isinstance(spec, OpSpec) for spec in specs):
+        return
+    if len(compiled) != len(specs):
+        return
+
+    rewritten_consumers: set[int] = set()
+    reusable_lx_sources: dict[tuple[str, str, str], int] = {}
+    for producer_index in range(max(len(specs) - 1, 0)):
+        consumer_index = producer_index + 1
+        if consumer_index in rewritten_consumers:
+            continue
+        producer = specs[producer_index]
+        consumer = specs[consumer_index]
+        if not isinstance(producer, OpSpec) or not isinstance(consumer, OpSpec):
+            continue
+        match = _adjacent_move_match(producer, consumer)
+        if match is None:
+            continue
+        plan, producer_output_idx, consumer_input_idx = match
+        producer_entry = compiled[producer_index]
+        consumer_entry = compiled[consumer_index]
+        if producer_entry[0] is None or consumer_entry[0] is None:
+            continue
+        if producer_entry[1] or consumer_entry[1]:
+            continue
+
+        try:
+            patched_producer, mixed_consumer = build_lx_relayout_sdsc(
+                producer_index,
+                consumer_index,
+                producer_entry[0],
+                consumer_entry[0],
+                producer.args[producer_output_idx],
+                consumer.args[consumer_input_idx],
+                producer_output_idx,
+                consumer_input_idx,
+                plan,
+            )
+        except Exception:  # noqa: BLE001
+            continue
+
+        compiled[producer_index] = (patched_producer, [], [], [])
+        compiled[consumer_index] = (mixed_consumer, [], [], [])
+        rewritten_consumers.add(consumer_index)
+        reusable_lx_sources[_reuse_key(plan)] = int(config.lx_relayout_consumer_lx_base)
+
+    for consumer_index, consumer in enumerate(specs):
+        if consumer_index in rewritten_consumers or not isinstance(consumer, OpSpec):
+            continue
+        consumer_entry = compiled[consumer_index]
+        if consumer_entry[0] is None:
+            continue
+        if consumer_entry[1]:
+            continue
+        move_info = (consumer.op_info or {}).get(LX_RELAYOUT_OP_INFO_KEY)
+        if not isinstance(move_info, dict):
+            continue
+        for source_name, plan in move_info.items():
+            if not isinstance(plan, dict):
+                continue
+            reuse_base = reusable_lx_sources.get(_reuse_key(plan))
+            try:
+                consumer_input_idx = _consumer_input_arg_idx(consumer, source_name)
+                if reuse_base is not None:
+                    patched_consumer = copy.deepcopy(consumer_entry[0])
+                    consumer_root = next(iter(patched_consumer.values()))
+                    _patch_lx_endpoint(
+                        consumer_root,
+                        dsc_index=0,
+                        lds_idx=_matching_input_lds_idx(
+                            consumer_root, consumer_input_idx
+                        ),
+                        base=reuse_base,
+                    )
+                    compiled[consumer_index] = (patched_consumer, [], [], [])
+                    break
+
+                producer_match = _producer_match_for_plan(
+                    specs,
+                    compiled,
+                    consumer_index=consumer_index,
+                    source_name=source_name,
+                    plan=plan,
+                )
+                if producer_match is None:
+                    continue
+                producer_index, producer, producer_output_idx = producer_match
+                producer_entry = compiled[producer_index]
+                if producer_entry[0] is None:
+                    continue
+                if producer_entry[1]:
+                    continue
+
+                patched_producer, mixed_consumer = build_lx_relayout_sdsc(
+                    producer_index,
+                    consumer_index,
+                    producer_entry[0],
+                    consumer_entry[0],
+                    producer.args[producer_output_idx],
+                    consumer.args[consumer_input_idx],
+                    producer_output_idx,
+                    consumer_input_idx,
+                    plan,
+                )
+            except Exception:  # noqa: BLE001
+                continue
+            compiled[producer_index] = (patched_producer, [], [], [])
+            compiled[consumer_index] = (mixed_consumer, [], [], [])
+            rewritten_consumers.add(consumer_index)
+            reusable_lx_sources[_reuse_key(plan)] = int(
+                config.lx_relayout_consumer_lx_base
+            )
+            break
+
+
+def build_lx_relayout_sdsc(
+    producer_index: int,
+    consumer_index: int,
+    producer_payload: dict[str, Any],
+    consumer_payload: dict[str, Any],
+    producer_output: TensorArg,
+    consumer_input: TensorArg,
+    producer_output_idx: int,
+    consumer_input_idx: int,
+    plan: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    producer_name, producer_root_src = next(iter(producer_payload.items()))
+    producer_root = copy.deepcopy(producer_root_src)
+    consumer_root = copy.deepcopy(next(iter(consumer_payload.values())))
+    producer_base = int(config.lx_relayout_producer_lx_base)
+    consumer_base = int(config.lx_relayout_consumer_lx_base)
+    producer_region_bytes = _region_bytes(plan, "producer_region_bytes", "source")
+    consumer_region_bytes = _region_bytes(plan, "consumer_region_bytes", "dest")
+    _validate_lx_regions(
+        producer_base=producer_base,
+        consumer_base=consumer_base,
+        producer_region_bytes=producer_region_bytes,
+        consumer_region_bytes=consumer_region_bytes,
+    )
+
+    dataop_name = f"{producer_index}_LXRelayout{_selected_dataop_op_func()}"
+    datadscs, dataop_core_sets = _lx_relayout_datadsc_chunks(plan, dataop_name)
+
+    _patch_lx_endpoint(
+        producer_root,
+        dsc_index=0,
+        lds_idx=producer_output_idx,
+        base=producer_base,
+    )
+    _patch_lx_endpoint(
+        consumer_root,
+        dsc_index=0,
+        lds_idx=_matching_input_lds_idx(consumer_root, consumer_input_idx),
+        base=consumer_base,
+    )
+
+    root = copy.deepcopy(consumer_root)
+    root["dscs_"] = copy.deepcopy(consumer_root.get("dscs_", []) or [])
+    root["datadscs_"] = datadscs
+    root["numCoresUsed_"] = max(
+        int(consumer_root.get("numCoresUsed_", 1) or 1),
+        max((max(core_set) for core_set in dataop_core_sets if core_set), default=0)
+        + 1,
+    )
+    _ensure_root_core_maps(root, root["numCoresUsed_"])
+    root["coreIdToDscSchedule"] = _consumer_chunked_mixed_schedule(
+        dataop_core_sets=dataop_core_sets,
+        consumer_cores=_dsc_core_ids(root, 0),
+        num_cores=root["numCoresUsed_"],
+    )
+    root["opFuncsUsed_"] = sorted(
+        _dldsc_op_names(root)
+        | {_selected_dataop_op_func()}
+        | set(root.get("opFuncsUsed_", []) or [])
+    )
+    return {producer_name: producer_root}, {
+        f"{consumer_index}_LXRelayout{_selected_mixed_sdsc_suffix()}": root
+    }
+
+
+def _ensure_root_core_maps(root: dict[str, Any], num_cores: int) -> None:
+    core_to_dsc = {
+        str(core): int(dsc) for core, dsc in (root.get("coreIdToDsc_") or {}).items()
+    }
+    default_dsc = next(iter(core_to_dsc.values()), 0)
+    for core in range(num_cores):
+        core_to_dsc.setdefault(str(core), default_dsc)
+    root["coreIdToDsc_"] = core_to_dsc
+
+    wk_slices = {
+        str(core): dict(value)
+        for core, value in (root.get("coreIdToWkSlice_") or {}).items()
+    }
+    default_slice = next(iter(wk_slices.values()), None)
+    if default_slice is None:
+        default_slice = {
+            dim: 0 for dim in (root.get("numWkSlicesPerDim_") or {}).keys()
+        }
+    for core in range(num_cores):
+        wk_slices.setdefault(str(core), dict(default_slice))
+    root["coreIdToWkSlice_"] = wk_slices
+
+
+def _adjacent_move_match(
+    producer: OpSpec,
+    consumer: OpSpec,
+) -> tuple[dict[str, Any], int, int] | None:
+    move_info = (consumer.op_info or {}).get(LX_RELAYOUT_OP_INFO_KEY)
+    if not isinstance(move_info, dict):
+        return None
+    producer_outputs = [
+        (idx, arg) for idx, arg in enumerate(producer.args) if not arg.is_input
+    ]
+    consumer_inputs = [
+        (idx, arg) for idx, arg in enumerate(consumer.args) if arg.is_input
+    ]
+    for source_name, plan in move_info.items():
+        if not isinstance(plan, dict):
+            continue
+        for producer_idx, producer_arg in producer_outputs:
+            if producer_arg.name != source_name:
+                continue
+            for consumer_idx, consumer_arg in consumer_inputs:
+                if consumer_arg.name == source_name:
+                    return plan, producer_idx, consumer_idx
+    return None
+
+
+def _consumer_input_arg_idx(consumer: OpSpec, source_name: str) -> int:
+    for idx, arg in enumerate(consumer.args):
+        if arg.is_input and arg.name == source_name:
+            return idx
+    raise ValueError(f"consumer-input-not-found:{source_name}")
+
+
+def _producer_match_for_plan(
+    specs: list[Any],
+    compiled: list[tuple[Any, list[int], list[dict], list[Any]]],
+    *,
+    consumer_index: int,
+    source_name: str,
+    plan: dict[str, Any],
+) -> tuple[int, OpSpec, int] | None:
+    producer_name = str(plan.get("producer", ""))
+    for producer_index in range(consumer_index - 1, -1, -1):
+        producer = specs[producer_index]
+        if not isinstance(producer, OpSpec):
+            continue
+        if compiled[producer_index][0] is None:
+            continue
+        if producer_name and _op_spec_output_name(producer) != producer_name:
+            continue
+        for arg_index, arg in enumerate(producer.args):
+            if not arg.is_input and arg.name == source_name:
+                return producer_index, producer, arg_index
+    return None
+
+
+def _op_spec_output_name(spec: OpSpec) -> str:
+    for arg in spec.args:
+        if not arg.is_input and arg.name:
+            return str(arg.name)
+    return ""
+
+
+def _reuse_key(plan: dict[str, Any]) -> tuple[str, str, str]:
+    dataop = (
+        ((plan.get("lx_relayout") or {}).get("deeptools_dataop") or {})
+        if isinstance(plan.get("lx_relayout"), dict)
+        else {}
+    )
+    return (
+        str(plan.get("source_name")),
+        str(plan.get("producer")),
+        json.dumps(
+            {
+                "movement_subview": plan.get("movement_subview"),
+                "movement_ranges": dataop.get("movementRanges"),
+                "bytes_moved": plan.get("bytes_moved"),
+                "consumer_region_bytes": plan.get("consumer_region_bytes"),
+            },
+            sort_keys=True,
+        ),
+    )
+
+
+def _lx_relayout_dataop_movements(dataop: dict[str, Any]) -> list[dict[str, Any]]:
+    movements = list(dataop.get("movements", []) or [])
+    if movements:
+        return movements
+    return _expand_dataop_movement_ranges(list(dataop.get("movementRanges", []) or []))
+
+
+def _selected_mixed_sdsc_suffix() -> str:
+    return "STCDPOpLx"
+
+
+def _selected_dataop_op_func() -> str:
+    return "STCDPOpLx"
+
+
+def _selected_dataop_chunk(chunk: dict[str, Any]) -> dict[str, Any]:
+    range_payload_keys = {
+        "schemaVersion",
+        "sourceName",
+        "producer",
+        "consumer",
+        "producerLxBase",
+        "consumerLxBase",
+        "coverage",
+        "dependencyOrder",
+        "lowering",
+        "movements",
+        "movementRanges",
+    }
+    range_payload = {
+        key: copy.deepcopy(value)
+        for key, value in chunk.items()
+        if key in range_payload_keys
+    }
+    return {
+        "op": {
+            "name": "STCDPOpLx",
+            "rangedLxRemap": range_payload,
+        },
+        "coreIdsUsed_": copy.deepcopy(chunk.get("coreIdsUsed_", [])),
+    }
+
+
+def _lx_relayout_dataop(plan: dict[str, Any]) -> dict[str, Any]:
+    metadata = plan.get("lx_relayout")
+    if not isinstance(metadata, dict):
+        raise ValueError("lx-relayout-metadata-missing")
+    dataop = metadata.get("deeptools_dataop")
+    if not isinstance(dataop, dict):
+        raise ValueError("lx-relayout-dataop-missing")
+    if (dataop.get("op") or {}).get("name") != "STCDPOpLx":
+        raise ValueError("lx-relayout-dataop-op-mismatch")
+    movements = _lx_relayout_dataop_movements(dataop)
+    if not movements:
+        raise ValueError("lx-relayout-dataop-has-no-movements")
+    core_ids = sorted(
+        {int(movement["source"]["core"]) for movement in movements}
+        | {int(movement["destination"]["core"]) for movement in movements}
+    )
+    result = copy.deepcopy(dataop)
+    result["movements"] = movements
+    result["coreIdsUsed_"] = core_ids
+    return result
+
+
+def _lx_relayout_datadsc_chunks(
+    plan: dict[str, Any],
+    dataop_name: str,
+) -> tuple[list[dict[str, Any]], list[set[int]]]:
+    dataop = _lx_relayout_dataop(plan)
+    movements = list(dataop.get("movements", []) or [])
+    chunk_size = max(1, int(config.lx_relayout_chunk_cells))
+
+    datadscs: list[dict[str, Any]] = []
+    core_sets: list[set[int]] = []
+    static_fields = {
+        key: copy.deepcopy(value)
+        for key, value in dataop.items()
+        if key not in {"movements", "movementRanges", "coreIdsUsed_"}
+    }
+
+    def append_chunk(chunk_movements_src: list[dict[str, Any]]) -> None:
+        if not chunk_movements_src:
+            return
+        chunk_movements = copy.deepcopy(chunk_movements_src)
+        chunk_core_ids = sorted(
+            {int(movement["source"]["core"]) for movement in chunk_movements}
+            | {int(movement["destination"]["core"]) for movement in chunk_movements}
+        )
+        chunk = copy.deepcopy(static_fields)
+        if config.lx_relayout_range_encoding:
+            movement_ranges = _dataop_movement_ranges(chunk_movements)
+            chunk["movementRanges"] = movement_ranges
+            lowering = chunk.setdefault("lowering", {})
+            lowering["rangeEncoded"] = True
+            lowering["movementRanges"] = len(movement_ranges)
+            lowering["expandedMovements"] = len(chunk_movements)
+        else:
+            chunk["movements"] = chunk_movements
+            lowering = chunk.setdefault("lowering", {})
+            lowering["rangeEncoded"] = False
+        chunk["coreIdsUsed_"] = chunk_core_ids
+        datadscs.append(
+            {f"{dataop_name}_{len(datadscs)}": _selected_dataop_chunk(chunk)}
+        )
+        core_sets.append(set(chunk_core_ids))
+
+    cross_movements = [
+        movement
+        for movement in movements
+        if int(movement["source"]["core"]) != int(movement["destination"]["core"])
+    ]
+    local_movements = [
+        movement
+        for movement in movements
+        if int(movement["source"]["core"]) == int(movement["destination"]["core"])
+    ]
+
+    if not local_movements and len(cross_movements) <= chunk_size:
+        compact_dataop = copy.deepcopy(dataop)
+        if config.lx_relayout_range_encoding:
+            movement_ranges = _dataop_movement_ranges(cross_movements)
+            compact_dataop.pop("movements", None)
+            compact_dataop["movementRanges"] = movement_ranges
+            lowering = compact_dataop.setdefault("lowering", {})
+            lowering["rangeEncoded"] = True
+            lowering["movementRanges"] = len(movement_ranges)
+            lowering["expandedMovements"] = len(cross_movements)
+        return [{dataop_name: _selected_dataop_chunk(compact_dataop)}], [
+            set(dataop["coreIdsUsed_"])
+        ]
+
+    for start in range(0, len(cross_movements), chunk_size):
+        append_chunk(cross_movements[start : start + chunk_size])
+
+    for first_legs, second_legs in _relay_local_lx_relayout_chunks(
+        local_movements,
+        producer_base=int(config.lx_relayout_producer_lx_base),
+        producer_region_bytes=_region_bytes(plan, "producer_region_bytes", "source"),
+        consumer_base=int(config.lx_relayout_consumer_lx_base),
+        consumer_region_bytes=_region_bytes(plan, "consumer_region_bytes", "dest"),
+        chunk_size=chunk_size,
+    ):
+        append_chunk(first_legs)
+        append_chunk(second_legs)
+    return datadscs, core_sets
+
+
+def _relay_local_lx_relayout_chunks(
+    movements: list[dict[str, Any]],
+    *,
+    producer_base: int,
+    producer_region_bytes: int,
+    consumer_base: int,
+    consumer_region_bytes: int,
+    chunk_size: int,
+) -> list[tuple[list[dict[str, Any]], list[dict[str, Any]]]]:
+    if not movements:
+        return []
+
+    relay_base, relay_capacity = _local_relay_scratch_window(
+        producer_base=producer_base,
+        producer_region_bytes=producer_region_bytes,
+        consumer_base=consumer_base,
+        consumer_region_bytes=consumer_region_bytes,
+    )
+    if relay_capacity <= 0:
+        raise ValueError("lx-relayout-local-relay-lx-capacity")
+
+    next_move_index = (
+        max((int(movement["moveIndex"]) for movement in movements), default=-1) + 1
+    )
+    batches: list[tuple[list[dict[str, Any]], list[dict[str, Any]]]] = []
+    for chunk in _local_relay_batches(
+        sorted(
+            movements,
+            key=lambda movement: (
+                int(movement["source"]["core"]),
+                int(movement["source"]["lxAddress"]),
+                int(movement["destination"]["lxAddress"]),
+                int(movement["moveIndex"]),
+            ),
+        ),
+        chunk_size=chunk_size,
+        relay_capacity=relay_capacity,
+    ):
+        first_legs: list[dict[str, Any]] = []
+        second_legs: list[dict[str, Any]] = []
+        relay_offset = 0
+        for movement in chunk:
+            source_core = int(movement["source"]["core"])
+            sencores = int(config.sencores)
+            if sencores <= 1:
+                raise ValueError(
+                    "local relay lx relayout requires at least two SEN cores"
+                )
+            if source_core < 0 or source_core >= sencores:
+                raise ValueError(
+                    f"local relay source core {source_core} is outside SENCORES={sencores}"
+                )
+            relay_core = (source_core + 1) % sencores
+            byte_count = int(movement["bytes"])
+            relay_lx_address = relay_base + relay_offset
+            relay_offset += byte_count
+
+            first = copy.deepcopy(movement)
+            first["moveIndex"] = next_move_index
+            next_move_index += 1
+            first["destination"]["core"] = relay_core
+            first["destination"]["lxAddress"] = relay_lx_address
+            first["destination"]["localByteRange"] = {
+                "start": relay_lx_address - relay_base,
+                "end": relay_lx_address - relay_base + byte_count,
+            }
+            first["destination"]["lxByteRange"] = {
+                "start": relay_lx_address,
+                "end": relay_lx_address + byte_count,
+            }
+            first["relay"] = {
+                "kind": "local_first_leg",
+                "originalMoveIndex": int(movement["moveIndex"]),
+                "relayCore": relay_core,
+            }
+            first_legs.append(first)
+
+            second = copy.deepcopy(movement)
+            second["moveIndex"] = next_move_index
+            next_move_index += 1
+            second["source"]["core"] = relay_core
+            second["source"]["lxAddress"] = relay_lx_address
+            second["source"]["localByteRange"] = first["destination"]["localByteRange"]
+            second["source"]["lxByteRange"] = first["destination"]["lxByteRange"]
+            second["relay"] = {
+                "kind": "local_second_leg",
+                "originalMoveIndex": int(movement["moveIndex"]),
+                "relayCore": relay_core,
+            }
+            second_legs.append(second)
+
+        batches.append((first_legs, second_legs))
+    return batches
+
+
+def _local_relay_batches(
+    movements: list[dict[str, Any]],
+    *,
+    chunk_size: int,
+    relay_capacity: int,
+) -> list[list[dict[str, Any]]]:
+    batches: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_bytes = 0
+    for movement in movements:
+        byte_count = int(movement["bytes"])
+        if byte_count > relay_capacity:
+            raise ValueError("lx-relayout-local-relay-lx-capacity")
+        if current and (
+            len(current) >= chunk_size or current_bytes + byte_count > relay_capacity
+        ):
+            batches.append(current)
+            current = []
+            current_bytes = 0
+        current.append(movement)
+        current_bytes += byte_count
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _local_relay_scratch_window(
+    *,
+    producer_base: int,
+    producer_region_bytes: int,
+    consumer_base: int,
+    consumer_region_bytes: int,
+) -> tuple[int, int]:
+    protected: list[tuple[int, int]] = []
+    if producer_region_bytes > 0:
+        protected.append((producer_base, producer_base + producer_region_bytes))
+    if consumer_region_bytes > 0:
+        protected.append((consumer_base, consumer_base + consumer_region_bytes))
+    protected = [
+        (max(0, start), min(_LX_SIZE_BYTES, end))
+        for start, end in protected
+        if start < _LX_SIZE_BYTES and end > 0 and start < end
+    ]
+    protected.sort()
+
+    best_start = 0
+    best_end = 0
+    cursor = 0
+    for start, end in protected:
+        aligned_cursor = ((cursor + 127) // 128) * 128
+        aligned_start = (start // 128) * 128
+        if aligned_start - aligned_cursor > best_end - best_start:
+            best_start, best_end = aligned_cursor, aligned_start
+        cursor = max(cursor, end)
+    aligned_cursor = ((cursor + 127) // 128) * 128
+    if _LX_SIZE_BYTES - aligned_cursor > best_end - best_start:
+        best_start, best_end = aligned_cursor, _LX_SIZE_BYTES
+    return best_start, max(0, best_end - best_start)
+
+
+def _first_compute_dsc(root: dict[str, Any]) -> dict[str, Any] | None:
+    for dsc_group in root.get("dscs_", []) or []:
+        if isinstance(dsc_group, dict) and dsc_group:
+            dsc = next(iter(dsc_group.values()))
+            if isinstance(dsc, dict):
+                return dsc
+    return None
+
+
+def _keep_missing_size_one_dims(
+    output_layout: dict[str, Any] | None,
+    input_layout: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if output_layout is None or input_layout is None:
+        return output_layout
+
+    output_dim_order = [str(dim) for dim in output_layout["layout_dim_order"]]
+    output_dim_set = set(output_dim_order)
+    missing_size_one_dims = [
+        str(dim)
+        for dim in input_layout["layout_dim_order"]
+        if str(dim) not in output_dim_set
+    ]
+    if not missing_size_one_dims:
+        return output_layout
+
+    result = dict(output_layout)
+    result["layout_dim_order"] = [*output_dim_order, *missing_size_one_dims]
+    result["layout_sizes"] = dict(output_layout["layout_sizes"])
+    for dim in missing_size_one_dims:
+        if int(input_layout["layout_sizes"][dim]) != 1:
+            raise ValueError("output-layout-drops-non-size-one-dim")
+        result["layout_sizes"][dim] = 1
+    result["stick_dim_order"] = list(output_layout["stick_dim_order"])
+    result["stick_sizes"] = dict(output_layout["stick_sizes"])
+    return result
+
+
+def _region_bytes(plan: dict[str, Any], explicit_key: str, offset_side: str) -> int:
+    explicit = int(plan.get(explicit_key, 0) or 0)
+    if explicit > 0:
+        return explicit
+    offset_key = f"{offset_side}_offset_bytes"
+    cells = list(plan.get("cells", []) or [])
+    if not cells:
+        return 0
+    return max(
+        int(cell.get(offset_key, 0) or 0) + int(cell.get("bytes", 0) or 0)
+        for cell in cells
+    )
+
+
+def _validate_lx_regions(
+    *,
+    producer_base: int,
+    consumer_base: int,
+    producer_region_bytes: int,
+    consumer_region_bytes: int,
+) -> None:
+    if producer_base < 0 or consumer_base < 0:
+        raise ValueError("lx-base-negative")
+    producer_end = producer_base + producer_region_bytes
+    consumer_end = consumer_base + consumer_region_bytes
+    if producer_end > _LX_SIZE_BYTES:
+        raise ValueError("producer-lx-region-exceeds-capacity")
+    if consumer_end > _LX_SIZE_BYTES:
+        raise ValueError("consumer-lx-region-exceeds-capacity")
+    if producer_region_bytes and consumer_region_bytes:
+        if max(producer_base, consumer_base) < min(producer_end, consumer_end):
+            raise ValueError("producer-consumer-lx-regions-overlap")
+
+
+def _matching_input_lds_idx(root: dict[str, Any], consumer_input_idx: int) -> int:
+    dsc = next(iter((root.get("dscs_", []) or [])[0].values()))
+    input_labels = dsc.get("computeOp_", [{}])[0].get("inputLabeledDs", [])
+    input_indices = {_lds_idx_from_label(label) for label in input_labels}
+    if consumer_input_idx in input_indices:
+        return consumer_input_idx
+    raise ValueError(f"consumer-input-not-found:{consumer_input_idx}")
+
+
+def _lds_idx_from_label(label: str) -> int:
+    if "-idx" not in label:
+        return -1
+    return int(label.rsplit("-idx", 1)[1])
+
+
+def _patch_lx_endpoint(
+    root: dict[str, Any],
+    *,
+    dsc_index: int,
+    lds_idx: int,
+    base: int,
+) -> None:
+    dsc = next(iter(root["dscs_"][dsc_index].values()))
+    num_cores = int(dsc.get("numCoresUsed_", root.get("numCoresUsed_", 1)) or 1)
+    core_ids = [int(core) for core in dsc.get("coreIdsUsed_", range(num_cores))]
+    core_factor = int(root.get("coreFoldProp_", {}).get("factor_", 32) or 32)
+    for node in dsc.get("scheduleTree_", []):
+        if int(node.get("ldsIdx_", -1)) != int(lds_idx):
+            continue
+        node["component_"] = "lx"
+        node["name_"] = str(node.get("name_", "")).replace("_hbm", "_lx")
+        node["startAddressCoreCorelet_"] = _folded_start_address(
+            core_ids, int(base), core_factor=core_factor
+        )
+        for dim_gap in (node.get("backGapCore_") or {}).values():
+            if "-1" not in dim_gap:
+                continue
+            uniform_gap = dim_gap["-1"]
+            for core in core_ids:
+                dim_gap[str(core)] = uniform_gap
+    for lds in dsc.get("labeledDs_", []):
+        if int(lds.get("ldsIdx_", -1)) == int(lds_idx):
+            lds["memOrg_"] = {"lx": {"isPresent": 1}}
+
+
+def _folded_start_address(
+    core_ids: list[int],
+    base: int,
+    *,
+    core_factor: int = 32,
+) -> dict[str, Any]:
+    return {
+        "dim_prop_func": [
+            {"Map": {}},
+            {"Const": {}},
+            {"Const": {}},
+        ],
+        "dim_prop_attr": [
+            {"factor_": int(core_factor), "label_": "core"},
+            {"factor_": 1, "label_": "corelet"},
+            {"factor_": 1, "label_": "time"},
+        ],
+        "data_": {f"[{int(core)}, 0, 0]": int(base) for core in core_ids},
+    }
+
+
+def _dsc_core_ids(root: dict[str, Any], dsc_index: int) -> set[int]:
+    dsc = next(iter(root["dscs_"][dsc_index].values()))
+    return {int(core) for core in dsc.get("coreIdsUsed_", [])}
+
+
+def _consumer_chunked_mixed_schedule(
+    *,
+    dataop_core_sets: list[set[int]],
+    consumer_cores: set[int],
+    num_cores: int,
+) -> dict[str, list[list[int]]]:
+    schedule: dict[str, list[list[int]]] = {}
+    for core in range(num_cores):
+        steps: list[list[int]] = []
+        for dataop_index, dataop_cores in enumerate(dataop_core_sets):
+            if core in dataop_cores:
+                steps.append([dataop_index, -1, 0, 0])
+        if core in consumer_cores:
+            steps.append([-1, 0, 0, 0])
+        schedule[str(core)] = _with_dependencies(steps)
+    return schedule
+
+
+def _with_dependencies(steps: list[list[int]]) -> list[list[int]]:
+    return [
+        [step[0], step[1], 1 if idx > 0 else 0, 1 if idx < len(steps) - 1 else 0]
+        for idx, step in enumerate(steps)
+    ]
+
+
+def _dldsc_op_names(root: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for dsc in root.get("dscs_", []) or []:
+        names.update(str(name) for name in dsc.keys())
+    return names
+
+
+def _collect_opspecs(specs: list[Any], result: list[OpSpec]) -> None:
+    for spec in specs:
+        if isinstance(spec, LoopSpec):
+            _collect_opspecs(spec.body, result)
+        elif isinstance(spec, OpSpec):
+            result.append(spec)

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -89,4 +89,27 @@ unroll_loops: bool = os.environ.get("UNROLL_LOOPS", "1") == "1"
 # TODO(isuruf): Change to firstfit when deeptools PR4298 lands
 layout_solver: Literal["greedy", "bestfit", "firstfit"] = "greedy"
 
+# Cross-core LX-to-LX relayout extension for the LX planner.
+# Same-core persistence remains handled by the existing scratchpad allocator;
+# this subfeature plans explicit STCDPOpLx movement for mismatched views.
+lx_planner_relayout: bool = os.environ.get("SPYRE_LX_PLANNER_RELAYOUT", "0") == "1"
+lx_planner_relayout_realize: bool = (
+    os.environ.get("SPYRE_LX_PLANNER_RELAYOUT_REALIZE", "0") == "1"
+)
+lx_relayout_max_cells: int = int(
+    os.environ.get("SPYRE_LX_RELAYOUT_MAX_CELLS", "131072")
+)
+lx_relayout_chunk_cells: int = int(
+    os.environ.get("SPYRE_LX_RELAYOUT_CHUNK_CELLS", "8192")
+)
+lx_relayout_range_encoding: bool = (
+    os.environ.get("SPYRE_LX_RELAYOUT_RANGE_ENCODING", "1") != "0"
+)
+lx_relayout_producer_lx_base: int = int(
+    os.environ.get("SPYRE_LX_RELAYOUT_PRODUCER_LX_BASE", "0"), 0
+)
+lx_relayout_consumer_lx_base: int = int(
+    os.environ.get("SPYRE_LX_RELAYOUT_CONSUMER_LX_BASE", str(1024 * 1024)), 0
+)
+
 install_config_module(sys.modules[__name__])

--- a/torch_spyre/_inductor/lx_relayout.py
+++ b/torch_spyre/_inductor/lx_relayout.py
@@ -1,0 +1,1548 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experimental cross-core LX-to-LX relayout planner.
+
+The regular LX planner already handles same-core scratchpad persistence.  This
+module only records edges where producer and consumer slice the same buffer with
+different per-core ownership, which requires explicit LX relayout.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import copy
+import itertools
+import math
+from typing import Any
+
+import sympy
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import ComputedBuffer, Operation
+
+from torch_spyre._inductor import config
+from torch_spyre._inductor.codegen.compute_ops import num_bytes
+from torch_spyre._inductor.logging_utils import get_inductor_logger
+from torch_spyre._inductor.pass_utils import (
+    PerCoreView,
+    _per_core_view_on_buf,
+    device_coordinates,
+)
+
+logger = get_inductor_logger("lx_relayout")
+
+LX_RELAYOUT_ATTR = "_spyre_lx_relayout_plan"
+LX_RELAYOUT_OP_INFO_KEY = "lx_relayout"
+
+
+@dataclasses.dataclass(frozen=True)
+class LXRelayoutCell:
+    cell_index: int
+    source_core: int
+    dest_core: int
+    dim_starts: dict[str, int]
+    dim_sizes: dict[str, int]
+    bytes: int
+    source_offset_bytes: int
+    dest_offset_bytes: int
+
+
+@dataclasses.dataclass(frozen=True)
+class LXRelayoutSubview:
+    starts: list[int]
+    sizes: list[int]
+
+
+@dataclasses.dataclass(frozen=True)
+class LXRelayoutPlan:
+    source_name: str
+    producer_name: str
+    consumer_name: str
+    device_sizes: list[int]
+    device_stride_map: list[int]
+    element_bytes: int
+    producer_core_count: int
+    consumer_core_count: int
+    producer_region_bytes: int
+    consumer_region_bytes: int
+    cells: list[LXRelayoutCell]
+    movement_subview: LXRelayoutSubview | None = None
+
+    @property
+    def bytes_moved(self) -> int:
+        return sum(cell.bytes for cell in self.cells)
+
+
+def _op_num_cores(op: Operation) -> int:
+    splits: tuple[dict, dict] = getattr(op, "op_it_space_splits", ({}, {}))
+    factors = [int(factor) for per_dim in splits for factor in per_dim.values()]
+    return math.prod(factors) if factors else 1
+
+
+def _single_write_dep(op: ComputedBuffer, buf_name: str) -> MemoryDep | None:
+    matches = [
+        dep
+        for dep in op.get_read_writes().writes
+        if isinstance(dep, MemoryDep) and dep.name == buf_name
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _device_layout_and_element_bytes(buf: Any) -> tuple[list[int], list[int], int]:
+    layout = getattr(buf, "layout", None)
+    dev_layout = getattr(layout, "device_layout", None)
+    if dev_layout is None:
+        raise ValueError("buffer-has-no-device-layout")
+    device_sizes = [int(size) for size in dev_layout.device_size]
+    device_stride_map = [int(stride) for stride in dev_layout.stride_map]
+    element_bytes = num_bytes(dev_layout.device_dtype)
+    return device_sizes, device_stride_map, element_bytes
+
+
+def _normalize_view_splits(view: PerCoreView) -> dict[int, int]:
+    return {int(dim): int(split) for dim, split in view.work_slice_dims}
+
+
+def _owner_lookup(
+    view: PerCoreView,
+    core_count: int,
+) -> tuple[dict[tuple[int, ...], int], str | None]:
+    dims = tuple(int(dim) for dim, _split in view.work_slice_dims)
+    expr_by_dim = {int(dim): expr for dim, expr in view.core_to_slot}
+    core_id = sympy.Symbol("core_id")
+    owners: dict[tuple[int, ...], int] = {}
+    for core in range(core_count):
+        key = tuple(
+            int(sympy.sympify(expr_by_dim.get(dim, 0)).subs(core_id, core))
+            for dim in dims
+        )
+        if key in owners:
+            return {}, "duplicate-owner"
+        owners[key] = core
+    return owners, None
+
+
+def _owner_key(
+    common_index: dict[int, int],
+    owner_dims: tuple[int, ...],
+    *,
+    side_splits: dict[int, int],
+    common_splits: dict[int, int],
+) -> tuple[int, ...]:
+    return tuple(
+        int(common_index.get(dim, 0))
+        * int(side_splits.get(dim, 1))
+        // int(common_splits.get(dim, 1))
+        for dim in owner_dims
+    )
+
+
+def _side_slice_geometry(
+    *,
+    view: PerCoreView,
+    owner_key: tuple[int, ...],
+    device_sizes: list[int],
+) -> tuple[dict[int, int], dict[int, int]]:
+    """Return per-device-dim start/size for one side's owning core slice."""
+
+    splits = _normalize_view_splits(view)
+    owner_dims = tuple(int(dim) for dim, _split in view.work_slice_dims)
+    slot_by_dim = dict(zip(owner_dims, owner_key))
+    starts: dict[int, int] = {}
+    sizes: dict[int, int] = {}
+    for dim, dim_size in enumerate(device_sizes):
+        split = int(splits.get(dim, 1))
+        chunk = int(dim_size) // split
+        slot = int(slot_by_dim.get(dim, 0))
+        starts[dim] = slot * chunk
+        sizes[dim] = chunk
+    return starts, sizes
+
+
+def _default_subview(device_sizes: list[int]) -> LXRelayoutSubview:
+    return LXRelayoutSubview(
+        starts=[0 for _size in device_sizes],
+        sizes=[int(size) for size in device_sizes],
+    )
+
+
+def _is_full_subview(
+    subview: LXRelayoutSubview,
+    *,
+    device_sizes: list[int],
+) -> bool:
+    return (
+        len(subview.starts) == len(device_sizes)
+        and len(subview.sizes) == len(device_sizes)
+        and all(int(start) == 0 for start in subview.starts)
+        and [int(size) for size in subview.sizes]
+        == [int(size) for size in device_sizes]
+    )
+
+
+def _validate_subview(
+    subview: LXRelayoutSubview,
+    *,
+    device_sizes: list[int],
+) -> str | None:
+    if len(subview.starts) != len(device_sizes) or len(subview.sizes) != len(
+        device_sizes
+    ):
+        return "subview-rank-mismatch"
+    for start, size, device_size in zip(subview.starts, subview.sizes, device_sizes):
+        start = int(start)
+        size = int(size)
+        device_size = int(device_size)
+        if start < 0 or size <= 0 or start + size > device_size:
+            return "subview-out-of-bounds"
+    return None
+
+
+def _subview_ranges_for_common_splits(
+    *,
+    subview: LXRelayoutSubview,
+    device_sizes: list[int],
+    common_splits: dict[int, int],
+    moved_dims: tuple[int, ...],
+) -> tuple[list[range], str | None]:
+    """Return common-refinement index ranges clipped to a logical subview."""
+
+    reason = _validate_subview(subview, device_sizes=device_sizes)
+    if reason is not None:
+        return [], reason
+
+    restricted_dims = {
+        dim
+        for dim, (start, size, device_size) in enumerate(
+            zip(subview.starts, subview.sizes, device_sizes)
+        )
+        if int(start) != 0 or int(size) != int(device_size)
+    }
+    missing_restricted_dims = restricted_dims - set(common_splits)
+    if missing_restricted_dims:
+        return [], "subview-requires-unsplit-device-dim"
+
+    ranges: list[range] = []
+    for dim in moved_dims:
+        split = int(common_splits[dim])
+        chunk = int(device_sizes[dim]) // split
+        start = int(subview.starts[dim])
+        end = start + int(subview.sizes[dim])
+        if start % chunk != 0 or end % chunk != 0:
+            return [], "subview-not-aligned-to-common-cell"
+        ranges.append(range(start // chunk, end // chunk))
+    return ranges, None
+
+
+def _local_offset_bytes(
+    *,
+    cell_starts: dict[str, int],
+    cell_sizes: dict[str, int],
+    slice_starts: dict[int, int],
+    slice_sizes: dict[int, int],
+    element_bytes: int,
+    device_stride_map: list[int] | None = None,
+    dim_order: list[int] | None = None,
+) -> tuple[int, str | None]:
+    """Return the packed per-core byte offset for a cell.
+
+    When a device stride map is available, preserve its fastest-to-slowest
+    physical order while recomputing packed strides inside the per-core slice.
+    Without a stride map, retain the legacy d0_, d1_, ... packed order.
+    """
+
+    dim_count = len(slice_sizes)
+    if dim_order is not None:
+        if sorted(dim_order) != list(range(dim_count)):
+            return 0, "invalid-local-dim-order"
+    elif device_stride_map is not None and len(device_stride_map) == dim_count:
+        dim_order = sorted(
+            range(dim_count), key=lambda dim: (device_stride_map[dim], dim)
+        )
+    else:
+        dim_order = list(range(dim_count))
+
+    stride_by_dim: dict[int, int] = {}
+    stride = 1
+    for dim in dim_order:
+        stride_by_dim[dim] = stride
+        stride *= int(slice_sizes[dim])
+
+    offset_elements = 0
+    for dim in range(dim_count):
+        start = int(cell_starts[f"d{dim}_"])
+        size = int(cell_sizes[f"d{dim}_"])
+        slice_start = int(slice_starts[dim])
+        slice_size = int(slice_sizes[dim])
+        delta = start - slice_start
+        if delta < 0 or delta + size > slice_size:
+            return 0, "cell-outside-side-slice"
+        offset_elements += delta * stride_by_dim[dim]
+    return offset_elements * int(element_bytes), None
+
+
+def _lx_relayout_v1_stride_map(
+    *,
+    device_sizes: list[int],
+    device_stride_map: list[int],
+    element_bytes: int,
+) -> tuple[list[int], str | None]:
+    """Return a physical device-dim stride map for whole-stick data move planning.
+
+    Some BMM-shaped fixed-tile layouts carry an extra trailing host stride or a
+    collapsed size-one dimension for the in-stick coordinate, e.g.
+    ``device_size=[M, out_sticks, 1, 64]`` with
+    ``stride_map=[512, 64, -1, 1]``.  For movement planning the final device
+    dim is the physical stick element dim and nonpositive sentinel strides
+    should not be considered faster than that stick dim.
+    """
+
+    if len(device_stride_map) == len(device_sizes) + 1:
+        if int(device_stride_map[-1]) != 1:
+            return [], "lx-relayout-v1-requires-device-stride-map"
+        strides = [int(stride) for stride in device_stride_map[:-1]]
+    elif len(device_stride_map) == len(device_sizes):
+        strides = [int(stride) for stride in device_stride_map]
+    else:
+        return [], "lx-relayout-v1-requires-device-stride-map"
+
+    if (
+        strides
+        and int(device_sizes[-1]) * int(element_bytes) == 128
+        and int(strides[-1]) != 1
+    ):
+        strides[-1] = 1
+    if any(int(stride) <= 0 for stride in strides):
+        positive_strides = [int(stride) for stride in strides if int(stride) > 0]
+        if not positive_strides:
+            return [], "lx-relayout-v1-requires-device-stride-map"
+        sentinel_stride = max(positive_strides) * max(math.prod(device_sizes), 1)
+        strides = [
+            int(stride) if int(stride) > 0 else int(sentinel_stride)
+            for stride in strides
+        ]
+    return strides, None
+
+
+def _lx_relayout_v1_lx_dim_order(
+    *,
+    device_sizes: list[int],
+    device_stride_map: list[int],
+    element_bytes: int,
+) -> tuple[list[int], str | None]:
+    """Return Deeptools' local LX order for fixed-tiled whole-stick moves.
+
+    Fixed-tiled matrix tensors use one unit-stride stick-element dimension and
+    one outer stick dimension.  DCC lowers LX views with stick elements fastest,
+    non-stick logical dimensions next, and the outer stick dimension slowest.
+    The global device stride map orders the outer stick before the row/M dim,
+    which is correct for logical tensor indexing but wrong for per-core LX
+    addresses consumed by data ops.
+    """
+
+    device_stride_map, reason = _lx_relayout_v1_stride_map(
+        device_sizes=device_sizes,
+        device_stride_map=device_stride_map,
+        element_bytes=element_bytes,
+    )
+    if reason is not None:
+        return [], reason
+    fastest_dim = min(
+        range(len(device_sizes)),
+        key=lambda dim: (int(device_stride_map[dim]), dim),
+    )
+    if int(device_stride_map[fastest_dim]) != 1:
+        return [], "lx-relayout-v1-requires-unit-stride-stick-dim"
+
+    stick_elems = int(device_sizes[fastest_dim])
+    stick_outer_dims = [
+        dim
+        for dim, stride in enumerate(device_stride_map)
+        if dim != fastest_dim and int(stride) == stick_elems
+    ]
+    if len(stick_outer_dims) > 1:
+        return [], "lx-relayout-v1-ambiguous-stick-outer-dim"
+
+    stick_outer = set(stick_outer_dims)
+    non_stick_dims = [
+        dim
+        for dim in range(len(device_sizes))
+        if dim != fastest_dim and dim not in stick_outer
+    ]
+    non_stick_dims.sort(key=lambda dim: (int(device_stride_map[dim]), dim))
+    stick_outer_dims.sort(key=lambda dim: (int(device_stride_map[dim]), dim))
+    return [fastest_dim, *non_stick_dims, *stick_outer_dims], None
+
+
+def _lx_relayout_v1_refined_splits(
+    *,
+    common_splits: dict[int, int],
+    device_sizes: list[int],
+    device_stride_map: list[int],
+    element_bytes: int,
+) -> tuple[dict[int, int], str | None]:
+    """Refine common splits to physical whole-stick movements for v1 lowering."""
+
+    device_stride_map, reason = _lx_relayout_v1_stride_map(
+        device_sizes=device_sizes,
+        device_stride_map=device_stride_map,
+        element_bytes=element_bytes,
+    )
+    if reason is not None:
+        return {}, reason
+    fastest_dim = min(
+        range(len(device_sizes)),
+        key=lambda dim: (int(device_stride_map[dim]), dim),
+    )
+    if int(device_stride_map[fastest_dim]) != 1:
+        return {}, "lx-relayout-v1-requires-unit-stride-stick-dim"
+    if int(device_sizes[fastest_dim]) * int(element_bytes) != 128:
+        return {}, "lx-relayout-v1-requires-128-byte-stick-dim"
+    if int(common_splits.get(fastest_dim, 1)) != 1:
+        return {}, "lx-relayout-v1-cannot-data move-split-stick-dim"
+
+    refined = dict(common_splits)
+    for dim, dim_size in enumerate(device_sizes):
+        if dim == fastest_dim:
+            continue
+        refined[dim] = max(int(refined.get(dim, 1)), int(dim_size))
+    return refined, None
+
+
+def _view_region_bytes(
+    view: PerCoreView,
+    *,
+    device_sizes: list[int],
+    element_bytes: int,
+) -> int:
+    splits = _normalize_view_splits(view)
+    elements = 1
+    for dim, dim_size in enumerate(device_sizes):
+        elements *= int(dim_size) // int(splits.get(dim, 1))
+    return elements * int(element_bytes)
+
+
+def _static_int(expr: Any) -> int | None:
+    try:
+        sym_expr = sympy.sympify(expr)
+    except Exception:  # noqa: BLE001
+        return None
+    if getattr(sym_expr, "free_symbols", None):
+        return None
+    try:
+        return int(sym_expr)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _range_size_by_symbol(ranges: dict[Any, Any]) -> dict[sympy.Symbol, int]:
+    result: dict[sympy.Symbol, int] = {}
+    for sym, value in ranges.items():
+        size = _static_int(value)
+        if size is None or size <= 0:
+            continue
+        key = sym if isinstance(sym, sympy.Symbol) else sympy.Symbol(str(sym))
+        result[key] = size
+    return result
+
+
+def _single_free_symbol(expr: sympy.Expr) -> sympy.Symbol | None:
+    free_symbols = list(getattr(expr, "free_symbols", set()))
+    if len(free_symbols) != 1:
+        return None
+    return next(iter(free_symbols))
+
+
+def _as_symbol_floor_div(expr: sympy.Expr) -> tuple[sympy.Symbol, int] | None:
+    expr = sympy.simplify(expr)
+    if expr.func.__name__ == "FloorDiv" and len(expr.args) == 2:
+        sym = _single_free_symbol(sympy.sympify(expr.args[0]))
+        divisor = _static_int(expr.args[1])
+        if sym is not None and divisor is not None and divisor > 0:
+            return sym, divisor
+
+    if expr.func == sympy.floor and len(expr.args) == 1:
+        arg = sympy.simplify(expr.args[0])
+    else:
+        arg = expr
+    sym = _single_free_symbol(arg)
+    if sym is None:
+        return None
+    coeff = sympy.simplify(arg.coeff(sym))
+    if coeff.is_Rational and coeff.p == 1 and coeff.q > 0:
+        return sym, int(coeff.q)
+    return None
+
+
+def _as_symbol_mod(expr: sympy.Expr) -> tuple[sympy.Symbol, int] | None:
+    expr = sympy.simplify(expr)
+    if expr.func != sympy.Mod or len(expr.args) != 2:
+        return None
+    sym = _single_free_symbol(sympy.sympify(expr.args[0]))
+    modulus = _static_int(expr.args[1])
+    if sym is not None and modulus is not None and modulus > 0:
+        return sym, modulus
+    return None
+
+
+def _coord_subview_range(
+    coord: sympy.Expr,
+    *,
+    ranges: dict[sympy.Symbol, int],
+    device_size: int,
+) -> tuple[int, int] | None:
+    coord = sympy.simplify(coord)
+    free_symbols: set[sympy.Symbol] = set(coord.free_symbols)
+    if not free_symbols:
+        start = _static_int(coord)
+        if start is None or start < 0 or start >= int(device_size):
+            return None
+        return start, 1
+
+    zero_subs = {sym: 0 for sym in free_symbols}
+    const = _static_int(coord.subs(zero_subs))
+    if const is None:
+        return None
+    residual = sympy.simplify(coord - const)
+
+    sym = _single_free_symbol(residual)
+    if sym is not None and sym in ranges and sympy.simplify(residual - sym) == 0:
+        size = int(ranges[sym])
+        if const < 0 or const + size > int(device_size):
+            return None
+        return const, size
+
+    floor_div = _as_symbol_floor_div(residual)
+    if floor_div is not None:
+        sym, divisor = floor_div
+        source_size = ranges.get(sym)
+        if source_size is None or source_size % divisor != 0:
+            return None
+        size = source_size // divisor
+        if const < 0 or const + size > int(device_size):
+            return None
+        return const, size
+
+    mod = _as_symbol_mod(residual)
+    if mod is not None:
+        sym, modulus = mod
+        source_size = ranges.get(sym)
+        if source_size is None:
+            return None
+        if source_size <= modulus:
+            size = source_size
+        elif source_size % modulus == 0:
+            size = modulus
+        else:
+            return None
+        if const < 0 or const + size > int(device_size):
+            return None
+        return const, size
+
+    return None
+
+
+def _subview_from_device_coordinates(
+    *,
+    coordinates: list[sympy.Expr],
+    ranges: dict[Any, Any],
+    device_sizes: list[int],
+) -> LXRelayoutSubview | None:
+    range_sizes = _range_size_by_symbol(ranges)
+    if len(coordinates) != len(device_sizes):
+        return None
+
+    starts: list[int] = []
+    sizes: list[int] = []
+    for coord, device_size in zip(coordinates, device_sizes):
+        subrange = _coord_subview_range(
+            sympy.sympify(coord),
+            ranges=range_sizes,
+            device_size=int(device_size),
+        )
+        if subrange is None:
+            return None
+        start, size = subrange
+        starts.append(start)
+        sizes.append(size)
+    return LXRelayoutSubview(starts=starts, sizes=sizes)
+
+
+def _movement_subview_from_read_dep(
+    buf: Any,
+    read_dep: MemoryDep,
+    *,
+    device_sizes: list[int],
+) -> LXRelayoutSubview:
+    layout = getattr(buf, "layout", None)
+    dev_layout = getattr(layout, "device_layout", None)
+    if dev_layout is None:
+        return _default_subview(device_sizes)
+    try:
+        coords = device_coordinates(dev_layout, read_dep)
+        subview = _subview_from_device_coordinates(
+            coordinates=coords,
+            ranges=getattr(read_dep, "ranges", {}),
+            device_sizes=device_sizes,
+        )
+    except Exception:  # noqa: BLE001
+        subview = None
+    if subview is None:
+        return _default_subview(device_sizes)
+    return subview
+
+
+def build_lx_relayout_cells(
+    *,
+    producer_view: PerCoreView,
+    consumer_view: PerCoreView,
+    device_sizes: list[int],
+    device_stride_map: list[int] | None = None,
+    element_bytes: int,
+    producer_core_count: int,
+    consumer_core_count: int,
+    max_cells: int | None = None,
+    lx_relayout_v1: bool = False,
+    movement_subview: LXRelayoutSubview | None = None,
+) -> tuple[list[LXRelayoutCell], str | None]:
+    """Return common-refinement movement cells, or a skip reason."""
+
+    subview = movement_subview or _default_subview(device_sizes)
+    reason = _validate_subview(subview, device_sizes=device_sizes)
+    if reason is not None:
+        return [], reason
+
+    producer_splits = _normalize_view_splits(producer_view)
+    consumer_splits = _normalize_view_splits(consumer_view)
+    moved_dims = tuple(sorted(set(producer_splits) | set(consumer_splits)))
+    common_splits = {
+        dim: math.lcm(producer_splits.get(dim, 1), consumer_splits.get(dim, 1))
+        for dim in moved_dims
+    }
+    if lx_relayout_v1:
+        common_splits, reason = _lx_relayout_v1_refined_splits(
+            common_splits=common_splits,
+            device_sizes=device_sizes,
+            device_stride_map=device_stride_map or [],
+            element_bytes=element_bytes,
+        )
+        if reason is not None:
+            return [], reason
+        moved_dims = tuple(sorted(common_splits))
+        local_dim_order, reason = _lx_relayout_v1_lx_dim_order(
+            device_sizes=device_sizes,
+            device_stride_map=device_stride_map or [],
+            element_bytes=element_bytes,
+        )
+        if reason is not None:
+            return [], reason
+    else:
+        local_dim_order = None
+
+    for dim, split in common_splits.items():
+        if dim < 0 or dim >= len(device_sizes):
+            return [], "view-dim-outside-device-layout"
+        if int(device_sizes[dim]) % int(split) != 0:
+            return [], "device-dim-not-divisible-by-common-split"
+
+    producer_owners, reason = _owner_lookup(producer_view, producer_core_count)
+    if reason is not None:
+        return [], f"producer-{reason}"
+    consumer_owners, reason = _owner_lookup(consumer_view, consumer_core_count)
+    if reason is not None:
+        return [], f"consumer-{reason}"
+
+    producer_owner_dims = tuple(dim for dim, _split in producer_view.work_slice_dims)
+    consumer_owner_dims = tuple(dim for dim, _split in consumer_view.work_slice_dims)
+    cells: list[LXRelayoutCell] = []
+
+    ranges, reason = _subview_ranges_for_common_splits(
+        subview=subview,
+        device_sizes=device_sizes,
+        common_splits=common_splits,
+        moved_dims=moved_dims,
+    )
+    if reason is not None:
+        return [], reason
+    cell_count = math.prod(len(r) for r in ranges) if ranges else 1
+    if max_cells is not None and cell_count > max_cells:
+        return [], "too-many-common-refinement-cells"
+
+    iterator = math.prod(len(r) for r in ranges)
+    if iterator == 0:
+        return [], "empty-common-refinement"
+
+    for cell_index, indices in enumerate(itertools.product(*ranges)):
+        common_index = dict(zip(moved_dims, indices))
+        producer_key = _owner_key(
+            common_index,
+            producer_owner_dims,
+            side_splits=producer_splits,
+            common_splits=common_splits,
+        )
+        consumer_key = _owner_key(
+            common_index,
+            consumer_owner_dims,
+            side_splits=consumer_splits,
+            common_splits=common_splits,
+        )
+        if producer_key not in producer_owners:
+            return [], "producer-owner-map-incomplete"
+        if consumer_key not in consumer_owners:
+            return [], "consumer-owner-map-incomplete"
+
+        starts: dict[str, int] = {}
+        sizes: dict[str, int] = {}
+        for dim, dim_size in enumerate(device_sizes):
+            split = common_splits.get(dim, 1)
+            chunk = int(dim_size) // int(split)
+            starts[f"d{dim}_"] = int(common_index.get(dim, 0)) * chunk
+            sizes[f"d{dim}_"] = chunk
+        cell_bytes = math.prod(sizes.values()) * int(element_bytes)
+        producer_starts, producer_sizes = _side_slice_geometry(
+            view=producer_view,
+            owner_key=producer_key,
+            device_sizes=device_sizes,
+        )
+        consumer_starts, consumer_sizes = _side_slice_geometry(
+            view=consumer_view,
+            owner_key=consumer_key,
+            device_sizes=device_sizes,
+        )
+        source_offset, reason = _local_offset_bytes(
+            cell_starts=starts,
+            cell_sizes=sizes,
+            slice_starts=producer_starts,
+            slice_sizes=producer_sizes,
+            element_bytes=element_bytes,
+            device_stride_map=device_stride_map,
+            dim_order=local_dim_order,
+        )
+        if reason is not None:
+            return [], f"producer-{reason}"
+        dest_offset, reason = _local_offset_bytes(
+            cell_starts=starts,
+            cell_sizes=sizes,
+            slice_starts=consumer_starts,
+            slice_sizes=consumer_sizes,
+            element_bytes=element_bytes,
+            device_stride_map=device_stride_map,
+            dim_order=local_dim_order,
+        )
+        if reason is not None:
+            return [], f"consumer-{reason}"
+        cells.append(
+            LXRelayoutCell(
+                cell_index=cell_index,
+                source_core=producer_owners[producer_key],
+                dest_core=consumer_owners[consumer_key],
+                dim_starts=starts,
+                dim_sizes=sizes,
+                bytes=cell_bytes,
+                source_offset_bytes=source_offset,
+                dest_offset_bytes=dest_offset,
+            )
+        )
+
+    return cells, None
+
+
+def validate_lx_relayout_cell_coverage(
+    cells: list[LXRelayoutCell],
+    *,
+    device_sizes: list[int],
+    movement_subview: LXRelayoutSubview | None = None,
+) -> str | None:
+    """Check that movement cells tile the logical device rectangle exactly."""
+
+    if not cells:
+        return "no-cells"
+
+    subview = movement_subview or _default_subview(device_sizes)
+    reason = _validate_subview(subview, device_sizes=device_sizes)
+    if reason is not None:
+        return reason
+
+    dims = len(device_sizes)
+    boxes: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    boundaries: list[set[int]] = [
+        {int(start), int(start) + int(size)}
+        for start, size in zip(subview.starts, subview.sizes)
+    ]
+    total_volume = 0
+    for cell in cells:
+        starts: list[int] = []
+        ends: list[int] = []
+        volume = 1
+        for dim, _device_size in enumerate(device_sizes):
+            key = f"d{dim}_"
+            if key not in cell.dim_starts or key not in cell.dim_sizes:
+                return "coverage-cell-missing-dim"
+            start = int(cell.dim_starts[key])
+            size = int(cell.dim_sizes[key])
+            end = start + size
+            subview_start = int(subview.starts[dim])
+            subview_end = subview_start + int(subview.sizes[dim])
+            if start < subview_start or size <= 0 or end > subview_end:
+                return "coverage-cell-out-of-bounds"
+            starts.append(start)
+            ends.append(end)
+            boundaries[dim].add(start)
+            boundaries[dim].add(end)
+            volume *= size
+        boxes.append((tuple(starts), tuple(ends)))
+        total_volume += volume
+
+    expected_volume = math.prod(int(size) for size in subview.sizes)
+    if total_volume != expected_volume:
+        return "coverage-volume-mismatch"
+
+    axes = [sorted(axis) for axis in boundaries]
+    interval_counts = [max(len(axis) - 1, 0) for axis in axes]
+    compressed_cell_count = math.prod(interval_counts)
+    if compressed_cell_count > max(1_000_000, len(cells) * 16):
+        return "coverage-validation-too-complex"
+
+    axis_indices = [
+        {boundary: index for index, boundary in enumerate(axis)} for axis in axes
+    ]
+    strides: list[int] = []
+    stride = 1
+    for count in reversed(interval_counts):
+        strides.append(stride)
+        stride *= count
+    strides.reverse()
+
+    occupied: set[int] = set()
+    for box_starts, box_ends in boxes:
+        cell_ranges = [
+            range(
+                axis_indices[dim][box_starts[dim]],
+                axis_indices[dim][box_ends[dim]],
+            )
+            for dim in range(dims)
+        ]
+        for index_tuple in itertools.product(*cell_ranges):
+            linear_index = sum(
+                int(index) * strides[dim] for dim, index in enumerate(index_tuple)
+            )
+            if linear_index in occupied:
+                return "coverage-cell-overlap"
+            occupied.add(linear_index)
+    return None
+
+
+def _lx_relayout_v1_support_reason(cells: list[LXRelayoutCell]) -> str | None:
+    """Return why the current Deeptools lx-relayout carrier cannot lower cells.
+
+    The v1 Deeptools lowering emits whole-stick L3 load/store movements. It is
+    only valid when each logical movement is also a non-overlapping contiguous
+    destination byte range with 128-byte aligned source/destination addresses.
+    """
+
+    stick_bytes = 128
+    destination_ranges_by_core: dict[int, list[tuple[int, int]]] = {}
+    producer_base = int(config.lx_relayout_producer_lx_base)
+    consumer_base = int(config.lx_relayout_consumer_lx_base)
+    for cell in cells:
+        if int(cell.bytes) <= 0 or int(cell.bytes) % stick_bytes != 0:
+            return "lx-relayout-v1-requires-stick-sized-moves"
+        source_lx_address = producer_base + int(cell.source_offset_bytes)
+        dest_lx_address = consumer_base + int(cell.dest_offset_bytes)
+        if source_lx_address % stick_bytes != 0:
+            return "lx-relayout-v1-requires-stick-aligned-source-address"
+        if dest_lx_address % stick_bytes != 0:
+            return "lx-relayout-v1-requires-stick-aligned-destination-address"
+        start = int(cell.dest_offset_bytes)
+        end = start + int(cell.bytes)
+        destination_ranges_by_core.setdefault(int(cell.dest_core), []).append(
+            (start, end)
+        )
+
+    for ranges in destination_ranges_by_core.values():
+        ranges.sort()
+        previous_end: int | None = None
+        for start, end in ranges:
+            if previous_end is not None and start < previous_end:
+                return "lx-relayout-v1-requires-contiguous-destination-cells"
+            previous_end = end
+    return None
+
+
+def _slice_payload(starts: dict[str, int], sizes: dict[str, int]) -> dict[str, Any]:
+    return {
+        "starts": {dim: int(starts[dim]) for dim in sorted(starts)},
+        "sizes": {dim: int(sizes[dim]) for dim in sorted(sizes)},
+    }
+
+
+def _byte_range_payload(start: int, size: int) -> dict[str, int]:
+    return {"start": int(start), "end": int(start) + int(size)}
+
+
+def _dataop_movement_payload(move: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "moveIndex": int(move["move_index"]),
+        "bytes": int(move["bytes"]),
+        "source": {
+            "core": int(move["source_core"]),
+            "logicalSlice": move["source_slice"],
+            "lxAddress": int(move["source_lx_address"]),
+            "localByteRange": move["source_local_byte_range"],
+            "lxByteRange": move["source_lx_byte_range"],
+        },
+        "destination": {
+            "core": int(move["destination_core"]),
+            "logicalSlice": move["destination_slice"],
+            "lxAddress": int(move["destination_lx_address"]),
+            "localByteRange": move["destination_local_byte_range"],
+            "lxByteRange": move["destination_lx_byte_range"],
+        },
+    }
+
+
+def _try_extend_logical_slice(
+    current: dict[str, Any],
+    next_slice: dict[str, Any],
+) -> dict[str, Any] | None:
+    current_starts = copy.deepcopy(current.get("starts", {}))
+    current_sizes = copy.deepcopy(current.get("sizes", {}))
+    next_starts = next_slice.get("starts", {})
+    next_sizes = next_slice.get("sizes", {})
+    if set(current_starts) != set(next_starts) or set(current_sizes) != set(next_sizes):
+        return None
+
+    extending_dim: str | None = None
+    for dim in sorted(current_starts):
+        current_start = int(current_starts[dim])
+        current_size = int(current_sizes[dim])
+        next_start = int(next_starts[dim])
+        next_size = int(next_sizes[dim])
+        if current_start == next_start and current_size == next_size:
+            continue
+        if next_start == current_start + current_size:
+            if extending_dim is not None:
+                return None
+            extending_dim = dim
+            current_sizes[dim] = current_size + next_size
+            continue
+        return None
+
+    if extending_dim is None:
+        return copy.deepcopy(current)
+    return {"starts": current_starts, "sizes": current_sizes}
+
+
+def _merge_logical_slice_for_dataop(
+    current: dict[str, Any],
+    next_slice: dict[str, Any],
+) -> dict[str, Any]:
+    merged = _try_extend_logical_slice(current, next_slice)
+    if merged is not None:
+        return merged
+    # Deeptools lowers lx relayouts from byte ranges and core ids; the
+    # logical slice is diagnostic metadata.  Keep it compact when adjacent byte
+    # ranges do not form a single rectangular logical slice.
+    return {"starts": {}, "sizes": {}, "coalesced": True}
+
+
+def _coalesce_dataop_movements(movements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if len(movements) < 2:
+        return movements
+
+    sorted_movements = sorted(
+        movements,
+        key=lambda move: (
+            int(move["source"]["core"]),
+            int(move["destination"]["core"]),
+            int(move["source"]["lxAddress"]),
+            int(move["destination"]["lxAddress"]),
+            int(move["moveIndex"]),
+        ),
+    )
+    coalesced: list[dict[str, Any]] = []
+    for movement in sorted_movements:
+        movement = copy.deepcopy(movement)
+        if not coalesced:
+            coalesced.append(movement)
+            continue
+
+        previous = coalesced[-1]
+        same_cores = int(previous["source"]["core"]) == int(
+            movement["source"]["core"]
+        ) and int(previous["destination"]["core"]) == int(
+            movement["destination"]["core"]
+        )
+        previous_source = previous["source"]["lxByteRange"]
+        movement_source = movement["source"]["lxByteRange"]
+        previous_dest = previous["destination"]["lxByteRange"]
+        movement_dest = movement["destination"]["lxByteRange"]
+        contiguous = int(previous_source["end"]) == int(
+            movement_source["start"]
+        ) and int(previous_dest["end"]) == int(movement_dest["start"])
+        if not same_cores or not contiguous:
+            coalesced.append(movement)
+            continue
+
+        merged_source_slice = _merge_logical_slice_for_dataop(
+            previous["source"]["logicalSlice"],
+            movement["source"]["logicalSlice"],
+        )
+        merged_dest_slice = _merge_logical_slice_for_dataop(
+            previous["destination"]["logicalSlice"],
+            movement["destination"]["logicalSlice"],
+        )
+        previous["bytes"] = int(previous["bytes"]) + int(movement["bytes"])
+        previous["source"]["localByteRange"]["end"] = movement["source"][
+            "localByteRange"
+        ]["end"]
+        previous["source"]["lxByteRange"]["end"] = movement_source["end"]
+        previous["source"]["logicalSlice"] = merged_source_slice
+        previous["destination"]["localByteRange"]["end"] = movement["destination"][
+            "localByteRange"
+        ]["end"]
+        previous["destination"]["lxByteRange"]["end"] = movement_dest["end"]
+        previous["destination"]["logicalSlice"] = merged_dest_slice
+
+    for index, movement in enumerate(coalesced):
+        movement["moveIndex"] = index
+    return coalesced
+
+
+def _side_stride(
+    previous: dict[str, Any], movement: dict[str, Any], side: str
+) -> int | None:
+    previous_side = previous[side]
+    movement_side = movement[side]
+    lx_stride = int(movement_side["lxAddress"]) - int(previous_side["lxAddress"])
+    local_stride = int(movement_side["localByteRange"]["start"]) - int(
+        previous_side["localByteRange"]["start"]
+    )
+    lx_range_stride = int(movement_side["lxByteRange"]["start"]) - int(
+        previous_side["lxByteRange"]["start"]
+    )
+    if lx_stride != local_stride or lx_stride != lx_range_stride:
+        return None
+    if (
+        int(movement_side["localByteRange"]["end"])
+        - int(previous_side["localByteRange"]["end"])
+        != lx_stride
+    ):
+        return None
+    if (
+        int(movement_side["lxByteRange"]["end"])
+        - int(previous_side["lxByteRange"]["end"])
+        != lx_stride
+    ):
+        return None
+    return lx_stride
+
+
+def _range_side_payload(side: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "core": int(side["core"]),
+        "logicalSlice": copy.deepcopy(side.get("logicalSlice", {})),
+        "lxAddress": int(side["lxAddress"]),
+        "localByteRange": copy.deepcopy(side["localByteRange"]),
+        "lxByteRange": copy.deepcopy(side["lxByteRange"]),
+    }
+
+
+def _dataop_movement_ranges(movements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not movements:
+        return []
+
+    ranges: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    previous: dict[str, Any] | None = None
+
+    def flush() -> None:
+        nonlocal current
+        if current is None:
+            return
+        current["rangeIndex"] = len(ranges)
+        ranges.append(current)
+        current = None
+
+    for movement in movements:
+        movement = copy.deepcopy(movement)
+        if current is None:
+            current = {
+                "rangeIndex": -1,
+                "moveIndex": int(movement["moveIndex"]),
+                "count": 1,
+                "bytesPerMove": int(movement["bytes"]),
+                "sourceStrideBytes": 0,
+                "destinationStrideBytes": 0,
+                "source": _range_side_payload(movement["source"]),
+                "destination": _range_side_payload(movement["destination"]),
+                **(
+                    {"relay": copy.deepcopy(movement["relay"])}
+                    if "relay" in movement
+                    else {}
+                ),
+            }
+            previous = movement
+            continue
+
+        assert previous is not None
+        source_stride = _side_stride(previous, movement, "source")
+        destination_stride = _side_stride(previous, movement, "destination")
+        expected_source_stride = int(current["sourceStrideBytes"])
+        expected_destination_stride = int(current["destinationStrideBytes"])
+        compatible = (
+            int(movement["bytes"]) == int(current["bytesPerMove"])
+            and int(movement["source"]["core"]) == int(current["source"]["core"])
+            and int(movement["destination"]["core"])
+            == int(current["destination"]["core"])
+            and source_stride is not None
+            and destination_stride is not None
+            and int(movement["moveIndex"]) == int(previous["moveIndex"]) + 1
+            and movement.get("relay") == current.get("relay")
+            and (int(current["count"]) == 1 or source_stride == expected_source_stride)
+            and (
+                int(current["count"]) == 1
+                or destination_stride == expected_destination_stride
+            )
+        )
+        if not compatible:
+            flush()
+            current = {
+                "rangeIndex": -1,
+                "moveIndex": int(movement["moveIndex"]),
+                "count": 1,
+                "bytesPerMove": int(movement["bytes"]),
+                "sourceStrideBytes": 0,
+                "destinationStrideBytes": 0,
+                "source": _range_side_payload(movement["source"]),
+                "destination": _range_side_payload(movement["destination"]),
+                **(
+                    {"relay": copy.deepcopy(movement["relay"])}
+                    if "relay" in movement
+                    else {}
+                ),
+            }
+            previous = movement
+            continue
+
+        assert source_stride is not None
+        assert destination_stride is not None
+        if int(current["count"]) == 1:
+            current["sourceStrideBytes"] = int(source_stride)
+            current["destinationStrideBytes"] = int(destination_stride)
+        current["count"] = int(current["count"]) + 1
+        previous = movement
+
+    flush()
+    return ranges
+
+
+def _expand_dataop_movement_ranges(
+    ranges: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    movements: list[dict[str, Any]] = []
+    for movement_range in ranges:
+        count = int(movement_range.get("count") or 0)
+        bytes_per_move = int(movement_range.get("bytesPerMove") or 0)
+        source_stride = int(movement_range.get("sourceStrideBytes") or 0)
+        destination_stride = int(movement_range.get("destinationStrideBytes") or 0)
+        if count <= 0 or bytes_per_move <= 0:
+            continue
+        for offset in range(count):
+            move = {
+                "moveIndex": int(movement_range["moveIndex"]) + offset,
+                "bytes": bytes_per_move,
+                "source": copy.deepcopy(movement_range["source"]),
+                "destination": copy.deepcopy(movement_range["destination"]),
+            }
+            if "relay" in movement_range:
+                move["relay"] = copy.deepcopy(movement_range["relay"])
+            for side_name, stride in (
+                ("source", source_stride),
+                ("destination", destination_stride),
+            ):
+                side = move[side_name]
+                byte_offset = offset * stride
+                side["lxAddress"] = int(side["lxAddress"]) + byte_offset
+                side["localByteRange"]["start"] = (
+                    int(side["localByteRange"]["start"]) + byte_offset
+                )
+                side["localByteRange"]["end"] = (
+                    int(side["localByteRange"]["end"]) + byte_offset
+                )
+                side["lxByteRange"]["start"] = (
+                    int(side["lxByteRange"]["start"]) + byte_offset
+                )
+                side["lxByteRange"]["end"] = (
+                    int(side["lxByteRange"]["end"]) + byte_offset
+                )
+            movements.append(move)
+    return movements
+
+
+def _compact_lx_relayout_dataop_for_json(dataop: dict[str, Any]) -> dict[str, Any]:
+    compact = copy.deepcopy(dataop)
+    if config.lx_relayout_range_encoding and compact.get("movementRanges"):
+        compact.pop("movements", None)
+        lowering = compact.setdefault("lowering", {})
+        lowering["rangeEncoded"] = True
+    return compact
+
+
+def _lx_relayout_dataop_payload(
+    *,
+    source_name: str,
+    producer_name: str,
+    consumer_name: str,
+    producer_base: int,
+    consumer_base: int,
+    coverage: dict[str, Any],
+    dependency_order: list[dict[str, Any]],
+    movements: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the backend-facing Deeptools data-op JSON form."""
+
+    dataop_movements = _coalesce_dataop_movements(
+        [_dataop_movement_payload(move) for move in movements]
+    )
+    return {
+        "op": {"name": "STCDPOpLx"},
+        "schemaVersion": 0,
+        "sourceName": source_name,
+        "producer": producer_name,
+        "consumer": consumer_name,
+        "producerLxBase": int(producer_base),
+        "consumerLxBase": int(consumer_base),
+        "coverage": coverage,
+        "dependencyOrder": [
+            {
+                "order": int(row["order"]),
+                "kind": row["kind"],
+                **({"op": row["op"]} if "op" in row else {}),
+                **({"sourceName": row["source_name"]} if "source_name" in row else {}),
+                **({"primitive": row["primitive"]} if "primitive" in row else {}),
+                **(
+                    {"cellCount": int(row["cell_count"])} if "cell_count" in row else {}
+                ),
+            }
+            for row in dependency_order
+        ],
+        "lowering": {
+            "strategy": "explicit_lx_copy_via_l3",
+            "addressUnits": "bytes",
+            "coalescedMovements": len(dataop_movements),
+            "sourceMovements": len(movements),
+            "movementRanges": len(_dataop_movement_ranges(dataop_movements)),
+            "rangeEncoded": False,
+        },
+        "movements": dataop_movements,
+        "movementRanges": _dataop_movement_ranges(dataop_movements),
+    }
+
+
+def build_lx_relayout_metadata(plan: LXRelayoutPlan) -> dict[str, Any]:
+    """Build torch-spyre-side metadata for a STCDPOpLx range data-op."""
+
+    producer_base = int(config.lx_relayout_producer_lx_base)
+    consumer_base = int(config.lx_relayout_consumer_lx_base)
+    movements: list[dict[str, Any]] = []
+    for cell in plan.cells:
+        source_lx_address = producer_base + int(cell.source_offset_bytes)
+        dest_lx_address = consumer_base + int(cell.dest_offset_bytes)
+        logical_slice = _slice_payload(cell.dim_starts, cell.dim_sizes)
+        movements.append(
+            {
+                "move_index": int(cell.cell_index),
+                "bytes": int(cell.bytes),
+                "source_core": int(cell.source_core),
+                "source_slice": logical_slice,
+                "source_lx_address": source_lx_address,
+                "source_local_byte_range": _byte_range_payload(
+                    cell.source_offset_bytes,
+                    cell.bytes,
+                ),
+                "source_lx_byte_range": _byte_range_payload(
+                    source_lx_address,
+                    cell.bytes,
+                ),
+                "destination_core": int(cell.dest_core),
+                "destination_slice": logical_slice,
+                "destination_lx_address": dest_lx_address,
+                "destination_local_byte_range": _byte_range_payload(
+                    cell.dest_offset_bytes,
+                    cell.bytes,
+                ),
+                "destination_lx_byte_range": _byte_range_payload(
+                    dest_lx_address,
+                    cell.bytes,
+                ),
+            }
+        )
+
+    coverage: dict[str, Any] = {
+        "device_sizes": [int(size) for size in plan.device_sizes],
+        "status": validate_lx_relayout_cell_coverage(
+            plan.cells,
+            device_sizes=plan.device_sizes,
+            movement_subview=plan.movement_subview,
+        )
+        or "complete",
+    }
+    if plan.movement_subview is not None and not _is_full_subview(
+        plan.movement_subview,
+        device_sizes=plan.device_sizes,
+    ):
+        coverage["subview"] = {
+            "starts": [int(start) for start in plan.movement_subview.starts],
+            "sizes": [int(size) for size in plan.movement_subview.sizes],
+        }
+    dependency_order: list[dict[str, Any]] = [
+        {
+            "order": 0,
+            "kind": "producer_lx_write_before_relayout",
+            "op": plan.producer_name,
+            "source_name": plan.source_name,
+        },
+        {
+            "order": 1,
+            "kind": "lx_relayout",
+            "primitive": "lx_relayout_v0",
+            "cell_count": len(plan.cells),
+        },
+        {
+            "order": 2,
+            "kind": "consumer_lx_read_after_relayout",
+            "op": plan.consumer_name,
+            "source_name": plan.source_name,
+        },
+    ]
+    metadata = {
+        "primitive": "lx_relayout_v0",
+        "schema_version": 0,
+        "source_name": plan.source_name,
+        "producer": plan.producer_name,
+        "consumer": plan.consumer_name,
+        "producer_lx_base": producer_base,
+        "consumer_lx_base": consumer_base,
+        "coverage": coverage,
+        "dependency_order": dependency_order,
+        "deeptools_dataop": _lx_relayout_dataop_payload(
+            source_name=plan.source_name,
+            producer_name=plan.producer_name,
+            consumer_name=plan.consumer_name,
+            producer_base=producer_base,
+            consumer_base=consumer_base,
+            coverage=coverage,
+            dependency_order=dependency_order,
+            movements=movements,
+        ),
+    }
+    if "subview" in coverage:
+        metadata["logical_subview"] = copy.deepcopy(coverage["subview"])
+    return metadata
+
+
+def _planned_payload(plan: LXRelayoutPlan) -> dict[str, Any]:
+    payload = {
+        "source_name": plan.source_name,
+        "producer": plan.producer_name,
+        "consumer": plan.consumer_name,
+        "device_sizes": plan.device_sizes,
+        "device_stride_map": plan.device_stride_map,
+        "element_bytes": plan.element_bytes,
+        "producer_core_count": plan.producer_core_count,
+        "consumer_core_count": plan.consumer_core_count,
+        "producer_region_bytes": plan.producer_region_bytes,
+        "consumer_region_bytes": plan.consumer_region_bytes,
+        "cell_count": len(plan.cells),
+        "bytes_moved": plan.bytes_moved,
+    }
+    if plan.movement_subview is not None and not _is_full_subview(
+        plan.movement_subview,
+        device_sizes=plan.device_sizes,
+    ):
+        payload["movement_subview"] = {
+            "starts": [int(start) for start in plan.movement_subview.starts],
+            "sizes": [int(size) for size in plan.movement_subview.sizes],
+        }
+    metadata = build_lx_relayout_metadata(plan)
+    metadata["deeptools_dataop"] = _compact_lx_relayout_dataop_for_json(
+        metadata["deeptools_dataop"]
+    )
+    payload["lx_relayout"] = metadata
+    return payload
+
+
+def plan_lx_relayout_edge(
+    graph: GraphLowering,
+    producer: ComputedBuffer,
+    consumer: ComputedBuffer,
+    read_dep: MemoryDep,
+    *,
+    cache: dict | None = None,
+) -> LXRelayoutPlan | None:
+    write_dep = _single_write_dep(producer, read_dep.name)
+    if write_dep is None:
+        return None
+
+    producer_view, producer_partial = _per_core_view_on_buf(
+        producer,
+        write_dep,
+        read_dep.name,
+        cache=cache,
+    )
+    consumer_view, _consumer_partial = _per_core_view_on_buf(
+        consumer,
+        read_dep,
+        read_dep.name,
+        cache=cache,
+    )
+    if producer_partial:
+        return None
+    if producer_view == consumer_view:
+        return None
+
+    try:
+        buf = graph.get_buffer(read_dep.name)
+        device_sizes, device_stride_map, element_bytes = (
+            _device_layout_and_element_bytes(buf)
+        )
+        movement_subview = _movement_subview_from_read_dep(
+            buf,
+            read_dep,
+            device_sizes=device_sizes,
+        )
+        cells, reason = build_lx_relayout_cells(
+            producer_view=producer_view,
+            consumer_view=consumer_view,
+            device_sizes=device_sizes,
+            device_stride_map=device_stride_map,
+            element_bytes=element_bytes,
+            producer_core_count=_op_num_cores(producer),
+            consumer_core_count=_op_num_cores(consumer),
+            max_cells=config.lx_relayout_max_cells,
+            lx_relayout_v1=True,
+            movement_subview=movement_subview,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "lx_relayout skipped %s -> %s for %s: %s",
+            producer.get_name(),
+            consumer.get_name(),
+            read_dep.name,
+            type(exc).__name__,
+        )
+        return None
+    if reason is not None:
+        logger.debug(
+            "lx_relayout skipped %s -> %s for %s: %s",
+            producer.get_name(),
+            consumer.get_name(),
+            read_dep.name,
+            reason,
+        )
+        return None
+    reason = _lx_relayout_v1_support_reason(cells)
+    if reason is not None:
+        logger.debug(
+            "lx_relayout skipped %s -> %s for %s: %s",
+            producer.get_name(),
+            consumer.get_name(),
+            read_dep.name,
+            reason,
+        )
+        return None
+
+    return LXRelayoutPlan(
+        source_name=read_dep.name,
+        producer_name=producer.get_name(),
+        consumer_name=consumer.get_name(),
+        device_sizes=device_sizes,
+        device_stride_map=device_stride_map,
+        element_bytes=element_bytes,
+        producer_core_count=_op_num_cores(producer),
+        consumer_core_count=_op_num_cores(consumer),
+        producer_region_bytes=_view_region_bytes(
+            producer_view,
+            device_sizes=device_sizes,
+            element_bytes=element_bytes,
+        ),
+        consumer_region_bytes=_view_region_bytes(
+            consumer_view,
+            device_sizes=device_sizes,
+            element_bytes=element_bytes,
+        ),
+        cells=cells,
+        movement_subview=movement_subview,
+    )
+
+
+def _attach_plan_to_consumer(consumer: ComputedBuffer, plan: LXRelayoutPlan) -> None:
+    plan_payload = _planned_payload(plan)
+    existing_move_info = getattr(consumer, LX_RELAYOUT_ATTR, None)
+    move_info = existing_move_info if isinstance(existing_move_info, dict) else {}
+    move_info[plan.source_name] = plan_payload
+    setattr(consumer, LX_RELAYOUT_ATTR, move_info)
+
+    data = getattr(consumer, "data", None)
+    op_info = getattr(data, "op_info", None)
+    if isinstance(op_info, dict):
+        op_move_info = op_info.setdefault(LX_RELAYOUT_OP_INFO_KEY, {})
+        if not isinstance(op_move_info, dict):
+            op_move_info = {}
+            op_info[LX_RELAYOUT_OP_INFO_KEY] = op_move_info
+        op_move_info[plan.source_name] = plan_payload
+
+
+def plan_lx_relayouts(graph: GraphLowering) -> None:
+    if not config.lx_planner_relayout:
+        return
+
+    name_to_op = {
+        op.get_name(): op for op in graph.operations if isinstance(op, ComputedBuffer)
+    }
+    cache: dict = {}
+    plans: list[LXRelayoutPlan] = []
+    edge_count = 0
+    for consumer in graph.operations:
+        if not isinstance(consumer, ComputedBuffer):
+            continue
+        for dep in consumer.get_read_writes().reads:
+            if not isinstance(dep, MemoryDep):
+                continue
+            producer = name_to_op.get(dep.name)
+            if producer is None:
+                continue
+            edge_count += 1
+            plan = plan_lx_relayout_edge(
+                graph,
+                producer,
+                consumer,
+                dep,
+                cache=cache,
+            )
+            if plan is None:
+                continue
+            plans.append(plan)
+            _attach_plan_to_consumer(consumer, plan)
+
+    if edge_count:
+        logger.info(
+            "lx_relayout summary edges=%d planned=%d bytes=%d realize=%s",
+            edge_count,
+            len(plans),
+            sum(plan.bytes_moved for plan in plans),
+            config.lx_planner_relayout_realize,
+        )

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -62,6 +62,7 @@ from .work_division import (
     work_distribution,
     cost_model_matmul_division,
 )
+from .lx_relayout import plan_lx_relayouts
 from .pass_utils import apply_splits_from_index_coeff, iteration_space_from_op
 from .scratchpad.allocator import (
     StrategyBCoOptimizingAllocator,
@@ -285,7 +286,7 @@ def _distribute_work(graph: GraphLowering) -> None:
     work_distribution(graph, preassigned_ops)
 
 
-@_runs(scratchpad_planning)
+@_runs(scratchpad_planning, plan_lx_relayouts)
 def _maybe_scratchpad_planning(graph: GraphLowering) -> None:
     if not config.lx_planning:
         return
@@ -335,7 +336,6 @@ class CustomPreSchedulingPasses:
             # Core Division
             span_reduction,
             _distribute_work,
-            #
             # LX Planning
             _maybe_scratchpad_planning,
         ]

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -59,6 +59,7 @@ from torch_spyre._inductor.scratchpad.utils import (
 from torch_spyre._inductor.scratchpad.graph_editor import GraphEditor
 
 from torch_spyre._inductor import config
+from torch_spyre._inductor.lx_relayout import plan_lx_relayouts
 
 logger = logging.getLogger(__name__)
 
@@ -531,6 +532,9 @@ def scratchpad_planning(
         graph: Lowered graph to plan scratchpad memory for.
         allocator: Allocator strategy to use. Defaults to DefaultAllocator.
     """
+    if config.lx_planner_relayout:
+        plan_lx_relayouts(graph)
+
     if allocator is None:
         allocator = DefaultAllocator()
     allocator.plan_allocation(graph)

--- a/torch_spyre/_inductor/spyre_kernel.py
+++ b/torch_spyre/_inductor/spyre_kernel.py
@@ -41,6 +41,7 @@ from .constants import (
 )
 from .errors import Unsupported
 from .ir import FixedTiledLayout
+from .lx_relayout import LX_RELAYOUT_ATTR, LX_RELAYOUT_OP_INFO_KEY
 from .pass_utils import (
     concretize_expr,
     concretize_index,
@@ -60,6 +61,24 @@ from .op_spec import (
 import logging
 
 logger = get_inductor_logger("spyre_kernel")
+
+
+def _current_node_op_info(current_node) -> dict[str, Any]:
+    op_info: dict[str, Any] = {}
+    node = getattr(current_node, "node", None)
+    data = getattr(node, "data", None)
+    data_op_info = getattr(data, "op_info", None)
+    if isinstance(data_op_info, dict):
+        op_info.update(data_op_info)
+
+    move_info = getattr(node, LX_RELAYOUT_ATTR, None)
+    if isinstance(move_info, dict):
+        existing = op_info.get(LX_RELAYOUT_OP_INFO_KEY)
+        if isinstance(existing, dict):
+            existing.update(move_info)
+        else:
+            op_info[LX_RELAYOUT_OP_INFO_KEY] = dict(move_info)
+    return op_info
 
 
 class RValue(ABC):
@@ -512,7 +531,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             tensor.layout.allocation,
             stride_map=list(tensor.layout.device_layout.stride_map),
             per_tile_fixed=getattr(tensor.layout, "per_tile_fixed", False),
-            name=opspec_name,
+            name=opspec_name or name,
         )
         if (
             "lx" not in tensor.layout.allocation
@@ -661,7 +680,7 @@ class SpyreKernel(Kernel[CSEVariable]):
         if real_dst_name != name:
             # Skip allocating an output buffer; this name is an alias to another buffer
             V.graph.removed_buffers.add(name)
-        op_info: dict[str, Any] = {}
+        op_info = _current_node_op_info(self.current_node)
         if logger.isEnabledFor(logging.DEBUG):
             value_type = type(value).__name__
             logger.debug(
@@ -758,9 +777,7 @@ class SpyreKernel(Kernel[CSEVariable]):
             self.op_specs.append(value)
             return
 
-        op_info = {}
-        if hasattr(self.current_node.node.data, "op_info"):  # type: ignore[union-attr]
-            op_info.update(self.current_node.node.data.op_info)  # type: ignore[union-attr]
+        op_info = _current_node_op_info(self.current_node)
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:

<!--
Please describe your changes
-->
Common ops like SwiGLU and Attention, have a producer and consumer that want different optimal work divisions. Currently, that mismatch is solved by materializing through HBM.
The LX relayout extension keeps the producer's preferred split, keeps the consumer's preferred split, and inserts an explicit on-chip movement plan between the two.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
https://github.com/torch-spyre/torch-spyre/issues/2787

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
