### PR TITLE
chore(cicd): move x4 label and lx op test to request 2 and rest all 1 (hard to get jobs scheduled at 4 at peak capacity)

### DIFF
--- a/.github/workflows/_test_matrix.yaml
+++ b/.github/workflows/_test_matrix.yaml
@@ -167,7 +167,6 @@ jobs:
             config: torch_spyre_tests/inductor/test_inductor_ops_pointwise_config.yaml
           - name: Inductor Ops Misc Shape A
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_a_config.yaml
-            runner: spyre_pf_x4
           - name: Inductor Ops Misc Shape B
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_shape_b_config.yaml
           - name: Inductor Ops Misc Shape C
@@ -178,10 +177,9 @@ jobs:
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_b_config.yaml
           - name: Inductor Ops Misc Compute C
             config: torch_spyre_tests/inductor/test_inductor_ops_misc_compute_c_config.yaml
-            runner: spyre_pf_x4
           - name: Inductor Ops LX Planning
             config: torch_spyre_tests/inductor/test_ops_lx_planning_config.yaml
-            runner: spyre_pf_x4
+            runner: spyre_pf_x2
           - name: Inductor Scalar
             config: torch_spyre_tests/inductor/test_inductor_scalar_config.yaml
           - name: Inductor Logging


### PR DESCRIPTION
Thanks for sending a pull request! Please make sure you read the [contributing guidelines](https://github.com/torch-spyre/torch-spyre/blob/main/CONTRIBUTING.md).

#### What type of PR is this?

- [ ] bug
- [ ] feature
- [ ] documentation
- [x] cleanup