### PR TITLE
Automatic hints generator for PW OPS

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -209,6 +209,8 @@ jobs:
             config: torch_spyre_tests/inductor/test_coarse_tiling_config.yaml
           - name: Inductor Coarse Tile E2E
             config: torch_spyre_tests/inductor/test_coarse_tile_e2e_config.yaml
+          - name: Inductor Span Overflow Hint Analysis
+            config: torch_spyre_tests/inductor/test_span_overflow_hint_analysis_config.yaml
           - name: Inductor Unroll Loop Specs
             config: torch_spyre_tests/inductor/test_unroll_loop_specs_config.yaml
           - name: Inductor Work Division Hint

--- a/docs/source/compiler/index.rst
+++ b/docs/source/compiler/index.rst
@@ -55,5 +55,6 @@ test coverage, bug classification), see :doc:`/contributing/op_enablement`.
    
    working_set_reduction
    coarse_tiling_loops
+   span_overflow_hint_analysis
    work_division_planning
    scratchpad_planning

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -72,13 +72,15 @@ groups in the exact format consumed by `coarse_tile()`:
 [([op], [(hint_id, split_count, is_reduction_level)])]
 ```
 
-`passes.py` wires this into `_maybe_coarse_tile()` after honoring the coarse-tiling debug flag:
+`passes.py` wires this into `_maybe_coarse_tile()` alongside user coarse-tiling hints:
 
 ```python
-if config.ignore_wsr_hints:
-    return
-
-groups = hints_to_coarse_tile_groups(graph) + span_overflow_groups(graph)
+groups = []
+if not config.ignore_wsr_hints:
+    reorder_unhinted_interlopers(graph)
+    groups += hints_to_coarse_tile_groups(graph)
+if not config.ignore_span_overflow_hints:
+    groups += span_overflow_groups(graph)
 if groups:
     groups.sort(key=graph_order)
     coarse_tile(graph, groups=groups)
@@ -286,7 +288,7 @@ already carry user `dim_hints`.  Mixed graphs can therefore contain both manual
 hint groups and automatic span-overflow groups in the same `coarse_tile()` call.
 
 `span_overflow_groups()` returns no groups when `config.chunk_large_tensors` or
-`config.ignore_wsr_hints` is enabled.
+`config.ignore_span_overflow_hints` is enabled.
 
 For every returned plan, the adapter:
 
@@ -425,6 +427,6 @@ The pointwise implementation is intentionally narrow:
   pass raises `Unsupported`; it does not try a later mapped dimension, emit
   nested multi-dimensional tile plans, or search split combinations across
   multiple host dimensions.
-- If `config.chunk_large_tensors` is enabled, `span_overflow_groups()` returns
-  no groups so the legacy chunking path remains in control.
+- If `config.chunk_large_tensors` or `config.ignore_span_overflow_hints` is
+  enabled, `span_overflow_groups()` returns no groups.
 - Reduction output-range tiling and reduction-range tiling are follow-up work.

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -72,21 +72,23 @@ groups in the exact format consumed by `coarse_tile()`:
 [([op], [(hint_id, split_count, is_reduction_level)])]
 ```
 
-`passes.py` wires this into `_maybe_coarse_tile()` after user hint grouping:
+`passes.py` wires this into `_maybe_coarse_tile()` after honoring the coarse-tiling debug flag:
 
 ```python
-groups = hints_to_coarse_tile_groups(graph)
-if not groups:
-    groups = span_overflow_groups(graph)
+if config.ignore_wsr_hints:
+    return
+
+groups = hints_to_coarse_tile_groups(graph) + span_overflow_groups(graph)
 if groups:
+    groups.sort(key=graph_order)
     coarse_tile(graph, groups=groups)
 ```
 
-This ordering is important.  User-authored `spyre_hint` groups take precedence;
-automatic span-overflow hints are only generated when no user coarse-tiling
-groups exist for the graph.  From `coarse_tile()` onward, automatic groups and
-manual `spyre_hint` groups share the same IR stamping, scheduler wrapping, and
-`LoopSpec` codegen path.
+This ordering is important.  User-authored `spyre_hint` groups take precedence
+per operation; automatic span-overflow hints are generated only for eligible ops
+that do not already carry user dim hints.  From `coarse_tile()` onward,
+automatic groups and manual `spyre_hint` groups share the same IR stamping,
+scheduler wrapping, and `LoopSpec` codegen path.
 
 ## Scope
 
@@ -95,10 +97,10 @@ The pass is deliberately conservative:
 - supports `ComputedBuffer` operations whose `data` is `Pointwise`;
 - requires a `FixedTiledLayout`, because decisions are based on Spyre physical
   device layout;
+- requires concrete/static layout metadata; symbolic layouts are skipped;
 - produces one coarse-tile level over one selected output dimension;
 - requires the split count to exactly divide that selected dimension;
 - rejects candidates that would cut through physical sticks;
-- caps the split count to avoid excessive `LoopSpec` / SDSC generation;
 - raises `Unsupported` if the selected dimension cannot be tiled safely;
 - does not auto-tile reductions or reduction ranges.
 
@@ -146,9 +148,11 @@ tile.
 
 ## Choosing the Controlling Dimension
 
-The pass walks physical device dimensions from outer to inner, skipping the
-final stick dimension.  For each device dimension, it uses `stride_map` to find
-the corresponding logical host/output dimension.
+The pass walks physical device dimensions from outer to inner, skipping size-1
+physical dimensions and the final stick dimension.  For each remaining device
+dimension, it uses `stride_map` to find the corresponding logical host/output
+dimension.  Exact host-stride matches are preferred over stick-scaled matches so
+ambiguous non-standard strides do not select the wrong host dimension.
 
 For a shape like `[1, 8195, 256, 64]`, the physical layout may expose:
 
@@ -185,8 +189,8 @@ per_core_span = (
 where:
 
 - `selected_device_dim_size` is the physical extent of the selected device dim;
-- `core_split_estimate` is the largest divisor of that extent no larger than
-  `SENCORES`;
+- `core_split_estimate` comes from `work_division.core_split`, so analysis and
+  work division use the same core-split estimate;
 - `selected_device_span_stride_elems` is the product of all inner physical dims,
   including the stick dim;
 - `itemsize` is the dtype size in bytes.
@@ -225,16 +229,10 @@ per-tile host size     = 1639
 ```
 
 If the required count is not itself a divisor, the pass considers larger exact
-divisors up to this cap:
-
-```python
-max_reasonable_split = required_count * max_cores
-```
-
-Candidates must also preserve physical stick alignment.  If every legal
-candidate either still overflows, cuts through a stick, or exceeds the cap, the
-pass raises `Unsupported` rather than emitting a plan that still overflows or
-would generate excessive `LoopSpec` / SDSC iterations.
+divisors of the selected dimension.  Candidates must also preserve physical
+stick alignment.  If every legal candidate either still overflows or cuts
+through a stick, the pass raises `Unsupported` rather than emitting a plan that
+still overflows or would corrupt physical stick addressing.
 
 ## Internal Planner Flow
 
@@ -255,8 +253,8 @@ plan_span_overflow_tile()
 
 The important detail is that `_post_tile_validated_split_count()` is not just a
 rounding helper.  It is the guardrail that keeps the planner from accepting a
-split count until the candidate is exact-divisible, within the over-split cap,
-stick-aligned, and safe under the rebuilt per-tile `SpyreTensorLayout`.
+split count until the candidate is exact-divisible, stick-aligned, and safe
+under the rebuilt per-tile `SpyreTensorLayout`.
 
 ## Post-Tile Validation
 
@@ -273,18 +271,22 @@ split_count:  5
 after tiling: [1, 1639, 256, 64]
 ```
 
-Only if the candidate is exact-divisible, stick-aligned, within the split cap,
-and passes the post-tile span/total checks does the planner return the split
-count.  This prevents the analysis from approving a tile count that looks safe
-in the original layout but is unsafe after Spyre layout reconstruction.
+Only if the candidate is exact-divisible, stick-aligned, and passes the
+post-tile span/total checks does the planner return the split count.  This
+prevents the analysis from approving a tile count that looks safe in the
+original layout but is unsafe after Spyre layout reconstruction.
 
 ## Adapter and Coarse-Tile Consumption
 
 The adapter lives in `coarse_tile.span_overflow_groups()`.
 
-When user `spyre_hint` groups exist, they take precedence.  Automatic
-span-overflow groups are only generated when no user coarse-tiling groups were
-found.
+User `spyre_hint` groups take precedence per operation.  Automatic
+span-overflow groups are generated only for eligible pointwise ops that do not
+already carry user `dim_hints`.  Mixed graphs can therefore contain both manual
+hint groups and automatic span-overflow groups in the same `coarse_tile()` call.
+
+`span_overflow_groups()` returns no groups when `config.chunk_large_tensors` or
+`config.ignore_wsr_hints` is enabled.
 
 For every returned plan, the adapter:
 
@@ -361,10 +363,10 @@ The pass raises `Unsupported` when automatic tiling would need behavior outside
 the current pointwise contract.  Common cases are:
 
 - the selected host dimension is not present in `op.data.ranges`;
+- the op has symbolic layout metadata, which is skipped before planning;
 - the selected range is symbolic or otherwise not an integer size;
 - the selected range is size 1 and cannot be tiled;
 - the required split count is larger than the selected dimension;
-- the smallest legal divisor exceeds the over-split cap;
 - every legal divisor cuts through physical sticks;
 - no divisor of the selected dimension makes the post-tile layout safe; or
 - the adapter cannot map the selected output coordinate to exactly one loop
@@ -395,7 +397,7 @@ Recommended coverage:
 |---|---|
 | `torch_spyre/_inductor/span_overflow_hint_analysis.py` | Pointwise planner: choose selected dim and split count |
 | `torch_spyre/_inductor/coarse_tile.py` | Adapter (`span_overflow_groups`) and coarse-tile IR stamping |
-| `torch_spyre/_inductor/passes.py` | Invokes automatic span-overflow groups when no user hint groups exist |
+| `torch_spyre/_inductor/passes.py` | Combines user hint groups and automatic span-overflow groups, then invokes coarse tiling |
 | `torch_spyre/_inductor/scheduler.py` | Wraps stamped ops in `CountedLoopSchedulerNode` |
 | `torch_spyre/_inductor/spyre_kernel.py` | Emits `LoopSpec` around generated `OpSpec` objects |
 | `tests/inductor/test_span_overflow_hint_analysis.py` | Unit/codegen coverage for the planner-to-LoopSpec path |
@@ -408,6 +410,8 @@ The pointwise implementation is intentionally narrow:
   automatically.
 - The op must have a `FixedTiledLayout`; the policy depends on Spyre physical
   `device_size` and `stride_map`.
+- Symbolic layout metadata is skipped because exact divisor selection and
+  post-tile layout validation require concrete sizes.
 - The planner emits one coarse-tile level over one output/host dimension.
 - `span_overflow_groups()` emits one group per planned op; it does not yet try
   to coalesce producer/consumer chains into a shared automatic group.
@@ -417,8 +421,6 @@ The pointwise implementation is intentionally narrow:
   divides `op.data.ranges` and `op.layout.size` by the loop count.
 - Candidate tiles must stay physical-stick aligned; the pass rejects candidates
   that would cut through sticks.
-- Candidate split counts are capped to avoid generating excessive `LoopSpec`
-  iterations and many SDSC files.
 - If no divisor of the selected dimension makes the post-tile layout safe, the
   pass raises `Unsupported`; it does not try a later mapped dimension, emit
   nested multi-dimensional tile plans, or search split combinations across

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -26,6 +26,53 @@ span_overflow_hint_analysis
   -> LoopSpec codegen
 ```
 
+
+## Entry Point and Pass Integration
+
+The planner entry point is:
+
+```python
+from torch_spyre._inductor.span_overflow_hint_analysis import plan_span_overflow_tile
+
+plan = plan_span_overflow_tile(op, max_cores=config.sencores)
+```
+
+`plan_span_overflow_tile()` is intentionally side-effect free: it inspects one
+`ComputedBuffer` and returns either a `SpanOverflowTilePlan` or `None`.  It does
+not attach hints, rewrite ranges, mutate layouts, or insert loop metadata.
+
+The compiler consumes the planner through the coarse-tiling adapter:
+
+```python
+from torch_spyre._inductor.coarse_tile import span_overflow_groups
+
+groups = span_overflow_groups(graph)
+```
+
+`span_overflow_groups(graph)` walks `graph.operations`, calls the planner for
+each eligible op, attaches a synthetic `DimHint` to planned ops, and returns
+groups in the exact format consumed by `coarse_tile()`:
+
+```python
+[([op], [(hint_id, split_count, is_reduction_level)])]
+```
+
+`passes.py` wires this into `_maybe_coarse_tile()` after user hint grouping:
+
+```python
+groups = hints_to_coarse_tile_groups(graph)
+if not groups:
+    groups = span_overflow_groups(graph)
+if groups:
+    coarse_tile(graph, groups=groups)
+```
+
+This ordering is important.  User-authored `spyre_hint` groups take precedence;
+automatic span-overflow hints are only generated when no user coarse-tiling
+groups exist for the graph.  From `coarse_tile()` onward, automatic groups and
+manual `spyre_hint` groups share the same IR stamping, scheduler wrapping, and
+`LoopSpec` codegen path.
+
 ## Scope
 
 The initial pass is deliberately conservative:
@@ -285,10 +332,26 @@ Recommended coverage:
 
 ## Current Limitations
 
-- Only pointwise ops are planned automatically.
-- Only one output dimension is tiled.
-- Exact divisibility is required by the current `coarse_tile` range rewrite.
-- If one selected dimension is insufficient, the pass raises `Unsupported`; it
-  does not yet emit nested multi-dimensional tile plans.
-- Reduction output-range tiling and reduction-range tiling are future work.
+The pointwise implementation is intentionally narrow for the first PR:
 
+- Only `ComputedBuffer` ops whose `data` is `Pointwise` are planned
+  automatically.
+- The op must have a `FixedTiledLayout`; the policy depends on Spyre physical
+  `device_size` and `stride_map`.
+- The planner emits one coarse-tile level over one output/host dimension.
+- `span_overflow_groups()` emits one group per planned op; it does not yet try
+  to coalesce producer/consumer chains into a shared automatic group.
+- The selected output coordinate must resolve to exactly one loop symbol through
+  `op_out_coords(op)`, so the adapter can create a valid synthetic `DimHint`.
+- Exact divisibility is required because current `coarse_tile` range rewriting
+  divides `op.data.ranges` and `op.layout.size` by the loop count.
+- If no divisor of the selected dimension makes the post-tile layout safe, the
+  pass raises `Unsupported`; it does not yet emit nested multi-dimensional tile
+  plans.
+- If `config.chunk_large_tensors` is enabled, `span_overflow_groups()` returns
+  no groups so the legacy chunking path remains in control.
+- Reduction output-range tiling and reduction-range tiling are follow-up work.
+  The planned reduction phase should start conservatively with scalar
+  reductions whose output ranges can be tiled without splitting
+  `reduction_ranges`; reduction-dimension tiling needs separate policy and
+  validation.

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -1,0 +1,294 @@
+# Span-Overflow Hint Analysis
+
+## Background
+
+Spyre work division must keep each core's memory span within the hardware
+addressing limit.  For large tensors, a pointwise operation can have a physical
+device layout whose per-core span is still too large after normal
+`work_division` splitting.  User-authored `spyre_hint` scopes can fix this by
+asking coarse tiling to run the operation in multiple outer loop iterations.
+
+`span_overflow_hint_analysis.py` is the compiler-generated version of that
+decision for pointwise operations.  It does not transform the graph directly.
+Instead, it answers one question:
+
+> Does this pointwise `ComputedBuffer` need coarse tiling, and if yes, which
+> output dimension and split count should coarse tiling use?
+
+The result is adapted into the same coarse-tiling group format used by
+`spyre_hint`, so the downstream pipeline stays shared:
+
+```
+span_overflow_hint_analysis
+  -> span_overflow_groups adapter
+  -> coarse_tile
+  -> CountedLoopSchedulerNode
+  -> LoopSpec codegen
+```
+
+## Scope
+
+The initial pass is deliberately conservative:
+
+- supports `ComputedBuffer` operations whose `data` is `Pointwise`;
+- requires a `FixedTiledLayout`, because decisions are based on Spyre physical
+  device layout;
+- produces one coarse-tile level over one output dimension;
+- raises `Unsupported` if the selected dimension cannot be tiled enough to make
+  the post-tile layout safe;
+- does not yet auto-tile reductions or reduction ranges.
+
+This keeps the pass as a planner.  Coarse tiling owns mutation of
+`op.data.ranges`, layout sizes, `CoarseTileInfo`, and scheduler/codegen loop
+structure.
+
+## Planner Output
+
+The planner returns a `SpanOverflowTilePlan`:
+
+```python
+SpanOverflowTilePlan(
+    selected_host_dim=1,
+    split_count=5,
+    is_reduction=False,
+    chunking_info=...,
+    reason="output span overflow",
+)
+```
+
+For example, a pointwise add over shape `[1, 8195, 256, 64]` can produce:
+
+```text
+selected_host_dim = 1
+split_count       = 5
+```
+
+The adapter converts that into a synthetic `DimHint` and group equivalent to a
+manual user hint:
+
+```python
+with spyre_hint(num_tiles_per_dim={"H": 5}):
+    return x + y
+```
+
+The coarse-tile group has the usual shape:
+
+```python
+[([op], [(hint_id, 5, False)])]
+```
+
+where `False` means this is an output-dimension tile, not a reduction-dimension
+tile.
+
+## Choosing the Controlling Dimension
+
+The pass walks physical device dimensions from outer to inner, skipping the
+final stick dimension.  For each device dimension, it uses `stride_map` to find
+the corresponding logical host/output dimension.
+
+For a shape like `[1, 8195, 256, 64]`, the physical layout may expose:
+
+```text
+host size   = [1, 8195, 256, 64]
+host stride = [134266880, 16384, 64, 1]
+device size = [8195, 256, 1, 1, 64]
+stride_map  = [16384, 64, 64, -1, 1]
+```
+
+The first useful physical dimension has `stride_map=16384`, matching host dim
+1, so the selected dimension is the `H`-like dimension of size `8195`.
+
+Skipped outer device dimensions are kept only for debug context.  They do not
+multiply the span calculation, because constant outer coordinates do not
+increase the per-core address span seen by `work_division`.
+
+## Span Estimate
+
+The pass estimates the same quantity that `work_division` cares about:
+
+```python
+per_core_span = (
+    ceil(selected_device_dim_size / core_split_estimate)
+    * selected_device_span_stride_elems
+    * itemsize
+)
+```
+
+where:
+
+- `selected_device_dim_size` is the physical extent of the selected device dim;
+- `core_split_estimate` is the largest divisor of that extent no larger than
+  `SENCORES`;
+- `selected_device_span_stride_elems` is the product of all inner physical dims,
+  including the stick dim;
+- `itemsize` is the dtype size in bytes.
+
+There is also a whole-tensor safety check:
+
+```python
+total_bytes > MAX_SPAN_BYTES * SENCORES
+```
+
+The required coarse-tile count is:
+
+```python
+required_count = max(
+    ceil(per_core_span / MAX_SPAN_BYTES),
+    ceil(total_bytes / (MAX_SPAN_BYTES * SENCORES)),
+)
+```
+
+If `required_count <= 1`, the op is safe and no automatic hint is emitted.
+
+## Split Count Selection
+
+`coarse_tile` currently divides `op.data.ranges` by the loop count, so the
+chosen split count must divide the selected host dimension exactly.  The planner
+therefore rounds the required count up to the smallest divisor of the selected
+dimension.
+
+Example:
+
+```text
+selected host dim size = 8195
+required_count         = 5
+chosen split_count     = 5
+per-tile host size     = 1639
+```
+
+If the required count is not itself a divisor, the pass tries the next larger
+divisor.  If no divisor on the selected dimension can satisfy the constraints,
+the pass raises `Unsupported` rather than emitting a plan that still overflows.
+
+## Post-Tile Validation
+
+The initial span estimate is not the final check.  Before returning a plan, the
+pass rebuilds the per-tile `FixedTiledLayout` that coarse tiling will create and
+runs the span check again on that layout.
+
+For the `[1, 8195, 256, 64]` example:
+
+```text
+before tiling: [1, 8195, 256, 64]
+split_count:  5
+after tiling: [1, 1639, 256, 64]
+```
+
+Only if the post-tile physical layout passes the same span/total checks does the
+planner return the split count.  This prevents the analysis from approving a
+tile count that looks safe in the original layout but still violates the span
+limit after Spyre layout reconstruction.
+
+## Adapter and Coarse-Tile Consumption
+
+The adapter lives in `coarse_tile.span_overflow_groups()`.
+
+When user `spyre_hint` groups exist, they take precedence.  Automatic
+span-overflow groups are only generated when no user coarse-tiling groups were
+found.
+
+For every returned plan, the adapter:
+
+1. maps `selected_host_dim` to the concrete output loop symbol via
+   `op_out_coords(op)`;
+2. creates a synthetic `DimHint` with a private hint id;
+3. attaches that hint to the op as `op.dim_hints`;
+4. returns a group shaped like user-hint output:
+
+```python
+([op], [(hint_id, split_count, False)])
+```
+
+`coarse_tile()` then uses its normal path:
+
+- resolves `hint_id` back to the op's tiled output dimension;
+- divides `op.data.ranges` and `op.layout.size` by `split_count`;
+- stamps `CoarseTileInfo` on the op.
+
+For the example above, coarse tiling stamps:
+
+```python
+CoarseTileInfo(
+    loop_group_id=(0,),
+    loop_count=[5],
+    loop_tiled_dims=[[1]],
+    loop_tiled_reduction_dims=[[]],
+)
+```
+
+and rewrites the per-tile shape to:
+
+```text
+ranges      = [1, 1639, 256, 64]
+layout.size = [1, 1639, 256, 64]
+```
+
+## Scheduler and Codegen
+
+After `coarse_tile`, the downstream layers do not know whether the loop came
+from a user hint or automatic span-overflow analysis.
+
+`build_loop_scheduler_nodes()` sees `CoarseTileInfo` and wraps the scheduled op
+run in a `CountedLoopSchedulerNode(count=5)`.
+
+`SpyreKernel` then emits a `LoopSpec`:
+
+```python
+LoopSpec(
+    count=sympify("5"),
+    body=[
+        OpSpec(
+            op="add",
+            iteration_space={
+                c0: (1639, 1),
+                c1: (256, 4),
+                c2: (64, 1),
+            },
+            tiled_symbols=[c1],
+            ...
+        )
+    ],
+    tiled_symbols=[c0],
+)
+```
+
+This is intentionally the same loop structure produced by the equivalent
+manual `spyre_hint`.
+
+## Validation Strategy
+
+Most validation should use small mock or patched-limit tests because true span
+overflow usually requires large tensors.
+
+Recommended coverage:
+
+1. **Planner-level:** verify selected dim and split count.
+2. **Adapter-level:** verify synthetic `DimHint` and coarse-tile group format.
+3. **Coarse-tile IR-level:** verify rewritten ranges/layout and `CoarseTileInfo`.
+4. **Scheduler/codegen-level:** verify generated source contains the expected
+   `LoopSpec` count.
+5. **One E2E smoke test:** use a real large pointwise tensor and compare Spyre
+   output against CPU.
+
+
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `torch_spyre/_inductor/span_overflow_hint_analysis.py` | Pointwise planner: choose selected dim and split count |
+| `torch_spyre/_inductor/coarse_tile.py` | Adapter (`span_overflow_groups`) and coarse-tile IR stamping |
+| `torch_spyre/_inductor/passes.py` | Invokes automatic span-overflow groups when no user hint groups exist |
+| `torch_spyre/_inductor/scheduler.py` | Wraps stamped ops in `CountedLoopSchedulerNode` |
+| `torch_spyre/_inductor/spyre_kernel.py` | Emits `LoopSpec` around generated `OpSpec` objects |
+| `tests/inductor/test_span_overflow_hint_analysis.py` | Unit/codegen coverage for the planner-to-LoopSpec path |
+
+## Current Limitations
+
+- Only pointwise ops are planned automatically.
+- Only one output dimension is tiled.
+- Exact divisibility is required by the current `coarse_tile` range rewrite.
+- If one selected dimension is insufficient, the pass raises `Unsupported`; it
+  does not yet emit nested multi-dimensional tile plans.
+- Reduction output-range tiling and reduction-range tiling are future work.
+

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -90,15 +90,17 @@ manual `spyre_hint` groups share the same IR stamping, scheduler wrapping, and
 
 ## Scope
 
-The initial pass is deliberately conservative:
+The pass is deliberately conservative:
 
 - supports `ComputedBuffer` operations whose `data` is `Pointwise`;
 - requires a `FixedTiledLayout`, because decisions are based on Spyre physical
   device layout;
-- produces one coarse-tile level over one output dimension;
-- raises `Unsupported` if the selected dimension cannot be tiled enough to make
-  the post-tile layout safe;
-- does not yet auto-tile reductions or reduction ranges.
+- produces one coarse-tile level over one selected output dimension;
+- requires the split count to exactly divide that selected dimension;
+- rejects candidates that would cut through physical sticks;
+- caps the split count to avoid excessive `LoopSpec` / SDSC generation;
+- raises `Unsupported` if the selected dimension cannot be tiled safely;
+- does not auto-tile reductions or reduction ranges.
 
 This keeps the pass as a planner.  Coarse tiling owns mutation of
 `op.data.ranges`, layout sizes, `CoarseTileInfo`, and scheduler/codegen loop
@@ -160,7 +162,11 @@ stride_map  = [16384, 64, 64, -1, 1]
 The first useful physical dimension has `stride_map=16384`, matching host dim
 1, so the selected dimension is the `H`-like dimension of size `8195`.
 
-Skipped outer device dimensions are kept only for debug context.  They do not
+The current policy uses this first mapped span-controlling dimension only.  If
+validation fails for that selected dimension, the planner raises `Unsupported`;
+it does not try the next mapped dimension or build a multi-dimensional tile plan.
+
+Skipped outer device dimensions are diagnostic context only.  They do not
 multiply the span calculation, because constant outer coordinates do not
 increase the per-core address span seen by `work_division`.
 
@@ -218,9 +224,17 @@ chosen split_count     = 5
 per-tile host size     = 1639
 ```
 
-If the required count is not itself a divisor, the pass tries the next larger
-divisor.  If no divisor on the selected dimension can satisfy the constraints,
-the pass raises `Unsupported` rather than emitting a plan that still overflows.
+If the required count is not itself a divisor, the pass considers larger exact
+divisors up to this cap:
+
+```python
+max_reasonable_split = required_count * max_cores
+```
+
+Candidates must also preserve physical stick alignment.  If every legal
+candidate either still overflows, cuts through a stick, or exceeds the cap, the
+pass raises `Unsupported` rather than emitting a plan that still overflows or
+would generate excessive `LoopSpec` / SDSC iterations.
 
 ## Internal Planner Flow
 
@@ -234,19 +248,22 @@ plan_span_overflow_tile()
        -> _compute_num_chunks()
        -> _post_tile_validated_split_count()
             -> _choose_divisible_split_count()
+            -> _post_tile_stick_alignment_error()
             -> _post_tile_span_ok()
                  -> _post_tile_layout()
 ```
 
 The important detail is that `_post_tile_validated_split_count()` is not just a
 rounding helper.  It is the guardrail that keeps the planner from accepting a
-split count until the rebuilt per-tile `SpyreTensorLayout` is safe.
+split count until the candidate is exact-divisible, within the over-split cap,
+stick-aligned, and safe under the rebuilt per-tile `SpyreTensorLayout`.
 
 ## Post-Tile Validation
 
 The initial span estimate is not the final check.  Before returning a plan, the
-pass rebuilds the per-tile `FixedTiledLayout` that coarse tiling will create and
-runs the span check again on that layout.
+pass rejects non-stick-aligned candidates, rebuilds the per-tile
+`FixedTiledLayout` that coarse tiling will create, and runs the span check again
+on that layout.
 
 For the `[1, 8195, 256, 64]` example:
 
@@ -256,10 +273,10 @@ split_count:  5
 after tiling: [1, 1639, 256, 64]
 ```
 
-Only if the post-tile physical layout passes the same span/total checks does the
-planner return the split count.  This prevents the analysis from approving a
-tile count that looks safe in the original layout but still violates the span
-limit after Spyre layout reconstruction.
+Only if the candidate is exact-divisible, stick-aligned, within the split cap,
+and passes the post-tile span/total checks does the planner return the split
+count.  This prevents the analysis from approving a tile count that looks safe
+in the original layout but is unsafe after Spyre layout reconstruction.
 
 ## Adapter and Coarse-Tile Consumption
 
@@ -347,6 +364,8 @@ the current pointwise contract.  Common cases are:
 - the selected range is symbolic or otherwise not an integer size;
 - the selected range is size 1 and cannot be tiled;
 - the required split count is larger than the selected dimension;
+- the smallest legal divisor exceeds the over-split cap;
+- every legal divisor cuts through physical sticks;
 - no divisor of the selected dimension makes the post-tile layout safe; or
 - the adapter cannot map the selected output coordinate to exactly one loop
   symbol.
@@ -383,7 +402,7 @@ Recommended coverage:
 
 ## Current Limitations
 
-The pointwise implementation is intentionally narrow for the first PR:
+The pointwise implementation is intentionally narrow:
 
 - Only `ComputedBuffer` ops whose `data` is `Pointwise` are planned
   automatically.
@@ -396,13 +415,14 @@ The pointwise implementation is intentionally narrow for the first PR:
   `op_out_coords(op)`, so the adapter can create a valid synthetic `DimHint`.
 - Exact divisibility is required because current `coarse_tile` range rewriting
   divides `op.data.ranges` and `op.layout.size` by the loop count.
+- Candidate tiles must stay physical-stick aligned; the pass rejects candidates
+  that would cut through sticks.
+- Candidate split counts are capped to avoid generating excessive `LoopSpec`
+  iterations and many SDSC files.
 - If no divisor of the selected dimension makes the post-tile layout safe, the
-  pass raises `Unsupported`; it does not yet emit nested multi-dimensional tile
-  plans.
+  pass raises `Unsupported`; it does not try a later mapped dimension, emit
+  nested multi-dimensional tile plans, or search split combinations across
+  multiple host dimensions.
 - If `config.chunk_large_tensors` is enabled, `span_overflow_groups()` returns
   no groups so the legacy chunking path remains in control.
 - Reduction output-range tiling and reduction-range tiling are follow-up work.
-  The planned reduction phase should start conservatively with scalar
-  reductions whose output ranges can be tiled without splitting
-  `reduction_ranges`; reduction-dimension tiling needs separate policy and
-  validation.

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -26,7 +26,6 @@ span_overflow_hint_analysis
   -> LoopSpec codegen
 ```
 
-
 ## Entry Point and Pass Integration
 
 The planner entry point is:
@@ -316,8 +315,6 @@ Recommended coverage:
    `LoopSpec` count.
 5. **One E2E smoke test:** use a real large pointwise tensor and compare Spyre
    output against CPU.
-
-
 
 ## Key Files
 

--- a/docs/source/compiler/span_overflow_hint_analysis.md
+++ b/docs/source/compiler/span_overflow_hint_analysis.md
@@ -26,6 +26,22 @@ span_overflow_hint_analysis
   -> LoopSpec codegen
 ```
 
+## Mental Model
+
+Think of the pass as an automatic `spyre_hint` author.  It does not tile
+tensors directly and it does not create a separate execution path.  It only:
+
+1. detects that the current physical layout can exceed the 256 MB per-core span
+   limit;
+2. picks the output dimension that controls that span;
+3. computes the smallest legal coarse-tile count for that dimension;
+4. validates the real post-tile physical layout; and
+5. hands the result to `coarse_tile` as a synthetic `DimHint`.
+
+That means the correctness contract is small: if the planner returns a
+`SpanOverflowTilePlan`, the downstream code should behave like a user had
+written the equivalent `spyre_hint`.
+
 ## Entry Point and Pass Integration
 
 The planner entry point is:
@@ -206,6 +222,26 @@ If the required count is not itself a divisor, the pass tries the next larger
 divisor.  If no divisor on the selected dimension can satisfy the constraints,
 the pass raises `Unsupported` rather than emitting a plan that still overflows.
 
+## Internal Planner Flow
+
+The pointwise planner follows this path:
+
+```text
+plan_span_overflow_tile()
+  -> _plan_pointwise_span_overflow_tile()
+       -> _find_outermost_span_dim()
+       -> _needs_chunking()
+       -> _compute_num_chunks()
+       -> _post_tile_validated_split_count()
+            -> _choose_divisible_split_count()
+            -> _post_tile_span_ok()
+                 -> _post_tile_layout()
+```
+
+The important detail is that `_post_tile_validated_split_count()` is not just a
+rounding helper.  It is the guardrail that keeps the planner from accepting a
+split count until the rebuilt per-tile `SpyreTensorLayout` is safe.
+
 ## Post-Tile Validation
 
 The initial span estimate is not the final check.  Before returning a plan, the
@@ -237,7 +273,8 @@ For every returned plan, the adapter:
 
 1. maps `selected_host_dim` to the concrete output loop symbol via
    `op_out_coords(op)`;
-2. creates a synthetic `DimHint` with a private hint id;
+2. creates a synthetic `DimHint` with a reserved automatic hint id starting at
+   `_SPAN_OVERFLOW_HINT_ID = 10000`;
 3. attaches that hint to the op as `op.dim_hints`;
 4. returns a group shaped like user-hint output:
 
@@ -300,6 +337,23 @@ LoopSpec(
 
 This is intentionally the same loop structure produced by the equivalent
 manual `spyre_hint`.
+
+## Failure Policy
+
+The pass raises `Unsupported` when automatic tiling would need behavior outside
+the current pointwise contract.  Common cases are:
+
+- the selected host dimension is not present in `op.data.ranges`;
+- the selected range is symbolic or otherwise not an integer size;
+- the selected range is size 1 and cannot be tiled;
+- the required split count is larger than the selected dimension;
+- no divisor of the selected dimension makes the post-tile layout safe; or
+- the adapter cannot map the selected output coordinate to exactly one loop
+  symbol.
+
+These failures are intentional.  They prevent the pass from silently emitting a
+coarse-tile group that still violates the hardware span limit or cannot be
+represented by the existing `coarse_tile` machinery.
 
 ## Validation Strategy
 

--- a/tests/configs/torch_spyre_tests/inductor/test_span_overflow_hint_analysis_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_span_overflow_hint_analysis_config.yaml
@@ -1,0 +1,4 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_span_overflow_hint_analysis.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -329,6 +329,17 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         self.assertFalse(plan.is_reduction)
         self.assertEqual(plan.chunking_info.selected_device_dim_size, _E2E_SHAPE[1])
 
+    def test_planner_skips_pointwise_with_indirect_reads(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with patch(
+            "torch_spyre._inductor.span_overflow_hint_analysis.indirect_info_from_op",
+            return_value=({"arg1"}, {}, {sympy.Symbol("indirect0"): 8}),
+        ):
+            plan = plan_span_overflow_tile(op, max_cores=4)
+
+        self.assertIsNone(plan)
+
     def test_planner_skips_size_one_device_dims(self):
         layout = SimpleNamespace(
             size=[1, 8195, 256, 64],

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -66,6 +66,8 @@ import torch_spyre._inductor.propagate_named_dims as _pnd
 
 
 _LAUNCH_KERNEL = "torch_spyre.execution.kernel_runner.launch_kernel"
+_LAUNCH_JOBPLAN = "torch_spyre.execution.kernel_runner.launch_jobplan"
+_PREPARE_KERNEL = "torch_spyre.execution.kernel_runner.prepare_kernel"
 
 
 def _fixed_tiled_layout(shape, dtype=torch.float16):
@@ -564,7 +566,12 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
             return x + y
 
         cfn = torch.compile(fn, dynamic=False)
-        with patch(_LAUNCH_KERNEL), patch("subprocess.run"):
+        with (
+            patch(_LAUNCH_KERNEL),
+            patch(_LAUNCH_JOBPLAN),
+            patch(_PREPARE_KERNEL),
+            patch("subprocess.run"),
+        ):
             _, source_codes = run_and_get_code(cfn, x, y)
 
         self.assertTrue(source_codes)
@@ -603,7 +610,12 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
         _pnd.name_tensor_dims(x, ["SO_B", "SO_H", "SO_L", "SO_D"])
         _pnd.name_tensor_dims(y, ["SO_B", "SO_H", "SO_L", "SO_D"])
 
-        with patch(_LAUNCH_KERNEL), patch("subprocess.run"):
+        with (
+            patch(_LAUNCH_KERNEL),
+            patch(_LAUNCH_JOBPLAN),
+            patch(_PREPARE_KERNEL),
+            patch("subprocess.run"),
+        ):
             _, auto_sources = run_and_get_code(
                 torch.compile(auto_fn, dynamic=False), x, y
             )

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -59,6 +59,7 @@ from torch_spyre._inductor.scheduler import (
     build_loop_scheduler_nodes,
 )
 from torch_spyre._inductor.span_overflow_hint_analysis import (
+    _find_outermost_span_dim,
     plan_span_overflow_tile,
 )
 import torch_spyre._inductor.propagate_named_dims as _pnd
@@ -262,10 +263,51 @@ class TestSpanOverflowGroups(InductorTestCase):
 
         self.assertEqual(groups, [])
 
+    def test_symbolic_layout_skipped(self):
+        op = _pointwise_op(_E2E_SHAPE)
+        op.layout.size[1] = sympy.Symbol("s0")
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = span_overflow_groups(_graph([op]))
+
+        self.assertEqual(groups, [])
+
     def test_chunk_large_tensors_config_suppresses_groups(self):
         op = _pointwise_op(_E2E_SHAPE)
 
         with config.patch({"sencores": 4, "chunk_large_tensors": True}):
+            groups = _run_span_overflow_groups(op)
+
+        self.assertEqual(groups, [])
+
+    def test_user_hinted_ops_do_not_block_unhinted_auto_groups(self):
+        hinted_op = _pointwise_op(_E2E_SHAPE, name="hinted")
+        hinted_op.dim_hints = [
+            DimHint(
+                dim_names=["H"],
+                split_count=5,
+                loop_var=sympy.Symbol("h"),
+                is_reduction=False,
+                hint_id=1,
+            )
+        ]
+        unhinted_op = _pointwise_op(_E2E_SHAPE, name="unhinted")
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            with patch(
+                "torch_spyre._inductor.coarse_tile.op_out_coords",
+                _out_coords_for_bhld,
+            ):
+                groups = span_overflow_groups(_graph([hinted_op, unhinted_op]))
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], [unhinted_op])
+        self.assertEqual(getattr(hinted_op, "dim_hints")[0].hint_id, 1)
+
+    def test_ignore_wsr_hints_config_suppresses_groups(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "ignore_wsr_hints": True}):
             groups = _run_span_overflow_groups(op)
 
         self.assertEqual(groups, [])
@@ -285,6 +327,39 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         self.assertFalse(plan.is_reduction)
         self.assertEqual(plan.chunking_info.selected_device_dim_size, _E2E_SHAPE[1])
 
+    def test_planner_skips_size_one_device_dims(self):
+        layout = SimpleNamespace(
+            size=[1, 8195, 256, 64],
+            stride=[8195 * 256 * 64, 256 * 64, 64, 1],
+            device_layout=SimpleNamespace(
+                device_size=[1, 8195, 256, 64],
+                stride_map=[8195 * 256 * 64, 256 * 64, 64, 1],
+                elems_per_stick=lambda: 64,
+            ),
+        )
+
+        span_dim = _find_outermost_span_dim(layout, max_cores=4)
+
+        self.assertIsNotNone(span_dim)
+        self.assertEqual(span_dim.selected_device_dim_size, 8195)
+        self.assertEqual(span_dim.selected_host_dim, 1)
+
+    def test_planner_prefers_exact_stride_match(self):
+        layout = SimpleNamespace(
+            size=[4, 8, 64],
+            stride=[64, 8, 1],
+            device_layout=SimpleNamespace(
+                device_size=[4, 8, 64],
+                stride_map=[64, 8, 1],
+                elems_per_stick=lambda: 64,
+            ),
+        )
+
+        span_dim = _find_outermost_span_dim(layout, max_cores=4)
+
+        self.assertIsNotNone(span_dim)
+        self.assertEqual(span_dim.selected_host_dim, 0)
+
     def test_planner_rejects_when_stick_dim_tile_is_unaligned(self):
         # Granite-like vocab dim: 49159 is not 64-aligned.  The outermost
         # span dim maps to the vocab/within-stick host dim and would choose
@@ -296,17 +371,16 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         with self.assertRaisesRegex(Unsupported, "stick alignment"):
             plan_span_overflow_tile(op, max_cores=4)
 
-    def test_planner_rejects_excessive_split_count(self):
-        # Prime/non-friendly dims can require a legal divisor far larger than
-        # the split actually needed for span safety.  Reject instead of
-        # generating thousands of LoopSpec iterations / SDSC files.
+    def test_planner_allows_full_size_exact_divisor(self):
         op = _pointwise_op((1, 17, 16, 64))
 
         with patch(
             "torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 32768
         ):
-            with self.assertRaisesRegex(Unsupported, "over-split cap"):
-                plan_span_overflow_tile(op, max_cores=4)
+            plan = plan_span_overflow_tile(op, max_cores=4)
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.split_count, 17)
 
     @patch("torch_spyre._inductor.span_overflow_hint_analysis._post_tile_span_ok")
     def test_planner_raises_when_no_divisor_satisfies_post_tile_span(

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -304,10 +304,10 @@ class TestSpanOverflowGroups(InductorTestCase):
         self.assertEqual(groups[0][0], [unhinted_op])
         self.assertEqual(getattr(hinted_op, "dim_hints")[0].hint_id, 1)
 
-    def test_ignore_wsr_hints_config_suppresses_groups(self):
+    def test_ignore_span_overflow_hints_config_suppresses_groups(self):
         op = _pointwise_op(_E2E_SHAPE)
 
-        with config.patch({"sencores": 4, "ignore_wsr_hints": True}):
+        with config.patch({"sencores": 4, "ignore_span_overflow_hints": True}):
             groups = _run_span_overflow_groups(op)
 
         self.assertEqual(groups, [])

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -21,6 +21,17 @@ These tests intentionally mirror the compiler layers used by user
 2. Adapter: span_overflow_groups creates a synthetic DimHint/group.
 3. Coarse-tile IR: coarse_tile consumes the group and stamps CoarseTileInfo.
 4. Scheduler/codegen: generated source contains the expected LoopSpec count.
+
+Coverage in this file:
+
+- no-op behavior for small tensors and non-FixedTiledLayout ops;
+- automatic group/DimHint structure, including the reserved hint-id sentinel;
+- multiple independent overflowing pointwise ops producing separate groups;
+- planner boundary errors when no legal divisor validates post-tile span;
+- total-size fallback when no device dim maps through stride_map;
+- adapter mapping with both constant and symbolic batch output coordinates;
+- coarse_tile stamping of ranges/layout/CoarseTileInfo;
+- equivalence between auto span-overflow hints and manual spyre_hint codegen.
 """
 
 from types import SimpleNamespace
@@ -35,8 +46,10 @@ from torch._inductor.utils import run_and_get_code
 
 from torch_spyre._C import SpyreTensorLayout
 from torch_spyre._inductor import config
+from torch_spyre._inductor.errors import Unsupported
 from torch_spyre._inductor.propagate_hints import DimHint
 from torch_spyre._inductor.coarse_tile import (
+    _SPAN_OVERFLOW_HINT_ID,
     coarse_tile,
     span_overflow_groups,
 )
@@ -88,6 +101,16 @@ def _out_coords_for_bhld(_op):
     """Coordinates for shape [B, H, L, D] with B size 1 in these tests."""
     return [
         sympy.Integer(0),
+        sympy.Symbol("h"),
+        sympy.Symbol("l"),
+        sympy.Symbol("d"),
+    ]
+
+
+def _out_coords_for_symbolic_bhld(_op):
+    """Coordinates for shape [B, H, L, D] with B as a real loop var."""
+    return [
+        sympy.Symbol("b"),
         sympy.Symbol("h"),
         sympy.Symbol("l"),
         sympy.Symbol("d"),
@@ -172,10 +195,27 @@ class TestSpanOverflowGroups(InductorTestCase):
         self.assertEqual(ops_list, [op])
         self.assertEqual(len(levels), 1)
         hint_id, count, is_reduction_level = levels[0]
+        self.assertEqual(hint_id, _SPAN_OVERFLOW_HINT_ID)
         self.assertIsInstance(count, sympy.Integer)
         self.assertEqual(count, sympy.Integer(_E2E_SPLIT_COUNT))
         self.assertFalse(is_reduction_level)
         self.assertEqual(hint_id, op.dim_hints[0].hint_id)
+
+    def test_two_overflow_ops_produce_two_groups(self):
+        op0 = _pointwise_op(_E2E_SHAPE, name="buf0")
+        op1 = _pointwise_op(_E2E_SHAPE, name="buf1")
+
+        with patch(
+            "torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld
+        ):
+            with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+                groups = span_overflow_groups(_graph([op0, op1]))
+
+        self.assertEqual(len(groups), 2)
+        self.assertIs(groups[0][0][0], op0)
+        self.assertIs(groups[1][0][0], op1)
+        self.assertEqual(groups[0][1][0][0], _SPAN_OVERFLOW_HINT_ID)
+        self.assertEqual(groups[1][1][0][0], _SPAN_OVERFLOW_HINT_ID + 1)
 
     def test_dim_hint_attached_to_op(self):
         from torch_spyre._inductor.propagate_hints import DimHint
@@ -245,6 +285,36 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         self.assertFalse(plan.is_reduction)
         self.assertEqual(plan.chunking_info.selected_device_dim_size, _E2E_SHAPE[1])
 
+    @patch("torch_spyre._inductor.span_overflow_hint_analysis._post_tile_span_ok")
+    def test_planner_raises_when_no_divisor_satisfies_post_tile_span(
+        self,
+        mock_post_tile_span_ok,
+    ):
+        mock_post_tile_span_ok.return_value = False
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with self.assertRaisesRegex(Unsupported, "no divisor"):
+            plan_span_overflow_tile(op, max_cores=4)
+
+    @patch("torch_spyre._inductor.span_overflow_hint_analysis._post_tile_span_ok")
+    @patch("torch_spyre._inductor.span_overflow_hint_analysis._find_outermost_span_dim")
+    @patch("torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 1024)
+    def test_planner_falls_back_to_largest_host_dim_when_no_device_dim_maps(
+        self,
+        mock_find_outermost_span_dim,
+        mock_post_tile_span_ok,
+    ):
+        mock_find_outermost_span_dim.return_value = None
+        mock_post_tile_span_ok.return_value = True
+        op = _pointwise_op((4, 8, 16, 64))
+
+        plan = plan_span_overflow_tile(op, max_cores=1)
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.selected_host_dim, 3)
+        self.assertEqual(plan.chunking_info.selected_device_dim_size, 0)
+        self.assertIn("no device dimension", plan.chunking_info.reason)
+
     @patch("torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld)
     def test_adapter_creates_dim_hint_and_group(self):
         op = _pointwise_op(_E2E_SHAPE)
@@ -260,6 +330,23 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         self.assertEqual(len(op.dim_hints), 1)
         self.assertEqual(op.dim_hints[0].split_count, _E2E_SPLIT_COUNT)
         self.assertEqual(op.dim_hints[0].loop_var, sympy.Symbol("h"))
+
+    @patch(
+        "torch_spyre._inductor.coarse_tile.op_out_coords",
+        _out_coords_for_symbolic_bhld,
+    )
+    def test_adapter_handles_nontrivial_batch_coord(self):
+        op = _pointwise_op((4, 8195, 256, 64))
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = span_overflow_groups(_graph([op]))
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(len(op.dim_hints), 1)
+        # Batch is a real loop var in this test, but this shape's span-driving
+        # physical dim still maps to H, so the adapter should choose h.
+        self.assertEqual(op.dim_hints[0].loop_var, sympy.Symbol("h"))
+        self.assertEqual(groups[0][1][0][1], sympy.Integer(_E2E_SPLIT_COUNT))
 
     @patch("torch_spyre._inductor.coarse_tile.insert_tiling_propagation")
     @patch("torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld)
@@ -346,7 +433,9 @@ class TestSpanOverflowLargeShapeContract(InductorTestCase):
 
         auto_snode = _scheduler_node_for_op(auto_op, "auto_snode")
         manual_snode = _scheduler_node_for_op(manual_op, "manual_snode")
-        with patch.object(CountedLoopSchedulerNode, "create", staticmethod(fake_create)):
+        with patch.object(
+            CountedLoopSchedulerNode, "create", staticmethod(fake_create)
+        ):
             auto_wrapped = build_loop_scheduler_nodes([auto_snode])
             manual_wrapped = build_loop_scheduler_nodes([manual_snode])
 
@@ -437,4 +526,3 @@ class TestSpanOverflowPointwiseCodegen(InductorTestCase):
         self.assertIn("sympify('4')", manual_src)
         self.assertIn("op='add'", auto_src)
         self.assertIn("op='add'", manual_src)
-

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -1,0 +1,440 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for automatic span-overflow coarse-tiling hints.
+
+These tests intentionally mirror the compiler layers used by user
+``spyre_hint`` coarse tiling:
+
+1. Planner: span_overflow_hint_analysis returns a selected dim and split count.
+2. Adapter: span_overflow_groups creates a synthetic DimHint/group.
+3. Coarse-tile IR: coarse_tile consumes the group and stamps CoarseTileInfo.
+4. Scheduler/codegen: generated source contains the expected LoopSpec count.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import sympy
+import torch
+from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise
+from torch._inductor.scheduler import SchedulerNode
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import run_and_get_code
+
+from torch_spyre._C import SpyreTensorLayout
+from torch_spyre._inductor import config
+from torch_spyre._inductor.propagate_hints import DimHint
+from torch_spyre._inductor.coarse_tile import (
+    coarse_tile,
+    span_overflow_groups,
+)
+from torch_spyre._inductor.ir import FixedTiledLayout
+from torch_spyre._inductor.scheduler import (
+    CountedLoopSchedulerNode,
+    build_loop_scheduler_nodes,
+)
+from torch_spyre._inductor.span_overflow_hint_analysis import (
+    plan_span_overflow_tile,
+)
+import torch_spyre._inductor.propagate_named_dims as _pnd
+
+
+_LAUNCH_KERNEL = "torch_spyre.execution.kernel_runner.launch_kernel"
+
+
+def _fixed_tiled_layout(shape, dtype=torch.float16):
+    """Build the same kind of physical layout used by real Spyre lowering."""
+    size = list(shape)
+    stride = list(FlexibleLayout.contiguous_strides(size))
+    stride_ints = [int(s) for s in stride]
+    size_ints = [int(s) for s in size]
+    within_stick_dim = len(size_ints) - 1
+    dim_order = [i for i in range(len(size_ints)) if i != within_stick_dim]
+    dim_order.append(within_stick_dim)
+    device_layout = SpyreTensorLayout(size_ints, stride_ints, dtype, dim_order)
+    return FixedTiledLayout("spyre:0", dtype, size, stride, device_layout)
+
+
+def _pointwise_op(shape, name="buf0"):
+    """Return a real ComputedBuffer with a lightweight Pointwise mock."""
+    data = MagicMock(spec=Pointwise)
+    data.ranges = list(shape)
+    op = ComputedBuffer(
+        name=name,
+        layout=_fixed_tiled_layout(shape),
+        data=data,
+    )
+    op.operation_name = name
+    return op
+
+
+def _graph(operations):
+    return SimpleNamespace(operations=operations)
+
+
+def _out_coords_for_bhld(_op):
+    """Coordinates for shape [B, H, L, D] with B size 1 in these tests."""
+    return [
+        sympy.Integer(0),
+        sympy.Symbol("h"),
+        sympy.Symbol("l"),
+        sympy.Symbol("d"),
+    ]
+
+
+def _run_span_overflow_groups(op):
+    """Run span_overflow_groups with op_out_coords patched for one test op."""
+    graph = _graph([op])
+
+    with patch("torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld):
+        return span_overflow_groups(graph)
+
+
+_E2E_SHAPE = (1, 8195, 256, 64)
+_E2E_SPLIT_COUNT = 5
+_E2E_TILE_SHAPE = [1, 1639, 256, 64]
+
+
+def _manual_h_hint_group(op, hint_id=1, split_count=_E2E_SPLIT_COUNT):
+    """Return the coarse-tile group produced by spyre_hint over dim H."""
+    hint = DimHint(
+        dim_names=["H"],
+        split_count=split_count,
+        loop_var=sympy.Symbol("h"),
+        is_reduction=False,
+        hint_id=hint_id,
+    )
+    op.dim_hints = [hint]
+    return [([op], [(hint_id, sympy.Integer(split_count), False)])]
+
+
+def _scheduler_node_for_op(op, name):
+    """Return a minimal SchedulerNode mock wrapping one IR op."""
+    scheduler = MagicMock()
+    scheduler.name_to_fused_node = {}
+    scheduler.removed_ops = set()
+
+    snode = MagicMock(spec=SchedulerNode)
+    snode.scheduler = scheduler
+    snode.node = op
+    snode.get_name.return_value = name
+    snode.get_nodes.return_value = [snode]
+    snode.ancestors = set()
+    snode.min_order = 0
+    snode.max_order = 0
+    return snode
+
+
+class TestSpanOverflowGroups(InductorTestCase):
+    """Adapter-focused tests matching the user-hint group contract.
+
+    These are intentionally close to the coarse-tiling draft tests: build one
+    op, patch output coordinates, then inspect the generated group and DimHint.
+    """
+
+    def test_no_overflow_returns_empty(self):
+        op = _pointwise_op((1, 2, 16, 64), name="small_op")
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = _run_span_overflow_groups(op)
+
+        self.assertEqual(groups, [])
+
+    def test_overflow_pointwise_returns_one_group(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = _run_span_overflow_groups(op)
+
+        self.assertEqual(len(groups), 1)
+        self.assertIs(groups[0][0][0], op)
+
+    def test_group_structure(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = _run_span_overflow_groups(op)
+
+        self.assertEqual(len(groups), 1)
+        ops_list, levels = groups[0]
+        self.assertEqual(ops_list, [op])
+        self.assertEqual(len(levels), 1)
+        hint_id, count, is_reduction_level = levels[0]
+        self.assertIsInstance(count, sympy.Integer)
+        self.assertEqual(count, sympy.Integer(_E2E_SPLIT_COUNT))
+        self.assertFalse(is_reduction_level)
+        self.assertEqual(hint_id, op.dim_hints[0].hint_id)
+
+    def test_dim_hint_attached_to_op(self):
+        from torch_spyre._inductor.propagate_hints import DimHint
+
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            _run_span_overflow_groups(op)
+
+        self.assertTrue(hasattr(op, "dim_hints"))
+        self.assertEqual(len(op.dim_hints), 1)
+        hint = op.dim_hints[0]
+        self.assertIsInstance(hint, DimHint)
+        self.assertEqual(hint.dim_names, ["_span_overflow"])
+        self.assertEqual(hint.split_count, _E2E_SPLIT_COUNT)
+        self.assertEqual(hint.loop_var, sympy.Symbol("h"))
+        self.assertFalse(hint.is_reduction)
+
+    def test_trip_count_matches_level_and_hint(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = _run_span_overflow_groups(op)
+
+        _, levels = groups[0]
+        _, level_count, _ = levels[0]
+        self.assertEqual(op.dim_hints[0].split_count, int(level_count))
+
+    def test_non_fixed_tiled_layout_skipped(self):
+        op = MagicMock(spec=ComputedBuffer)
+        op.data = MagicMock(spec=Pointwise)
+        op.data.ranges = [
+            sympy.Integer(1),
+            sympy.Integer(20),
+            sympy.Integer(16),
+            sympy.Integer(64),
+        ]
+        op.layout = MagicMock()
+        op.get_name.return_value = "non_fixed_tiled"
+        op.get_operation_name.return_value = "non_fixed_tiled"
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = span_overflow_groups(_graph([op]))
+
+        self.assertEqual(groups, [])
+
+    def test_chunk_large_tensors_config_suppresses_groups(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": True}):
+            groups = _run_span_overflow_groups(op)
+
+        self.assertEqual(groups, [])
+
+
+class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
+    """Mock-heavy tests for the first three compiler layers."""
+
+    def test_planner_selects_dim_and_split_count(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        plan = plan_span_overflow_tile(op, max_cores=4)
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.selected_host_dim, 1)
+        self.assertEqual(plan.split_count, _E2E_SPLIT_COUNT)
+        self.assertFalse(plan.is_reduction)
+        self.assertEqual(plan.chunking_info.selected_device_dim_size, _E2E_SHAPE[1])
+
+    @patch("torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld)
+    def test_adapter_creates_dim_hint_and_group(self):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            groups = span_overflow_groups(_graph([op]))
+
+        self.assertEqual(len(groups), 1)
+        group_ops, levels = groups[0]
+        self.assertEqual(group_ops, [op])
+        self.assertEqual(levels[0][1], sympy.Integer(_E2E_SPLIT_COUNT))
+        self.assertEqual(levels[0][2], False)
+        self.assertEqual(len(op.dim_hints), 1)
+        self.assertEqual(op.dim_hints[0].split_count, _E2E_SPLIT_COUNT)
+        self.assertEqual(op.dim_hints[0].loop_var, sympy.Symbol("h"))
+
+    @patch("torch_spyre._inductor.coarse_tile.insert_tiling_propagation")
+    @patch("torch_spyre._inductor.coarse_tile.op_out_coords", _out_coords_for_bhld)
+    def test_coarse_tile_consumes_auto_group_and_stamps_op(
+        self,
+        _mock_insert_tiling_propagation,
+    ):
+        op = _pointwise_op(_E2E_SHAPE)
+
+        with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+            graph = _graph([op])
+            groups = span_overflow_groups(graph)
+            coarse_tile(graph, groups)
+
+        self.assertEqual(list(op.data.ranges), _E2E_TILE_SHAPE)
+        self.assertEqual(list(op.layout.size), _E2E_TILE_SHAPE)
+        self.assertEqual(op.loop_info.loop_count, [sympy.Integer(_E2E_SPLIT_COUNT)])
+        self.assertEqual(op.loop_info.loop_tiled_dims, [[1]])
+        self.assertEqual(op.loop_info.loop_tiled_reduction_dims, [[]])
+
+
+class TestSpanOverflowLargeShapeContract(InductorTestCase):
+    """Unit-style coverage for the real large shape used in E2E testing."""
+
+    def test_large_shape_planner_adapter_and_coarse_tile_match_manual_hint(self):
+        auto_op = _pointwise_op(_E2E_SHAPE, name="auto_buf")
+        manual_op = _pointwise_op(_E2E_SHAPE, name="manual_buf")
+
+        # Layer 1: planner chooses the same H split observed in the E2E run.
+        plan = plan_span_overflow_tile(auto_op, max_cores=4)
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.selected_host_dim, 1)
+        self.assertEqual(plan.split_count, _E2E_SPLIT_COUNT)
+        self.assertFalse(plan.is_reduction)
+
+        with patch(
+            "torch_spyre._inductor.coarse_tile.op_out_coords",
+            _out_coords_for_bhld,
+        ):
+            with patch("torch_spyre._inductor.coarse_tile.insert_tiling_propagation"):
+                with config.patch({"sencores": 4, "chunk_large_tensors": False}):
+                    # Layer 2: adapter emits the same group shape as user hints.
+                    auto_graph = _graph([auto_op])
+                    auto_groups = span_overflow_groups(auto_graph)
+                    manual_graph = _graph([manual_op])
+                    manual_groups = _manual_h_hint_group(manual_op)
+
+                    self.assertEqual(len(auto_groups), 1)
+                    self.assertEqual(len(manual_groups), 1)
+                    self.assertEqual(auto_groups[0][1][0][1], sympy.Integer(5))
+                    self.assertEqual(manual_groups[0][1][0][1], sympy.Integer(5))
+                    self.assertFalse(auto_groups[0][1][0][2])
+                    self.assertFalse(manual_groups[0][1][0][2])
+                    self.assertEqual(auto_op.dim_hints[0].loop_var, sympy.Symbol("h"))
+                    self.assertEqual(manual_op.dim_hints[0].loop_var, sympy.Symbol("h"))
+
+                    # Layer 3: coarse_tile stamps identical per-tile IR shape.
+                    coarse_tile(auto_graph, auto_groups)
+                    coarse_tile(manual_graph, manual_groups)
+
+        self.assertEqual(list(auto_op.data.ranges), _E2E_TILE_SHAPE)
+        self.assertEqual(list(manual_op.data.ranges), _E2E_TILE_SHAPE)
+        self.assertEqual(list(auto_op.layout.size), _E2E_TILE_SHAPE)
+        self.assertEqual(list(manual_op.layout.size), _E2E_TILE_SHAPE)
+        self.assertEqual(auto_op.loop_info.loop_count, [sympy.Integer(5)])
+        self.assertEqual(manual_op.loop_info.loop_count, [sympy.Integer(5)])
+        self.assertEqual(auto_op.loop_info.loop_tiled_dims, [[1]])
+        self.assertEqual(manual_op.loop_info.loop_tiled_dims, [[1]])
+        self.assertEqual(auto_op.loop_info.loop_tiled_reduction_dims, [[]])
+        self.assertEqual(manual_op.loop_info.loop_tiled_reduction_dims, [[]])
+
+        # Layer 4: scheduler wrapping sees the same counted loop on both paths.
+        created = []
+
+        def fake_create(snodes, loop_count):
+            node = MagicMock(spec=CountedLoopSchedulerNode)
+            node.snodes = snodes
+            node.loop_count = loop_count
+            node.get_nodes.return_value = snodes
+            node.get_name.return_value = "_".join(n.get_name() for n in snodes)
+            node.scheduler = snodes[0].scheduler
+            created.append(node)
+            return node
+
+        auto_snode = _scheduler_node_for_op(auto_op, "auto_snode")
+        manual_snode = _scheduler_node_for_op(manual_op, "manual_snode")
+        with patch.object(CountedLoopSchedulerNode, "create", staticmethod(fake_create)):
+            auto_wrapped = build_loop_scheduler_nodes([auto_snode])
+            manual_wrapped = build_loop_scheduler_nodes([manual_snode])
+
+        self.assertEqual(len(auto_wrapped), 1)
+        self.assertEqual(len(manual_wrapped), 1)
+        self.assertEqual(created[0].loop_count, sympy.Integer(5))
+        self.assertEqual(created[1].loop_count, sympy.Integer(5))
+        self.assertEqual(auto_wrapped[0].loop_count, manual_wrapped[0].loop_count)
+
+
+class TestSpanOverflowPointwiseCodegen(InductorTestCase):
+    """Small codegen test for scheduler/codegen LoopSpec emission."""
+
+    @patch("torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 8192)
+    @config.patch(
+        {
+            "sencores": 4,
+            "chunk_large_tensors": False,
+            "unroll_loops": False,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_codegen_contains_auto_span_overflow_loop_spec(self):
+        x = torch.randn(1, 20, 16, 64, dtype=torch.float16).to("spyre")
+        y = torch.randn(1, 20, 16, 64, dtype=torch.float16).to("spyre")
+
+        def fn(x, y):
+            return x + y
+
+        cfn = torch.compile(fn, dynamic=False)
+        with patch(_LAUNCH_KERNEL), patch("subprocess.run"):
+            _, source_codes = run_and_get_code(cfn, x, y)
+
+        self.assertTrue(source_codes)
+        src = source_codes[0]
+        self.assertIn("LoopSpec(", src)
+        self.assertIn("sympify('5')", src)
+
+    @patch("torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 8192)
+    @config.patch(
+        {
+            "sencores": 4,
+            "chunk_large_tensors": False,
+            "unroll_loops": False,
+            "lx_planning": True,
+            "allow_all_ops_in_lx_planning": True,
+        }
+    )
+    def test_auto_span_overflow_matches_equivalent_spyre_hint_loop_spec(self):
+        from torch_spyre._inductor import spyre_hint
+
+        shape = (1, 20, 16, 64)
+        x = torch.randn(shape, dtype=torch.float16).to("spyre")
+        y = torch.randn(shape, dtype=torch.float16).to("spyre")
+
+        def auto_fn(x, y):
+            return x + y
+
+        def manual_hint_fn(x, y):
+            with spyre_hint(num_tiles_per_dim={"SO_H": 5}):
+                return x + y
+
+        _pnd.declare_tensor_dim("SO_B", shape[0])
+        _pnd.declare_tensor_dim("SO_H", shape[1])
+        _pnd.declare_tensor_dim("SO_L", shape[2])
+        _pnd.declare_tensor_dim("SO_D", shape[3])
+        _pnd.name_tensor_dims(x, ["SO_B", "SO_H", "SO_L", "SO_D"])
+        _pnd.name_tensor_dims(y, ["SO_B", "SO_H", "SO_L", "SO_D"])
+
+        with patch(_LAUNCH_KERNEL), patch("subprocess.run"):
+            _, auto_sources = run_and_get_code(
+                torch.compile(auto_fn, dynamic=False), x, y
+            )
+            _, manual_sources = run_and_get_code(
+                torch.compile(manual_hint_fn, dynamic=False), x, y
+            )
+
+        auto_src = auto_sources[0]
+        manual_src = manual_sources[0]
+
+        # Automatic span-overflow tiling should lower to the same one-level
+        # counted loop shape as the equivalent explicit spyre_hint.
+        self.assertEqual(auto_src.count("LoopSpec("), manual_src.count("LoopSpec("))
+        self.assertEqual(auto_src.count("sympify('5')"), 1)
+        self.assertEqual(manual_src.count("sympify('5')"), 1)
+        self.assertIn("sympify('4')", auto_src)
+        self.assertIn("sympify('4')", manual_src)
+        self.assertIn("op='add'", auto_src)
+        self.assertIn("op='add'", manual_src)
+

--- a/tests/inductor/test_span_overflow_hint_analysis.py
+++ b/tests/inductor/test_span_overflow_hint_analysis.py
@@ -285,6 +285,29 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
         self.assertFalse(plan.is_reduction)
         self.assertEqual(plan.chunking_info.selected_device_dim_size, _E2E_SHAPE[1])
 
+    def test_planner_rejects_when_stick_dim_tile_is_unaligned(self):
+        # Granite-like vocab dim: 49159 is not 64-aligned.  The outermost
+        # span dim maps to the vocab/within-stick host dim and would choose
+        # split_count=11, producing tile size 4469, which cuts through a
+        # physical stick.  The planner must reject this instead of emitting
+        # an unsafe plan or falling back to an unrelated dimension.
+        op = _pointwise_op((8192, 49159))
+
+        with self.assertRaisesRegex(Unsupported, "stick alignment"):
+            plan_span_overflow_tile(op, max_cores=4)
+
+    def test_planner_rejects_excessive_split_count(self):
+        # Prime/non-friendly dims can require a legal divisor far larger than
+        # the split actually needed for span safety.  Reject instead of
+        # generating thousands of LoopSpec iterations / SDSC files.
+        op = _pointwise_op((1, 17, 16, 64))
+
+        with patch(
+            "torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 32768
+        ):
+            with self.assertRaisesRegex(Unsupported, "over-split cap"):
+                plan_span_overflow_tile(op, max_cores=4)
+
     @patch("torch_spyre._inductor.span_overflow_hint_analysis._post_tile_span_ok")
     def test_planner_raises_when_no_divisor_satisfies_post_tile_span(
         self,
@@ -298,7 +321,7 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
 
     @patch("torch_spyre._inductor.span_overflow_hint_analysis._post_tile_span_ok")
     @patch("torch_spyre._inductor.span_overflow_hint_analysis._find_outermost_span_dim")
-    @patch("torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 1024)
+    @patch("torch_spyre._inductor.span_overflow_hint_analysis.MAX_SPAN_BYTES", 8192)
     def test_planner_falls_back_to_largest_host_dim_when_no_device_dim_maps(
         self,
         mock_find_outermost_span_dim,
@@ -306,12 +329,12 @@ class TestSpanOverflowPointwisePlannerAndAdapter(InductorTestCase):
     ):
         mock_find_outermost_span_dim.return_value = None
         mock_post_tile_span_ok.return_value = True
-        op = _pointwise_op((4, 8, 16, 64))
+        op = _pointwise_op((4, 128, 16, 64))
 
         plan = plan_span_overflow_tile(op, max_cores=1)
 
         self.assertIsNotNone(plan)
-        self.assertEqual(plan.selected_host_dim, 3)
+        self.assertEqual(plan.selected_host_dim, 1)
         self.assertEqual(plan.chunking_info.selected_device_dim_size, 0)
         self.assertIn("no device dimension", plan.chunking_info.reason)
 

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -379,11 +379,11 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
 
     This adapter converts a SpanOverflowTilePlan into the same group shape as
     user spyre_hint annotations: ``[([op], [(hint_id, count, is_reduction)])]``.
-    It only runs when user hints did not already form coarse-tile groups.
+    Ops that already carry user hints are left for the user-hint grouping path.
     """
     from . import config
 
-    if config.chunk_large_tensors:
+    if config.chunk_large_tensors or getattr(config, "ignore_wsr_hints", False):
         return []
 
     groups: list[tuple] = []
@@ -392,9 +392,11 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
     for op in graph.operations:
         if not isinstance(op, ComputedBuffer):
             continue
-        if not isinstance(op.data, (Pointwise, Reduction)):
+        if not isinstance(op.data, Pointwise):
             continue
         if not isinstance(op.layout, FixedTiledLayout):
+            continue
+        if getattr(op, "dim_hints", []):
             continue
 
         plan = plan_span_overflow_tile(op, config.sencores)
@@ -406,20 +408,7 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
         levels: list[tuple] = []
         level_summary: list[tuple[int, int]] = []
 
-        tile_levels = getattr(plan, "tile_levels", None)
-        if tile_levels:
-            planned_levels = [
-                (
-                    level.selected_host_dim,
-                    level.split_count,
-                    level.is_reduction,
-                )
-                for level in tile_levels
-            ]
-        else:
-            planned_levels = [
-                (plan.selected_host_dim, plan.split_count, plan.is_reduction)
-            ]
+        planned_levels = [(plan.selected_host_dim, plan.split_count, plan.is_reduction)]
 
         for host_dim, split_count, is_reduction in planned_levels:
             if host_dim >= len(out_coords):

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -383,7 +383,7 @@ def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
     """
     from . import config
 
-    if config.chunk_large_tensors or getattr(config, "ignore_wsr_hints", False):
+    if config.chunk_large_tensors or config.ignore_span_overflow_hints:
         return []
 
     groups: list[tuple] = []

--- a/torch_spyre/_inductor/coarse_tile.py
+++ b/torch_spyre/_inductor/coarse_tile.py
@@ -70,13 +70,19 @@ from torch.utils._ordered_set import OrderedSet
 from torch_spyre._C import SpyreTensorLayout
 
 from .constants import BATCH_MATMUL_OP
+from .errors import Unsupported
 from .logging_utils import get_inductor_logger
 from .loop_info import CoarseTileInfo
-from .propagate_hints import get_op_hints
+from .propagate_hints import DimHint, get_op_hints
 from .pass_utils import op_out_coords
+from .span_overflow_hint_analysis import plan_span_overflow_tile
+from .ir import FixedTiledLayout
 
 logger = get_inductor_logger("coarse_tile")
 hints_logger = get_inductor_logger("assign_dim_hints")
+
+
+_SPAN_OVERFLOW_HINT_ID = 10000
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +370,108 @@ def hints_to_coarse_tile_groups(graph: GraphLowering) -> list[tuple]:
         if pending_ungrouped:
             summary_lines.append(f"  ungrouped: [{', '.join(pending_ungrouped)}]")
         hints_logger.info("%s", "\n".join(summary_lines))
+
+    return groups
+
+
+def span_overflow_groups(graph: GraphLowering) -> list[tuple]:
+    """Build coarse_tile() groups from automatic span-overflow plans.
+
+    This adapter converts a SpanOverflowTilePlan into the same group shape as
+    user spyre_hint annotations: ``[([op], [(hint_id, count, is_reduction)])]``.
+    It only runs when user hints did not already form coarse-tile groups.
+    """
+    from . import config
+
+    if config.chunk_large_tensors:
+        return []
+
+    groups: list[tuple] = []
+    next_hint_id = _SPAN_OVERFLOW_HINT_ID
+
+    for op in graph.operations:
+        if not isinstance(op, ComputedBuffer):
+            continue
+        if not isinstance(op.data, (Pointwise, Reduction)):
+            continue
+        if not isinstance(op.layout, FixedTiledLayout):
+            continue
+
+        plan = plan_span_overflow_tile(op, config.sencores)
+        if plan is None:
+            continue
+
+        out_coords = op_out_coords(op)
+        hints: list[DimHint] = []
+        levels: list[tuple] = []
+        level_summary: list[tuple[int, int]] = []
+
+        tile_levels = getattr(plan, "tile_levels", None)
+        if tile_levels:
+            planned_levels = [
+                (
+                    level.selected_host_dim,
+                    level.split_count,
+                    level.is_reduction,
+                )
+                for level in tile_levels
+            ]
+        else:
+            planned_levels = [
+                (plan.selected_host_dim, plan.split_count, plan.is_reduction)
+            ]
+
+        for host_dim, split_count, is_reduction in planned_levels:
+            if host_dim >= len(out_coords):
+                raise Unsupported(
+                    f"Cannot adapt span-overflow plan for {op.get_name()}: "
+                    f"host_dim={host_dim} is out of bounds for "
+                    f"{len(out_coords)} output coordinates."
+                )
+
+            coord = out_coords[host_dim]
+            free_symbols = coord.free_symbols
+            if len(free_symbols) != 1:
+                raise Unsupported(
+                    f"Cannot adapt span-overflow plan for {op.get_name()}: "
+                    f"host_dim={host_dim} output coordinate {coord} has "
+                    f"{len(free_symbols)} free symbols; expected exactly one loop var."
+                )
+
+            hint_id = next_hint_id
+            next_hint_id += 1
+            loop_var = next(iter(free_symbols))
+            hints.append(
+                DimHint(
+                    dim_names=["_span_overflow"],
+                    split_count=split_count,
+                    loop_var=loop_var,
+                    is_reduction=is_reduction,
+                    hint_id=hint_id,
+                )
+            )
+            levels.append(
+                (
+                    hint_id,
+                    sympy.Integer(split_count),
+                    is_reduction,
+                )
+            )
+            level_summary.append((host_dim, split_count))
+
+        if not levels:
+            continue
+
+        op.dim_hints = hints  # type: ignore[attr-defined]
+        groups.append(([op], levels))
+
+        logger.info(
+            "span_overflow_groups: op %s levels=%s total=%.2fGB per_core_span=%.2fMB",
+            op.get_name(),
+            level_summary,
+            plan.chunking_info.total_bytes / (1024**3),
+            plan.chunking_info.per_core_span / (1024**2),
+        )
 
     return groups
 

--- a/torch_spyre/_inductor/config.py
+++ b/torch_spyre/_inductor/config.py
@@ -62,6 +62,14 @@ ignore_work_division_hints: bool = (
 
 ignore_wsr_hints: bool = os.environ.get("SPYRE_INDUCTOR_IGNORE_HINTS", "0") == "1"
 
+# Disable compiler-generated span-overflow coarse-tiling hints.  The global
+# SPYRE_INDUCTOR_IGNORE_HINTS flag also disables these so one switch can still
+# suppress all WSR/coarse-tiling hint paths.
+ignore_span_overflow_hints: bool = (
+    ignore_wsr_hints
+    or os.environ.get("SPYRE_INDUCTOR_IGNORE_SPAN_OVERFLOW_HINTS", "0") == "1"
+)
+
 # For K-split matmuls, permute physical core IDs so the cores collaborating on a
 # K reduction land on adjacent ring positions, cutting PSUM chain hops from m*n
 # to 1. The split itself is chosen by the cost-model planner; this only reorders

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -43,8 +43,11 @@ from .temp_passes import (
     mark_direct_unit_bmm_pass,
     mm_to_bmm_pass,
 )
-
-from .coarse_tile import hints_to_coarse_tile_groups, reorder_unhinted_interlopers, span_overflow_groups
+from .coarse_tile import (
+    hints_to_coarse_tile_groups,
+    reorder_unhinted_interlopers,
+    span_overflow_groups,
+)
 from . import config
 from .propagate_hints import (
     collect_spyre_hints,

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -43,7 +43,8 @@ from .temp_passes import (
     mark_direct_unit_bmm_pass,
     mm_to_bmm_pass,
 )
-from .coarse_tile import hints_to_coarse_tile_groups, reorder_unhinted_interlopers
+
+from .coarse_tile import hints_to_coarse_tile_groups, reorder_unhinted_interlopers, span_overflow_groups
 from . import config
 from .propagate_hints import (
     collect_spyre_hints,
@@ -270,11 +271,13 @@ def _maybe_chunk_large_tensors(graph: GraphLowering) -> None:
         chunk_large_tensors(graph)
 
 
-@_runs(reorder_unhinted_interlopers, hints_to_coarse_tile_groups, coarse_tile)
+@_runs(reorder_unhinted_interlopers, hints_to_coarse_tile_groups, span_overflow_groups, coarse_tile)
 def _maybe_coarse_tile(graph: GraphLowering) -> None:
     if not config.ignore_wsr_hints:
         reorder_unhinted_interlopers(graph)
         groups = hints_to_coarse_tile_groups(graph)
+        if not groups:
+            groups = span_overflow_groups(graph)
         if groups:
             coarse_tile(graph, groups=groups)
 

--- a/torch_spyre/_inductor/passes.py
+++ b/torch_spyre/_inductor/passes.py
@@ -274,15 +274,23 @@ def _maybe_chunk_large_tensors(graph: GraphLowering) -> None:
         chunk_large_tensors(graph)
 
 
-@_runs(reorder_unhinted_interlopers, hints_to_coarse_tile_groups, span_overflow_groups, coarse_tile)
+@_runs(
+    reorder_unhinted_interlopers,
+    hints_to_coarse_tile_groups,
+    span_overflow_groups,
+    coarse_tile,
+)
 def _maybe_coarse_tile(graph: GraphLowering) -> None:
+    groups = []
     if not config.ignore_wsr_hints:
         reorder_unhinted_interlopers(graph)
-        groups = hints_to_coarse_tile_groups(graph)
-        if not groups:
-            groups = span_overflow_groups(graph)
-        if groups:
-            coarse_tile(graph, groups=groups)
+        groups += hints_to_coarse_tile_groups(graph)
+    if not config.ignore_span_overflow_hints:
+        groups += span_overflow_groups(graph)
+    if groups:
+        op_order = {id(op): idx for idx, op in enumerate(graph.operations)}
+        groups.sort(key=lambda group: op_order.get(id(group[0][0]), len(op_order)))
+        coarse_tile(graph, groups=groups)
 
 
 @_runs(cost_model_matmul_division, work_distribution)

--- a/torch_spyre/_inductor/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/span_overflow_hint_analysis.py
@@ -230,6 +230,9 @@ def _post_tile_layout(
     new_size[selected_host_dim] = full_size // split_count
     new_stride = list(FlexibleLayout.contiguous_strides(new_size))
 
+    # TODO: Replace this copied coarse_tile layout-resize pattern with the
+    # _resize_device_layout helper from PR #2912 once it lands.  The helper is
+    # more robust for preserving Spyre physical layout details.
     orig_stl = original_layout.device_layout
     sm_last = int(list(orig_stl.stride_map)[-1])
     new_strides_ints = [int(s) for s in new_stride]

--- a/torch_spyre/_inductor/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/span_overflow_hint_analysis.py
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Span-overflow analysis for oversized pointwise ops.
-
-This module only decides whether a pointwise ComputedBuffer should be coarse
-tiled and what single output dimension/count should be used.  The actual
-DimHint/group adaptation and execution path live in coarse tiling.
-"""
+"""Span-overflow tile planning for oversized pointwise ops."""
 
 from __future__ import annotations
 
@@ -39,13 +34,7 @@ logger = get_inductor_logger("span_overflow_hint_analysis")
 
 @dataclass(frozen=True)
 class ChunkingInfo:
-    """Physical span facts for one op before coarse tiling.
-
-    ``selected_host_dim`` is the logical/output dim we can tile.
-    ``selected_device_dim_size`` and ``selected_device_span_stride_elems`` are
-    the corresponding physical dim and inner physical stride used to estimate
-    work_division's per-core address span.
-    """
+    """Physical span facts for one op before coarse tiling."""
 
     total_bytes: int
     per_core_span: int
@@ -59,12 +48,7 @@ class ChunkingInfo:
 
 @dataclass(frozen=True)
 class SpanOverflowTilePlan:
-    """Coarse-tiling request produced by span-overflow analysis.
-
-    The adapter layer turns this into a synthetic DimHint/group, e.g.
-    ``selected_host_dim=1, split_count=5`` means tile output dim 1 into five
-    coarse-tile loop iterations.
-    """
+    """Coarse-tiling request produced by span-overflow analysis."""
 
     selected_host_dim: int
     split_count: int
@@ -85,36 +69,27 @@ class SpanDimInfo:
 
 
 def _find_max_divisible_core_split(dim_size: int, max_cores: int) -> int:
-    """Return the best work_division split estimate for one physical dim.
-
-    Example: ``dim_size=8195, max_cores=4`` returns 1, while
-    ``dim_size=8196, max_cores=4`` returns 4.
-    """
+    """Return the largest core split that evenly divides the dim."""
     for i in range(min(max_cores, dim_size), 0, -1):
         if dim_size % i == 0:
             return i
     return 1
 
 
-def _find_outermost_span_dim(
+def _iter_span_dim_infos(
     layout: FixedTiledLayout,
     max_cores: int,
-) -> SpanDimInfo | None:
-    """Find the outermost mapped device dim that can reduce memory span.
-
-    Device dims are walked outer-to-inner, skipping the final stick dim.  Dims
-    that cannot be mapped to a splittable host dim are skipped for selection.
-    Span math intentionally does not multiply skipped outer dims: this mirrors
-    work_division.get_per_core_span(), where constant outer coordinates do not
-    contribute to the per-core address span.
-    """
+) -> list[SpanDimInfo]:
+    """Return mappable span-controlling dims in outer-to-inner order."""
     stl = layout.device_layout
     device_size = [int(s) for s in stl.device_size]
     host_size = [int(s) for s in layout.size]
     host_stride = [int(s) for s in layout.stride]
     stick_elems = stl.elems_per_stick()
 
+    infos: list[SpanDimInfo] = []
     skipped_outer_device_dims: list[int] = []
+    seen_host_dims: set[int] = set()
 
     for device_dim in range(len(device_size) - 1):
         sm = int(stl.stride_map[device_dim])
@@ -122,8 +97,6 @@ def _find_outermost_span_dim(
             skipped_outer_device_dims.append(device_dim)
             continue
 
-        # For a non-stick host dim, stride_map is the host stride.  For the
-        # outer-stick device dim, stride_map can be host_stride * stick_elems.
         matching_dims = [
             d
             for d, s in enumerate(host_stride)
@@ -134,30 +107,44 @@ def _find_outermost_span_dim(
             skipped_outer_device_dims.append(device_dim)
             continue
 
+        selected_host_dim = matching_dims[0]
+        if selected_host_dim in seen_host_dims:
+            skipped_outer_device_dims.append(device_dim)
+            continue
+        seen_host_dims.add(selected_host_dim)
+
         selected_device_dim_size = device_size[device_dim]
-        return SpanDimInfo(
-            selected_host_dim=matching_dims[0],
-            selected_device_dim_size=selected_device_dim_size,
-            selected_device_span_stride_elems=math.prod(device_size[device_dim + 1 :]),
-            core_split_estimate=_find_max_divisible_core_split(
-                selected_device_dim_size, max_cores
-            ),
-            skipped_outer_device_dims=tuple(skipped_outer_device_dims),
+        infos.append(
+            SpanDimInfo(
+                selected_host_dim=selected_host_dim,
+                selected_device_dim_size=selected_device_dim_size,
+                selected_device_span_stride_elems=math.prod(
+                    device_size[device_dim + 1 :]
+                ),
+                core_split_estimate=_find_max_divisible_core_split(
+                    selected_device_dim_size, max_cores
+                ),
+                skipped_outer_device_dims=tuple(skipped_outer_device_dims),
+            )
         )
 
-    return None
+    return infos
+
+
+def _find_outermost_span_dim(
+    layout: FixedTiledLayout,
+    max_cores: int,
+) -> SpanDimInfo | None:
+    """Find the outermost mapped device dim that can reduce memory span."""
+    infos = _iter_span_dim_infos(layout, max_cores)
+    return infos[0] if infos else None
 
 
 def _compute_num_chunks(
     chunking_info: ChunkingInfo,
     max_cores: int,
 ) -> int:
-    """Return the minimum coarse-tile count required by hardware limits.
-
-    ``num_from_span`` asks how many coarse tiles are needed so the selected
-    physical dim's per-core span is under 256 MB.  ``num_from_total`` is a
-    whole-tensor safety check against ``256 MB * SENCORES``.
-    """
+    """Return the minimum coarse-tile count required by span and total limits."""
     if chunking_info.selected_device_dim_size == 0:
         return max(
             1, math.ceil(chunking_info.total_bytes / (MAX_SPAN_BYTES * max_cores))
@@ -169,12 +156,7 @@ def _compute_num_chunks(
 
 
 def _choose_divisible_split_count(full_size: int, required_count: int) -> int:
-    """Choose the smallest legal coarse-tile count at least ``required_count``.
-
-    ``coarse_tile`` currently requires exact divisibility when it divides
-    op.data.ranges by the loop count.  Span analysis gives a minimum safe
-    count; this helper rounds that up to the smallest divisor of ``full_size``.
-    """
+    """Choose the smallest divisor of ``full_size`` at least ``required_count``."""
     if required_count <= 1:
         return 1
     if required_count > full_size:
@@ -201,13 +183,7 @@ def _post_tile_layout(
     split_count: int,
     op_name: str,
 ) -> FixedTiledLayout:
-    """Build the per-tile layout that coarse_tile._divide_ranges would create.
-
-    Example: shape ``[1, 8195, 256, 64]`` tiled on dim 1 by 5 becomes
-    ``[1, 1639, 256, 64]``.  We rebuild ``SpyreTensorLayout`` for that tile
-    shape so validation uses the same physical layout model as downstream
-    coarse tiling.
-    """
+    """Build the per-tile layout used for post-tile validation."""
     if split_count <= 0:
         raise Unsupported(
             f"Cannot auto-tile {op_name}: split_count must be positive, "
@@ -239,8 +215,6 @@ def _post_tile_layout(
     new_size[selected_host_dim] = full_size // split_count
     new_stride = list(FlexibleLayout.contiguous_strides(new_size))
 
-    # Mirror coarse_tile's range division closely enough for analysis: compute
-    # contiguous per-tile host strides, then rebuild the Spyre physical layout.
     orig_stl = original_layout.device_layout
     sm_last = int(list(orig_stl.stride_map)[-1])
     new_strides_ints = [int(s) for s in new_stride]
@@ -268,6 +242,61 @@ def _post_tile_layout(
     )
 
 
+def _within_stick_host_dim(layout: FixedTiledLayout) -> int:
+    """Return the host dim represented by the physical within-stick dim."""
+    sm_last = int(list(layout.device_layout.stride_map)[-1])
+    host_stride = [int(s) for s in layout.stride]
+    return next(
+        (i for i, s in enumerate(host_stride) if s == sm_last),
+        len(host_stride) - 1,
+    )
+
+
+def _post_tile_stick_alignment_ok(
+    original_layout: FixedTiledLayout,
+    selected_host_dim: int,
+    split_count: int,
+) -> bool:
+    """Return whether the selected tile preserves physical stick alignment."""
+    if split_count <= 1:
+        return True
+
+    within_stick_dim = _within_stick_host_dim(original_layout)
+    if selected_host_dim != within_stick_dim:
+        return True
+
+    full_size = int(original_layout.size[selected_host_dim])
+    tile_size = full_size // split_count
+    stick_elems = original_layout.device_layout.elems_per_stick()
+    return tile_size % stick_elems == 0
+
+
+def _post_tile_stick_alignment_error(
+    original_layout: FixedTiledLayout,
+    selected_host_dim: int,
+    split_count: int,
+) -> str | None:
+    """Return a diagnostic if coarse tiling cuts through physical sticks."""
+    if split_count <= 1:
+        return None
+
+    within_stick_dim = _within_stick_host_dim(original_layout)
+    if selected_host_dim != within_stick_dim:
+        return None
+
+    full_size = int(original_layout.size[selected_host_dim])
+    tile_size = full_size // split_count
+    stick_elems = original_layout.device_layout.elems_per_stick()
+    if tile_size % stick_elems == 0:
+        return None
+
+    return (
+        f"split_count {split_count} makes selected host dim {selected_host_dim} "
+        f"tile size {tile_size}, which is not aligned to Spyre stick size "
+        f"{stick_elems}; coarse-tile boundaries would cut through physical sticks"
+    )
+
+
 def _post_tile_span_ok(
     split_count: int,
     original_layout: FixedTiledLayout,
@@ -275,12 +304,19 @@ def _post_tile_span_ok(
     max_cores: int,
     op_name: str,
 ) -> bool:
-    """Return True if the post-coarse-tile layout no longer overflows.
+    """Return whether the post-tile layout fits span and total limits."""
+    if not _post_tile_stick_alignment_ok(
+        original_layout, selected_host_dim, split_count
+    ):
+        logger.debug(
+            "plan_span_overflow_tile: %s candidate=%d rejected because it "
+            "creates a non-stick-aligned tile on host dim %d",
+            op_name,
+            split_count,
+            selected_host_dim,
+        )
+        return False
 
-    This is the guardrail that keeps analysis honest: a candidate split count
-    is accepted only if the real per-tile physical layout would pass the same
-    span/total checks.
-    """
     tiled_layout = _post_tile_layout(
         original_layout,
         selected_host_dim,
@@ -308,43 +344,54 @@ def _post_tile_validated_split_count(
     original_layout: FixedTiledLayout,
     max_cores: int,
 ) -> int:
-    """Return the smallest legal split_count that makes the tiled layout safe.
-
-    The first candidate is the smallest divisor of ``full_size`` that is at
-    least the required count.  If that candidate still overflows after coarse
-    tile rebuilds the physical layout, walk larger divisors.  If no divisor on
-    this single selected dimension is sufficient, raise ``Unsupported`` instead
-    of emitting a tile plan that can still overflow.
-    """
+    """Return the smallest bounded, stick-safe split count that validates."""
     initial = _choose_divisible_split_count(full_size, required_count)
     selected_host_dim = chunking_info.selected_host_dim
+    max_reasonable_split = required_count * max(1, max_cores)
+    if initial > max_reasonable_split:
+        raise Unsupported(
+            f"Cannot auto-tile {op_name}: selected host dim size {full_size} "
+            f"requires at least {required_count} tiles, but the smallest legal "
+            f"divisor is {initial}, which exceeds the over-split cap "
+            f"{max_reasonable_split}."
+        )
 
-    if _post_tile_span_ok(
-        initial, original_layout, selected_host_dim, max_cores, op_name
-    ):
-        return initial
-
-    upper_divisors = sorted(
+    candidates = sorted(
         {
             d
             for i in range(1, math.isqrt(full_size) + 1)
             if full_size % i == 0
             for d in (i, full_size // i)
-            if d > initial
+            if required_count <= d <= max_reasonable_split
         }
     )
 
-    for candidate in upper_divisors:
+    stick_alignment_errors: list[str] = []
+    for candidate in candidates:
+        stick_error = _post_tile_stick_alignment_error(
+            original_layout, selected_host_dim, candidate
+        )
+        if stick_error is not None:
+            stick_alignment_errors.append(stick_error)
+            logger.debug(
+                "plan_span_overflow_tile: %s candidate=%d rejected: %s",
+                op_name,
+                candidate,
+                stick_error,
+            )
+            continue
+
         if _post_tile_span_ok(
             candidate, original_layout, selected_host_dim, max_cores, op_name
         ):
-            logger.debug(
-                "plan_span_overflow_tile: %s bumped split_count %d -> %d "
-                "after post-tile layout validation",
-                op_name,
-                initial,
-                candidate,
-            )
+            if candidate != initial:
+                logger.debug(
+                    "plan_span_overflow_tile: %s bumped split_count %d -> %d "
+                    "after post-tile layout validation",
+                    op_name,
+                    initial,
+                    candidate,
+                )
             return candidate
 
         logger.debug(
@@ -352,6 +399,14 @@ def _post_tile_validated_split_count(
             "post-tile layout validation; trying next divisor",
             op_name,
             candidate,
+        )
+
+    if stick_alignment_errors:
+        raise Unsupported(
+            f"Cannot auto-tile {op_name}: selected_host_dim size {full_size} "
+            f"has no legal split >= {required_count} that preserves Spyre "
+            f"stick alignment. First rejected candidate: "
+            f"{stick_alignment_errors[0]}."
         )
 
     raise Unsupported(
@@ -373,12 +428,7 @@ def _needs_chunking(
     op_name: str | None = None,
     trigger: str = "output_span",
 ) -> ChunkingInfo | None:
-    """Return chunking info if this layout exceeds span or total limits.
-
-    The span formula intentionally matches work_division's model:
-    ``ceil(selected_device_dim_size / core_split_estimate) * inner_stride *
-    itemsize``.  Skipped outer device dims are debug context, not multipliers.
-    """
+    """Return chunking info when the layout exceeds span or total limits."""
     device_size = [int(s) for s in layout.device_layout.device_size]
     itemsize = layout.dtype.itemsize
     total_bytes = math.prod(device_size) * itemsize
@@ -409,8 +459,6 @@ def _needs_chunking(
     selected_device_dim_size = span_dim_info.selected_device_dim_size
     selected_device_span_stride_elems = span_dim_info.selected_device_span_stride_elems
     core_split_estimate = span_dim_info.core_split_estimate
-    # Match work_division.get_per_core_span(): first varying physical dim's
-    # per-core extent times all inner physical dimensions, in bytes.
     per_core_span = (
         math.ceil(selected_device_dim_size / core_split_estimate)
         * selected_device_span_stride_elems
@@ -518,9 +566,6 @@ def _plan_pointwise_span_overflow_tile(
     if required_count <= 1:
         return None
 
-    # Keep v1 conservative: use one selected dim only.  If no divisor of that
-    # dim validates, _post_tile_validated_split_count raises Unsupported rather
-    # than trying a nested multi-dimensional tile plan.
     split_count = _post_tile_validated_split_count(
         op.get_name(), full_size, required_count, chunking_info, op.layout, max_cores
     )

--- a/torch_spyre/_inductor/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/span_overflow_hint_analysis.py
@@ -26,6 +26,7 @@ from torch_spyre._C import SpyreTensorLayout
 from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
+from .pass_utils import indirect_info_from_op
 from .work_division import MAX_SPAN_BYTES, core_split
 
 
@@ -486,6 +487,15 @@ def _needs_chunking(
     )
 
 
+def _has_indirect_reads(op: ComputedBuffer) -> bool:
+    """Return True if the op uses indirect/gather-style input reads."""
+    try:
+        _, _, indirect_sizes = indirect_info_from_op(op)
+    except (AttributeError, RuntimeError, TypeError, Unsupported):
+        return False
+    return indirect_sizes is not None
+
+
 def plan_span_overflow_tile(
     op: ComputedBuffer,
     max_cores: int,
@@ -499,6 +509,12 @@ def plan_span_overflow_tile(
         return None
 
     if not _layout_has_static_span_metadata(op.layout):
+        return None
+
+    # Gather/indirect-access ops can lower as Pointwise ComputedBuffers, but
+    # they require the dedicated indirect-access SDSC path rather than automatic
+    # output coarse tiling.
+    if _has_indirect_reads(op):
         return None
 
     return _plan_pointwise_span_overflow_tile(op, max_cores)

--- a/torch_spyre/_inductor/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/span_overflow_hint_analysis.py
@@ -26,7 +26,7 @@ from torch_spyre._C import SpyreTensorLayout
 from .errors import Unsupported
 from .ir import FixedTiledLayout
 from .logging_utils import get_inductor_logger
-from .work_division import MAX_SPAN_BYTES
+from .work_division import MAX_SPAN_BYTES, core_split
 
 
 logger = get_inductor_logger("span_overflow_hint_analysis")
@@ -69,11 +69,25 @@ class SpanDimInfo:
 
 
 def _find_max_divisible_core_split(dim_size: int, max_cores: int) -> int:
-    """Return the largest core split that evenly divides the dim."""
-    for i in range(min(max_cores, dim_size), 0, -1):
-        if dim_size % i == 0:
-            return i
-    return 1
+    """Return the work-division core split estimate for one dim."""
+    return core_split(dim_size, max_cores)
+
+
+def _layout_has_static_span_metadata(layout: FixedTiledLayout) -> bool:
+    """Return True when span planning can use concrete layout metadata."""
+    try:
+        for values in (
+            layout.size,
+            layout.stride,
+            layout.device_layout.device_size,
+            layout.device_layout.stride_map,
+        ):
+            for value in values:
+                int(value)
+        int(layout.device_layout.elems_per_stick())
+    except (TypeError, ValueError):
+        return False
+    return True
 
 
 def _iter_span_dim_infos(
@@ -89,30 +103,31 @@ def _iter_span_dim_infos(
 
     infos: list[SpanDimInfo] = []
     skipped_outer_device_dims: list[int] = []
-    seen_host_dims: set[int] = set()
-
     for device_dim in range(len(device_size) - 1):
+        if device_size[device_dim] <= 1:
+            skipped_outer_device_dims.append(device_dim)
+            continue
+
         sm = int(stl.stride_map[device_dim])
         if sm <= 0:
             skipped_outer_device_dims.append(device_dim)
             continue
 
-        matching_dims = [
+        exact_matches = [
+            d for d, s in enumerate(host_stride) if host_size[d] > 1 and s == sm
+        ]
+        stick_scaled_matches = [
             d
             for d, s in enumerate(host_stride)
-            if host_size[d] > 1 and (s == sm or s * stick_elems == sm)
+            if host_size[d] > 1 and s * stick_elems == sm and d not in exact_matches
         ]
+        matching_dims = exact_matches or stick_scaled_matches
 
         if not matching_dims:
             skipped_outer_device_dims.append(device_dim)
             continue
 
         selected_host_dim = matching_dims[0]
-        if selected_host_dim in seen_host_dims:
-            skipped_outer_device_dims.append(device_dim)
-            continue
-        seen_host_dims.add(selected_host_dim)
-
         selected_device_dim_size = device_size[device_dim]
         infos.append(
             SpanDimInfo(
@@ -252,25 +267,6 @@ def _within_stick_host_dim(layout: FixedTiledLayout) -> int:
     )
 
 
-def _post_tile_stick_alignment_ok(
-    original_layout: FixedTiledLayout,
-    selected_host_dim: int,
-    split_count: int,
-) -> bool:
-    """Return whether the selected tile preserves physical stick alignment."""
-    if split_count <= 1:
-        return True
-
-    within_stick_dim = _within_stick_host_dim(original_layout)
-    if selected_host_dim != within_stick_dim:
-        return True
-
-    full_size = int(original_layout.size[selected_host_dim])
-    tile_size = full_size // split_count
-    stick_elems = original_layout.device_layout.elems_per_stick()
-    return tile_size % stick_elems == 0
-
-
 def _post_tile_stick_alignment_error(
     original_layout: FixedTiledLayout,
     selected_host_dim: int,
@@ -305,18 +301,6 @@ def _post_tile_span_ok(
     op_name: str,
 ) -> bool:
     """Return whether the post-tile layout fits span and total limits."""
-    if not _post_tile_stick_alignment_ok(
-        original_layout, selected_host_dim, split_count
-    ):
-        logger.debug(
-            "plan_span_overflow_tile: %s candidate=%d rejected because it "
-            "creates a non-stick-aligned tile on host dim %d",
-            op_name,
-            split_count,
-            selected_host_dim,
-        )
-        return False
-
     tiled_layout = _post_tile_layout(
         original_layout,
         selected_host_dim,
@@ -347,22 +331,13 @@ def _post_tile_validated_split_count(
     """Return the smallest bounded, stick-safe split count that validates."""
     initial = _choose_divisible_split_count(full_size, required_count)
     selected_host_dim = chunking_info.selected_host_dim
-    max_reasonable_split = required_count * max(1, max_cores)
-    if initial > max_reasonable_split:
-        raise Unsupported(
-            f"Cannot auto-tile {op_name}: selected host dim size {full_size} "
-            f"requires at least {required_count} tiles, but the smallest legal "
-            f"divisor is {initial}, which exceeds the over-split cap "
-            f"{max_reasonable_split}."
-        )
-
     candidates = sorted(
         {
             d
             for i in range(1, math.isqrt(full_size) + 1)
             if full_size % i == 0
             for d in (i, full_size // i)
-            if required_count <= d <= max_reasonable_split
+            if d >= required_count
         }
     )
 
@@ -518,6 +493,9 @@ def plan_span_overflow_tile(
         and isinstance(op.data, Pointwise)
         and isinstance(op.layout, FixedTiledLayout)
     ):
+        return None
+
+    if not _layout_has_static_span_metadata(op.layout):
         return None
 
     return _plan_pointwise_span_overflow_tile(op, max_cores)

--- a/torch_spyre/_inductor/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/span_overflow_hint_analysis.py
@@ -46,6 +46,7 @@ class ChunkingInfo:
     the corresponding physical dim and inner physical stride used to estimate
     work_division's per-core address span.
     """
+
     total_bytes: int
     per_core_span: int
     core_split_estimate: int
@@ -64,6 +65,7 @@ class SpanOverflowTilePlan:
     ``selected_host_dim=1, split_count=5`` means tile output dim 1 into five
     coarse-tile loop iterations.
     """
+
     selected_host_dim: int
     split_count: int
     is_reduction: bool
@@ -74,6 +76,7 @@ class SpanOverflowTilePlan:
 @dataclass(frozen=True)
 class SpanDimInfo:
     """Mapping from the first span-controlling device dim to a host dim."""
+
     selected_host_dim: int
     selected_device_dim_size: int
     selected_device_span_stride_elems: int
@@ -135,9 +138,7 @@ def _find_outermost_span_dim(
         return SpanDimInfo(
             selected_host_dim=matching_dims[0],
             selected_device_dim_size=selected_device_dim_size,
-            selected_device_span_stride_elems=math.prod(
-                device_size[device_dim + 1 :]
-            ),
+            selected_device_span_stride_elems=math.prod(device_size[device_dim + 1 :]),
             core_split_estimate=_find_max_divisible_core_split(
                 selected_device_dim_size, max_cores
             ),
@@ -251,9 +252,7 @@ def _post_tile_layout(
         within_stick_dim = len(new_size_ints) - 1
 
     ndim = len(new_size_ints)
-    dim_order = [i for i in range(ndim) if i != within_stick_dim] + [
-        within_stick_dim
-    ]
+    dim_order = [i for i in range(ndim) if i != within_stick_dim] + [within_stick_dim]
     device_layout = SpyreTensorLayout(
         new_size_ints,
         new_strides_ints,

--- a/torch_spyre/_inductor/span_overflow_hint_analysis.py
+++ b/torch_spyre/_inductor/span_overflow_hint_analysis.py
@@ -1,0 +1,535 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Span-overflow analysis for oversized pointwise ops.
+
+This module only decides whether a pointwise ComputedBuffer should be coarse
+tiled and what single output dimension/count should be used.  The actual
+DimHint/group adaptation and execution path live in coarse tiling.
+"""
+
+from __future__ import annotations
+
+import math
+
+from dataclasses import dataclass
+
+from torch._inductor.ir import ComputedBuffer, FlexibleLayout, Pointwise
+from torch_spyre._C import SpyreTensorLayout
+
+from .errors import Unsupported
+from .ir import FixedTiledLayout
+from .logging_utils import get_inductor_logger
+from .work_division import MAX_SPAN_BYTES
+
+
+logger = get_inductor_logger("span_overflow_hint_analysis")
+
+
+@dataclass(frozen=True)
+class ChunkingInfo:
+    """Physical span facts for one op before coarse tiling.
+
+    ``selected_host_dim`` is the logical/output dim we can tile.
+    ``selected_device_dim_size`` and ``selected_device_span_stride_elems`` are
+    the corresponding physical dim and inner physical stride used to estimate
+    work_division's per-core address span.
+    """
+    total_bytes: int
+    per_core_span: int
+    core_split_estimate: int
+    selected_device_dim_size: int
+    selected_device_span_stride_elems: int
+    selected_host_dim: int
+    stick_elems: int
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SpanOverflowTilePlan:
+    """Coarse-tiling request produced by span-overflow analysis.
+
+    The adapter layer turns this into a synthetic DimHint/group, e.g.
+    ``selected_host_dim=1, split_count=5`` means tile output dim 1 into five
+    coarse-tile loop iterations.
+    """
+    selected_host_dim: int
+    split_count: int
+    is_reduction: bool
+    chunking_info: ChunkingInfo
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SpanDimInfo:
+    """Mapping from the first span-controlling device dim to a host dim."""
+    selected_host_dim: int
+    selected_device_dim_size: int
+    selected_device_span_stride_elems: int
+    core_split_estimate: int
+    skipped_outer_device_dims: tuple[int, ...] = ()
+
+
+def _find_max_divisible_core_split(dim_size: int, max_cores: int) -> int:
+    """Return the best work_division split estimate for one physical dim.
+
+    Example: ``dim_size=8195, max_cores=4`` returns 1, while
+    ``dim_size=8196, max_cores=4`` returns 4.
+    """
+    for i in range(min(max_cores, dim_size), 0, -1):
+        if dim_size % i == 0:
+            return i
+    return 1
+
+
+def _find_outermost_span_dim(
+    layout: FixedTiledLayout,
+    max_cores: int,
+) -> SpanDimInfo | None:
+    """Find the outermost mapped device dim that can reduce memory span.
+
+    Device dims are walked outer-to-inner, skipping the final stick dim.  Dims
+    that cannot be mapped to a splittable host dim are skipped for selection.
+    Span math intentionally does not multiply skipped outer dims: this mirrors
+    work_division.get_per_core_span(), where constant outer coordinates do not
+    contribute to the per-core address span.
+    """
+    stl = layout.device_layout
+    device_size = [int(s) for s in stl.device_size]
+    host_size = [int(s) for s in layout.size]
+    host_stride = [int(s) for s in layout.stride]
+    stick_elems = stl.elems_per_stick()
+
+    skipped_outer_device_dims: list[int] = []
+
+    for device_dim in range(len(device_size) - 1):
+        sm = int(stl.stride_map[device_dim])
+        if sm <= 0:
+            skipped_outer_device_dims.append(device_dim)
+            continue
+
+        # For a non-stick host dim, stride_map is the host stride.  For the
+        # outer-stick device dim, stride_map can be host_stride * stick_elems.
+        matching_dims = [
+            d
+            for d, s in enumerate(host_stride)
+            if host_size[d] > 1 and (s == sm or s * stick_elems == sm)
+        ]
+
+        if not matching_dims:
+            skipped_outer_device_dims.append(device_dim)
+            continue
+
+        selected_device_dim_size = device_size[device_dim]
+        return SpanDimInfo(
+            selected_host_dim=matching_dims[0],
+            selected_device_dim_size=selected_device_dim_size,
+            selected_device_span_stride_elems=math.prod(
+                device_size[device_dim + 1 :]
+            ),
+            core_split_estimate=_find_max_divisible_core_split(
+                selected_device_dim_size, max_cores
+            ),
+            skipped_outer_device_dims=tuple(skipped_outer_device_dims),
+        )
+
+    return None
+
+
+def _compute_num_chunks(
+    chunking_info: ChunkingInfo,
+    max_cores: int,
+) -> int:
+    """Return the minimum coarse-tile count required by hardware limits.
+
+    ``num_from_span`` asks how many coarse tiles are needed so the selected
+    physical dim's per-core span is under 256 MB.  ``num_from_total`` is a
+    whole-tensor safety check against ``256 MB * SENCORES``.
+    """
+    if chunking_info.selected_device_dim_size == 0:
+        return max(
+            1, math.ceil(chunking_info.total_bytes / (MAX_SPAN_BYTES * max_cores))
+        )
+
+    num_from_span = math.ceil(chunking_info.per_core_span / MAX_SPAN_BYTES)
+    num_from_total = math.ceil(chunking_info.total_bytes / (MAX_SPAN_BYTES * max_cores))
+    return max(num_from_span, num_from_total)
+
+
+def _choose_divisible_split_count(full_size: int, required_count: int) -> int:
+    """Choose the smallest legal coarse-tile count at least ``required_count``.
+
+    ``coarse_tile`` currently requires exact divisibility when it divides
+    op.data.ranges by the loop count.  Span analysis gives a minimum safe
+    count; this helper rounds that up to the smallest divisor of ``full_size``.
+    """
+    if required_count <= 1:
+        return 1
+    if required_count > full_size:
+        raise Unsupported(
+            f"Cannot choose coarse-tile split count for dimension size {full_size}: "
+            f"required count {required_count} exceeds the dimension size."
+        )
+
+    best = full_size
+    for divisor in range(1, math.isqrt(full_size) + 1):
+        if full_size % divisor != 0:
+            continue
+        paired = full_size // divisor
+        if required_count <= divisor < best:
+            best = divisor
+        if required_count <= paired < best:
+            best = paired
+    return best
+
+
+def _post_tile_layout(
+    original_layout: FixedTiledLayout,
+    selected_host_dim: int,
+    split_count: int,
+    op_name: str,
+) -> FixedTiledLayout:
+    """Build the per-tile layout that coarse_tile._divide_ranges would create.
+
+    Example: shape ``[1, 8195, 256, 64]`` tiled on dim 1 by 5 becomes
+    ``[1, 1639, 256, 64]``.  We rebuild ``SpyreTensorLayout`` for that tile
+    shape so validation uses the same physical layout model as downstream
+    coarse tiling.
+    """
+    if split_count <= 0:
+        raise Unsupported(
+            f"Cannot auto-tile {op_name}: split_count must be positive, "
+            f"got {split_count}."
+        )
+
+    new_size = list(original_layout.size)
+    if selected_host_dim >= len(new_size):
+        raise Unsupported(
+            f"Cannot auto-tile {op_name}: selected host dim {selected_host_dim} "
+            f"is out of bounds for layout size {new_size}."
+        )
+
+    try:
+        full_size = int(new_size[selected_host_dim])
+    except (TypeError, ValueError) as exc:
+        raise Unsupported(
+            f"Cannot auto-tile {op_name}: selected host dim "
+            f"{selected_host_dim} has non-integral layout size "
+            f"{new_size[selected_host_dim]!r}."
+        ) from exc
+
+    if full_size % split_count != 0:
+        raise Unsupported(
+            f"Cannot auto-tile {op_name}: selected host dim size {full_size} "
+            f"is not divisible by split_count {split_count}."
+        )
+
+    new_size[selected_host_dim] = full_size // split_count
+    new_stride = list(FlexibleLayout.contiguous_strides(new_size))
+
+    # Mirror coarse_tile's range division closely enough for analysis: compute
+    # contiguous per-tile host strides, then rebuild the Spyre physical layout.
+    orig_stl = original_layout.device_layout
+    sm_last = int(list(orig_stl.stride_map)[-1])
+    new_strides_ints = [int(s) for s in new_stride]
+    new_size_ints = [int(s) for s in new_size]
+    within_stick_dim = next(
+        (i for i, s in enumerate(new_strides_ints) if s == sm_last), None
+    )
+    if within_stick_dim is None:
+        within_stick_dim = len(new_size_ints) - 1
+
+    ndim = len(new_size_ints)
+    dim_order = [i for i in range(ndim) if i != within_stick_dim] + [
+        within_stick_dim
+    ]
+    device_layout = SpyreTensorLayout(
+        new_size_ints,
+        new_strides_ints,
+        original_layout.dtype,
+        dim_order,
+    )
+    return FixedTiledLayout(
+        original_layout.device,
+        original_layout.dtype,
+        new_size,
+        new_stride,
+        device_layout,
+    )
+
+
+def _post_tile_span_ok(
+    split_count: int,
+    original_layout: FixedTiledLayout,
+    selected_host_dim: int,
+    max_cores: int,
+    op_name: str,
+) -> bool:
+    """Return True if the post-coarse-tile layout no longer overflows.
+
+    This is the guardrail that keeps analysis honest: a candidate split count
+    is accepted only if the real per-tile physical layout would pass the same
+    span/total checks.
+    """
+    tiled_layout = _post_tile_layout(
+        original_layout,
+        selected_host_dim,
+        split_count,
+        op_name,
+    )
+    post_span_dim_info = _find_outermost_span_dim(tiled_layout, max_cores)
+    return (
+        _needs_chunking(
+            tiled_layout,
+            max_cores,
+            post_span_dim_info,
+            op_name=f"{op_name}:post_tile",
+            trigger="post_tile_validation",
+        )
+        is None
+    )
+
+
+def _post_tile_validated_split_count(
+    op_name: str,
+    full_size: int,
+    required_count: int,
+    chunking_info: ChunkingInfo,
+    original_layout: FixedTiledLayout,
+    max_cores: int,
+) -> int:
+    """Return the smallest legal split_count that makes the tiled layout safe.
+
+    The first candidate is the smallest divisor of ``full_size`` that is at
+    least the required count.  If that candidate still overflows after coarse
+    tile rebuilds the physical layout, walk larger divisors.  If no divisor on
+    this single selected dimension is sufficient, raise ``Unsupported`` instead
+    of emitting a tile plan that can still overflow.
+    """
+    initial = _choose_divisible_split_count(full_size, required_count)
+    selected_host_dim = chunking_info.selected_host_dim
+
+    if _post_tile_span_ok(
+        initial, original_layout, selected_host_dim, max_cores, op_name
+    ):
+        return initial
+
+    upper_divisors = sorted(
+        {
+            d
+            for i in range(1, math.isqrt(full_size) + 1)
+            if full_size % i == 0
+            for d in (i, full_size // i)
+            if d > initial
+        }
+    )
+
+    for candidate in upper_divisors:
+        if _post_tile_span_ok(
+            candidate, original_layout, selected_host_dim, max_cores, op_name
+        ):
+            logger.debug(
+                "plan_span_overflow_tile: %s bumped split_count %d -> %d "
+                "after post-tile layout validation",
+                op_name,
+                initial,
+                candidate,
+            )
+            return candidate
+
+        logger.debug(
+            "plan_span_overflow_tile: %s candidate=%d still overflows after "
+            "post-tile layout validation; trying next divisor",
+            op_name,
+            candidate,
+        )
+
+    raise Unsupported(
+        f"Cannot auto-tile {op_name}: no divisor of selected_host_dim "
+        f"size {full_size} >= {required_count} makes the post-tile layout fit "
+        f"within span_limit={MAX_SPAN_BYTES / (1024**2):.0f} MB and "
+        f"total_limit={(MAX_SPAN_BYTES * max_cores) / (1024**3):.2f} GB "
+        f"(selected_device_dim_size={chunking_info.selected_device_dim_size}, "
+        f"stride_elems={chunking_info.selected_device_span_stride_elems}, "
+        f"dtype_itemsize={original_layout.dtype.itemsize})."
+    )
+
+
+def _needs_chunking(
+    layout: FixedTiledLayout,
+    max_cores: int,
+    span_dim_info: SpanDimInfo | None,
+    *,
+    op_name: str | None = None,
+    trigger: str = "output_span",
+) -> ChunkingInfo | None:
+    """Return chunking info if this layout exceeds span or total limits.
+
+    The span formula intentionally matches work_division's model:
+    ``ceil(selected_device_dim_size / core_split_estimate) * inner_stride *
+    itemsize``.  Skipped outer device dims are debug context, not multipliers.
+    """
+    device_size = [int(s) for s in layout.device_layout.device_size]
+    itemsize = layout.dtype.itemsize
+    total_bytes = math.prod(device_size) * itemsize
+    stick_elems = layout.device_layout.elems_per_stick()
+
+    if span_dim_info is None:
+        if total_bytes > MAX_SPAN_BYTES * max_cores:
+            host_size = [int(s) for s in layout.size]
+            fallback_selected_host_dim = max(
+                range(len(host_size)), key=lambda d: host_size[d]
+            )
+            return ChunkingInfo(
+                total_bytes=total_bytes,
+                per_core_span=total_bytes,
+                core_split_estimate=1,
+                selected_device_dim_size=0,
+                selected_device_span_stride_elems=0,
+                selected_host_dim=fallback_selected_host_dim,
+                stick_elems=stick_elems,
+                reason=(
+                    "no device dimension could be mapped to a splittable "
+                    "host dimension via stride_map; using largest host dim "
+                    "as fallback"
+                ),
+            )
+        return None
+
+    selected_device_dim_size = span_dim_info.selected_device_dim_size
+    selected_device_span_stride_elems = span_dim_info.selected_device_span_stride_elems
+    core_split_estimate = span_dim_info.core_split_estimate
+    # Match work_division.get_per_core_span(): first varying physical dim's
+    # per-core extent times all inner physical dimensions, in bytes.
+    per_core_span = (
+        math.ceil(selected_device_dim_size / core_split_estimate)
+        * selected_device_span_stride_elems
+        * itemsize
+    )
+
+    needs_chunk_for_span = per_core_span > MAX_SPAN_BYTES
+    needs_chunk_for_total = total_bytes > MAX_SPAN_BYTES * max_cores
+    if not (needs_chunk_for_span or needs_chunk_for_total):
+        return None
+
+    logger.info(
+        "[span_overflow_hint_analysis] trigger=%s op=%s "
+        "selected_host_dim=%d selected_device_dim_size=%d "
+        "selected_device_span_stride_elems=%d core_split_estimate=%d "
+        "per_core_span=%.2f MB total=%.2f GB "
+        "(shape=%s, dtype=%s, device_size=%s, "
+        "span_limit=%.2f MB, total_limit=%.2f GB)",
+        trigger,
+        op_name or "<unknown>",
+        span_dim_info.selected_host_dim,
+        selected_device_dim_size,
+        selected_device_span_stride_elems,
+        core_split_estimate,
+        per_core_span / (1024**2),
+        total_bytes / (1024**3),
+        list(layout.size),
+        layout.dtype,
+        device_size,
+        MAX_SPAN_BYTES / (1024**2),
+        (MAX_SPAN_BYTES * max_cores) / (1024**3),
+    )
+    return ChunkingInfo(
+        total_bytes=total_bytes,
+        per_core_span=per_core_span,
+        core_split_estimate=core_split_estimate,
+        selected_device_dim_size=selected_device_dim_size,
+        selected_device_span_stride_elems=selected_device_span_stride_elems,
+        selected_host_dim=span_dim_info.selected_host_dim,
+        stick_elems=stick_elems,
+        reason=(
+            "skipped unmapped outer device dims "
+            f"{span_dim_info.skipped_outer_device_dims}"
+            if span_dim_info.skipped_outer_device_dims
+            else None
+        ),
+    )
+
+
+def plan_span_overflow_tile(
+    op: ComputedBuffer,
+    max_cores: int,
+) -> SpanOverflowTilePlan | None:
+    """Return an automatic coarse-tile plan for a pointwise op if needed."""
+    if not (
+        isinstance(op, ComputedBuffer)
+        and isinstance(op.data, Pointwise)
+        and isinstance(op.layout, FixedTiledLayout)
+    ):
+        return None
+
+    return _plan_pointwise_span_overflow_tile(op, max_cores)
+
+
+def _plan_pointwise_span_overflow_tile(
+    op: ComputedBuffer,
+    max_cores: int,
+) -> SpanOverflowTilePlan | None:
+    """Plan one single-dimension coarse tile for an oversized pointwise op."""
+    span_dim_info = _find_outermost_span_dim(op.layout, max_cores)
+    chunking_info = _needs_chunking(
+        op.layout,
+        max_cores,
+        span_dim_info,
+        op_name=op.get_name(),
+        trigger="output_span",
+    )
+    if chunking_info is None:
+        return None
+
+    selected_host_dim = chunking_info.selected_host_dim
+    ranges = list(op.data.ranges)
+    if selected_host_dim >= len(ranges):
+        raise Unsupported(
+            f"Cannot auto-tile {op.get_name()}: selected host dim "
+            f"{selected_host_dim} is out of bounds for given data ranges {ranges}."
+        )
+
+    try:
+        full_size = int(ranges[selected_host_dim])
+    except (TypeError, ValueError) as exc:
+        raise Unsupported(
+            f"Cannot auto-tile {op.get_name()}: selected host dim "
+            f"{selected_host_dim} has non-integral range "
+            f"{ranges[selected_host_dim]!r}."
+        ) from exc
+
+    if full_size <= 1:
+        raise Unsupported(
+            f"Cannot auto-tile {op.get_name()}: selected host dim "
+            f"{selected_host_dim} has unsplittable range {full_size}."
+        )
+
+    required_count = _compute_num_chunks(chunking_info, max_cores)
+    if required_count <= 1:
+        return None
+
+    # Keep v1 conservative: use one selected dim only.  If no divisor of that
+    # dim validates, _post_tile_validated_split_count raises Unsupported rather
+    # than trying a nested multi-dimensional tile plan.
+    split_count = _post_tile_validated_split_count(
+        op.get_name(), full_size, required_count, chunking_info, op.layout, max_cores
+    )
+
+    return SpanOverflowTilePlan(
+        selected_host_dim=selected_host_dim,
+        split_count=split_count,
+        is_reduction=False,
+        chunking_info=chunking_info,
+        reason=chunking_info.reason or "output span overflow",
+    )


### PR DESCRIPTION

## PR Description

Adds pointwise span-overflow hint analysis for automatic coarse tiling.

This introduces a planner that detects oversized pointwise `ComputedBuffer` ops whose physical Spyre layout can exceed the per-core span limit, computes a validated single-dimension coarse-tile split, and feeds that decision into the existing coarse-tiling path as synthetic `DimHint` groups.

User-authored `spyre_hint` coarse-tile groups still take precedence per operation. Automatic span-overflow groups are generated only for eligible unhinted pointwise ops, so mixed graphs can contain both manual hint groups and automatic span-overflow groups in the same `coarse_tile()` call.

Reference: Coarse tile span reduction [#2695](https://github.com/torch-spyre/torch-spyre/pull/2695)

## What Changed

### Added `span_overflow_hint_analysis.py`

- Plans automatic coarse tiling for `Pointwise` ops with `FixedTiledLayout`.
- Skips symbolic layout metadata because exact divisor selection and post-tile layout validation require concrete sizes.
- Selects the first outer-to-inner span-controlling physical dimension that maps to a splittable host/output dimension.
- Skips size-1 physical dimensions and the final within-stick dimension during selection.
- Prefers exact host-stride matches over stick-scaled matches for ambiguous layouts.
- Computes the required split count from per-core span and total tensor size.
- Uses `work_division.core_split` so analysis and work division use the same core-split estimate.
- Rounds the required split count to an exact divisor of the selected host dimension.
- Rejects candidates that would split through the physical stick dimension.
- Rebuilds the post-tile layout and validates that the selected split satisfies span and total-size limits.
- Raises `Unsupported` when the selected single-dimension tile plan cannot safely satisfy the hardware limits.

### Integrated automatic groups into coarse tiling

- `span_overflow_groups()` adapts planner output into the same group format used by user `spyre_hint`.
- Generated groups attach synthetic `DimHint`s to planned pointwise ops.
- Ops that already carry user `dim_hints` are skipped by the automatic path.
- `_maybe_coarse_tile()` combines user hint groups and automatic span-overflow groups, sorts them by graph order, and invokes `coarse_tile()`.
- `config.ignore_wsr_hints=True` suppresses both manual and automatic coarse tiling.
- `config.chunk_large_tensors=True` keeps the legacy chunking path in control by disabling automatic span-overflow groups.

### Added docs

- New compiler doc: `docs/source/compiler/span_overflow_hint_analysis.md`
- Covers entry point, pass integration, span formula, dimension selection, split-count selection, stick-alignment checks, post-tile validation, adapter flow, testing strategy, and current limitations.

### Added tests

- Planner-level tests for selected dimension and split count.
- Planner tests for symbolic layout skip.
- Planner tests for size-1 physical dimension skip.
- Planner tests for exact-stride match preference.
- Planner tests for rejecting unsafe stick-dimension splits.
- Planner tests for post-tile validation failure.
- Adapter tests for generated group structure and attached `DimHint`.
- Adapter tests for mixed manual-hint and automatic span-overflow grouping.
- Config tests for `chunk_large_tensors` and `ignore_wsr_hints`.
- Coarse-tile IR tests for rewritten ranges/layout and `CoarseTileInfo`.
- Scheduler/codegen tests for `LoopSpec` generation.
- Exact-shape unit contract for the E2E-style case:
  - `SENCORES=4`
  - shape `(1, 8195, 256, 64)`
  - expected split count `5`
  - expected per-tile shape `[1, 1639, 256, 64]`
- Auto-generated hints are compared against an equivalent manual `spyre_hint` path.

## Current Limitations

The first implementation is intentionally conservative.

- Symbolic layout metadata is skipped.
- The planner emits one coarse-tile level over one selected output/host dimension.
- If the selected dimension cannot be tiled safely, the pass raises `Unsupported`; it does not try another mapped dimension.
- Nested or multi-dimensional tile plans are not generated yet.
- Producer/consumer pointwise chains are not coalesced into one shared automatic group; `span_overflow_groups()` emits one group per planned op.
- Exact divisibility is required because current `coarse_tile` rewriting divides `op.data.ranges` and `op.layout.size` by the loop count.
- Non-stick-aligned tiling is rejected to avoid incorrect results or backend EAR overflow.
- Reduction output-range tiling and reduction-dimension tiling are not covered by this PR.
- `int8`, `int32`, `float8`, and unimplemented pointwise ops such as `logical_or` remain backend/codegen limitations, not span-overflow planner behavior.

## Future Work

- Try additional mapped dimensions when the first selected dimension cannot be tiled safely.
- Support nested or multi-dimensional coarse-tile plans.
- Coalesce dependent pointwise producer/consumer chains into a shared automatic coarse-tile group.
- Extend support to reductions with separate policy and validation.
- Add broader model-shape FVT coverage for supported pointwise cases.

**test logs **

```
(dt-inductor) hemaprasanna@hemaprasanna-torch-spyre:~/dt-inductor/torch-spyre$ PYTHONPATH=. python3 -m pytest -q tests/inductor/test_span_overflow_hint_analysis.py
.........................                                                                                          [100%]
==================================================== warnings summary ====================================================
tests/inductor/test_span_overflow_hint_analysis.py::TestSpanOverflowPointwiseCodegen::test_auto_span_overflow_matches_equivalent_spyre_hint_loop_spec
tests/inductor/test_span_overflow_hint_analysis.py::TestSpanOverflowPointwiseCodegen::test_auto_span_overflow_matches_equivalent_spyre_hint_loop_spec
tests/inductor/test_span_overflow_hint_analysis.py::TestSpanOverflowPointwiseCodegen::test_codegen_contains_auto_span_overflow_loop_spec
  /home/hemaprasanna/dt-inductor/.venv/lib64/python3.12/site-packages/torch/_dynamo/pgo.py:538: UserWarning: dynamo_pgo force disabled by torch.compiler.config.force_disable_caches
    warn_once(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
25 passed, 3 warnings in 7.92s

```