### PR TITLE
fix: named dim propagation for permuted intermediate inputs; add test suite

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -184,6 +184,8 @@ jobs:
             config: torch_spyre_tests/inductor/test_padding_config.yaml
           - name: Inductor Overwrite
             config: torch_spyre_tests/inductor/test_overwrite.yaml
+          - name: Inductor Propagate Named Dims
+            config: torch_spyre_tests/inductor/test_propagate_named_dims_config.yaml
           - name: Inductor Restickify
             config: torch_spyre_tests/inductor/test_restickify_config.yaml
           - name: Inductor Scratchpad Patterns

--- a/tests/configs/torch_spyre_tests/inductor/test_propagate_named_dims_config.yaml
+++ b/tests/configs/torch_spyre_tests/inductor/test_propagate_named_dims_config.yaml
@@ -1,0 +1,4 @@
+test_suite_config:
+  files:
+    - path: ${TORCH_DEVICE_ROOT}/tests/inductor/test_propagate_named_dims.py
+      unlisted_test_mode: mandatory_success

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -676,3 +676,75 @@ def test_reshape_1d_to_2d_exp():
             declarations={"A": _A},
             annotations={x: ["A"]},
         )
+
+
+# -------- Stride-0 broadcast (torch.expand) tests --------
+
+
+def test_broadcast_expand_leading_dim():
+    """Broadcast annotation not yet supported: [1,N] annotated ["M","N"] produces _untracked_.
+
+    The size-1 leading dim is skipped; _consume_names(["M","N"], 128) fails because
+    "M"=64 is at the front of remaining. Both loop vars fall back to _untracked_.
+    See broadcast_named_dims_fix.txt for the full fix.
+    """
+    x = torch.randn(1, _N, dtype=torch.float16, device=DEVICE)
+    y = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a, b):
+        return a.expand(_M, _N) + b
+
+    result = _run_and_capture(
+        fn,
+        [x, y],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["_untracked_64", "_untracked_128"], f"got {result}"
+
+
+def test_broadcast_expand_trailing_dims():
+    """Broadcast annotation not yet supported: [M,1] annotated ["M","N"] produces _untracked_.
+
+    The M dim is assigned correctly; the trailing size-1 dim is skipped and "N"
+    remains in remaining. Inductor elides the N loop var from dep.ranges entirely
+    so it is never found. Falls back to _untracked_ for N.
+    See broadcast_named_dims_fix.txt for the full fix.
+    """
+    x = torch.randn(_M, 1, dtype=torch.float16, device=DEVICE)
+    y = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a, b):
+        return a.expand(_M, _N) + b
+
+    result = _run_and_capture(
+        fn,
+        [x, y],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["M", "_untracked_128"], f"got {result}"
+
+
+def test_broadcast_expand_middle_dim():
+    """Broadcast annotation not yet supported: [B,1,D] annotated ["B","H","D"] mis-maps.
+
+    B is assigned correctly; the middle size-1 dim is skipped and "H" stays in
+    remaining. _consume_names(["H","D"], D2=64) fails because "H"=32 is at the
+    front. D falls back to _untracked_ as well.
+    See broadcast_named_dims_fix.txt for the full fix.
+    """
+    _B2, _H2, _D2 = 4, 32, 64
+    x = torch.randn(_B2, 1, _D2, dtype=torch.float16, device=DEVICE)
+    y = torch.randn(_B2, _H2, _D2, dtype=torch.float16, device=DEVICE)
+
+    def fn(a, b):
+        return a.expand(_B2, _H2, _D2) + b
+
+    result = _run_and_capture(
+        fn,
+        [x, y],
+        declarations={"B2": _B2, "H2": _H2, "D2": _D2},
+        annotations={x: ["B2", "H2", "D2"]},
+    )
+    assert result == ["B2", "_untracked_32", "_untracked_64"], f"got {result}"

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -243,7 +243,7 @@ def test_2d_transposed_reduce_on_N():
     assert result == ["M"], f"got {result}"
 
 
-# -------- Tests --------
+# -------- 4-D attention-shaped tests --------
 
 
 def test_no_permute():
@@ -281,7 +281,7 @@ def test_permute_then_contiguous():
 
 
 def test_permute_no_contiguous():
-    """Same as test_permute_no_contiguous but scale passed as function argument."""
+    """Permuted input [B, Lq, H, D] -> permute(0,2,1,3) * scale, no contiguous."""
     queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
     scale = 1.0 / math.sqrt(D)
 
@@ -502,7 +502,7 @@ def test_permute_mul_equal_dims():
     assert result == ["B", "L", "L", "D"], f"got {result}"
 
 
-# -------- Equal-size dim variants with distinct names (expected to fail) --------
+# -------- Equal-size dims with distinct names --------
 
 
 def test_permute_matmul_equal_lqlk_distinct_names():

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -486,6 +486,8 @@ def test_broadcast_unsqueeze_mul():
 
     amax forces c_reduced to materialize as a ComputedBuffer. Without the fix,
     zeroing the missing D sym inflates strides by D=128, mapping H to the wrong loop var.
+
+    x is left unannotated to exercise the untracked fallback path.
     """
     x = torch.randn(B, H, Lq, D, dtype=torch.float16, device=DEVICE)
     c = torch.randn(B, H, Lk, D, dtype=torch.float16, device=DEVICE)

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -576,6 +576,35 @@ def test_permuted_intermediate_then_reduce():
     assert result == ["B", "H", "Lq"], f"got {result}"
 
 
+def test_permuted_intermediate_then_pointwise():
+    """Permuted ComputedBuffer fed into a second Pointwise op (no contiguous between).
+
+    q [B, Lq, H, D] -> (q * scale).permute(0,2,1,3) -> exp() -> intermediate [B,H,Lq,D]
+    -> * bias -> output [B, H, Lq, D]
+
+    The exp() intermediate is a ComputedBuffer with non-contiguous (permuted) strides.
+    dep.index for that buffer has the same free symbols as write_dep.index but different
+    strides. The missing_syms check correctly uses write_dep.index; the simpler == check
+    would also use write_dep.index here. This test validates the permuted-intermediate
+    case that originally motivated write_dep.index substitution.
+    """
+    q = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    bias = torch.randn(B, H, Lq, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q, bias):
+        inter = (q * scale).permute(0, 2, 1, 3).exp()
+        return inter * bias
+
+    result = _run_and_capture(
+        fn,
+        [q, bias],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={q: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
 def test_view_reshape_a_distinct_names():
     """Like test_view_reshape_a but with distinct names A/D for the equal-size dims."""
     a, b, c, d, e = 2, 3, 4, 2, 64

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -1,0 +1,526 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for propagate_named_dims — the pass that annotates each op's output
+# with semantic named dim labels (B, H, Lq, etc.) by propagating them from
+# annotated graph inputs through the op graph.
+#
+# Each test compiles a small function, intercepts the pass via patching, and
+# asserts that the graph output buffer carries the expected named dims.
+# No coarse tiling hints are used — these tests cover propagation only.
+
+import math
+
+import torch
+from torch._inductor.ir import ComputedBuffer
+from unittest.mock import patch
+
+import torch_spyre._inductor.passes as _passes
+import torch_spyre._inductor.propagate_named_dims as _pnd
+from utils_inductor import _compile_and_run
+
+DEVICE = torch.device("spyre")
+
+# Dim sizes shared by the attention-shaped tests.
+B, H, Lq, Lk, D = 12, 32, 256, 256, 128
+
+
+# -------- Helper --------
+
+
+def _run_and_capture(fn, args, declarations, annotations):
+    """Declare dims, annotate device tensors, compile, return output named dims.
+
+    args must be device tensors — the pass matches annotations via object identity
+    against V.get_real_inputs(), which are the runtime device tensors.
+    _compile_and_run's .to(device) is a no-op for already-on-device tensors.
+    """
+    for name, size in declarations.items():
+        _pnd.declare_tensor_dim(name, size)
+    for tensor, dims in annotations.items():
+        _pnd.name_tensor_dims(tensor, dims)
+
+    captured = {}
+    real_fn = _passes.propagate_named_dims
+
+    def capturing_propagate(graph):
+        real_fn(graph)
+        # _dim_prop_info is set by propagate_named_dims and deleted by
+        # assign_dim_hints (the next pass). Capture the output dims here,
+        # in the window between the two passes.
+        output_names = set(graph.get_output_names())
+        output_ops = [
+            op
+            for op in graph.operations
+            if isinstance(op, ComputedBuffer)
+            and op.get_name() in output_names
+            and hasattr(op, "_dim_prop_info")
+        ]
+        if output_ops:
+            captured["named_dims"] = list(output_ops[-1]._dim_prop_info.named_dims)
+
+    with patch.object(_passes, "propagate_named_dims", capturing_propagate):
+        _compile_and_run(fn, args, DEVICE)
+
+    return captured.get("named_dims", [])
+
+
+# -------- Basic 2-D tests --------
+
+_M, _N = 64, 128
+
+
+def test_2d_add():
+    """2-D pointwise add of two [M,N] tensors; output dims match."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+    y = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a, b):
+        return a + b
+
+    result = _run_and_capture(
+        fn,
+        [x, y],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"], y: ["M", "N"]},
+    )
+    assert result == ["M", "N"], f"got {result}"
+
+
+def test_2d_add_transposed():
+    """2-D pointwise add where one input is transposed: [M,N] + [N,M].t()."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+    y = torch.randn(_N, _M, dtype=torch.float16, device=DEVICE)
+
+    def fn(a, b):
+        return a + b.t()
+
+    result = _run_and_capture(
+        fn,
+        [x, y],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"], y: ["N", "M"]},
+    )
+    assert result == ["M", "N"], f"got {result}"
+
+
+def test_2d_reduce_on_M():
+    """2-D sum reduction over M: [M,N] -> [N]."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.sum(dim=0)
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["N"], f"got {result}"
+
+
+def test_2d_reduce_on_N():
+    """2-D sum reduction over N: [M,N] -> [M]."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.sum(dim=1)
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["M"], f"got {result}"
+
+
+def test_2d_transposed_reduce_on_M():
+    """Transpose [N,M] -> [M,N], then reduce over M: output [N]."""
+    x = torch.randn(_N, _M, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.t().sum(dim=0)
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["N", "M"]},
+    )
+    assert result == ["N"], f"got {result}"
+
+
+def test_2d_transposed_reduce_on_N():
+    """Transpose [N,M] -> [M,N], then reduce over N: output [M]."""
+    x = torch.randn(_N, _M, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.t().sum(dim=1)
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["N", "M"]},
+    )
+    assert result == ["M"], f"got {result}"
+
+
+# -------- Tests --------
+
+
+def test_no_permute():
+    """Baseline: input already in [B, H, Lq, D] order, output dims match."""
+    queries = torch.randn(B, H, Lq, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q):
+        return (q * scale).contiguous()
+
+    result = _run_and_capture(
+        fn,
+        [queries],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={queries: ["B", "H", "Lq", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
+def test_permute_then_contiguous():
+    """Permuted input [B, Lq, H, D] -> permute(0,2,1,3) * scale -> contiguous."""
+    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q):
+        return (q.permute(0, 2, 1, 3) * scale).contiguous()
+
+    result = _run_and_capture(
+        fn,
+        [queries],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={queries: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
+def test_permute_no_contiguous():
+    """Permuted input [B, Lq, H, D] -> permute(0,2,1,3) * scale, no clone."""
+    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q):
+        return q.permute(0, 2, 1, 3) * scale
+
+    result = _run_and_capture(
+        fn,
+        [queries],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={queries: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
+def test_permute_no_contiguous_scale_arg():
+    """Same as test_permute_no_contiguous but scale passed as function argument."""
+    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q, s):
+        return q.permute(0, 2, 1, 3) * s
+
+    result = _run_and_capture(
+        fn,
+        [queries, scale],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={queries: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
+def test_contiguous_then_mul():
+    """contiguous before multiply: permute -> contiguous -> * scale."""
+    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q):
+        return q.permute(0, 2, 1, 3).contiguous() * scale
+
+    result = _run_and_capture(
+        fn,
+        [queries],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={queries: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
+def test_permute_matmul():
+    """Two permuted inputs into matmul; checks reduction dim propagation.
+
+    queries [B, L, H, D] -> permute -> [B, H, L, D]
+    keys    [B, L, H, D] -> permute -> [B, H, D, L]
+    output  matmul -> [B, H, L, L]
+
+    # Original used separate Lq/Lk names with Lq==Lk==256, which requires
+    # stride-based disambiguation that is not yet implemented.
+    # declarations={"B": B, "H": H, "Lq": Lq, "Lk": Lk, "D": D}
+    # annotations={queries: ["B", "Lq", "H", "D"], keys: ["B", "Lk", "H", "D"]}
+    # assert result == ["B", "H", "Lq", "Lk"]
+    """
+    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    keys = torch.randn(B, Lk, H, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q, k):
+        q_perm = q.permute(0, 2, 1, 3) * scale
+        k_perm = k.permute(0, 2, 3, 1) * scale
+        return torch.matmul(q_perm, k_perm)
+
+    result = _run_and_capture(
+        fn,
+        [queries, keys],
+        declarations={"B": B, "H": H, "L": Lq, "D": D},
+        annotations={
+            queries: ["B", "L", "H", "D"],
+            keys: ["B", "L", "H", "D"],
+        },
+    )
+    assert result == ["B", "H", "L", "L"], f"got {result}"
+
+
+def test_view_reshape_a():
+    """View/reshape with shared name for equal-size dims (A==D, both called AD).
+
+    Dims of size 2 share one name AD; all other dims are distinct.
+    w, x: [1, AD, B*AD*E] annotated ["AD", "B", "AD", "E"]
+    y:    [1, AD, C, AD, E] annotated ["AD", "C", "AD", "E"]
+    z:    [1, AD, C, 1, 1, 1] annotated ["AD", "C"]
+    output shape: [1, AD, C, B, AD, E]
+
+    # Original used separate names A and D both of size 2, which requires
+    # stride-based disambiguation not yet implemented.
+    # a, b, c, d, e = 2, 3, 4, 2, 64
+    # declarations={"A": a, "B": b, "C": c, "D": d, "E": e}
+    # annotations={w: ["A","B","D","E"], x: ["A","B","D","E"],
+    #              y: ["A","C","D","E"], z: ["A","C"]}
+    # assert result == ["A", "C", "B", "D", "E"]
+    """
+    ad, b, c, e = 2, 3, 4, 64
+    w = torch.randn(1, ad, b * ad * e, dtype=torch.float16, device=DEVICE) * 0.1
+    x = torch.randn(1, ad, b * ad * e, dtype=torch.float16, device=DEVICE) * 0.1
+    y = torch.randn(1, ad, c, ad, e, dtype=torch.float16, device=DEVICE) * 0.1
+    z = torch.randn(1, ad, c, 1, 1, 1, dtype=torch.float16, device=DEVICE) * 0.1
+
+    def fn(w, x, y, z):
+        t = w + x
+        t = t.view(1, ad, b, ad, e)
+        t = t.unsqueeze(2) + y.unsqueeze(3)
+        return t + z
+
+    result = _run_and_capture(
+        fn,
+        [w, x, y, z],
+        declarations={"AD": ad, "B": b, "C": c, "E": e},
+        annotations={
+            w: ["AD", "B", "AD", "E"],
+            x: ["AD", "B", "AD", "E"],
+            y: ["AD", "C", "AD", "E"],
+            z: ["AD", "C"],
+        },
+    )
+    assert result == ["AD", "C", "B", "AD", "E"], f"got {result}"
+
+
+def test_view_reshape_b():
+    """View/reshape with all unique dim sizes.
+
+    w, x: [1, A, B*D*E] annotated ["A", "B", "D", "E"]
+    y:    [1, A, C, D, E] annotated ["A", "C", "D", "E"]
+    z:    [1, A, C, 1, 1, 1] annotated ["A", "C"]
+    output shape: [1, A, C, B, D, E]
+    """
+    a, b, c, d, e = 2, 3, 4, 5, 64
+    w = torch.randn(1, a, b * d * e, dtype=torch.float16, device=DEVICE) * 0.1
+    x = torch.randn(1, a, b * d * e, dtype=torch.float16, device=DEVICE) * 0.1
+    y = torch.randn(1, a, c, d, e, dtype=torch.float16, device=DEVICE) * 0.1
+    z = torch.randn(1, a, c, 1, 1, 1, dtype=torch.float16, device=DEVICE) * 0.1
+
+    def fn(w, x, y, z):
+        t = w + x
+        t = t.view(1, a, b, d, e)
+        t = t.unsqueeze(2) + y.unsqueeze(3)
+        return t + z
+
+    result = _run_and_capture(
+        fn,
+        [w, x, y, z],
+        declarations={"A": a, "B": b, "C": c, "D": d, "E": e},
+        annotations={
+            w: ["A", "B", "D", "E"],
+            x: ["A", "B", "D", "E"],
+            y: ["A", "C", "D", "E"],
+            z: ["A", "C"],
+        },
+    )
+    assert result == ["A", "C", "B", "D", "E"], f"got {result}"
+
+
+def test_permute_exp():
+    """Permute + exp — no constant, split_multi_ops does not fire, passes cleanly.
+
+    queries [B, Lq, H, D] -> permute(0,2,1,3) -> exp()
+    Loop vars stay in input stride order; propagation works correctly.
+    """
+    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+
+    def fn(q):
+        return q.permute(0, 2, 1, 3).exp()
+
+    result = _run_and_capture(
+        fn,
+        [queries],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={queries: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
+def test_permute_matmul_distinct_lqlk():
+    """Two permuted inputs into matmul with Lq != Lk; passes with distinct sizes.
+
+    queries [B, Lq, H, D] -> permute -> [B, H, Lq, D]
+    keys    [B, Lk, H, D] -> permute -> [B, H, D, Lk]
+    output  matmul -> [B, H, Lq, Lk]
+    """
+    _B, _H, _Lq, _Lk, _D = 2, 4, 16, 32, 64
+    queries = torch.randn(_B, _Lq, _H, _D, dtype=torch.float16, device=DEVICE)
+    keys = torch.randn(_B, _Lk, _H, _D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(_D)
+
+    def fn(q, k):
+        q_perm = q.permute(0, 2, 1, 3) * scale
+        k_perm = k.permute(0, 2, 3, 1) * scale
+        return torch.matmul(q_perm, k_perm)
+
+    result = _run_and_capture(
+        fn,
+        [queries, keys],
+        declarations={"B": _B, "H": _H, "Lq": _Lq, "Lk": _Lk, "D": _D},
+        annotations={
+            queries: ["B", "Lq", "H", "D"],
+            keys: ["B", "Lk", "H", "D"],
+        },
+    )
+    assert result == ["B", "H", "Lq", "Lk"], f"got {result}"
+
+
+def test_permute_mul_equal_dims():
+    """Permute + constant multiply where the two middle dims share the same size.
+
+    Declared as one name "L" since both dims have the same value — stride-based
+    disambiguation of two distinct names with equal sizes is not yet implemented.
+
+    queries [B, L, L, D] -> permute(0,2,1,3) * 0.5 -> [B, L, L, D]
+
+    # Original intent: distinguish H from Lq even when H==Lq==16.
+    # declarations={"B": _B, "H": _H, "Lq": _Lq, "D": _D}
+    # annotations={queries: ["B", "Lq", "H", "D"]}
+    # assert result == ["B", "H", "Lq", "D"]
+    """
+    _B, _L, _D = 2, 16, 64
+    queries = torch.randn(_B, _L, _L, _D, dtype=torch.float16, device=DEVICE)
+
+    def fn(q):
+        return q.permute(0, 2, 1, 3) * 0.5
+
+    result = _run_and_capture(
+        fn,
+        [queries],
+        declarations={"B": _B, "L": _L, "D": _D},
+        annotations={queries: ["B", "L", "L", "D"]},
+    )
+    assert result == ["B", "L", "L", "D"], f"got {result}"
+
+
+# -------- Equal-size dim variants with distinct names (expected to fail) --------
+
+
+def test_permute_matmul_equal_lqlk_distinct_names():
+    """Like test_permute_matmul but with distinct names Lq/Lk for the equal dims."""
+    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    keys = torch.randn(B, Lk, H, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q, k):
+        q_perm = q.permute(0, 2, 1, 3) * scale
+        k_perm = k.permute(0, 2, 3, 1) * scale
+        return torch.matmul(q_perm, k_perm)
+
+    result = _run_and_capture(
+        fn,
+        [queries, keys],
+        declarations={"B": B, "H": H, "Lq": Lq, "Lk": Lk, "D": D},
+        annotations={
+            queries: ["B", "Lq", "H", "D"],
+            keys: ["B", "Lk", "H", "D"],
+        },
+    )
+    assert result == ["B", "H", "Lq", "Lk"], f"got {result}"
+
+
+def test_view_reshape_a_distinct_names():
+    """Like test_view_reshape_a but with distinct names A/D for the equal-size dims."""
+    a, b, c, d, e = 2, 3, 4, 2, 64
+    w = torch.randn(1, a, b * d * e, dtype=torch.float16, device=DEVICE) * 0.1
+    x = torch.randn(1, a, b * d * e, dtype=torch.float16, device=DEVICE) * 0.1
+    y = torch.randn(1, a, c, d, e, dtype=torch.float16, device=DEVICE) * 0.1
+    z = torch.randn(1, a, c, 1, 1, 1, dtype=torch.float16, device=DEVICE) * 0.1
+
+    def fn(w, x, y, z):
+        t = w + x
+        t = t.view(1, a, b, d, e)
+        t = t.unsqueeze(2) + y.unsqueeze(3)
+        return t + z
+
+    result = _run_and_capture(
+        fn,
+        [w, x, y, z],
+        declarations={"A": a, "B": b, "C": c, "D": d, "E": e},
+        annotations={
+            w: ["A", "B", "D", "E"],
+            x: ["A", "B", "D", "E"],
+            y: ["A", "C", "D", "E"],
+            z: ["A", "C"],
+        },
+    )
+    assert result == ["A", "C", "B", "D", "E"], f"got {result}"
+
+
+def test_permute_mul_equal_dims_distinct_names():
+    """Like test_permute_mul_equal_dims but with distinct names H/Lq for equal dims."""
+    _B, _H, _Lq, _D = 2, 16, 16, 64
+    queries = torch.randn(_B, _Lq, _H, _D, dtype=torch.float16, device=DEVICE)
+
+    def fn(q):
+        return q.permute(0, 2, 1, 3) * 0.5
+
+    result = _run_and_capture(
+        fn,
+        [queries],
+        declarations={"B": _B, "H": _H, "Lq": _Lq, "D": _D},
+        annotations={queries: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq", "D"], f"got {result}"

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -477,15 +477,7 @@ def test_permute_matmul_distinct_lqlk():
 def test_permute_mul_equal_dims():
     """Permute + constant multiply where the two middle dims share the same size.
 
-    Declared as one name "L" since both dims have the same value — stride-based
-    disambiguation of two distinct names with equal sizes is not yet implemented.
-
     queries [B, L, L, D] -> permute(0,2,1,3) * 0.5 -> [B, L, L, D]
-
-    # Original intent: distinguish H from Lq even when H==Lq==16.
-    # declarations={"B": _B, "H": _H, "Lq": _Lq, "D": _D}
-    # annotations={queries: ["B", "Lq", "H", "D"]}
-    # assert result == ["B", "H", "Lq", "D"]
     """
     _B, _L, _D = 2, 16, 64
     queries = torch.randn(_B, _L, _L, _D, dtype=torch.float16, device=DEVICE)
@@ -523,7 +515,7 @@ def test_broadcast_unsqueeze_mul():
             c: ["B", "H", "Lk", "D"],
         },
     )
-    assert result[0] == "B" and result[1] == "H" and result[2] == "Lk", f"got {result}"
+    assert result == ["B", "H", "Lk", "_untracked_128"], f"got {result}"
 
 
 # -------- Equal-size dims with distinct names --------

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -22,6 +22,7 @@
 
 import math
 
+import pytest
 import torch
 from torch._inductor.ir import ComputedBuffer
 from unittest.mock import patch
@@ -320,12 +321,6 @@ def test_permute_matmul():
     queries [B, L, H, D] -> permute -> [B, H, L, D]
     keys    [B, L, H, D] -> permute -> [B, H, D, L]
     output  matmul -> [B, H, L, L]
-
-    # Original used separate Lq/Lk names with Lq==Lk==256, which requires
-    # stride-based disambiguation that is not yet implemented.
-    # declarations={"B": B, "H": H, "Lq": Lq, "Lk": Lk, "D": D}
-    # annotations={queries: ["B", "Lq", "H", "D"], keys: ["B", "Lk", "H", "D"]}
-    # assert result == ["B", "H", "Lq", "Lk"]
     """
     queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
     keys = torch.randn(B, Lk, H, D, dtype=torch.float16, device=DEVICE)
@@ -356,14 +351,6 @@ def test_view_reshape_a():
     y:    [1, AD, C, AD, E] annotated ["AD", "C", "AD", "E"]
     z:    [1, AD, C, 1, 1, 1] annotated ["AD", "C"]
     output shape: [1, AD, C, B, AD, E]
-
-    # Original used separate names A and D both of size 2, which requires
-    # stride-based disambiguation not yet implemented.
-    # a, b, c, d, e = 2, 3, 4, 2, 64
-    # declarations={"A": a, "B": b, "C": c, "D": d, "E": e}
-    # annotations={w: ["A","B","D","E"], x: ["A","B","D","E"],
-    #              y: ["A","C","D","E"], z: ["A","C"]}
-    # assert result == ["A", "C", "B", "D", "E"]
     """
     ad, b, c, e = 2, 3, 4, 64
     w = torch.randn(1, ad, b * ad * e, dtype=torch.float16, device=DEVICE) * 0.1
@@ -669,3 +656,23 @@ def test_permute_mul_equal_dims_distinct_names():
         annotations={queries: ["B", "Lq", "H", "D"]},
     )
     assert result == ["B", "H", "Lq", "D"], f"got {result}"
+
+
+def test_reshape_1d_to_2d_exp():
+    """1-D tensor [4096] annotated ['A'] -> reshape(64,64) raises Unsupported.
+
+    A single named dim split by reshape cannot be propagated accurately.
+    """
+    _A = 4096
+    x = torch.randn(_A, dtype=torch.float16, device=DEVICE)
+
+    def fn(x):
+        return x.reshape(64, 64).exp()
+
+    with pytest.raises(Exception, match="reshape split a named dim"):
+        _run_and_capture(
+            fn,
+            [x],
+            declarations={"A": _A},
+            annotations={x: ["A"]},
+        )

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -147,6 +147,70 @@ def test_2d_reduce_on_N():
     assert result == ["M"], f"got {result}"
 
 
+def test_2d_reduce_on_M_contiguous_before():
+    """Contiguous before reduction: [M,N].contiguous().sum(dim=0) -> [N]."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.contiguous().sum(dim=0)
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["N"], f"got {result}"
+
+
+def test_2d_reduce_on_M_contiguous_after():
+    """Contiguous after reduction: [M,N].sum(dim=0).contiguous() -> [N]."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.sum(dim=0).contiguous()
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["N"], f"got {result}"
+
+
+def test_2d_reduce_on_N_contiguous_before():
+    """Contiguous before reduction: [M,N].contiguous().sum(dim=1) -> [M]."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.contiguous().sum(dim=1)
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["M"], f"got {result}"
+
+
+def test_2d_reduce_on_N_contiguous_after():
+    """Contiguous after reduction: [M,N].sum(dim=1).contiguous() -> [M]."""
+    x = torch.randn(_M, _N, dtype=torch.float16, device=DEVICE)
+
+    def fn(a):
+        return a.sum(dim=1).contiguous()
+
+    result = _run_and_capture(
+        fn,
+        [x],
+        declarations={"M": _M, "N": _N},
+        annotations={x: ["M", "N"]},
+    )
+    assert result == ["M"], f"got {result}"
+
+
 def test_2d_transposed_reduce_on_M():
     """Transpose [N,M] -> [M,N], then reduce over M: output [N]."""
     x = torch.randn(_N, _M, dtype=torch.float16, device=DEVICE)
@@ -217,23 +281,6 @@ def test_permute_then_contiguous():
 
 
 def test_permute_no_contiguous():
-    """Permuted input [B, Lq, H, D] -> permute(0,2,1,3) * scale, no clone."""
-    queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
-    scale = 1.0 / math.sqrt(D)
-
-    def fn(q):
-        return q.permute(0, 2, 1, 3) * scale
-
-    result = _run_and_capture(
-        fn,
-        [queries],
-        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
-        annotations={queries: ["B", "Lq", "H", "D"]},
-    )
-    assert result == ["B", "H", "Lq", "D"], f"got {result}"
-
-
-def test_permute_no_contiguous_scale_arg():
     """Same as test_permute_no_contiguous but scale passed as function argument."""
     queries = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
     scale = 1.0 / math.sqrt(D)
@@ -481,6 +528,30 @@ def test_permute_matmul_equal_lqlk_distinct_names():
     assert result == ["B", "H", "Lq", "Lk"], f"got {result}"
 
 
+def test_permuted_intermediate_then_reduce():
+    """Permuted intermediate buffer fed into a reduction.
+
+    q [B, Lq, H, D] -> (q * scale).permute(0,2,1,3) -> intermediate [B, H, Lq, D]
+    -> sum over D -> output [B, H, Lq]
+
+    Tests that compute_input_named_dims correctly handles a permuted ComputedBuffer
+    as input to a Reduction op.
+    """
+    q = torch.randn(B, Lq, H, D, dtype=torch.float16, device=DEVICE)
+    scale = 1.0 / math.sqrt(D)
+
+    def fn(q):
+        return (q * scale).permute(0, 2, 1, 3).sum(dim=-1)
+
+    result = _run_and_capture(
+        fn,
+        [q],
+        declarations={"B": B, "H": H, "Lq": Lq, "D": D},
+        annotations={q: ["B", "Lq", "H", "D"]},
+    )
+    assert result == ["B", "H", "Lq"], f"got {result}"
+
+
 def test_view_reshape_a_distinct_names():
     """Like test_view_reshape_a but with distinct names A/D for the equal-size dims."""
     a, b, c, d, e = 2, 3, 4, 2, 64
@@ -507,6 +578,35 @@ def test_view_reshape_a_distinct_names():
         },
     )
     assert result == ["A", "C", "B", "D", "E"], f"got {result}"
