### PR TITLE
Remove unnecessary OP_GOOD_FOR_LX_INPLACE

### DIFF
--- a/docs/source/compiler/scratchpad_planning.md
+++ b/docs/source/compiler/scratchpad_planning.md
@@ -182,8 +182,7 @@ it sets up the next two optimizations, which are large.
 
 **Stage 3, in-place ops.** When a buffer is on LX and its last reader is
 itself dying-after-this-op, the output of the next op can reuse the same
-LX address. `exp` and `sub` are flagged
-[OP_GOOD_FOR_LX_INPLACE](https://github.com/torch-spyre/torch-spyre/blob/main/torch_spyre/_inductor/scratchpad/utils.py)
+LX address. `exp` and `sub` are flagged as `torch.Tag.pointwise`
 and therefore in-placeable. After stage 3, the only HBM access left is
 the graph input and graph output, for `3MN` bytes total, a 62% reduction.
 

--- a/torch_spyre/_inductor/scratchpad/allocator.py
+++ b/torch_spyre/_inductor/scratchpad/allocator.py
@@ -48,7 +48,6 @@ from torch_spyre._inductor.scratchpad.passes import (
 )
 from torch_spyre._inductor.scratchpad.utils import (
     OP_OUTPUT_GOOD_FOR_LX_REUSE,
-    OP_GOOD_FOR_LX_INPLACE,
     clone_at_graph_boundaries,
     mem_usage_by_buf,
     calculate_liveness,
@@ -109,9 +108,6 @@ class ScratchpadAllocator(ABC):
         if target is None:
             return []
         reads = [dep.name for dep in op.get_read_writes().reads]
-        if self._get_op_name(op) in OP_GOOD_FOR_LX_INPLACE:
-            # If the op is in the whitelist, allow all inputs
-            return reads
         if torch.Tag.pointwise in target.tags:
             # If the op is tagged as pointwise by pytorch upstream
             # allow all inputs. Does not work for all ops

--- a/torch_spyre/_inductor/scratchpad/utils.py
+++ b/torch_spyre/_inductor/scratchpad/utils.py
@@ -44,15 +44,6 @@ OP_OUTPUT_GOOD_FOR_LX_REUSE = frozenset(
     }
 )
 
-OP_GOOD_FOR_LX_INPLACE = frozenset(
-    {
-        "exp",
-        "sub",
-        "add",
-        "rsqrt",
-    }
-)
-
 
 def clone_at_graph_boundaries() -> bool:
     """True when clone ops are eligible for LX, enabling clone insertion at graph


### PR DESCRIPTION
Now ops are checked for torch.Tag.pointwise and then checked whether the inner_fn for the op is pointwise which makes the whitelist redundant.

Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup

#### What this PR does:

<!--
Please describe your changes
-->

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional note:
