### PR TITLE
Move JobPlan test with symbols from xfail->skip

### DIFF
--- a/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
+++ b/tests/configs/torch_spyre_tests/test_launch_jobplan_config.yaml
@@ -2,13 +2,11 @@ test_suite_config:
   files:
     - path: ${TORCH_DEVICE_ROOT}/tests/test_launch_jobplan.py
       unlisted_test_mode: mandatory_success
-      # Marking xfail because RuntimeError: DtException: Constant cannot be a variable, 
-      # file /mnt/datadisk1/jenkins/workspace/Runtimes_x86_64_deeptools_master/util/VariableDefinition.cpp line 441
       tests:
         - names:
             - TestLaunchJobPlan::test_abs_matches_cpu_with_symbols
             - TestLaunchJobPlan::test_mul_matches_cpu_with_symbols
-          mode: xfail
+          mode: skip
           tags:
             - jobplan_symbolic_args
         - names:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [ ] cleanup

#### What this PR does:
This PR moves JobPlan tests with symbols from xfail->skip to unblock CI. These previously crashed in deeptools, but now run and put the stream in an error state. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