+
+
+def test_view_reshape_then_reduce():
+    """View/reshape intermediate fed into a Reduction.
+
+    w, x: [1, A, B*D*E] -> add -> view(1, A, B, D, E) -> sum(dim=-1) -> [1, A, B, D]
+
+    The view intermediate has fused dims in its layout (dep.index has multi-symbol
+    coords). Tests that compute_input_named_dims handles this correctly for Reduction.
+    """
+    a, b, d, e = 2, 3, 5, 64
+    w = torch.randn(1, a, b * d * e, dtype=torch.float16, device=DEVICE) * 0.1
+    x = torch.randn(1, a, b * d * e, dtype=torch.float16, device=DEVICE) * 0.1
+
+    def fn(w, x):
+        t = w + x
+        t = t.view(1, a, b, d, e)
+        return t.sum(dim=-1)
+
+    result = _run_and_capture(
+        fn,
+        [w, x],
+        declarations={"A": a, "B": b, "D": d, "E": e},
+        annotations={
+            w: ["A", "B", "D", "E"],
+            x: ["A", "B", "D", "E"],
+        },
+    )
+    assert result == ["A", "B", "D"], f"got {result}"
 
 
 def test_permute_mul_equal_dims_distinct_names():

--- a/tests/inductor/test_propagate_named_dims.py
+++ b/tests/inductor/test_propagate_named_dims.py
@@ -502,6 +502,30 @@ def test_permute_mul_equal_dims():
     assert result == ["B", "L", "L", "D"], f"got {result}"
 
 
