### PR TITLE
feat: add raw host<->device copy bypassing DCI (#2744)

### DIFF
--- a/tests/test_spyre.py
+++ b/tests/test_spyre.py
@@ -661,6 +661,17 @@ class TestSpyre(TestCase):
             ),
         )
 
+    def test_copy_tensor_raw_round_trip(self):
+        """Raw H2D then raw D2H returns the exact same bytes."""
+        import torch_spyre._C as _C
+
+        cpu_src = torch.rand(4, 8, 64, dtype=torch.float16)
+        dev = torch.empty(4, 8, 64, dtype=torch.float16, device="spyre")
+        _C.copy_tensor_raw(cpu_src, dev, non_blocking=False)
+        cpu_dst = torch.zeros(4, 8, 64, dtype=torch.float16)
+        _C.copy_tensor_raw(dev, cpu_dst, non_blocking=False)
+        self.assertTrue(torch.equal(cpu_src, cpu_dst))
+
     def test_scalar_tensor(self):
         """Test to ensure we have scalar tensor on Spyre"""
         scalar = torch.tensor(3.14, dtype=torch.float16, device="spyre")

--- a/torch_spyre/csrc/module.cpp
+++ b/torch_spyre/csrc/module.cpp
@@ -338,7 +338,18 @@ PYBIND11_MODULE(_C, m) {
   // Memory copy function
   m.def("copy_tensor", &spyre::spyre_copy_from,
         "Copy tensor between host and device using DMA", py::arg("self"),
-        py::arg("dst"), py::arg("non_blocking") = false);
+        py::arg("dst"), py::arg("non_blocking") = false,
+        py::arg("raw_copy") = false);
+
+  // Raw (byte-for-byte) memory copy — bypasses layout/dtype conversion
+  m.def(
+      "copy_tensor_raw",
+      [](const at::Tensor& self, const at::Tensor& dst, bool non_blocking) {
+        return spyre::spyre_copy_from(self, dst, non_blocking,
+                                      /*raw_copy=*/true);
+      },
+      py::arg("self"), py::arg("dst"), py::arg("non_blocking") = false,
+      "Copy tensor between host and device without layout or dtype conversion");
 
   // Stream management functions
   m.def("get_stream_from_pool", &spyre::getStreamFromPool, py::arg("device"),

--- a/torch_spyre/csrc/spyre_mem.cpp
+++ b/torch_spyre/csrc/spyre_mem.cpp
@@ -592,7 +592,7 @@ at::Tensor& spyre_set_storage(at::Tensor& result, at::Storage storage,
  * proper handle to the Spyre allocation
  */
 at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
-                           bool non_blocking) {
+                           bool non_blocking, bool raw_copy) {
   SpyreStream stream;
   at::Tensor alloc_view;
   at::Tensor cpu_alloc;
@@ -637,7 +637,7 @@ at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
     }
   }
 
-  stream.copyAsync(*copy_from, *copy_to);
+  stream.copyAsync(*copy_from, *copy_to, raw_copy);
   if (!non_blocking) {
     stream.synchronize();
   }

--- a/torch_spyre/csrc/spyre_mem.h
+++ b/torch_spyre/csrc/spyre_mem.h
@@ -30,7 +30,7 @@ at::Tensor spyre_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
                                std::optional<bool> pin_memory_opt);
 
 at::Tensor spyre_copy_from(const at::Tensor& self, const at::Tensor& dst,
-                           bool non_blocking);
+                           bool non_blocking, bool raw_copy = false);
 
 class SpyreTensorLayout;
 at::Tensor spyre_empty_with_layout(c10::IntArrayRef size,

--- a/torch_spyre/csrc/spyre_stream.cpp
+++ b/torch_spyre/csrc/spyre_stream.cpp
@@ -140,8 +140,8 @@ void SpyreStream::copyProgramAsync(
   copyAsyncImpl(prog_cpu_ptr, device_address, nullptr, true);
 }
 
-void SpyreStream::copyAsync(const at::Tensor& src,
-                            const at::Tensor& dst) const {
+void SpyreStream::copyAsync(const at::Tensor& src, const at::Tensor& dst,
+                            bool raw_copy) const {
   DEBUGINFO("src (", src.scalar_type(), ") is on:", src.device());
   DEBUGINFO("dst (", dst.scalar_type(), ") on:", dst.device());
 
@@ -156,19 +156,23 @@ void SpyreStream::copyAsync(const at::Tensor& src,
     // Host-to-device or device-to-host copy
     void* cpu_ptr = const_cast<void*>(cpu_tensor->storage().data());
 
-    // Get SpyreTensorLayout using the public API
-    SpyreTensorLayout stl = get_spyre_tensor_layout(*dev_tensor);
-
     // Extract device allocation from Spyre tensor storage
     auto* spyre_impl =
         static_cast<SpyreTensorImpl*>(dev_tensor->unsafeGetTensorImpl());
     auto& storage = spyre_impl->storage();
     auto* ctx = static_cast<SharedOwnerCtx*>(storage.data_ptr().get_context());
 
-    DataConversionInfo dci = generate_dci(
-        cpu_tensor, dev_tensor, stl, cpu_tensor->storage_offset(), host2device);
+    if (raw_copy) {
+      copyAsyncImpl(cpu_ptr, &ctx->composite_addr, nullptr, host2device);
+    } else {
+      // Get SpyreTensorLayout using the public API
+      SpyreTensorLayout stl = get_spyre_tensor_layout(*dev_tensor);
 
-    copyAsyncImpl(cpu_ptr, &ctx->composite_addr, &dci, host2device);
+      DataConversionInfo dci =
+          generate_dci(cpu_tensor, dev_tensor, stl,
+                       cpu_tensor->storage_offset(), host2device);
+      copyAsyncImpl(cpu_ptr, &ctx->composite_addr, &dci, host2device);
+    }
 
   } else {
     TORCH_CHECK(false, "Unsupported copy types: src on ", src.device(),

--- a/torch_spyre/csrc/spyre_stream.h
+++ b/torch_spyre/csrc/spyre_stream.h
@@ -46,7 +46,8 @@ class SpyreStream {
   bool query() const;        // Check if work completed
   void synchronize() const;  // Block until work done
 
-  void copyAsync(const at::Tensor& src, const at::Tensor& dst) const;
+  void copyAsync(const at::Tensor& src, const at::Tensor& dst,
+                 bool raw_copy = false) const;
   void copyProgramAsync(void* prog_cpu_ptr,
                         const flex::CompositeAddress* device_address) const;
   void executeProgramAsync(const KernelArtifacts& arts,


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [x] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
<!--
Please describe your changes
-->
  - Add raw_copy=false param to SpyreStream::copyAsync; when true passes dci=nullptr to skip layout/dtype conversion
  - Add raw_copy=false param to spyre_copy_from to propagate flag to the stream call
  - Expose _C.copy_tensor_raw Python binding
  - Add test_copy_tensor_raw_round_trip to TestSpyre

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->
#2744 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
