### PR TITLE
feat(cicd): enable inductor lx op planning tests to run parallelly across 4 cards

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -174,7 +174,6 @@ jobs:
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_c_config.yaml
           - name: Inductor Ops Misc Compute A
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_a_config.yaml
-            runner: spyre_pf_x4
           - name: Inductor Ops Misc Compute B
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
           - name: Inductor Ops Misc Compute C
@@ -182,6 +181,7 @@ jobs:
             runner: spyre_pf_x4
           - name: Inductor Ops LX Planning
             config: torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
+            runner: spyre_pf_x4
           - name: Inductor Scalar
             config: torch_spyre_tests/inductor/test_inductor_scalar_config.yaml
           - name: Inductor Logging

--- a/torch_spyre/_inductor/dtype_ops.py
+++ b/torch_spyre/_inductor/dtype_ops.py
@@ -70,8 +70,8 @@ class DtypeOpTable:
         return cls._TYPECAST_OPS_TABLE
 
     @classmethod
-    def get_dtype_pairs(cls) -> set[tuple[torch.dtype, torch.dtype]]:
-        return cls._TYPECAST_OP_DTYPES
+    def get_dtype_pairs(cls) -> list[tuple[torch.dtype, torch.dtype]]:
+        return list(cls._TYPECAST_OPS_TABLE.keys())
 
     @classmethod
     def is_dtype_op(cls, op: str) -> bool:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

## What this PR does:

#### Change to dtye_ops.py specifically for handling LX Op Planning to run tests parallel across 4 cards

 `get_dtype_pairs()` returned a set, which has non-deterministic iteration order. When _canonical_test_names picks the first entry from `TO_DTYPE_OP_PARAMS_SETS` (built by iterating the set), the chosen canonical test name differs between the collection subprocess and the card subprocesses. On an x4 runner this surfaces because collection and execution run in separate processes where hash randomization picks different orderings.

The fix changes `get_dtype_pairs()` to return `list(cls._TYPECAST_OPS_TABLE.keys())` INSTEAD OF `set` which is ordered by dict insertion order (deterministic). Now `TO_DTYPE_OP_PARAMS_SETS` iterates in the same fixed order in every process, so the canonical test picked for test_to_dtype is always the same, and collected IDs match what each card actually finds.

Extension of PR https://github.com/torch-spyre/torch-spyre/pull/2786

Link: https://github.com/torch-spyre/torch-spyre/actions/runs/27943253472/job/82681528880?pr=2792

**Inductor Ops LX Planning : 7 mins 16 seconds ( a huge reduction from ~18-19 mins)**