+def test_broadcast_unsqueeze_mul():
+    """Regression: broadcast intermediate must not use write-dep index substitution.
+
+    amax forces c_reduced to materialize as a ComputedBuffer. Without the fix,
+    zeroing the missing D sym inflates strides by D=128, mapping H to the wrong loop var.
+    """
+    x = torch.randn(B, H, Lq, D, dtype=torch.float16, device=DEVICE)
+    c = torch.randn(B, H, Lk, D, dtype=torch.float16, device=DEVICE)
+
+    def fn(a, c_full):
+        c_reduced = c_full.amax(dim=-1)  # [B,H,Lk,D] -> [B,H,Lk]
+        return c_reduced.unsqueeze(-1) * a
+
+    result = _run_and_capture(
+        fn,
+        [x, c],
+        declarations={"B": B, "H": H, "Lq": Lq, "Lk": Lk, "D": D},
+        annotations={
+            c: ["B", "H", "Lk", "D"],
+        },
+    )
+    assert result[0] == "B" and result[1] == "H" and result[2] == "Lk", f"got {result}"
+
+
 # -------- Equal-size dims with distinct names --------
 
 

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -757,7 +757,7 @@ def compute_layouts(
 
     # Log substituted device coordinates for indirect index args. Useful for
     # debugging gather/scatter layout propagation, and also the canonical
-    # example of how to call device_coordinates() with indirect_load_subs
+    # example of how to call device_coordinates() with indirect_access_subs
     # pre-scheduler (keeping indirect_access_subs_from_op exercised and visible).
     if logger.isEnabledFor(logging.DEBUG):
         indirect_index_names = indirect_index_dep_names(op)

--- a/torch_spyre/_inductor/propagate_layouts.py
+++ b/torch_spyre/_inductor/propagate_layouts.py
@@ -757,7 +757,7 @@ def compute_layouts(
 
     # Log substituted device coordinates for indirect index args. Useful for
     # debugging gather/scatter layout propagation, and also the canonical
-    # example of how to call device_coordinates() with indirect_access_subs
+    # example of how to call device_coordinates() with indirect_load_subs
     # pre-scheduler (keeping indirect_access_subs_from_op exercised and visible).
     if logger.isEnabledFor(logging.DEBUG):
         indirect_index_names = indirect_index_dep_names(op)

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -161,7 +161,7 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             # Skip: size-1 dims are not annotated.  Broadcast dims (e.g. a [1,N]
             # buffer annotated ["M","N"]) silently become _untracked_ — we cannot
             # raise here without breaking legitimate unannotated size-1 dims.
-            # See test_broadcast_expand_* 
+            # See test_broadcast_expand_*
             continue
         names = _consume_names(remaining, dim_size)
         if not names:

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -139,14 +139,17 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
     # For Pointwise intermediates, dep.index may use non-contiguous strides (e.g.
     # permute+contiguous), so use the write dep's index. Graph inputs and Reduction
     # inputs are already consistent with the iteration space.
+    # Exception: broadcast inputs (unsqueeze) have fewer free symbols than the write dep.
+    # Zeroing the missing syms inflates all remaining strides by the product of the missing
+    # dims, producing wrong coordinate mappings. Use dep.index directly in that case.
     is_intermediate = isinstance(_get_buffer(dep), ComputedBuffer)
     if is_intermediate and op is not None and isinstance(op.data, Pointwise):
         write_dep = next(iter(op.get_read_writes().writes))
-        read_syms = dep.index.free_symbols
-        # Zero out output-space syms absent from this input's read index.
-        index = write_dep.index.xreplace(
-            {s: sympy.S.Zero for s in write_dep.index.free_symbols - read_syms}
-        )
+        missing_syms = write_dep.index.free_symbols - dep.index.free_symbols
+        if missing_syms:
+            index = dep.index
+        else:
+            index = write_dep.index
     else:
         index = dep.index
     coords = compute_coordinates(named_size, named_stride, dep.ranges, index)

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -133,27 +133,19 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             sym: [_untracked_name(context, sym, int(size))]
             for sym, size in dep.ranges.items()
         }
-    named_size, named_stride = _compute_named_layout(buf_named_dims)
+    # Use the buffer's actual layout strides when available — they reflect the real
+    # storage order (including permuted views) and match dep.index directly.
+    # Fall back to _compute_named_layout only when layout is absent or rank-mismatched
+    # (e.g. view/reshape where the buffer has fewer storage dims than named dims).
+    buf = _get_buffer(dep)
+    layout = getattr(buf, "layout", None)
+    if layout is not None and len(layout.size) == len(buf_named_dims):
+        named_size = [int(s) for s in layout.size]
+        named_stride = [int(s) for s in layout.stride]
+    else:
+        named_size, named_stride = _compute_named_layout(buf_named_dims)
 
-    # compute_coordinates needs an index whose strides match named_stride (contiguous
-    # storage order). dep.index uses the buffer's actual storage strides — correct when
-    # the buffer is contiguous, but wrong when it's non-contiguous (e.g. permuted).
-    # For Pointwise intermediates, use write_dep.index (contiguous output-space strides)
-    # unless the input has fewer symbols than the output (broadcast/unsqueeze): zeroing
-    # the missing syms inflates all remaining strides by the product of the missing dims.
-    # dep has *more* symbols than write_dep when an extra reduction dim leaks into the
-    # read index — use write_dep.index there too (missing_syms tracks write→dep gap only).
-    index = dep.index
-    if (
-        isinstance(_get_buffer(dep), ComputedBuffer)
-        and op is not None
-        and isinstance(op.data, Pointwise)
-    ):
-        write_dep = next(iter(op.get_read_writes().writes))
-        missing_syms = write_dep.index.free_symbols - dep.index.free_symbols
-        if not missing_syms:
-            index = write_dep.index
-    coords = compute_coordinates(named_size, named_stride, dep.ranges, index)
+    coords = compute_coordinates(named_size, named_stride, dep.ranges, dep.index)
     result: dict[sympy.Symbol, list[str]] = {}
     for i, coord in enumerate(coords):
         sym = _lone_sym(coord)

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -41,7 +41,6 @@ from .pass_utils import (
 )
 from .ir import SpyreConstantFallback
 from .propagate_hints import DimHint, get_op_hints
-from .views import compute_coordinates
 from torch_spyre._C import SpyreTensorLayout
 from torch.utils.weak import WeakTensorKeyDictionary
 
@@ -80,6 +79,16 @@ def _get_buffer(dep):
     return V.graph.get_buffer(dep.name)
 
 
+def _get_layout(dep) -> "FixedLayout | None":
+    buf = _get_buffer(dep)
+    if buf is not None and hasattr(buf, "get_layout"):
+        return buf.get_layout()
+    tb = V.graph.graph_inputs.get(dep.name)
+    if tb is not None:
+        return tb.data.data.layout
+    return None
+
+
 def _get_dim_prop_info(dep):
     buf = _get_buffer(dep)
     if buf is not None:
@@ -104,67 +113,56 @@ def _untracked_name(context: str, sym, size: int) -> str:
     return name
 
 
-def _compute_named_layout(named_dims):
-    """Compute size and stride from declared named dim sizes."""
-    size = []
-    stride = [1]
-    for s in reversed(named_dims):
-        if s not in _named_dims:
-            raise KeyError(
-                f"Named dim '{s}' used in name_tensor_dims but not declared -- "
-                f"call declare_tensor_dim('{s}', size) before compiling"
-            )
-        stride.append(stride[-1] * _named_dims[s])
-        size.append(_named_dims[s])
-    return list(reversed(size)), list(reversed(stride[:-1]))
+def _consume_names(remaining: list[str], layout_size: int) -> list[str]:
+    """Return the prefix of remaining whose declared sizes multiply to layout_size."""
+    product = 1
+    for i, name in enumerate(remaining):
+        product *= _named_dims.get(name, 1)
+        if product == layout_size:
+            return remaining[: i + 1]
+    return []
 
 
 def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
-    """Map loop vars to named dim names for a single input dep, using named-space coords."""
+    """Map loop vars to named dim names for a single input dep."""
     dpi = _get_dim_prop_info(dep)
     buf_named_dims = dpi.named_dims if dpi is not None else None
     if not buf_named_dims:
-        # Scalar broadcast: constant index, contributes nothing to loop_var_dims
         if not dep.index.free_symbols:
             return {}
-        # Unannotated tensor: synthesize _untracked_ names from dep ranges
         context = f"{op.get_name()}/{dep.name}" if op is not None else dep.name
         return {
             sym: [_untracked_name(context, sym, int(size))]
             for sym, size in dep.ranges.items()
         }
-    # Use the buffer's actual layout strides when available — they reflect the real
-    # storage order (including permuted views) and match dep.index directly.
-    # Fall back to _compute_named_layout only when layout is absent or rank-mismatched
-    # (e.g. view/reshape where the buffer has fewer storage dims than named dims).
-    buf = _get_buffer(dep)
-    layout = getattr(buf, "layout", None)
-    if layout is not None and len(layout.size) == len(buf_named_dims):
-        named_size = [int(s) for s in layout.size]
-        named_stride = [int(s) for s in layout.stride]
-    else:
-        named_size, named_stride = _compute_named_layout(buf_named_dims)
-
-    coords = compute_coordinates(named_size, named_stride, dep.ranges, dep.index)
+    layout = _get_layout(dep)
+    if layout is None:
+        return {}
+    coords = host_coordinates(layout, dep)
+    remaining = list(buf_named_dims)
     result: dict[sympy.Symbol, list[str]] = {}
     for i, coord in enumerate(coords):
-        sym = _lone_sym(coord)
-        if sym is not None and sym in dep.ranges:
-            result.setdefault(sym, []).append(buf_named_dims[i])
-    return result
-
-
-def coords_to_named_dims(coords: list, loop_var_dims: dict) -> list:
-    """Map coordinate expressions to named dim names via their loop variable."""
-    result = []
-    for c in coords:
-        sym = _lone_sym(c)
-        if sym is not None:
-            assert sym in loop_var_dims, (
-                f"coords_to_named_dims: no mapping for loop var {sym} -- "
-                f"this is a bug in _compute_named_dims synthesis"
-            )
-            result.extend(loop_var_dims[sym])
+        if not remaining:
+            break
+        dim_size = int(layout.size[i])
+        if dim_size == 1:
+            continue
+        names = _consume_names(remaining, dim_size)
+        if not names:
+            break
+        remaining = remaining[len(names) :]
+        syms = sorted(
+            coord.free_symbols & dep.ranges.keys(),
+            key=lambda s: int(abs(coord.coeff(s))),
+            reverse=True,
+        )
+        if len(syms) == 1:
+            # One loop var covers all fused names (e.g. a flat [A, B*D*E] read)
+            result.setdefault(syms[0], []).extend(names)
+        else:
+            # Multi-symbol coord: match each sym to one name by coefficient order
+            for sym, name in zip(syms, names):
+                result.setdefault(sym, []).append(name)
     return result
 
 
@@ -214,16 +212,17 @@ def _set_no_named_dims(op):
 
 def _compute_named_dims(op, inputs):
     loop_var_dims = get_input_named_dims(inputs, op)
-    out_coords = op_out_coords(op)
-    # Synthesize names for loop vars not covered by any input.
-    # This handles full/zeros_like/constant ops whose iteration space defines
-    # named dims but whose constant value contributes nothing to loop_var_dims.
     output_dep = next(iter(op.get_read_writes().writes))
-    for coord in out_coords:
-        sym = _lone_sym(coord)
-        if sym is not None and sym not in loop_var_dims:
+    for sym in output_dep.ranges:
+        if sym not in loop_var_dims:
             size = int(output_dep.ranges[sym])
             loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
+    out_coords = op_out_coords(op)
+    named_dims = []
+    for coord in out_coords:
+        sym = _lone_sym(coord)
+        if sym is not None:
+            named_dims.extend(loop_var_dims.get(sym, []))
     reduction_named_dims = None
     if isinstance(op.data, Reduction):
         reduction_sym = find_reduction_var(inputs[0], output_dep)
@@ -233,7 +232,6 @@ def _compute_named_dims(op, inputs):
                 _untracked_name(op.get_name(), reduction_sym, size)
             ]
         reduction_named_dims = loop_var_dims[reduction_sym]
-    named_dims = coords_to_named_dims(out_coords, loop_var_dims)
     op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
         named_dims=named_dims,
         loop_var_dims=loop_var_dims,

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -143,7 +143,7 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
     if is_intermediate and op is not None and isinstance(op.data, Pointwise):
         write_dep = next(iter(op.get_read_writes().writes))
         read_syms = dep.index.free_symbols
-        # Zero out syms not in this input's read index (broadcast dims from other inputs).
+        # Zero out output-space syms absent from this input's read index.
         index = write_dep.index.xreplace(
             {s: sympy.S.Zero for s in write_dep.index.free_symbols - read_syms}
         )
@@ -205,11 +205,6 @@ def get_input_named_dims(inputs: list, op=None) -> dict:
     return loop_var_dims
 
 
-def get_reduction_dim(dep: MemoryDep, out_dep: MemoryDep) -> sympy.Symbol:
-    """Return the reduction loop variable: present in the input index but not the output."""
-    return find_reduction_var(dep, out_dep)
-
-
 @dataclasses.dataclass
 class _DimPropInfo:
     named_dims: list = dataclasses.field(default_factory=list)
@@ -235,7 +230,7 @@ def _compute_named_dims(op, inputs):
             loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
     reduction_named_dims = None
     if isinstance(op.data, Reduction):
-        reduction_sym = get_reduction_dim(inputs[0], output_dep)
+        reduction_sym = find_reduction_var(inputs[0], output_dep)
         if reduction_sym not in loop_var_dims:
             size = int(inputs[0].ranges[reduction_sym])
             loop_var_dims[reduction_sym] = [

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -128,24 +128,29 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             for sym, size in dep.ranges.items()
         }
     named_size, named_stride = _compute_named_layout(buf_named_dims)
-    coords = compute_coordinates(named_size, named_stride, dep.ranges, dep.index)
+    # For Pointwise ops the iteration space is the output (write dep), so use the
+    # write index — it and dep.ranges are both output-space and consistent.
+    # For Reduction the iteration space is the input (read dep), so use the read
+    # index — already consistent with dep.ranges.
+    is_pointwise = op is not None and isinstance(op.data, Pointwise)
+    if is_pointwise:
+        write_dep = next(iter(op.get_read_writes().writes))
+        # Restrict write index to syms that appear in this input's read index.
+        # The write index spans the full output space; syms absent from the read
+        # index belong to other inputs (broadcast dims) and must be zeroed out.
+        read_syms = dep.index.free_symbols
+        index = write_dep.index.xreplace(
+            {s: sympy.S.Zero for s in write_dep.index.free_symbols - read_syms}
+        )
+    else:
+        index = dep.index
+    coords = compute_coordinates(named_size, named_stride, dep.ranges, index)
     result: dict[sympy.Symbol, list[str]] = {}
     for i, coord in enumerate(coords):
         if coord.free_symbols:
             sym = _lone_sym(coord)
             if sym in dep.ranges:
                 result.setdefault(sym, []).append(buf_named_dims[i])
-    for sym, names in result.items():
-        actual_range = int(dep.ranges[sym])
-        product = 1
-        for n in names:
-            product *= _named_dims.get(n, actual_range)
-        if actual_range != product:
-            logger.warning(
-                f"{dep.name}: loop var {sym} has range {actual_range} "
-                f"but maps to {names} with product {product} -- partial/sliced dim, "
-                f"continuing using range {actual_range}"
-            )
     return result
 
 

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -84,7 +84,11 @@ def _get_layout(dep) -> "FixedLayout | None":
     if buf is not None and hasattr(buf, "get_layout"):
         return buf.get_layout()
     tb = V.graph.graph_inputs.get(dep.name)
-    if tb is not None:
+    if (
+        isinstance(tb, TensorBox)
+        and isinstance(tb.data, StorageBox)
+        and isinstance(tb.data.data, InputBuffer)
+    ):
         return tb.data.data.layout
     return None
 
@@ -154,7 +158,10 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             break
         dim_size = int(layout.size[i])
         if dim_size == 1:
-            # Size-1 dims carry no information and are not annotated by the user.
+            # Skip: size-1 dims are not annotated.  Broadcast dims (e.g. a [1,N]
+            # buffer annotated ["M","N"]) silently become _untracked_ — we cannot
+            # raise here without breaking legitimate unannotated size-1 dims.
+            # See test_broadcast_expand_* and broadcast_named_dims_fix.txt.
             continue
         names = _consume_names(remaining, dim_size)
         if not names:
@@ -177,6 +184,14 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
                 f"{dep.name}: layout dim {i} has {len(loop_vars)} loop vars but only "
                 f"{len(names)} name(s) {names} -- reshape split a named dim, "
                 f"re-annotate after the reshape"
+            )
+        elif len(loop_vars) < len(names):
+            # Fewer loop vars than names: a size-1 declared dim was fused into
+            # this layout dim and zip would silently drop the trailing name(s).
+            raise Unsupported(
+                f"{dep.name}: layout dim {i} has {len(loop_vars)} loop var(s) "
+                f"but {len(names)} name(s) {names} -- a declared size-1 name "
+                f"may be fused here; omit size-1 names from the annotation"
             )
         else:
             # Multi-loop-var coord: match each loop var to one name by coefficient order

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -33,7 +33,12 @@ from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
 from torch._inductor.virtualized import V
 from .errors import Unsupported
-from .pass_utils import host_coordinates, device_coordinates, op_out_coords, find_reduction_var
+from .pass_utils import (
+    host_coordinates,
+    device_coordinates,
+    op_out_coords,
+    find_reduction_var,
+)
 from .ir import SpyreConstantFallback
 from .propagate_hints import DimHint, get_op_hints
 from .views import compute_coordinates
@@ -129,7 +134,7 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             for sym, size in dep.ranges.items()
         }
     named_size, named_stride = _compute_named_layout(buf_named_dims)
-    
+
     # Pointwise loop vars come from the output (write dep); see iteration_space_from_op.
     # For Pointwise intermediates, dep.index may use non-contiguous strides (e.g.
     # permute+contiguous), so use the write dep's index. Graph inputs and Reduction
@@ -226,8 +231,8 @@ def _compute_named_dims(op, inputs):
     for coord in out_coords:
         sym = _lone_sym(coord)
         if sym is not None and sym not in loop_var_dims:
-                size = int(output_dep.ranges[sym])
-                loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
+            size = int(output_dep.ranges[sym])
+            loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
     reduction_named_dims = None
     if isinstance(op.data, Reduction):
         reduction_sym = get_reduction_dim(inputs[0], output_dep)
@@ -245,11 +250,7 @@ def _compute_named_dims(op, inputs):
     )
 
 
-def _log_dep_debug(
-    label: str, dep: MemoryDep
-) -> (
-    None
-):  
+def _log_dep_debug(label: str, dep: MemoryDep) -> None:
     buf = _get_buffer(dep)
     layout = (
         buf.get_layout() if buf is not None and hasattr(buf, "get_layout") else None

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -33,10 +33,10 @@ from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
 from torch._inductor.virtualized import V
 from .errors import Unsupported
-from .pass_utils import host_coordinates, device_coordinates, op_out_coords
+from .pass_utils import host_coordinates, device_coordinates, op_out_coords, find_reduction_var
 from .ir import SpyreConstantFallback
 from .propagate_hints import DimHint, get_op_hints
-from .views import matching_dim, compute_coordinates
+from .views import compute_coordinates
 from torch_spyre._C import SpyreTensorLayout
 from torch.utils.weak import WeakTensorKeyDictionary
 
@@ -85,8 +85,9 @@ def _get_dim_prop_info(dep):
     return getattr(tb, "_dim_prop_info", None) if tb is not None else None
 
 
-def _lone_sym(coord: sympy.Expr) -> sympy.Symbol:
-    return next(iter(coord.free_symbols))
+def _lone_sym(coord: sympy.Expr) -> sympy.Symbol | None:
+    syms = coord.free_symbols
+    return next(iter(syms)) if len(syms) == 1 else None
 
 
 def _untracked_name(context: str, sym, size: int) -> str:
@@ -128,17 +129,16 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             for sym, size in dep.ranges.items()
         }
     named_size, named_stride = _compute_named_layout(buf_named_dims)
-    # For Pointwise ops the iteration space is the output (write dep), so use the
-    # write index — it and dep.ranges are both output-space and consistent.
-    # For Reduction the iteration space is the input (read dep), so use the read
-    # index — already consistent with dep.ranges.
-    is_pointwise = op is not None and isinstance(op.data, Pointwise)
-    if is_pointwise:
+    
+    # Pointwise loop vars come from the output (write dep); see iteration_space_from_op.
+    # For Pointwise intermediates, dep.index may use non-contiguous strides (e.g.
+    # permute+contiguous), so use the write dep's index. Graph inputs and Reduction
+    # inputs are already consistent with the iteration space.
+    is_intermediate = isinstance(_get_buffer(dep), ComputedBuffer)
+    if is_intermediate and op is not None and isinstance(op.data, Pointwise):
         write_dep = next(iter(op.get_read_writes().writes))
-        # Restrict write index to syms that appear in this input's read index.
-        # The write index spans the full output space; syms absent from the read
-        # index belong to other inputs (broadcast dims) and must be zeroed out.
         read_syms = dep.index.free_symbols
+        # Zero out syms not in this input's read index (broadcast dims from other inputs).
         index = write_dep.index.xreplace(
             {s: sympy.S.Zero for s in write_dep.index.free_symbols - read_syms}
         )
@@ -147,10 +147,9 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
     coords = compute_coordinates(named_size, named_stride, dep.ranges, index)
     result: dict[sympy.Symbol, list[str]] = {}
     for i, coord in enumerate(coords):
-        if coord.free_symbols:
-            sym = _lone_sym(coord)
-            if sym in dep.ranges:
-                result.setdefault(sym, []).append(buf_named_dims[i])
+        sym = _lone_sym(coord)
+        if sym is not None and sym in dep.ranges:
+            result.setdefault(sym, []).append(buf_named_dims[i])
     return result
 
 
@@ -158,8 +157,8 @@ def coords_to_named_dims(coords: list, loop_var_dims: dict) -> list:
     """Map coordinate expressions to named dim names via their loop variable."""
     result = []
     for c in coords:
-        if c.free_symbols:
-            sym = _lone_sym(c)
+        sym = _lone_sym(c)
+        if sym is not None:
             assert sym in loop_var_dims, (
                 f"coords_to_named_dims: no mapping for loop var {sym} -- "
                 f"this is a bug in _compute_named_dims synthesis"
@@ -179,9 +178,10 @@ def named_dims_for_coord(
     op: ComputedBuffer, coord: sympy.Expr
 ) -> list[tuple[str, int]] | None:
     """Return [(name, size), ...] for the named dims covered by a host coord expression."""
-    if not coord.free_symbols:
+    sym = _lone_sym(coord)
+    if sym is None:
         return None
-    return named_dims_for_sym(op, _lone_sym(coord))
+    return named_dims_for_sym(op, sym)
 
 
 def get_input_named_dims(inputs: list, op=None) -> dict:
@@ -200,13 +200,9 @@ def get_input_named_dims(inputs: list, op=None) -> dict:
     return loop_var_dims
 
 
-def get_reduction_dim(dep: MemoryDep, out_coords: list) -> sympy.Symbol:
-    """Return the reduction loop variable: the input coord absent from the output."""
-    in_coords = host_coordinates(_get_buffer(dep).get_layout(), dep)
-    reduction_coord = next(
-        c for c in in_coords if c.free_symbols and matching_dim(out_coords, c) is None
-    )
-    return _lone_sym(reduction_coord)
+def get_reduction_dim(dep: MemoryDep, out_dep: MemoryDep) -> sympy.Symbol:
+    """Return the reduction loop variable: present in the input index but not the output."""
+    return find_reduction_var(dep, out_dep)
 
 
 @dataclasses.dataclass
@@ -228,14 +224,13 @@ def _compute_named_dims(op, inputs):
     # named dims but whose constant value contributes nothing to loop_var_dims.
     output_dep = next(iter(op.get_read_writes().writes))
     for coord in out_coords:
-        if coord.free_symbols:
-            sym = _lone_sym(coord)
-            if sym not in loop_var_dims:
+        sym = _lone_sym(coord)
+        if sym is not None and sym not in loop_var_dims:
                 size = int(output_dep.ranges[sym])
                 loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
     reduction_named_dims = None
     if isinstance(op.data, Reduction):
-        reduction_sym = get_reduction_dim(inputs[0], out_coords)
+        reduction_sym = get_reduction_dim(inputs[0], output_dep)
         if reduction_sym not in loop_var_dims:
             size = int(inputs[0].ranges[reduction_sym])
             loop_var_dims[reduction_sym] = [
@@ -254,7 +249,7 @@ def _log_dep_debug(
     label: str, dep: MemoryDep
 ) -> (
     None
-):  # TODO: thread indirect_load_subs to show IndirectAccess in device_coordinates
+):  
     buf = _get_buffer(dep)
     layout = (
         buf.get_layout() if buf is not None and hasattr(buf, "get_layout") else None
@@ -369,9 +364,9 @@ def _propagate_named_dims_impl(graph: GraphLowering) -> None:
             if hint:
                 coords = op_out_coords(op)
                 loop_var_dims = {
-                    _lone_sym(coord): [dim_name]
+                    sym: [dim_name]
                     for coord, dim_name in zip(coords, named_dims)
-                    if len(coord.free_symbols) == 1
+                    if (sym := _lone_sym(coord)) is not None
                 }
                 op._dim_prop_info = _DimPropInfo(  # type: ignore[attr-defined]
                     named_dims=named_dims,
@@ -460,9 +455,9 @@ def _assign_dim_hints_impl(operations: list[Operation]) -> None:
 
         coord_for_name: dict[str, sympy.Symbol] = {}
         for coord in op_out_coords(op):
-            if not coord.free_symbols:
-                continue
             sym = _lone_sym(coord)
+            if sym is None:
+                continue
             for name, _ in named_dims_for_sym(op, sym):
                 coord_for_name[name] = sym
         # Also map reduction dim names to their loop variable.  Reduction dims

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -117,7 +117,12 @@ def _consume_names(remaining: list[str], layout_size: int) -> list[str]:
     """Return the prefix of remaining whose declared sizes multiply to layout_size."""
     product = 1
     for i, name in enumerate(remaining):
-        product *= _named_dims.get(name, 1)
+        if name not in _named_dims:
+            raise KeyError(
+                f"Named dim '{name}' used in name_tensor_dims but not declared -- "
+                f"call declare_tensor_dim('{name}', size) before compiling"
+            )
+        product *= _named_dims[name]
         if product == layout_size:
             return remaining[: i + 1]
     logger.warning(
@@ -149,23 +154,34 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             break
         dim_size = int(layout.size[i])
         if dim_size == 1:
+            # Size-1 dims carry no information and are not annotated by the user.
             continue
         names = _consume_names(remaining, dim_size)
         if not names:
             break
         remaining = remaining[len(names) :]
-        syms = sorted(
+        # Loop vars for this layout dim: symbols in the coord that are also
+        # loop variables of this dep (dep.ranges.keys()), sorted by coefficient
+        # descending so the outermost (largest-stride) var comes first.
+        loop_vars = sorted(
             coord.free_symbols & dep.ranges.keys(),
             key=lambda s: int(abs(coord.coeff(s))),
             reverse=True,
         )
-        if len(syms) == 1:
+        if len(loop_vars) == 1:
             # One loop var covers all fused names (e.g. a flat [A, B*D*E] read)
-            result.setdefault(syms[0], []).extend(names)
+            result.setdefault(loop_vars[0], []).extend(names)
+        elif len(loop_vars) > len(names):
+            # More loop vars than named dims: a single named dim was split by reshape.
+            raise Unsupported(
+                f"{dep.name}: layout dim {i} has {len(loop_vars)} loop vars but only "
+                f"{len(names)} name(s) {names} -- reshape split a named dim, "
+                f"re-annotate after the reshape"
+            )
         else:
-            # Multi-symbol coord: match each sym to one name by coefficient order
-            for sym, name in zip(syms, names):
-                result.setdefault(sym, []).append(name)
+            # Multi-loop-var coord: match each loop var to one name by coefficient order
+            for loop_var, name in zip(loop_vars, names):
+                result.setdefault(loop_var, []).append(name)
     return result
 
 
@@ -221,6 +237,7 @@ def _compute_named_dims(op, inputs):
             size = int(output_dep.ranges[sym])
             loop_var_dims[sym] = [_untracked_name(op.get_name(), sym, size)]
     out_coords = op_out_coords(op)
+
     named_dims = []
     for coord in out_coords:
         sym = _lone_sym(coord)

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -120,6 +120,9 @@ def _consume_names(remaining: list[str], layout_size: int) -> list[str]:
         product *= _named_dims.get(name, 1)
         if product == layout_size:
             return remaining[: i + 1]
+    logger.warning(
+        f"_consume_names: no prefix of {remaining} multiplies to {layout_size}"
+    )
     return []
 
 

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -135,23 +135,24 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
         }
     named_size, named_stride = _compute_named_layout(buf_named_dims)
 
-    # Pointwise loop vars come from the output (write dep); see iteration_space_from_op.
-    # For Pointwise intermediates, dep.index may use non-contiguous strides (e.g.
-    # permute+contiguous), so use the write dep's index. Graph inputs and Reduction
-    # inputs are already consistent with the iteration space.
-    # Exception: broadcast inputs (unsqueeze) have fewer free symbols than the write dep.
-    # Zeroing the missing syms inflates all remaining strides by the product of the missing
-    # dims, producing wrong coordinate mappings. Use dep.index directly in that case.
-    is_intermediate = isinstance(_get_buffer(dep), ComputedBuffer)
-    if is_intermediate and op is not None and isinstance(op.data, Pointwise):
+    # compute_coordinates needs an index whose strides match named_stride (contiguous
+    # storage order). dep.index uses the buffer's actual storage strides — correct when
+    # the buffer is contiguous, but wrong when it's non-contiguous (e.g. permuted).
+    # For Pointwise intermediates, use write_dep.index (contiguous output-space strides)
+    # unless the input has fewer symbols than the output (broadcast/unsqueeze): zeroing
+    # the missing syms inflates all remaining strides by the product of the missing dims.
+    # dep has *more* symbols than write_dep when an extra reduction dim leaks into the
+    # read index — use write_dep.index there too (missing_syms tracks write→dep gap only).
+    index = dep.index
+    if (
+        isinstance(_get_buffer(dep), ComputedBuffer)
+        and op is not None
+        and isinstance(op.data, Pointwise)
+    ):
         write_dep = next(iter(op.get_read_writes().writes))
         missing_syms = write_dep.index.free_symbols - dep.index.free_symbols
-        if missing_syms:
-            index = dep.index
-        else:
+        if not missing_syms:
             index = write_dep.index
-    else:
-        index = dep.index
     coords = compute_coordinates(named_size, named_stride, dep.ranges, index)
     result: dict[sympy.Symbol, list[str]] = {}
     for i, coord in enumerate(coords):

--- a/torch_spyre/_inductor/propagate_named_dims.py
+++ b/torch_spyre/_inductor/propagate_named_dims.py
@@ -161,7 +161,7 @@ def compute_input_named_dims(dep: MemoryDep, op=None) -> dict:
             # Skip: size-1 dims are not annotated.  Broadcast dims (e.g. a [1,N]
             # buffer annotated ["M","N"]) silently become _untracked_ — we cannot
             # raise here without breaking legitimate unannotated size-1 dims.
-            # See test_broadcast_expand_* and broadcast_named_dims_fix.txt.
+            # See test_broadcast_expand_* 
             continue
         names = _consume_names(remaining, dim_size)
         if not names:


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [x] bug
- [ ] feature
- [ ] documentation
- [x] cleanup


#### Body

This PR fixes incorrect named dim mappings in `compute_input_named_dims` for non-contiguous and fused-dim buffers, and attempts to remove a number of fragile assumptions in that code.

Instead of reconstructing strides from named dim sizes and using `compute_coordinates`, the new approach uses the actual layout strides to map loop variables to layout dims, then layers named dims on top by matching them to layout dims in declared order. So `host_coordinates` is the transport mechanism — input to loop vars to output — and named dims ride along on top.

The old code reconstructed contiguous strides from declared named-dim sizes and used those with `compute_coordinates` to decompose `dep.index`. This worked only when the buffer was contiguous. For permuted buffers the reconstructed strides don't match `dep.index`, so loop variables were mapped to the wrong named dims. For view/reshape intermediates, one layout dim covers multiple named dims — the old reconstruction had no way to express that grouping.                                
                             
Also adds `tests/inductor/test_propagate_named_dims.py` with 27 tests covering pointwise, reduction, permute, contiguous, matmul, view/reshape, broadcast/unsqueeze, and permuted intermediate cases.

Also fixes `_lone_sym` to return `None` for zero- or multi-symbol coordinate expressions instead of crashing, and removes `get_reduction_dim` (replaced by `find_reduction_var` from `pass_utils`).
